### PR TITLE
Weed "minimal" docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
-FROM cydev/go
-RUN go get github.com/chrislusf/weed-fs/go/weed
+FROM progrium/busybox
+
+WORKDIR /opt/weed
+
+RUN opkg-install curl
+RUN echo insecure >> ~/.curlrc
+
+RUN \
+  curl -Lks https://bintray.com$(curl -Lk http://bintray.com/chrislusf/Weed-FS/seaweed/_latestVersion | grep linux_amd64.tar.gz | sed -n "/href/ s/.*href=['\"]\([^'\"]*\)['\"].*/\1/gp") | gunzip | tar -xf - -C /opt/weed/ && \
+  mv weed_* bin && \
+  chmod +x ./bin/weed
+
 EXPOSE 8080
 EXPOSE 9333
+
 VOLUME /data
+
+ENV WEED_HOME /opt/weed
+ENV PATH ${PATH}:${WEED_HOME}/bin
+
 ENTRYPOINT ["weed"]

--- a/Dockerfile.go_build
+++ b/Dockerfile.go_build
@@ -1,0 +1,6 @@
+FROM cydev/go
+RUN go get github.com/chrislusf/weed-fs/go/weed
+EXPOSE 8080
+EXPOSE 9333
+VOLUME /data
+ENTRYPOINT ["weed"]

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -82,6 +82,9 @@ Using Seaweed-FS in docker
 
 You can use image "cydev/weed" or build your own with  `dockerfile <https://github.com/chrislusf/weed-fs/blob/master/Dockerfile>`_  in the root of repo.
 
+Using pre-built Docker image
+**************************************************************
+
 .. code-block:: bash
 
 	docker run --name weed cydev/weed server
@@ -97,6 +100,29 @@ And in another terminal
   		"Leader": "localhost:9333"
 	}
 	# use $IP as host for api queries
+
+Building image from dockerfile
+**************************************************************
+
+Make a local copy of weed-fs from github
+
+.. code-block:: bash
+
+	git clone https://github.com/chrislusf/weed-fs.git
+
+Minimal Image (~19.6 MB)
+
+.. code-block:: bash
+
+	docker build --no-cache --rm -t 'cydev/weed' .
+
+Go-Build Docker Image (~764 MB)
+
+.. code-block:: bash
+
+	mv Dockerfile Dockerfile.minimal
+	mv Dockerfile.go_build Dockerfile
+	docker build --no-cache --rm -t 'cydev/weed' .
 
 In production
 **************************************************************

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -114,7 +114,7 @@ Minimal Image (~19.6 MB)
 
 .. code-block:: bash
 
-	docker build --no-cache --rm -t 'cydev/weed' .
+	docker build --no-cache -t 'cydev/weed' .
 
 Go-Build Docker Image (~764 MB)
 
@@ -122,7 +122,7 @@ Go-Build Docker Image (~764 MB)
 
 	mv Dockerfile Dockerfile.minimal
 	mv Dockerfile.go_build Dockerfile
-	docker build --no-cache --rm -t 'cydev/weed' .
+	docker build --no-cache -t 'cydev/weed' .
 
 In production
 **************************************************************


### PR DESCRIPTION
I think the weed docker image which build from the given Dockerfile is too large, so I made this minimal version and it's only about 19.6 MB.