### PR TITLE
fix bug about the collection

### DIFF
--- a/go/weed/weed_server/common.go
+++ b/go/weed/weed_server/common.go
@@ -87,6 +87,7 @@ func submitForClientHandler(w http.ResponseWriter, r *http.Request, masterUrl st
 	}
 
 	debug("assigning file id for", fname)
+	r.ParseForm()
 	assignResult, ae := operation.Assign(masterUrl, 1, r.FormValue("replication"), r.FormValue("collection"), r.FormValue("ttl"))
 	if ae != nil {
 		writeJsonError(w, r, ae)


### PR DESCRIPTION
fix bug about the collection in volume is wrong when curl -F "file=@/tmp/test.jpg" "localhost:9333/submit?collection=picture"

bug:
```
curl -F "file=@/tmp/test.jpg" "localhost:9333/submit?collection=picture"
{"fid":"1,012515d9d5","fileName":"test.mp3","fileUrl":"localhost:8080/1,012515d9d5","size":4}
ls /tmp/data1
1.dat 1.idx 2.dat 2.idx 3.dat 3.idx 4.dat 4.idx 5.dat 5.idx
```

fixed:
```
curl -F "file=@/tmp/test.jpg" "localhost:9333/submit?collection=picture"
{"fid":"4,01a750e97c","fileName":"test.mp3","fileUrl":"localhost:8080/4,01a750e97c","size":4}
ls /tmp/data1
picture_1.dat picture_1.idx picture_2.dat picture_2.idx picture_3.dat picture_3.idx picture_4.dat picture_4.idx picture_5.dat picture_5.idx
```
