### PR TITLE
fix bug about : writed needle into localfile twice when replicating

### DIFF
--- a/go/weed/volume.go
+++ b/go/weed/volume.go
@@ -71,6 +71,7 @@ func runVolume(cmd *Command, args []string) bool {
 
 	if *publicIp == "" {
 		if *ip == "" {
+			*ip = "127.0.0.1"
 			*publicIp = "localhost"
 		} else {
 			*publicIp = *ip


### PR DESCRIPTION
fix bug about : writed needle into localfile twice when replicating,  because of the ip is not equal : ":8080" != "127.0.0.1:8080"

start one master and two volume:

```
go build && ./weed master -mdir="/tmp/weed_master_tmp" -defaultReplication="001"
go build && ./weed -v=5 volume -dir="/tmp/data1" -max=5  -mserver="localhost:9333" -port=8080 -rack=1
go build && ./weed -v=5 volume -dir="/tmp/data2" -max=5  -mserver="localhost:9333" -port=8081 -rack=1
```

bug:

```
curl -F "file=@/tmp/test.jpg" "127.0.0.1:9333/submit"
{"fid":"1,017b1359c4","fileName":"test.jpg","fileUrl":"localhost:8081/1,017b1359c4","size":4}

volume1:
I0107 16:43:32 66247 volume.go:164] writing needle 1,017b1359c4

volume2:
I0107 16:43:32 66248 volume.go:164] writing needle 1,017b1359c4
I0107 16:43:32 66248 volume.go:164] writing needle 1,017b1359c4
I0107 16:43:32 66248 volume.go:173] needle is unchanged!
```


fixed:

```
volume1:
I0107 16:45:36 66524 volume.go:164] writing needle 3,01a0823818

volume2:
I0107 16:45:36 66525 volume.go:164] writing needle 3,01a0823818
```
