### PR TITLE
fix bug: 'http: multiple response.WriteHeader calls'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 weed
+tags
+*.swp

--- a/go/weed/weed_server/common.go
+++ b/go/weed/weed_server/common.go
@@ -65,7 +65,6 @@ func writeJsonQuiet(w http.ResponseWriter, r *http.Request, httpStatus int, obj 
 	}
 }
 func writeJsonError(w http.ResponseWriter, r *http.Request, httpStatus int, err error) {
-	w.WriteHeader(http.StatusInternalServerError)
 	m := make(map[string]interface{})
 	m["error"] = err.Error()
 	writeJsonQuiet(w, r, httpStatus, m)


### PR DESCRIPTION

```
./weed master \
    -mdir="/tmp/weed_master_tmp" \
    -defaultReplication="001" \
    -volumeSizeLimitMB=1

```

```
./weed -v=5 volume \
    -dir="/tmp/data1" \
    -max=1  \
    -mserver="localhost:9333" \
    -port=8080 \
    -rack=1
``


bug:

```
2015/01/08 18:58:27 http: multiple response.WriteHeader calls
2015/01/08 18:58:27 http: multiple response.WriteHeader calls
```


fixed:

not error log printed.