### PR TITLE
use proto "github.com/golang/protobuf/proto"

### DIFF
--- a/go/operation/system_message.pb.go
+++ b/go/operation/system_message.pb.go
@@ -14,7 +14,7 @@ It has these top-level messages:
 */
 package operation
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
Please use `github.com/golang/protobuf/proto` instead of `code.google.com/p/goprotobuf/proto` .
The GFW in China  makes programmer's life so tough when project import `code.google.com...` .
