### PR TITLE
Fix the #9

### DIFF
--- a/go/weed/server.go
+++ b/go/weed/server.go
@@ -49,6 +49,7 @@ var cmdServer = &Command{
 var (
 	serverIp                      = cmdServer.Flag.String("ip", "", "ip or server name")
 	serverPublicIp                = cmdServer.Flag.String("publicIp", "", "ip or server name")
+	reverseProxyServer            = cmdServer.Flag.String("reverseProxyServer", "", "front-end reverse proxy server url <ip:port|domain_name>, for replication > 000")
 	serverBindIp                  = cmdServer.Flag.String("ip.bind", "0.0.0.0", "ip address to bind to")
 	serverMaxCpu                  = cmdServer.Flag.Int("maxCpu", 0, "maximum number of CPUs. 0 means all available CPUs")
 	serverTimeout                 = cmdServer.Flag.Int("idleTimeout", 10, "connection idle seconds")
@@ -230,10 +231,13 @@ func runServer(cmd *Command, args []string) bool {
 		*serverIp, *volumePort, *volumeAdminPort, *serverPublicIp,
 		folders, maxCounts,
 		*serverIp+":"+strconv.Itoa(*masterPort), *volumePulse, *serverDataCenter, *serverRack,
-		serverWhiteList, *volumeFixJpgOrientation,
+		serverWhiteList, *volumeFixJpgOrientation, *reverseProxyServer,
 	)
 
 	glog.V(0).Infoln("Start Seaweed volume server", util.VERSION, "at", *serverIp+":"+strconv.Itoa(*volumePort))
+	if *reverseProxyServer != "" {
+		glog.V(0).Infoln("The Seaweed volume server", util.VERSION, " is running behind the reverse proxy server", *reverseProxyServer)
+	}
 	volumeListener, e := util.NewListener(
 		*serverBindIp+":"+strconv.Itoa(*volumePort),
 		time.Duration(*serverTimeout)*time.Second,

--- a/go/weed/volume.go
+++ b/go/weed/volume.go
@@ -33,6 +33,7 @@ type VolumeServerOptions struct {
 	rack                  *string
 	whiteList             []string
 	fixJpgOrientation     *bool
+	reverseProxyServer    *string
 }
 
 func init() {
@@ -49,6 +50,7 @@ func init() {
 	v.dataCenter = cmdVolume.Flag.String("dataCenter", "", "current volume server's data center name")
 	v.rack = cmdVolume.Flag.String("rack", "", "current volume server's rack name")
 	v.fixJpgOrientation = cmdVolume.Flag.Bool("images.fix.orientation", true, "Adjust jpg orientation when uploading.")
+	v.reverseProxyServer = cmdVolume.Flag.String("reverseProxyServer", "", "front-end reverse proxy server url <ip:port|domain_name>, for replication > 000")
 }
 
 var cmdVolume = &Command{
@@ -122,6 +124,7 @@ func runVolume(cmd *Command, args []string) bool {
 		*v.master, *v.pulseSeconds, *v.dataCenter, *v.rack,
 		v.whiteList,
 		*v.fixJpgOrientation,
+		*v.reverseProxyServer,
 	)
 
 	listeningAddress := *v.bindIp + ":" + strconv.Itoa(*v.port)
@@ -150,6 +153,10 @@ func runVolume(cmd *Command, args []string) bool {
 
 	if e := http.Serve(listener, publicMux); e != nil {
 		glog.Fatalf("Volume server fail to serve: %v", e)
+	}
+
+	if *v.reverseProxyServer != "" {
+		glog.V(0).Infoln("The Seaweed volume server", util.VERSION, "is running behind the reverse proxy server", *v.reverseProxyServer)
 	}
 	return true
 }

--- a/go/weed/weed_server/volume_server.go
+++ b/go/weed/weed_server/volume_server.go
@@ -28,8 +28,13 @@ func NewVolumeServer(publicMux, adminMux *http.ServeMux, ip string,
 	masterNode string, pulseSeconds int,
 	dataCenter string, rack string,
 	whiteList []string,
-	fixJpgOrientation bool) *VolumeServer {
+	fixJpgOrientation bool,
+	reverseProxyServer string) *VolumeServer {
+
 	publicUrl := publicIp + ":" + strconv.Itoa(port)
+	if reverseProxyServer != "" {
+		publicUrl = reverseProxyServer
+	}
 	vs := &VolumeServer{
 		masterNode:        masterNode,
 		pulseSeconds:      pulseSeconds,


### PR DESCRIPTION

Why a new parameter '-reverseProxyServer="docvolume.xxx.com"'?

	1. the publicURL param is in complex usage case
	2. back-forward support, and do not impact the other users

For weedfs starting script:

		nohup ./weed master -ip="10.180.120.63" -defaultReplication="001" -mdir="." &
		nohup ./weed volume -max=100 -mserver="localhost:9333" -dir="./data/v1" -port=5083 -ip="10.180.120.63" -dataCenter="dc1" -rack="rack1"  -reverseProxyServer="docvolume.test.com" &
		nohup ./weed volume -max=100 -mserver="localhost:9333" -dir="./data/v2" -port=5084 -ip="10.180.120.63" -dataCenter="dc1" -rack="rack1"  -reverseProxyServer="docvolume.test.com"  &

For nginx config:

		upstream docvolume.test.com {	
			server 10.180.120.63:5083;
		   server 10.180.120.63:5084;	
	   }
	   server {
		  listen       80;
		  server_name  docvolume.test.com;
		  charset utf-8;    
		
		location / {
			proxy_pass http://docvolume.test.com;
			proxy_set_header  Host $host:$server_port;
			proxy_set_header  X-Real-IP  $remote_addr;
			client_max_body_size  100m;
		}

For client usage case:

	1. Always to post the file to 10.180.120.63:9333/submit instead of (two phase assign & post) to simplify the write ops. It will get the response:

			 {
				 "fid": "7,096efcf8ab",
				 "fileName": "1.jpg",
				 "fileUrl": "docvolume.test.com/7,096efcf8ab",
				 "size": 16562
			 }
			 
	2. To get the file, just access docvolume.test.com/7,096efcf8ab

        3. Current replication is 001, and other replication case is ok too, and the more than one group volume servers are supported too.
 
