### PR TITLE
use file.Truncate to reset file size to speedup test

### DIFF
--- a/weed/storage/needle_read_write_test.go
+++ b/weed/storage/needle_read_write_test.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"crypto/rand"
 	"github.com/chrislusf/seaweedfs/weed/storage/types"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -49,7 +47,7 @@ func TestAppend(t *testing.T) {
 	*/
 
 	fileSize := int64(4294967295) + 10000
-	io.CopyN(tempFile, rand.Reader, fileSize)
+	tempFile.Truncate(fileSize)
 	defer func() {
 		tempFile.Close()
 		os.Remove(tempFile.Name())


### PR DESCRIPTION
speedup  test data file more  than 4294967295 (max of uint32) with file.Truncate