### PR TITLE
Add extinsions for correct work with trino

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -146,7 +146,7 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 	if mimeType == "" {
 		if ext := filepath.Ext(entry.Name()); ext != "" {
 			switch ext {
-			case ".json",".orc",".parquet",".avro",".part":
+			case ".orc",".parquet",".avro",".part":
 				mimeType = "application/octet-stream"
 			}
 			mimeType = mime.TypeByExtension(ext)


### PR DESCRIPTION
# What problem are we solving?
MimeType from standard library don't know about trino file extensions 


# How are we solving the problem?
Add file extensions for working with trino files. Identify trino files like "application/octet-stream"