### PR TITLE
Fix test bucket listv2 delimiter prefix with  with start token

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -142,7 +142,7 @@ func (s3a *S3ApiServer) listFilerEntries(bucket string, originalPrefix string, m
 	var nextMarker string
 	cursor := &ListingCursor{
 		maxKeys:               maxKeys,
-		prefixEndsOnDelimiter: strings.HasSuffix(originalPrefix, "/"),
+		prefixEndsOnDelimiter: strings.HasSuffix(originalPrefix, "/") && len(originalPrefix) == 0,
 	}
 
 	// check filer
@@ -238,7 +238,11 @@ type ListingCursor struct {
 func normalizePrefixMarker(prefix, marker string) (alignedDir, alignedPrefix, alignedMarker string) {
 	// alignedDir should not end with "/"
 	// alignedDir, alignedPrefix, alignedMarker should only have "/" in middle
-	prefix = strings.Trim(prefix, "/")
+	if len(prefix) == 0 {
+		prefix = strings.Trim(prefix, "/")
+	} else {
+		prefix = strings.TrimLeft(prefix, "/")
+	}
 	marker = strings.TrimLeft(marker, "/")
 	if prefix == "" {
 		return "", "", marker


### PR DESCRIPTION
# What problem are we solving?

```
aws --endpoint-url http://127.0.0.1:8000 s3api list-objects-v2 --bucket yournamehere-jj72lna9s75u4hx9-1 --no-cli-pager --prefix "boo/" --delimiter '/' --starting-token 'boo/bar'
```
```
> fs.tree /buckets/yournamehere-jj72lna9s75u4hx9-1
yournamehere-jj72lna9s75u4hx9-1
├──asdf
├──boo
│   ├──bar
│   └──baz
│       └──xyzzy
└──cquux
    ├──bla
    └──thud
```

# How are we solving the problem?



# How is the PR tested?

```
========================================================================= short test summary info ==========================================================================
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_delimiter_basic - botocore.exceptions.ClientError: An error occurred (ExistingObjectIsFile) when calling the PutObject operation: Existing Object is a file.
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_encoding_basic - AssertionError: assert ['asdf+b'] == ['asdf%2Bb']
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_delimiter_prefix_ends_with_delimiter - AssertionError: assert ['asdf/asdf'] == ['asdf/']
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_fetchowner_defaultempty - assert not 'Owner' in {'ETag': '"82d0f0fa8551de8b7eb5ecb65eae0261"', 'Key': 'foo/bar', 'LastModified': datetime.datetime(2023, 4, 12, 16, 10, 35, tzinfo=tzlocal()), 'O...
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_fetchowner_empty - assert not 'Owner' in {'ETag': '"82d0f0fa8551de8b7eb5ecb65eae0261"', 'Key': 'foo/bar', 'LastModified': datetime.datetime(2023, 4, 12, 16, 10, 35, tzinfo=tzlocal()), 'O...
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_maxkeys_none - assert 10000 == 1000
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_unordered - AssertionError: ClientError not raised
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_continuationtoken_empty - KeyError: 'ContinuationToken'
============================================================== 26 failed, 26 passed, 476 deselected in 18.97s ==============================================================
ERROR: InvocationError for command /opt/s3-tests/.tox/py/bin/pytest s3tests_boto3/functional/test_s3.py -m list_objects_v2 (exited with code 1)
_________________________________________________________________________________ summary __________________________________________________________________________________
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
