### PR TITLE
Helm-Chart: Make MySQL credentials optional

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -84,11 +84,13 @@ spec:
                 secretKeyRef:
                   name: secret-seaweedfs-db
                   key: user
+                  optional: true
             - name: WEED_MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: secret-seaweedfs-db
                   key: password
+                  optional: true
             - name: SEAWEEDFS_FULLNAME
               value: "{{ template "seaweedfs.name" . }}"
             {{- if .Values.filer.extraEnvironmentVars }}


### PR DESCRIPTION
# What problem are we solving?
This allows removing the hard-coded MySQL credentials when they are not needed (in example when using another data store). See #5582 

# How are we solving the problem?
It makes the secret optional - users can remove the secret if they don't need it without breaking backwards compatibility.

# How is the PR tested?
* Deploy the chart on a fresh cluster with leveldb as data store. 
* remove the secret
* the statefulset for the filer still works

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
