### PR TITLE
[shell] volume copy add param noLock

### DIFF
--- a/weed/shell/command_volume_copy.go
+++ b/weed/shell/command_volume_copy.go
@@ -46,9 +46,6 @@ func (c *commandVolumeCopy) Do(args []string, commandEnv *CommandEnv, writer io.
 		return nil
 	}
 
-	if err = commandEnv.confirmIsLocked(args); err != nil {
-		return
-	}
 	if *noLock {
 		commandEnv.noLock = true
 	} else if err = commandEnv.confirmIsLocked(args); err != nil {


### PR DESCRIPTION
# What problem are we solving?

Manual rebalancing takes a long time, during which other shell scripts are blocked. It seems quite safe to do copy, since most of the time is spent copying volumes, if you do not interfere with the work.

This also allows you to manually launch moving to new DC for specific nodes in parallel, which significantly speeds up the process.

https://github.com/seaweedfs/seaweedfs/pull/6209


# How are we solving the problem?

Added an option to not block through lock those who understand what they are doing



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
