### PR TITLE
Helm Chart: support wildcards for s3-ingress host by quoting value

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3/s3-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-ingress.yaml
@@ -41,6 +41,6 @@ spec:
           servicePort: {{ .Values.s3.port }}
 {{- end }}
 {{- if .Values.s3.ingress.host }}
-    host: {{ .Values.s3.ingress.host }}
+    host: {{ .Values.s3.ingress.host | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# What problem are we solving?

When using a host containing a wildcard as `s3.ingress.host` (such as `*.s3.domain.example`), Helm templating fails with the following error:

> Error: YAML parse error on seaweedfs/templates/s3/s3-ingress.yaml: error converting YAML to JSON: yaml: line 32: did not find expected alphabetic or numeric character

The spec explicitly permits this format, though:

```
$ kubectl explain ingress.spec.rules.host
GROUP:      networking.k8s.io
KIND:       Ingress
VERSION:    v1

FIELD: host <string>


DESCRIPTION:
    host is the fully qualified domain name of a network host, as defined by RFC
    3986. Note the following deviations from the "host" part of the URI as
    defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue
    can only apply to
       the IP in the Spec of the parent Ingress.
    2. The `:` delimiter is not respected because ports are not allowed.
          Currently the port of an Ingress is implicitly :80 for http and
          :443 for https.
    Both these may change in the future. Incoming requests are matched against
    the host before the IngressRuleValue. If the host is unspecified, the
    Ingress routes all traffic based on the specified IngressRuleValue.
    
    host can be "precise" which is a domain name without the terminating dot of
    a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name
    prefixed with a single wildcard label (e.g. "*.foo.com"). The wildcard
    character '*' must appear by itself as the first DNS label and matches only
    a single label. You cannot have a wildcard label by itself (e.g. Host ==
    "*"). Requests will be matched against the Host field in the following way:
    1. If host is precise, the request matches this rule if the http host header
    is equal to Host. 2. If host is a wildcard, then the request matches this
    rule if the http host header is to equal to the suffix (removing the first
    label) of the wildcard rule.
```

# How are we solving the problem?

This PR solves the issue by applying single quotes to the host field during templating.

# How is the PR tested?

```
$ helm template . --name-template seaweedfs --namespace seaweedfs --kube-version 1.33 --values <path>/values.yaml --include-crds
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
