### PR TITLE
replace range delete with normal txn delete

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -383,6 +383,9 @@ enabled = false
 pdaddrs = "localhost:2379"
 # Enable 1PC
 enable_1pc = false
+# batch delete count, default 10000 in code
+#batchdelete_count = 20000
+
 # Set the CA certificate path
 ca_path=""
 # Set the certificate path

--- a/weed/filer/tikv/tikv_store.go
+++ b/weed/filer/tikv/tikv_store.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tikv/client-go/v2/txnkv"
 )
 
-const batchCommitSize = 10000
+const defaultBatchCommitSize = 10000
 
 var (
 	_ filer.FilerStore = ((*TikvStore)(nil))
@@ -31,8 +31,9 @@ func init() {
 }
 
 type TikvStore struct {
-	client *txnkv.Client
-	onePC  bool
+	client          *txnkv.Client
+	onePC           bool
+	batchCommitSize int
 }
 
 // Basic APIs
@@ -47,7 +48,13 @@ func (store *TikvStore) Initialize(config util.Configuration, prefix string) err
 	verify_cn := strings.Split(config.GetString(prefix+"verify_cn"), ",")
 	pdAddrs := strings.Split(config.GetString(prefix+"pdaddrs"), ",")
 
+	bdc := config.GetInt(prefix + "batchdelete_count")
+	if bdc <= 0 {
+		bdc = defaultBatchCommitSize
+	}
+
 	store.onePC = config.GetBool(prefix + "enable_1pc")
+	store.batchCommitSize = bdc
 	return store.initialize(ca, cert, key, verify_cn, pdAddrs)
 }
 
@@ -82,7 +89,7 @@ func (store *TikvStore) InsertEntry(ctx context.Context, entry *filer.Entry) err
 	if err != nil {
 		return err
 	}
-	err = txn.RunInTxn(func(txn *txnkv.KVTxn) error {
+	err = txn.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		return txn.Set(key, value)
 	})
 	if err != nil {
@@ -104,7 +111,7 @@ func (store *TikvStore) FindEntry(ctx context.Context, path util.FullPath) (*fil
 		return nil, err
 	}
 	var value []byte = nil
-	err = txn.RunInTxn(func(txn *txnkv.KVTxn) error {
+	err = txn.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		val, err := txn.Get(context.TODO(), key)
 		if err == nil {
 			value = val
@@ -139,7 +146,7 @@ func (store *TikvStore) DeleteEntry(ctx context.Context, path util.FullPath) err
 		return err
 	}
 
-	err = txn.RunInTxn(func(txn *txnkv.KVTxn) error {
+	err = txn.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		return txn.Delete(key)
 	})
 	if err != nil {
@@ -181,7 +188,7 @@ func (store *TikvStore) DeleteFolderChildren(ctx context.Context, path util.Full
 
 		keys = append(keys, append([]byte(nil), key...))
 
-		if len(keys) >= batchCommitSize {
+		if len(keys) >= store.batchCommitSize {
 			if err := store.deleteBatch(ctx, keys); err != nil {
 				return fmt.Errorf("delete batch in %s, error: %v", path, err)
 			}
@@ -208,14 +215,21 @@ func (store *TikvStore) deleteBatch(ctx context.Context, keys [][]byte) error {
 		return err
 	}
 
-	return deleteTxn.RunInTxn(func(txn *txnkv.KVTxn) error {
-		for _, key := range keys {
-			if err := txn.Delete(key); err != nil {
-				return err
-			}
+	if !deleteTxn.inContext {
+		defer func() { _ = deleteTxn.Rollback() }()
+	}
+
+	for _, key := range keys {
+		if err := deleteTxn.Delete(key); err != nil {
+			return err
 		}
-		return nil
-	})
+	}
+
+	if !deleteTxn.inContext {
+		return deleteTxn.Commit(ctx)
+	}
+
+	return nil
 }
 
 func (store *TikvStore) ListDirectoryEntries(ctx context.Context, dirPath util.FullPath, startFileName string, includeStartFile bool, limit int64, eachEntryFunc filer.ListEachEntryFunc) (string, error) {
@@ -234,7 +248,7 @@ func (store *TikvStore) ListDirectoryPrefixedEntries(ctx context.Context, dirPat
 	if err != nil {
 		return lastFileName, err
 	}
-	err = txn.RunInTxn(func(txn *txnkv.KVTxn) error {
+	err = txn.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		iter, err := txn.Iter(lastFileStart, nil)
 		if err != nil {
 			return err
@@ -342,15 +356,14 @@ type TxnWrapper struct {
 	inContext bool
 }
 
-func (w *TxnWrapper) RunInTxn(f func(txn *txnkv.KVTxn) error) error {
+func (w *TxnWrapper) RunInTxn(ctx context.Context, f func(txn *txnkv.KVTxn) error) error {
 	err := f(w.KVTxn)
 	if !w.inContext {
 		if err != nil {
 			w.KVTxn.Rollback()
 			return err
 		}
-		w.KVTxn.Commit(context.Background())
-		return nil
+		return w.KVTxn.Commit(ctx)
 	}
 	return err
 }

--- a/weed/filer/tikv/tikv_store_kv.go
+++ b/weed/filer/tikv/tikv_store_kv.go
@@ -15,7 +15,7 @@ func (store *TikvStore) KvPut(ctx context.Context, key []byte, value []byte) err
 	if err != nil {
 		return err
 	}
-	return tw.RunInTxn(func(txn *txnkv.KVTxn) error {
+	return tw.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		return txn.Set(key, value)
 	})
 }
@@ -26,7 +26,7 @@ func (store *TikvStore) KvGet(ctx context.Context, key []byte) ([]byte, error) {
 		return nil, err
 	}
 	var data []byte = nil
-	err = tw.RunInTxn(func(txn *txnkv.KVTxn) error {
+	err = tw.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		val, err := txn.Get(context.TODO(), key)
 		if err == nil {
 			data = val
@@ -44,7 +44,7 @@ func (store *TikvStore) KvDelete(ctx context.Context, key []byte) error {
 	if err != nil {
 		return err
 	}
-	return tw.RunInTxn(func(txn *txnkv.KVTxn) error {
+	return tw.RunInTxn(ctx, func(txn *txnkv.KVTxn) error {
 		return txn.Delete(key)
 	})
 }


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/issues/7187


# How are we solving the problem?
Replace range delete with entry delete and commit


# How is the PR tested?
Recreate the issue with following scenario:
1. Write a batch of files (like 5000) via fuse mount or s3 to one directory, e.g., /buckets/fs1/test01
2. Write 10000 kv pairs using rawkv client to same tikv cluster used by filer
3. At middle of 2, delete /buckets/fs1/test01
4. Found rawkv pairs missing at last


Above can recreate the issue at 100% if using old version of tikv store. After the fix, the problem is gone.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
