### PR TITLE
fix: helm chart with COSI deployment enabled breaks on helm upgrade

### DIFF
--- a/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -15,7 +15,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: objectstorage-provisioner
   template:


### PR DESCRIPTION
the `helm.sh/chart` line with the changing version number breaks helm upgrades to due to `matchLabels` being immutable.

drop the offending line as it does not belong into the `matchLabels`

# What problem are we solving?
helm upgrade with cosi enabled fails because helm tries to patch an immutable field in `spec.selector.matchLabels`: `helm.sh/chart: seaweedfs-MAJOR.MINOR.PATCH`.
Since the version will change during the upgrade kubernetes API will render this error:
```
Helm upgrade failed for release seaweedfs/seaweedfs with chart seaweedfs@4.0.392: cannot patch "seaweedfs-objectstorage-provisioner" with kind Deployment: Deployment.apps "seaweedfs-objectstorage-provisioner" is invalid:
spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"objectstorage-provisioner", "app.kubernetes.io/instance":"seaweedfs", "app.kubernetes.io/name":"seaweedfs", "helm.sh/chart":"seaweedfs-4.0.392"},
MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

# How are we solving the problem?
dropping the offending entry in the  `spec.selector.matchLabels`, since for the it is neither used to nor correct in that place

# How is the PR tested?
helm upgrade with cosi enabled with changing versions on a local k3s cluster


# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
