### PR TITLE
WEED_CLUSTER_SW_* Environment Variables should not be passed to allIn…

### DIFF
--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -101,7 +101,7 @@ spec:
               value: "{{ template "seaweedfs.name" . }}"
             {{- if .Values.allInOne.extraEnvironmentVars }}
             {{- range $key, $value := .Values.allInOne.extraEnvironmentVars }}
-            {{- if and (not (regexMatch "^WEED_CLUSTER_.*_MASTER$" $key)) (not (regexMatch "^WEED_CLUSTER_.*_FILER$" $key)) }}
+            {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
@@ -114,7 +114,7 @@ spec:
             {{- end }}
             {{- if .Values.global.extraEnvironmentVars }}
             {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- if and (not (regexMatch "^WEED_CLUSTER_.*_MASTER$" $key)) (not (regexMatch "^WEED_CLUSTER_.*_FILER$" $key)) }}
+            {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
               value: {{ $value | quote }}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -228,11 +228,11 @@ Compute the master service address to be used in cluster env vars.
 If allInOne is enabled, point to the all-in-one service; otherwise, point to the master service.
 */}}
 {{- define "seaweedfs.cluster.masterAddress" -}}
+{{- $serviceNameSuffix := "-master" -}}
 {{- if .Values.allInOne.enabled -}}
-{{- printf "%s-all-in-one.%s:%d" (include "seaweedfs.name" .) .Release.Namespace (int .Values.master.port) -}}
-{{- else -}}
-{{- printf "%s-master.%s:%d" (include "seaweedfs.name" .) .Release.Namespace (int .Values.master.port) -}}
+{{-   $serviceNameSuffix = "-all-in-one" -}}
 {{- end -}}
+{{- printf "%s%s.%s:%d" (include "seaweedfs.name" .) $serviceNameSuffix .Release.Namespace (int .Values.master.port) -}}
 {{- end -}}
 
 {{/*
@@ -240,9 +240,9 @@ Compute the filer service address to be used in cluster env vars.
 If allInOne is enabled, point to the all-in-one service; otherwise, point to the filer-client service.
 */}}
 {{- define "seaweedfs.cluster.filerAddress" -}}
+{{- $serviceNameSuffix := "-filer-client" -}}
 {{- if .Values.allInOne.enabled -}}
-{{- printf "%s-all-in-one.%s:%d" (include "seaweedfs.name" .) .Release.Namespace (int .Values.filer.port) -}}
-{{- else -}}
-{{- printf "%s-filer-client.%s:%d" (include "seaweedfs.name" .) .Release.Namespace (int .Values.filer.port) -}}
+{{-   $serviceNameSuffix = "-all-in-one" -}}
 {{- end -}}
+{{- printf "%s%s.%s:%d" (include "seaweedfs.name" .) $serviceNameSuffix .Release.Namespace (int .Values.filer.port) -}}
 {{- end -}}


### PR DESCRIPTION
…One config

# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7202

# How are we solving the problem?

* Added helpers in templates/shared/_helpers.tpl
* Compute and filter keys WEED_CLUSTER_<DEFAULT>_MASTER and WEED_CLUSTER_<DEFAULT>_FILER out of both .Values.allInOne.extraEnvironmentVars and .Values.global.extraEnvironmentVars.
* Inject computed endpoints for the default cluster

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
