### PR TITLE
[stats]: added s3 bucket stats

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -49,21 +49,22 @@ type MasterOptions struct {
 	volumePreallocate          *bool
 	maxParallelVacuumPerServer *int
 	// pulseSeconds       *int
-	defaultReplication *string
-	garbageThreshold   *float64
-	whiteList          *string
-	disableHttp        *bool
-	metricsAddress     *string
-	metricsIntervalSec *int
-	raftResumeState    *bool
-	metricsHttpPort    *int
-	metricsHttpIp      *string
-	heartbeatInterval  *time.Duration
-	electionTimeout    *time.Duration
-	raftHashicorp      *bool
-	raftBootstrap      *bool
-	telemetryUrl       *string
-	telemetryEnabled   *bool
+	defaultReplication     *string
+	garbageThreshold       *float64
+	whiteList              *string
+	disableHttp            *bool
+	metricsAddress         *string
+	metricsIntervalSec     *int
+	raftResumeState        *bool
+	metricsHttpPort        *int
+	metricsHttpIp          *string
+	heartbeatInterval      *time.Duration
+	electionTimeout        *time.Duration
+	raftHashicorp          *bool
+	raftBootstrap          *bool
+	telemetryUrl           *string
+	telemetryEnabled       *bool
+	intervalToCollectStats *time.Duration
 }
 
 func init() {
@@ -93,6 +94,7 @@ func init() {
 	m.raftBootstrap = cmdMaster.Flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	m.telemetryUrl = cmdMaster.Flag.String("telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL to send usage statistics")
 	m.telemetryEnabled = cmdMaster.Flag.Bool("telemetry", false, "enable telemetry reporting")
+	m.intervalToCollectStats = cmdMaster.Flag.Duration("intervalToCollectStats", time.Second*120, "interval to collect s3 stats")
 }
 
 var cmdMaster = &Command{
@@ -244,6 +246,7 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	}
 
 	go ms.MasterClient.KeepConnectedToMaster(context.Background())
+	go weed_server.CollectCollectionsStats(context.Background(), ms, *masterOption.intervalToCollectStats)
 
 	// start http server
 	var (

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -108,6 +108,7 @@ func init() {
 	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
 	masterOptions.telemetryUrl = cmdServer.Flag.String("master.telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL to send usage statistics")
 	masterOptions.telemetryEnabled = cmdServer.Flag.Bool("master.telemetry", false, "enable telemetry reporting")
+	masterOptions.intervalToCollectStats = cmdServer.Flag.Duration("master.intervalToCollectStats", time.Second*120, "interval to collect s3 stats")
 
 	filerOptions.filerGroup = cmdServer.Flag.String("filer.filerGroup", "", "share metadata with other filers in the same filerGroup")
 	filerOptions.collection = cmdServer.Flag.String("filer.collection", "", "all data will be stored in this collection")

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -382,6 +382,22 @@ var (
 			Name:      "uploaded_objects",
 			Help:      "Number of objects uploaded in each bucket.",
 		}, []string{"bucket"})
+
+	S3BucketFileCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "bucket_file_count",
+			Help:      "Number files in bucket",
+		}, []string{"bucket"})
+
+	S3BucketSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "bucket_size",
+			Help:      "Bucket size in bytes",
+		}, []string{"bucket"})
 )
 
 func init() {
@@ -433,6 +449,8 @@ func init() {
 	Gather.MustRegister(S3BucketTrafficSentBytesCounter)
 	Gather.MustRegister(S3DeletedObjectsCounter)
 	Gather.MustRegister(S3UploadedObjectsCounter)
+	Gather.MustRegister(S3BucketFileCount)
+	Gather.MustRegister(S3BucketSize)
 
 	go bucketMetricTTLControl()
 }


### PR DESCRIPTION
# What problem are we solving?
There is a need to monitor S3 buckets in SeaweedFS, specifically to collect metrics on total bucket size (in bytes) and the number of objects. While this information can be obtained using weed shell commands, it requires custom admin scripts and does not provide out-of-the-box metrics suitable for Prometheus/Grafana.
An earlier approach involved traversing all directories and fetching entry lists, but that solution had logarithmic complexity and generated a large number of database queries (equal to the number of files in the bucket).

# How are we solving the problem?
We leveraged SeaweedFS functionality to implement a direct way of exposing bucket metrics without the need for administrative scripts or a full traversal of all entries. This avoids excessive queries to the database while still providing accurate metrics for monitoring.

# How is the PR tested?
The functionality was tested locally to confirm correctness of metrics collection and ensure that the exposed values for bucket size and object count match expected results.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
