### PR TITLE
REFACTOR: Update telemetry deployment docs and README for new Docker flow

### DIFF
--- a/telemetry/DEPLOYMENT.md
+++ b/telemetry/DEPLOYMENT.md
@@ -174,7 +174,7 @@ You can build and run the telemetry server using Docker locally or on a remote h
 docker compose -f telemetry/docker-compose.yml build telemetry-server
 ```
 
-- Using docker build directly:
+- Using docker build directly (from the repository root):
 
 ```bash
 docker build -t seaweedfs-telemetry \
@@ -202,7 +202,7 @@ Notes:
 
 - The container runs as a non-root user by default.
 - The image listens on port `8080` inside the container. Map it with `-p <host_port>:8080`.
-- You can pass flags to the server by appending them after the image name, e.g. `... seaweedfs-telemetry -port=8353 -dashboard=false`.
+- You can pass flags to the server by appending them after the image name, e.g. `docker run -d -p 8353:8080 seaweedfs-telemetry -port=8353 -dashboard=false`.
 
 ## Server Directory Structure
 

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -220,7 +220,6 @@ docker compose -f telemetry/docker-compose.yml up -d --scale telemetry-server=3
 
 ```bash
 # Build and run telemetry server (build from repo root to include all sources)
-cd ..   # ensure you're at the repo root (seaweedfs)
 docker build -t seaweedfs-telemetry -f telemetry/server/Dockerfile .
 docker run -p 8080:8080 seaweedfs-telemetry -port=8080 -dashboard=true
 ```

--- a/telemetry/server/Dockerfile
+++ b/telemetry/server/Dockerfile
@@ -3,10 +3,6 @@ FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./
-COPY telemetry/server/go.mod telemetry/server/go.sum ./telemetry/server/
-COPY telemetry/proto/ ./telemetry/proto/
-
-WORKDIR /app/telemetry/server
 RUN go mod download
 
 WORKDIR /app


### PR DESCRIPTION
# What problem are we solving?
- Deployment docs didn’t reflect the new Docker build context and compose usage.
- README still showed outdated `docker-compose` and `./server` build context.
- Ports and server-only build/run examples were inconsistent with the current Dockerfile and compose setup.

# How are we solving the problem?
- Update `telemetry/DEPLOYMENT.md`:
  - Add a Docker deployment section with build/run commands using `docker compose` and `telemetry/server/Dockerfile`.
  - Clarify default container port 8080 and how to override with `-port`.
  - Note non-root runtime user and flags passing.
- Update `telemetry/README.md`:
  - Switch to `docker compose -f telemetry/docker-compose.yml ...` from the repo root.
  - Correct the server-only build to use `-f telemetry/server/Dockerfile` from the repo root.
  - Keep direct `go run` instructions under `telemetry/server`.

# How is the PR tested?
- Manually validated the commands:
  - `docker compose -f telemetry/docker-compose.yml build telemetry-server`
  - `docker compose -f telemetry/docker-compose.yml up -d telemetry-server`
- Verified endpoints at `http://localhost:8080`.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.