### PR TITLE
Fix #7060: Return 400 InvalidRequest instead of 500 for context canceled errors

### DIFF
--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -383,6 +383,9 @@ func filerErrorToS3Error(errString string) s3err.ErrorCode {
 	switch {
 	case errString == constants.ErrMsgBadDigest:
 		return s3err.ErrBadDigest
+	case strings.Contains(errString, "context canceled") || strings.Contains(errString, "code = Canceled"):
+		// Client canceled the request, return client error not server error
+		return s3err.ErrInvalidRequest
 	case strings.HasPrefix(errString, "existing ") && strings.HasSuffix(errString, "is a directory"):
 		return s3err.ErrExistingObjectIsDirectory
 	case strings.HasSuffix(errString, "is a file"):

--- a/weed/s3api/s3api_object_handlers_put_test.go
+++ b/weed/s3api/s3api_object_handlers_put_test.go
@@ -19,6 +19,16 @@ func TestFilerErrorToS3Error(t *testing.T) {
 			expectedErr: s3err.ErrBadDigest,
 		},
 		{
+			name:        "Context canceled error",
+			errString:   "rpc error: code = Canceled desc = context canceled",
+			expectedErr: s3err.ErrInvalidRequest,
+		},
+		{
+			name:        "Context canceled error (simple)",
+			errString:   "context canceled",
+			expectedErr: s3err.ErrInvalidRequest,
+		},
+		{
 			name:        "Directory exists error",
 			errString:   "existing /path/to/file is a directory",
 			expectedErr: s3err.ErrExistingObjectIsDirectory,


### PR DESCRIPTION
## Problem

When clients cancel HTTP requests (e.g., connection timeout, client disconnect), SeaweedFS returns **HTTP 500 Internal Server Error** instead of a client error (4xx). This causes:
- Incorrect error attribution (server blamed instead of client)
- False positives in monitoring/alerting
- Confusion about the root cause

### Error Flow
```
Client timeout/disconnect
  → Context canceled
  → masterclient: "Connection wait stopped: context canceled"
  → filer: "failing to assign a file id: rpc error: code = Canceled desc = context canceled"
  → S3 API: HTTP 500 Internal Server Error ❌
```

## Root Cause

The `filerErrorToS3Error()` function maps filer errors to S3 error codes. Context cancellation errors were falling through to the default case, which returns `ErrInternalError` (HTTP 500).

```go
func filerErrorToS3Error(errString string) s3err.ErrorCode {
    switch {
    // ... other cases ...
    default:
        return s3err.ErrInternalError  // ❌ Wrong for context canceled
    }
}
```

## Solution

Added detection for context canceled errors and return `ErrInvalidRequest` (HTTP 400) instead:

```go
case strings.Contains(errString, "context canceled") || strings.Contains(errString, "code = Canceled"):
    // Client canceled the request, return client error not server error
    return s3err.ErrInvalidRequest
```

### Error Flow After Fix
```
Client timeout/disconnect
  → Context canceled
  → S3 API: HTTP 400 Bad Request ✅
  → Proper client error attribution
```

## Changes

**File**: `weed/s3api/s3api_object_handlers_put.go`
- Added case to detect "context canceled" and "code = Canceled" errors
- Returns `ErrInvalidRequest` (400) for context cancellation
- Maintains existing error handling for other error types

**File**: `weed/s3api/s3api_object_handlers_put_test.go`
- Added test for gRPC-style context canceled error
- Added test for simple context canceled error
- Ensures proper error mapping

## Benefits

✅ **Correct HTTP Status**: Clients get 400 Bad Request instead of 500 Internal Server Error  
✅ **Proper Attribution**: Error correctly attributed to client, not server  
✅ **Better Monitoring**: Server metrics won't spike with false errors  
✅ **Clear Debugging**: Logs/metrics show client timeouts vs actual server issues  

## Testing

- ✅ New test cases pass
- ✅ All existing S3 API tests pass
- ✅ Build successful

## Compatibility

This is a behavioral change but improves correctness:
- **Before**: Context canceled → HTTP 500 (incorrect)
- **After**: Context canceled → HTTP 400 (correct)

Clients properly handling HTTP errors will benefit from the more accurate status code.

Fixes #7060