### PR TITLE
fix: helm release invalid version v prefix

### DIFF
--- a/.github/workflows/helm_chart_release.yml
+++ b/.github/workflows/helm_chart_release.yml
@@ -20,4 +20,4 @@ jobs:
           charts_dir: k8s/charts
           target_dir: helm
           branch: gh-pages
-          helm_version: v3.18.4
+          helm_version: "3.18.4"


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7327

# How are we solving the problem?

It looks to me like the stefanprodan/helm-gh-pages action is expecting the version without the v prefix

https://github.com/stefanprodan/helm-gh-pages/blob/89c6698c192e70ed0e495bee7d3d1ca5b477fe82/src/entrypoint.sh#L122

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
