### PR TITLE
fix(helm): set securitycontext for idx move initcontainer if enabled

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -88,6 +88,9 @@ spec:
             - name: {{ $dir.name }}
               mountPath: /{{ $dir.name }}
           {{- end }}
+          {{- if $volume.containerSecurityContext.enabled }}
+          securityContext: {{- omit $volume.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if $volume.initContainers }}
         {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.initContainers) $ | indent 8 | trim }}


### PR DESCRIPTION
# What problem are we solving?
When deploying the volume component with idx into a namespace that enforces pod security standards ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/)) we can't set the securityContext for the idx initContainer and so the resource is blocked.


# How are we solving the problem?
This pr aims to also apply the containerSecurityContext set for the volume service to the initContainer.


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
