### PR TITLE
Fix uncleanable orphans issue with `volume.fsck -forcePurging`

### DIFF
--- a/weed/storage/needle_map_memory.go
+++ b/weed/storage/needle_map_memory.go
@@ -36,7 +36,7 @@ func LoadCompactNeedleMap(file *os.File) (*NeedleMap, error) {
 func doLoading(file *os.File, nm *NeedleMap) (*NeedleMap, error) {
 	e := idx.WalkIndexFile(file, 0, func(key NeedleId, offset Offset, size Size) error {
 		nm.MaybeSetMaxFileKey(key)
-		if !offset.IsZero() && size.IsValid() {
+		if !offset.IsZero() && !size.IsDeleted() {
 			nm.FileCounter++
 			nm.FileByteCounter = nm.FileByteCounter + uint64(size)
 			oldOffset, oldSize := nm.m.Set(NeedleId(key), offset, size)

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -221,7 +221,7 @@ func (v *Volume) doDeleteRequest(n *needle.Needle) (Size, error) {
 	glog.V(4).Infof("delete needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
 	nv, ok := v.nm.Get(n.Id)
 	// fmt.Println("key", n.Id, "volume offset", nv.Offset, "data_size", n.Size, "cached size", nv.Size)
-	if ok && nv.Size.IsValid() {
+	if ok && !nv.Size.IsDeleted() {
 		var offset uint64
 		var err error
 		size := nv.Size


### PR DESCRIPTION
Fixes #7293 
# What problem are we solving?

In some cases, running `volume.fsck -forcePurging` did not clean up certain orphan needles. 
Although the occurrence of these orphans cannot be fully controlled and their root cause is unknown, 
**it is essential for operational stability that any generated orphans can be removed.** 

This PR fixes a bug where **orphans that were once created would remain uncleanable and accumulate over time**, 
ensuring that `fsck -forcePurging` can properly remove them.

- Resolved an issue where **needles with size=0B in the index but missing in volume data** were detected by fsck but not cleaned up during force purging
- These orphan needles were consuming time during fsck but remained uncleanable because they were ignored during needle map loading

# How are we solving the problem?

- Modified `needle_map_memory.go` to **include needles with size=0 during needle map loading**
- Updated `volume_write.go` to **handle size=0 needles in delete operations**


# How is the PR tested?

1. Copy a volume file containing uncleanable orphans.  
2. Update `docker/compose/local-dev-compose.yml` to mount the volume and launch the server.  
3. Use `volume.fsck` to check for orphan needles.  
4. Run `volume.fsck -forcePurging` and verify that 0B orphan needles are removed.

### AS-IS
```
$ docker exec -it seaweedfs-master-1 weed shell
master: localhost:9333 filer:
I1015 06:13:20.604679 masterclient.go:235 master localhost:9333 redirected to leader master:9333
master: localhost:9333 filers: [172.18.0.4:8888]
> lock
> volume.fsck
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:55      orphan:35       63.64%  9431728B

Total           entries:55      orphan:35       63.64%  9431728B
This could be normal if multiple filers or no filers are used.
> volume.fsck -forcePurging -reallyDeleteFromVolume -volumeId 2
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:55      orphan:35       63.64%  9431728B
purging orphan data for volume 2...
> volume.fsck
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:37      orphan:17       45.95%  0B

Total           entries:37      orphan:17       45.95%  0B
This could be normal if multiple filers or no filers are used.
> volume.fsck -forcePurging -reallyDeleteFromVolume -volumeId 2
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:37      orphan:17       45.95%  0B
purging orphan data for volume 2...
> volume.fsck
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:37      orphan:17       45.95%  0B

Total           entries:37      orphan:17       45.95%  0B
This could be normal if multiple filers or no filers are used.
> volume.fsck -forcePurging -reallyDeleteFromVolume -volumeId 2
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:37      orphan:17       45.95%  0B
purging orphan data for volume 2...
>
> volume.fsck
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:37      orphan:17       45.95%  0B

Total           entries:37      orphan:17       45.95%  0B
This could be normal if multiple filers or no filers are used.

>
```
### TO-BE (After the fix)
```
$ docker exec -it seaweedfs-master-1 weed shell
master: localhost:9333 filer:
I1015 06:19:21.157906 masterclient.go:235 master localhost:9333 redirected to leader master:9333
master: localhost:9333 filers: [172.18.0.4:8888]
> lock
> volume.fsck
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:55      orphan:35       63.64%  9431728B

Total           entries:55      orphan:35       63.64%  9431728B
This could be normal if multiple filers or no filers are used.
> volume.fsck -forcePurging -reallyDeleteFromVolume -volumeId 2
total 4 directories, 3 files
dataNode:volume:8080    volume:2        entries:55      orphan:35       63.64%  9431728B
purging orphan data for volume 2...
> volume.fsck -forcePurging -reallyDeleteFromVolume -volumeId 2
total 4 directories, 3 files
no orphan data
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
