### PR TITLE
Refactor connection locking to use read lock

### DIFF
--- a/weed/worker/client.go
+++ b/weed/worker/client.go
@@ -73,13 +73,13 @@ func NewGrpcAdminClient(adminAddress string, workerID string, dialOption grpc.Di
 
 // Connect establishes gRPC connection to admin server with TLS detection
 func (c *GrpcAdminClient) Connect() error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mutex.RLock()
 
 	if c.connected {
+		c.mutex.RUnlock()
 		return fmt.Errorf("already connected")
 	}
-
+	c.mutex.RUnlock()
 	// Always start the reconnection loop, even if initial connection fails
 	go c.reconnectionLoop()
 


### PR DESCRIPTION
Changed locking mechanism to use read lock for connection check.

# What problem are we solving?
Fixes #7192 


# How are we solving the problem?
The mutex lock was held for the entire duration of the Connect() function [defer unlock](https://github.com/seaweedfs/seaweedfs/blob/97f30287821e1c49b816f2e4c05be46728b06a0b/weed/worker/client.go#L77). This caused a deadlock when [attemptConnection tried to obtain the read lock](https://github.com/seaweedfs/seaweedfs/blob/97f30287821e1c49b816f2e4c05be46728b06a0b/weed/worker/client.go#L119). 

# How is the PR tested?
Fixes #7192 with admin server on v3.97


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
