### PR TITLE
Fix deadlock in worker client Connect() method

### DIFF
--- a/weed/worker/client.go
+++ b/weed/worker/client.go
@@ -74,11 +74,12 @@ func NewGrpcAdminClient(adminAddress string, workerID string, dialOption grpc.Di
 // Connect establishes gRPC connection to admin server with TLS detection
 func (c *GrpcAdminClient) Connect() error {
 	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	if c.connected {
+		c.mutex.Unlock()
 		return fmt.Errorf("already connected")
 	}
+	// Release lock before calling attemptConnection which needs to acquire locks internally
+	c.mutex.Unlock()
 
 	// Always start the reconnection loop, even if initial connection fails
 	go c.reconnectionLoop()


### PR DESCRIPTION
## What problem are we solving?

Fixes #7192

The  method in  has a deadlock that prevents workers from connecting to the admin server. This is caused by improper lock management.

## Root Cause

The original code held a write lock for the entire duration of  using . When  calls  at line 87, and  tries to acquire a read lock at line 119 to access `c.lastWorkerInfo`, a deadlock occurs because:

1. The same goroutine holds a write lock (from `Connect()`)
2. Tries to acquire a read lock (in `attemptConnection()`)
3. Read locks cannot be acquired while a write lock is held by the same goroutine

## How are we solving the problem?

The fix removes the `defer c.mutex.Unlock()` pattern and manually releases the lock after checking the connected state but before calling `attemptConnection()`. This allows `attemptConnection()` to safely acquire its own locks.

**Key changes:**
- Remove `defer c.mutex.Unlock()` 
- Add explicit `c.mutex.Unlock()` after the connected check
- Add comment explaining the lock management

This is a cleaner solution than PR #7341 which incorrectly used `RLock()` and would have created race conditions around state modifications.

## How is the PR tested?

This fixes the deadlock reported in #7192. The worker can now successfully connect to the admin server without hanging.

## Checks

- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.