### PR TITLE
fixing auto complete

### DIFF
--- a/weed/command/autocomplete.go
+++ b/weed/command/autocomplete.go
@@ -53,25 +53,25 @@ func printAutocompleteScript(shell string) bool {
 		return false
 	}
 
-	switch shell {
-	case "bash":
-		fmt.Printf("complete -C %s weed\n", binPath)
-	case "zsh":
-		fmt.Printf("autoload -U +X bashcompinit && bashcompinit\n")
-		fmt.Printf("complete -o nospace -C %s weed\n", binPath)
-	case "fish":
-		fmt.Printf(`function __complete_weed
+ 	switch shell {
+ 	case "bash":
+ 		fmt.Printf("complete -C %q weed\n", binPath)
+ 	case "zsh":
+ 		fmt.Printf("autoload -U +X bashcompinit && bashcompinit\n")
+ 		fmt.Printf("complete -o nospace -C %q weed\n", binPath)
+ 	case "fish":
+ 		fmt.Printf(`function __complete_weed
     set -lx COMP_LINE (commandline -cp)
     test -z (commandline -ct)
     and set COMP_LINE "$COMP_LINE "
-    %s
+    %q
 end
 complete -f -c weed -a "(__complete_weed)"
 `, binPath)
-	default:
-		fmt.Fprintf(os.Stderr, "unsupported shell: %s. Supported shells: bash, zsh, fish\n", shell)
-		return false
-	}
+ 	default:
+ 		fmt.Fprintf(os.Stderr, "unsupported shell: %s. Supported shells: bash, zsh, fish\n", shell)
+ 		return false
+ 	}
 	return true
 }
 


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7364

# How are we solving the problem?
   Modified the `weed autocomplete` command to support both behaviors:

   1. **Print to stdout** (new default behavior):
      - `weed autocomplete bash` - prints bash completion script
      - `weed autocomplete zsh` - prints zsh completion script
      - `weed autocomplete fish` - prints fish completion script

      Users can then use: `eval "$(weed autocomplete bash)"` in their shell config

   2. **Install directly** (backward compatible):
      - `weed autocomplete install` - automatically installs to shell config files
      - `weed autocomplete` (no args) - same as install (maintains backward compatibility)

# How is the PR tested?

Manual tests.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
