### PR TITLE
Fix 'NaN%' issue when running volume.fsck

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -384,11 +384,10 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 	}
 
 	if !applyPurging {
-		pct := 0.0
-		totalCount := totalOrphanChunkCount + totalInUseCount
+		var pct float64
 
-		if totalCount > 0 {
-			pct = float64(totalOrphanChunkCount*100) / (float64(totalCount))
+		if totalCount := totalOrphanChunkCount + totalInUseCount; totalCount > 0 {
+			pct = float64(totalOrphanChunkCount) * 100 / (float64(totalCount))
 		}
 
 		fmt.Fprintf(c.writer, "\nTotal\t\tentries:%d\torphan:%d\t%.2f%%\t%dB\n",


### PR DESCRIPTION
# What problem are we solving?

Running `volume.fsck` in `weed shell` on an empty cluster will display 'NaN%' for the orphan percentage.


# How are we solving the problem?

Initialize the percentage to `0.00` and only recalculate it if there orphan entries.


# How is the PR tested?

- Manual testing on an empty cluster.
- Manual testing on a cluster with a few files.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an edge-case in volume filesystem checks: percentage statistics for orphan entries are now computed safely when there is little or no data, preventing errors and improving reliability of integrity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->