### PR TITLE
Volume Server: Unexpected Deletion of Remote Tier Data

### DIFF
--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -56,17 +56,16 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 			return fmt.Errorf("load remote file %v: %w", v.volumeInfo, err)
 		}
 		// Set lastModifiedTsSeconds from remote file to prevent premature expiry on startup
-		files := v.volumeInfo.GetFiles()
-		if len(files) > 0 {
-			remoteFileModifiedTime := files[0].GetModifiedTime()
+		if len(v.volumeInfo.GetFiles()) > 0 {
+			remoteFileModifiedTime := v.volumeInfo.GetFiles()[0].GetModifiedTime()
 			if remoteFileModifiedTime > 0 {
 				v.lastModifiedTsSeconds = remoteFileModifiedTime
 			} else {
 				// Fallback: use .vif file's modification time
-				glog.Warningf("volume %d: remote file %v GetModifiedTime() returned 0, falling back to .vif file's modification time. This may cause incorrect expiry calculations.", v.Id, v.volumeInfo.GetFiles()[0])
 				if exists, _, _, modifiedTime, _ := util.CheckFile(v.FileName(".vif")); exists {
 					v.lastModifiedTsSeconds = uint64(modifiedTime.Unix())
 				}
+			}
 			glog.V(1).Infof("volume %d remote file lastModifiedTsSeconds set to %d", v.Id, v.lastModifiedTsSeconds)
 		}
 		alreadyHasSuperBlock = true


### PR DESCRIPTION
# What problem are we solving?

fix https://github.com/seaweedfs/seaweedfs/issues/7362

### 1. Missing `lastModifiedTsSeconds` for Remote Volumes

**Location:** `weed/storage/volume_loading.go:51-58`

When loading volumes with remote tier data:
- The code followed the `HasRemoteFile()` path
- **BUG:** `lastModifiedTsSeconds` was never set for remote volumes
- Compare to local volumes (line 72): `v.lastModifiedTsSeconds = uint64(modifiedTime.Unix())`
- Result: `lastModifiedTsSeconds` remained at 0 or an old value

### 2. Immediate Expiry Check During Startup

**Location:** `weed/server/volume_grpc_client_to_master.go:195` → `weed/storage/store.go:286-377`

During volume server startup:
1. Immediately after connecting to master, `CollectHeartbeat()` is called 
2. `CollectHeartbeat()` checks if volumes are expired via `v.expired()` (line 312)
3. The `expired()` function calculates: `livedMinutes := (time.Now().Unix() - lastModifiedTsSeconds) / 60`
4. With `lastModifiedTsSeconds == 0`, volumes appear expired
5. Expired volumes are marked for deletion (lines 315-318)
6. `location.deleteVolumeById(vid, false)` is called (line 367)

# How are we solving the problem?

* Added code to properly initialize `lastModifiedTsSeconds` when loading remote volumes


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced remote volume file loading to properly initialize modification timestamps, utilizing the earliest available timestamp from file data with appropriate fallback handling for improved timestamp accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->