### PR TITLE
Store full shell command in shell history

### DIFF
--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -84,6 +84,10 @@ func RunShell(options ShellOptions) {
 			return
 		}
 
+		if strings.TrimSpace(cmd) != "" {
+			line.AppendHistory(cmd)
+		}
+
 		for _, c := range util.StringSplit(cmd, ";") {
 			if processEachCmd(reg, c, commandEnv) {
 				return
@@ -94,8 +98,6 @@ func RunShell(options ShellOptions) {
 
 func processEachCmd(reg *regexp.Regexp, cmd string, commandEnv *CommandEnv) bool {
 	cmds := reg.FindAllString(cmd, -1)
-
-	line.AppendHistory(cmd)
 
 	if len(cmds) == 0 {
 		return false


### PR DESCRIPTION
# What problem are we solving?
Weed shell does not store compound commands. If a user types a compound command, the shell will split the commands using `;` and store each one in the history. Users will not be able to rerun the full command later on. This behavior feels counterintuitive and does not match the behavior of most other shells.

Example input: `lock; volume.fsck; unlock;`
History State:
  1. `lock`
  2. `volume.fsck`
  3. `unlock`

If a user runs the command and then presses the `UP` button to go back in the history, they will see `unlock` instead of `lock; volume.fsck; unlock;`. 

# How are we solving the problem?
The latest version stores commands after splitting them by the `;` character. The problem is solved by storing the command in history before splitting by `;` and executing each one.

# How is the PR tested?
Manual testing.



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command history to exclude empty entries, ensuring a cleaner history record that captures only actual commands executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->