### PR TITLE
S3: auth supports X-Forwarded-Host and X-Forwarded-Port

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -602,7 +602,7 @@ func extractHostHeader(r *http.Request) string {
 		}
 
 		// An IPv6 address literal must be enclosed in square brackets.
-		if ip := net.ParseIP(forwardedHost); ip != nil && ip.To4() == nil {
+		if ip := net.ParseIP(forwardedHost); ip != nil && strings.Contains(forwardedHost, ":") {
 			forwardedHost = "[" + forwardedHost + "]"
 		}
 

--- a/weed/s3api/auth_signature_v4_test.go
+++ b/weed/s3api/auth_signature_v4_test.go
@@ -223,6 +223,14 @@ func TestExtractHostHeader(t *testing.T) {
 			forwardedProto: "https",
 			expected:       "[2001:db8:85a3::8a2e:370:7334]:443",
 		},
+		{
+			name:           "IPv4-mapped IPv6 address without brackets, should add brackets with port",
+			hostHeader:     "backend:8333",
+			forwardedHost:  "::ffff:127.0.0.1",
+			forwardedPort:  "8080",
+			forwardedProto: "http",
+			expected:       "[::ffff:127.0.0.1]:8080",
+		},
 	}
 
 	for _, tt := range tests {

--- a/weed/s3api/auto_signature_v4_test.go
+++ b/weed/s3api/auto_signature_v4_test.go
@@ -491,6 +491,14 @@ func TestSignatureV4WithForwardedPort(t *testing.T) {
 			forwardedProto: "http",
 			expectedHost:   "[2001:db8::1]:8080",
 		},
+		{
+			name:           "IPv4-mapped IPv6 without port - should add port with brackets",
+			host:           "backend:8333",
+			forwardedHost:  "::ffff:127.0.0.1",
+			forwardedPort:  "8080",
+			forwardedProto: "http",
+			expectedHost:   "[::ffff:127.0.0.1]:8080",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6649

# How are we solving the problem?

The previous change was reverted by https://github.com/seaweedfs/seaweedfs/pull/7070 during refactoring.

# How is the PR tested?

Added unit tests

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host header handling when behind proxies: correctly parse forwarded host (including IPv6/bracketed forms), respect existing ports, and append non-standard ports based on forwarded protocol.

* **Tests**
  * Added comprehensive tests covering forwarded-host/port combinations, IPv6/bracketed formats, cases where forwarded host already includes a port, and signature validation with proxy header variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->