### PR TITLE
docker containers: add non-root user

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -41,7 +41,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filerldb2 && \
     chown -R seaweed:seaweed /data && \
-    chmod +x /entrypoint.sh
+    chmod 755 /entrypoint.sh
 
 VOLUME /data
 WORKDIR /data

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -32,7 +32,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filerldb2 && \
     chown -R seaweed:seaweed /data && \
-    chmod +x /entrypoint.sh
+    chmod 755 /entrypoint.sh
 
 VOLUME /data
 WORKDIR /data

--- a/docker/Dockerfile.rocksdb_large
+++ b/docker/Dockerfile.rocksdb_large
@@ -58,7 +58,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filer_rocksdb && \
     chown -R seaweed:seaweed /data && \
-    chmod +x /entrypoint.sh
+    chmod 755 /entrypoint.sh
 
 VOLUME /data
 

--- a/docker/Dockerfile.rocksdb_large_local
+++ b/docker/Dockerfile.rocksdb_large_local
@@ -41,7 +41,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filer_rocksdb && \
     chown -R seaweed:seaweed /data && \
-    chmod +x /entrypoint.sh
+    chmod 755 /entrypoint.sh
 
 VOLUME /data
 


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7397

From a security and compliance perspective (e.g. [OWASP Docker Security Guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user)), it’s generally recommended that containers run as a non-root user unless privileged access is absolutely required.

# How are we solving the problem?

add non-root user

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Containers now run as a non-root user to improve runtime security.
  * File and data-directory ownership and permissions standardized and ensured during image build.
  * Startup script made executable as part of the build (removed separate runtime permission step).
  * Additional service ports exposed in RocksDB container variants for expanded connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->