### PR TITLE
fix add user command

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -41,6 +41,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filerldb2 && \
     chown -R seaweed:seaweed /data && \
+    chown -R seaweed:seaweed /etc/seaweedfs && \
     chmod 755 /entrypoint.sh
 
 VOLUME /data

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -32,6 +32,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filerldb2 && \
     chown -R seaweed:seaweed /data && \
+    chown -R seaweed:seaweed /etc/seaweedfs && \
     chmod 755 /entrypoint.sh
 
 VOLUME /data

--- a/docker/Dockerfile.rocksdb_large
+++ b/docker/Dockerfile.rocksdb_large
@@ -58,6 +58,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filer_rocksdb && \
     chown -R seaweed:seaweed /data && \
+    chown -R seaweed:seaweed /etc/seaweedfs && \
     chmod 755 /entrypoint.sh
 
 VOLUME /data

--- a/docker/Dockerfile.rocksdb_large_local
+++ b/docker/Dockerfile.rocksdb_large_local
@@ -41,6 +41,7 @@ EXPOSE 7333
 # Create data directory and set proper ownership for seaweed user
 RUN mkdir -p /data/filer_rocksdb && \
     chown -R seaweed:seaweed /data && \
+    chown -R seaweed:seaweed /etc/seaweedfs && \
     chmod 755 /entrypoint.sh
 
 VOLUME /data


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7397#issuecomment-3460821529

# How are we solving the problem?

adjust the syntax

# How is the PR tested?

manually build the docker image

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized user group assignment in Docker build variants to use a supplementary group for the application user.
  * Ensured configuration directory ownership is set to the application user during image build.
  * Applied these adjustments consistently across multiple Docker build variants; no changes to runtime ports or entrypoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->