### PR TITLE
Filer: separate context for streaming

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -288,9 +288,10 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 
-		// Use background context for streaming so client disconnects/cancellations don't abort volume server operations.
+		// Use a detached context for streaming so client disconnects/cancellations don't abort volume server operations,
+		// while preserving request-scoped values like tracing IDs.
 		// Matches S3 API behavior. Request context (ctx) is used for metadata operations above.
-		streamCtx, streamCancel := context.WithCancel(context.Background())
+		streamCtx, streamCancel := context.WithCancel(context.WithoutCancel(ctx))
 
 		streamFn, err := filer.PrepareStreamContentWithThrottler(streamCtx, fs.filer.MasterClient, fs.maybeGetVolumeReadJwtAuthorizationToken, chunks, offset, size, fs.option.DownloadMaxBytesPs)
 		if err != nil {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7395

# How are we solving the problem?

Separate context for streaming.

# How is the PR tested?

Manual.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file streaming reliability by decoupling server operations from client connection status. Client disconnections will no longer interrupt active data transfers, improving stability during file streaming operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->