### PR TITLE
Don't make nginx the default ingress controller

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -235,27 +235,27 @@ master:
 
   ingress:
     enabled: false
-    className: "nginx"
+    className: ""
     # host: false for "*" hostname
     host: "master.seaweedfs.local"
     path: "/sw-master/?(.*)"
     pathType: ImplementationSpecific
-    annotations:
-      nginx.ingress.kubernetes.io/auth-type: "basic"
-      nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
-      nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Master'
-      nginx.ingress.kubernetes.io/service-upstream: "true"
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
-      nginx.ingress.kubernetes.io/use-regex: "true"
-      nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        sub_filter '<head>' '<head> <base href="/sw-master/">'; #add base url
-        sub_filter '="/' '="./';                                #make absolute paths to relative
-        sub_filter '=/' '=./';
-        sub_filter '/seaweedfsstatic' './seaweedfsstatic';
-        sub_filter_once off;
+    annotations: {}
+      # nginx.ingress.kubernetes.io/auth-type: "basic"
+      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Master'
+      # nginx.ingress.kubernetes.io/service-upstream: "true"
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   sub_filter '<head>' '<head> <base href="/sw-master/">'; #add base url
+      #   sub_filter '="/' '="./';                                #make absolute paths to relative
+      #   sub_filter '=/' '=./';
+      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+      #   sub_filter_once off;
     tls: []
 
   extraEnvironmentVars:
@@ -769,28 +769,28 @@ filer:
 
   ingress:
     enabled: false
-    className: "nginx"
+    className: ""
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
     path: "/sw-filer/?(.*)"
     pathType: ImplementationSpecific
-    annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: GRPC
-      nginx.ingress.kubernetes.io/auth-type: "basic"
-      nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
-      nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
-      nginx.ingress.kubernetes.io/service-upstream: "true"
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
-      nginx.ingress.kubernetes.io/use-regex: "true"
-      nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
-        sub_filter '="/' '="./';                               #make absolute paths to relative
-        sub_filter '=/' '=./';
-        sub_filter '/seaweedfsstatic' './seaweedfsstatic';
-        sub_filter_once off;
+    annotations: {}
+      # nginx.ingress.kubernetes.io/backend-protocol: GRPC
+      # nginx.ingress.kubernetes.io/auth-type: "basic"
+      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
+      # nginx.ingress.kubernetes.io/service-upstream: "true"
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
+      #   sub_filter '="/' '="./';                               #make absolute paths to relative
+      #   sub_filter '=/' '=./';
+      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+      #   sub_filter_once off;
 
   # extraEnvVars is a list of extra environment variables to set with the stateful set.
   extraEnvironmentVars:
@@ -1009,7 +1009,7 @@ s3:
 
   ingress:
     enabled: false
-    className: "nginx"
+    className: ""
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
     path: "/"


### PR DESCRIPTION
# What problem are we solving?

Not all configurations use nginx as ingress controller or not all options defined in the annotations are necessarily enabled and supported in managed clusters. To use this chart I would need to keep ingresses off and create them manually as standalone manifests.

# How are we solving the problem?

Let the end user decide how to configure the ingress when enabling it.

# How is the PR tested?

helm lint

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes ingress configurations to use default settings instead of explicit nginx class specifications and custom annotations, simplifying deployment configuration while maintaining TLS functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->