### PR TITLE
S3: Lazy Versioning Check, Conditional SSE Entry Fetch, HEAD Request Optimization

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -286,10 +286,12 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 	// Check for specific version ID in query parameters
 	versionId := r.URL.Query().Get("versionId")
 
-	var destUrl string
-	var entry *filer_pb.Entry // Declare entry at function scope for SSE processing
-	var versioningConfigured bool
-	var err error
+	var (
+		destUrl              string
+		entry                *filer_pb.Entry // Declare entry at function scope for SSE processing
+		versioningConfigured bool
+		err                  error
+	)
 
 	// Check if versioning is configured for the bucket (Enabled or Suspended)
 	// Note: We need to check this even if versionId is empty, because versioned buckets
@@ -453,10 +455,12 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 	// Check for specific version ID in query parameters
 	versionId := r.URL.Query().Get("versionId")
 
-	var destUrl string
-	var entry *filer_pb.Entry // Declare entry at function scope for SSE processing
-	var versioningConfigured bool
-	var err error
+	var (
+		destUrl              string
+		entry                *filer_pb.Entry // Declare entry at function scope for SSE processing
+		versioningConfigured bool
+		err                  error
+	)
 
 	// Check if versioning is configured for the bucket (Enabled or Suspended)
 	// Note: We need to check this even if versionId is empty, because versioned buckets


### PR DESCRIPTION

# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7462 reported slowness compared to 3.96

# How are we solving the problem?

* Lazy Versioning Check
* Conditional SSE Entry Fetch
* HEAD Request Optimization

# How is the PR tested?

Integration tests

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * GET and HEAD object requests are faster by reducing unnecessary metadata fetches and reusing prior results, improving response times for common reads.
* **Bug Fixes**
  * Conditional header and server-side encryption checks are centralized and only executed when needed, reducing spurious errors and improving reliability for versioned and encrypted objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->