### PR TITLE
chore: fix the diagram in RDMA sidecar readme

### DIFF
--- a/seaweedfs-rdma-sidecar/README.md
+++ b/seaweedfs-rdma-sidecar/README.md
@@ -16,7 +16,7 @@ This project implements a **high-performance RDMA (Remote Direct Memory Access) 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
 │   SeaweedFS     │    │   Go Sidecar    │    │  Rust Engine    │
-│  Volume Server  │◄──►│  (Control Plane) │◄──►│  (Data Plane)   │
+│  Volume Server  │◄──►│ (Control Plane) │◄──►│  (Data Plane)   │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
          │                       │                       │
          │                       │                       │


### PR DESCRIPTION
There was an extra space, which amde the diagram render badly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture diagram labeling in README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->