### PR TITLE
S3: JWT generation for volume server authentication

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1767,7 +1767,7 @@ func (s3a *S3ApiServer) fetchFullChunk(ctx context.Context, fileId string) (io.R
 
 	// Set JWT for authentication
 	if jwt != "" {
-		req.Header.Set("Authorization", "BEARER "+string(jwt))
+		req.Header.Set("Authorization", "BEARER "+jwt)
 	}
 
 	// Use shared HTTP client
@@ -1814,7 +1814,7 @@ func (s3a *S3ApiServer) fetchChunkViewData(ctx context.Context, chunkView *filer
 
 	// Set JWT for authentication
 	if jwt != "" {
-		req.Header.Set("Authorization", "BEARER "+string(jwt))
+		req.Header.Set("Authorization", "BEARER "+jwt)
 	}
 
 	// Use shared HTTP client with connection pooling


### PR DESCRIPTION

# What problem are we solving?

JWT error:
```
I1119 15:02:24.017521 common.go:81 response method:GET URL:/9,0129b0550e1805?readDeleted=true with httpStatus:401 and JSON:{"error":"wrong jwt"}
E1119 15:02:24.017852 s3api_object_handlers.go:982 streamFromVolumeServers: streamFn failed: read chunk: https://volume.mysite.com:8081/9,0129b0550e1805?readDeleted=true: 401 Unauthorized
E1119 15:02:24.017891 s3api_object_handlers.go:736 GetObjectHandler: failed to stream from volume servers: read chunk: https://volume.mysite.com:8081/9,0129b0550e1805?readDeleted=true: 401 Unauthorized
```
# How are we solving the problem?

JWT generation for volume server authentication

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal token generation and how tokens are attached to volume-server requests. Improves code organization and maintainability with no changes to public APIs or visible behavior for end users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->