### PR TITLE
Add explicit IP and binding parameters in Docker Compose

### DIFF
--- a/docker/seaweedfs-compose.yml
+++ b/docker/seaweedfs-compose.yml
@@ -7,14 +7,14 @@ services:
       - 9333:9333
       - 19333:19333
       - 9324:9324
-    command: "master -ip=master -ip.bind=0.0.0.0 -metricsPort=9324"
+    command: 'master -ip=master -ip.bind=0.0.0.0 -metricsPort=9324'
   volume:
     image: chrislusf/seaweedfs # use a remote image
     ports:
       - 8080:8080
       - 18080:18080
       - 9325:9325
-    command: 'volume -mserver="master:9333" -ip.bind=0.0.0.0 -port=8080  -metricsPort=9325'
+    command: 'volume -ip=volume -mserver="master:9333" -ip.bind=0.0.0.0 -port=8080 -metricsPort=9325'
     depends_on:
       - master
   filer:
@@ -23,7 +23,7 @@ services:
       - 8888:8888
       - 18888:18888
       - 9326:9326
-    command: 'filer -master="master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
+    command: 'filer -ip=filer -master="master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     tty: true
     stdin_open: true
     depends_on:
@@ -54,6 +54,6 @@ services:
       - 9000:9090
     volumes:
       - ./prometheus:/etc/prometheus
-    command: --web.enable-lifecycle  --config.file=/etc/prometheus/prometheus.yml
+    command: '--web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml'
     depends_on:
       - s3

--- a/docker/seaweedfs-dev-compose.yml
+++ b/docker/seaweedfs-dev-compose.yml
@@ -6,13 +6,13 @@ services:
     ports:
       - 9333:9333
       - 19333:19333
-    command: "master -ip=master"
+    command: 'master -ip=master -ip.bind=0.0.0.0'
   volume:
     image: chrislusf/seaweedfs:dev # use a remote dev image
     ports:
       - 8080:8080
       - 18080:18080
-    command: 'volume -mserver="master:9333" -port=8080 -ip=volume'
+    command: 'volume -ip=volume -mserver="master:9333" -ip.bind=0.0.0.0 -port=8080'
     depends_on:
       - master
   filer:
@@ -20,7 +20,7 @@ services:
     ports:
       - 8888:8888
       - 18888:18888
-    command: 'filer -master="master:9333" -ip.bind=0.0.0.0'
+    command: 'filer -ip=filer -master="master:9333" -ip.bind=0.0.0.0'
     depends_on:
       - master
       - volume


### PR DESCRIPTION
# What problem are we solving?

**Problem: Service discovery and IP binding configuration in Docker Compose was not explicitly defined**

When running SeaweedFS in a Docker Compose environment, several IP-related parameters were missing:

The volume service did not specify -ip=volume

The filer service did not specify -ip=filer

The master and volume services in the dev setup did not include -ip.bind=0.0.0.0

Although SeaweedFS may still work in some cases without these flags, relying on implicit behavior can lead to unpredictable or environment-dependent outcomes. Explicitly declaring -ip and -ip.bind is a safer and more reliable practice.

# How are we solving the problem?

**Solution: Explicitly define IP-related parameters to ensure stable behavior across environments**

Detailed updates:

Volume Service

- Added -ip=volume

  - Ensures the service registers with the intended hostname

- Added -ip.bind=0.0.0.0 (dev version)

  - Ensures the service listens on all interfaces

Filer Service

- Added -ip=filer

  - Ensures consistent identification within the cluster

Master Service

- Added -ip.bind=0.0.0.0 (dev version)

  - Ensures it is accessible from other containers

Additional Adjustments

- Harmonized command syntax

- Applied minor formatting fixes where needed

# How is the PR tested?

Yes.

# Checks

- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Standardized service command formatting and flag ordering in container configs.
  * Added explicit service IP flags for clearer service identification.
  * Enabled binding to all network interfaces for development containers to improve accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->