### PR TITLE
S3: Add `Vary` header for non-wildcard AllowOrigin

### DIFF
--- a/weed/s3api/cors/cors.go
+++ b/weed/s3api/cors/cors.go
@@ -361,6 +361,10 @@ func ApplyHeaders(w http.ResponseWriter, corsResp *CORSResponse) {
 
 	if corsResp.AllowOrigin != "" {
 		w.Header().Set("Access-Control-Allow-Origin", corsResp.AllowOrigin)
+
+		if corsResp.AllowOrigin != "*" {
+			w.Header().Add("Vary", "Origin")
+		}
 	}
 
 	if corsResp.AllowMethods != "" {

--- a/weed/s3api/cors/cors_test.go
+++ b/weed/s3api/cors/cors_test.go
@@ -480,6 +480,7 @@ func TestApplyHeaders(t *testing.T) {
 				"Access-Control-Allow-Headers":  "Content-Type",
 				"Access-Control-Expose-Headers": "ETag",
 				"Access-Control-Max-Age":        "3600",
+				"Vary":        					 "Origin",
 			},
 		},
 		{
@@ -493,6 +494,7 @@ func TestApplyHeaders(t *testing.T) {
 				"Access-Control-Allow-Origin":      "http://example.com",
 				"Access-Control-Allow-Methods":     "GET",
 				"Access-Control-Allow-Credentials": "true",
+				"Vary":        					    "Origin",
 			},
 		},
 	}


### PR DESCRIPTION
# What problem are we solving?

#7544 

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CORS response header handling to include Vary: Origin for non-wildcard origin scenarios, enhancing caching behavior for cross-origin requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->