### PR TITLE
S3: pass HTTP 429 from volume servers to S3 clients

### DIFF
--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -24,6 +24,7 @@ import (
 )
 
 var ErrNotFound = fmt.Errorf("not found")
+var ErrTooManyRequests = fmt.Errorf("too many requests")
 
 var (
 	jwtSigningReadKey        security.SigningKey
@@ -331,6 +332,9 @@ func ReadUrlAsStream(ctx context.Context, fileUrl, jwt string, cipherKey []byte,
 	if r.StatusCode >= 400 {
 		if r.StatusCode == http.StatusNotFound {
 			return true, fmt.Errorf("%s: %s: %w", fileUrl, r.Status, ErrNotFound)
+		}
+		if r.StatusCode == http.StatusTooManyRequests {
+			return false, fmt.Errorf("%s: %s: %w", fileUrl, r.Status, ErrTooManyRequests)
 		}
 		retryable = r.StatusCode >= 499
 		return retryable, fmt.Errorf("%s: %s", fileUrl, r.Status)


### PR DESCRIPTION
# What problem are we solving?

PR #7482 addressed passing HTTP 429 from volume servers when S3 was proxying through the filer. However, with the recent changes in commit c1b8d4bf0, S3 now directly accesses volume servers using FilerClient and the vidMap cache, bypassing the filer proxy for GET operations.

When volume servers rate limit requests with HTTP 429 (e.g., due to download/upload speed limitations per volume), these errors are currently being masked as generic HTTP 500 Internal Server errors when returned to S3 clients. This prevents proper client-side rate limiting and retry logic.

# How are we solving the problem?

This PR adds proper HTTP 429 handling in the direct volume server access path:

1. **Add ErrTooManyRequests sentinel error** in `weed/util/http/http_global_client_util.go`
   - Provides a typed error that can be detected with `errors.Is()`

2. **Detect HTTP 429 in ReadUrlAsStream** 
   - When a volume server returns HTTP 429, wrap the error with ErrTooManyRequests
   - Mark as non-retryable (don't hammer the rate-limited server)

3. **Handle in GetObjectHandler**
   - Check for ErrTooManyRequests using `errors.Is()`
   - Map to S3 error code ErrRequestBytesExceed (HTTP 503)
   - Consistent with PR #7482's approach

# How is the PR tested?

- [x] Code compiles successfully
- [x] Follows the same pattern as PR #7482 for consistency
- [ ] Manual testing with volume server rate limiting (needs deployment)

# Relationship to PR #7482

This PR complements PR #7482:
- **PR #7482**: Handles 429 when S3 proxies through filer (old path)
- **This PR**: Handles 429 when S3 directly accesses volume servers (new path since c1b8d4bf0)

Both PRs are needed for complete coverage as different code paths are used depending on configuration and SSE encryption settings.

# Notes

The error is mapped to `ErrRequestBytesExceed` (HTTP 503 Service Unavailable) to maintain compatibility with S3 API standards, consistent with PR #7482. While volume servers return HTTP 429, S3 clients typically expect HTTP 503 for rate limiting scenarios.
