### PR TITLE
s3api: Fix response-content-disposition query parameter not being honored

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1981,7 +1981,7 @@ func (s3a *S3ApiServer) setResponseHeaders(w http.ResponseWriter, r *http.Reques
 	// This allows presigned URLs to control how browsers handle the downloaded content
 	if r != nil {
 		for queryParam, headerValue := range r.URL.Query() {
-			if normalizedHeader, ok := s3_constants.PassThroughHeaders[strings.ToLower(queryParam)]; ok && len(headerValue) > 0 {
+			if normalizedHeader, ok := s3_constants.PassThroughHeaders[strings.ToLower(queryParam)]; ok && len(headerValue) > 0 && headerValue[0] != "" {
 				w.Header().Set(normalizedHeader, headerValue[0])
 			}
 		}


### PR DESCRIPTION
## Description

Fixes https://github.com/seaweedfs/seaweedfs/discussions/7486

This PR resolves an issue where S3 presigned URLs with query parameters like `response-content-disposition`, `response-content-type`, etc. were being ignored, causing browsers to use default file handling instead of the specified behavior.

## Problem

When creating a presigned URL with response header overrides:

```go
res, err := s.Presigner.PresignGetObject(ctx, &s3.GetObjectInput{
    Key: &key, 
    Bucket: &s.Bucket, 
    ResponseContentDisposition: aws.String(`attachment; filename="download"`),
}, s3.WithPresignExpires(time.Minute))
```

The generated URL includes the parameter `?response-content-disposition=attachment;filename="download"`, but SeaweedFS was returning `Content-Disposition: inline; filename="525"` instead of honoring the query parameter.

## Root Cause

The `setResponseHeaders()` function in `weed/s3api/s3api_object_handlers.go` was not processing query parameters for response header overrides, even though the `PassThroughHeaders` map was already defined in `s3_constants/header.go`.

## Changes

1. Modified `setResponseHeaders()` to accept the HTTP request object as a parameter
2. Added logic to process S3 passthrough headers from query parameters using the existing `PassThroughHeaders` mapping
3. Updated all 6 call sites in both `GetObjectHandler` and `HeadObjectHandler` to pass the request object

## Supported Query Parameters

The fix now properly handles all AWS S3 response override parameters:
- `response-content-disposition` → `Content-Disposition`
- `response-content-type` → `Content-Type`
- `response-cache-control` → `Cache-Control`
- `response-content-encoding` → `Content-Encoding`
- `response-content-language` → `Content-Language`
- `response-expires` → `Expires`

## Testing

- ✅ All existing S3 API tests pass without modification
- ✅ Build succeeds with no compilation errors
- ✅ Implementation follows the same pattern already used in the filer handler (`weed/server/common.go`)

## Impact

This fix enables proper browser behavior when downloading files via presigned URLs:
- Files can be forced to download (`attachment`) instead of displaying inline
- Custom filenames can be specified for downloads
- Content-Type can be overridden for specific use cases
- Cache behavior can be controlled per-request

This brings SeaweedFS into full compliance with the AWS S3 API specification for these parameters.

## Code Changes

```diff
 func (s3a *S3ApiServer) setResponseHeaders(w http.ResponseWriter, r *http.Request, entry *filer_pb.Entry, totalSize int64) {
     // ... existing code ...
     
+    // Apply S3 passthrough headers from query parameters
+    if r != nil {
+        for queryParam, headerValue := range r.URL.Query() {
+            if normalizedHeader, ok := s3_constants.PassThroughHeaders[strings.ToLower(queryParam)]; ok && len(headerValue) > 0 {
+                w.Header().Set(normalizedHeader, headerValue[0])
+            }
+        }
+    }
 }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 API now accepts response header overrides via request query parameters for object retrieval and presigned-like downloads, enabling clients to control headers such as Content-Type, Cache-Control, and related response headers.
  * Header passthrough is applied consistently across HEAD/GET and streaming responses when a request is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->