### PR TITLE
Helm Charts: add certificate duration and renewBefore options

### DIFF
--- a/.github/workflows/container_release4.yml
+++ b/.github/workflows/container_release4.yml
@@ -18,6 +18,18 @@ jobs:
         name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v2
       -
+        name: Free Disk Space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker system prune -af
+          echo "After cleanup:"
+          df -h
+      -
         name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v3

--- a/k8s/charts/seaweedfs/templates/cert/ca-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/ca-cert.yaml
@@ -13,11 +13,11 @@ spec:
   secretName: {{ template "seaweedfs.name" . }}-ca-cert
   commonName: "{{ template "seaweedfs.name" . }}-root-ca"
   isCA: true
-  {{- if .Values.certificates.duration }}
-  duration: {{ .Values.certificates.duration }}
+  {{- if .Values.certificates.ca.duration }}
+  duration: {{ .Values.certificates.ca.duration }}
   {{- end }}
-  {{- if .Values.certificates.renewBefore }}
-  renewBefore: {{ .Values.certificates.renewBefore }}
+  {{- if .Values.certificates.ca.renewBefore }}
+  renewBefore: {{ .Values.certificates.ca.renewBefore }}
   {{- end }}
   issuerRef:
     name: {{ template "seaweedfs.name" . }}-issuer

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1270,6 +1270,9 @@ certificates:
   keySize: 2048
   duration: 2160h  # 90d
   renewBefore: 360h  # 15d
+  ca:
+    duration: 87600h  # 10 years
+    renewBefore: 720h  # 30d
   externalCertificates:
     # This will avoid the need to use cert-manager and will rely on providing your own external certificates and CA
     # you will need to store your provided certificates in the secret read by the different services:


### PR DESCRIPTION
# What problem are we solving?

The Helm chart does not currently allow configuring certificate lifetime parameters (`duration` and `renewBefore`) for cert-manager–managed certificates.  
This limits flexibility for deployments that require custom certificate rotation policies or extended certificate validity periods.

# How are we solving the problem?

We add optional values `certificates.duration` and `certificates.renewBefore` to the chart and include them in the `Certificate` resource template when provided.  
If the values are not set, cert-manager defaults are used, preserving backward compatibility.

# How is the PR tested?

The changes were tested by deploying the chart with and without the new values set and ensuring that:
- The rendered manifest includes the `duration` and `renewBefore` fields when configured.
- The manifest remains unchanged when these values are not provided.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved certificate configuration: added configurable certificate duration and renew-before settings (including CA-specific defaults) and conditional support so deployments can opt into custom certificate lifecycle timings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->