### PR TITLE
Enable FIPS 140-3 compliant crypto by default

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -23,6 +23,9 @@ RUN mkdir -p /etc/seaweedfs
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/filer.toml /etc/seaweedfs/filer.toml
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh /entrypoint.sh
 
+# FIPS 140-3 mode is ON by default (Go 1.24+)
+# To disable: docker run -e GODEBUG=fips140=off ...
+
 # Install dependencies and create non-root user
 RUN apk add --no-cache fuse su-exec && \
     addgroup -g 1000 seaweed && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Enable FIPS 140-3 mode by default (Go 1.24+)
+# To disable: docker run -e GODEBUG=fips140=off ...
+export GODEBUG="${GODEBUG:+$GODEBUG,}fips140=on"
+
 # Fix permissions for mounted volumes
 # If /data is mounted from host, it might have different ownership
 # Fix this by ensuring seaweed user owns the directory


### PR DESCRIPTION
Addresses #6889

## Summary

Enable FIPS 140-3 compliant cryptography by default in Docker containers using Go 1.24+ native FIPS support.

## Changes

- **entrypoint.sh**: Set `GODEBUG=fips140=on` by default

## Usage

```bash
# FIPS is enabled by default
docker run chrislusf/seaweedfs server ...

# To disable FIPS mode
docker run -e GODEBUG=fips140=off chrislusf/seaweedfs server ...
```

## Cryptographic Algorithms Used (all FIPS-approved)

| Feature | Algorithm | FIPS Status |
|---------|-----------|-------------|
| Data Encryption | AES-256-GCM | ✅ Approved |
| SSE-C | AES-256-CTR | ✅ Approved |
| S3 Signatures | HMAC-SHA256 | ✅ Approved |
| Transport | TLS 1.2/1.3 | ✅ Approved |

## Documentation

See wiki: [Cryptography and FIPS Compliance](https://github.com/seaweedfs/seaweedfs/wiki/Cryptography-and-FIPS-Compliance)

Closes #6889