### PR TITLE
Fix issue #6847: S3 chunked encoding includes headers in stored content

### DIFF
--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -520,15 +520,14 @@ func parseChunkChecksum(b *bufio.Reader) (ChecksumAlgorithm, []byte, error) {
 			return ChecksumAlgorithmNone, nil, err
 		}
 
-		line := trimTrailingWhitespace(bytesRead)
-		if len(line) == 0 {
+		if len(bytesRead) == 0 {
 			break
 		}
 
-		parts := bytes.SplitN(line, []byte(":"), 2)
+		parts := bytes.SplitN(bytesRead, []byte(":"), 2)
 		if len(parts) == 2 {
-			key := string(parts[0])
-			value := trimTrailingWhitespace(parts[1])
+			key := string(bytes.TrimSpace(parts[0]))
+			value := bytes.TrimSpace(parts[1])
 			if alg, err := extractChecksumAlgorithm(key); err == nil {
 				if checksumAlgorithm != ChecksumAlgorithmNone {
 					glog.V(3).Infof("multiple checksum headers found in trailer, using last: %s", key)


### PR DESCRIPTION
This PR fixes issue #6847 where chunk-signature and x-amz headers were appearing in stored file content when using chunked encoding with newer AWS SDKs.

## Changes Made

In weed/s3api/chunked_reader_v4.go:
• Added hasTrailer field to s3ChunkedReader struct
• Modified newChunkedReader to detect trailer presence
• Updated state transition logic in readChunkTrailer to properly handle trailers
• Enhanced parseChunkChecksum to read multiple trailer lines until empty line
• Always validate checksums for data integrity (both signed and unsigned streaming)
• Added warning log when multiple checksum headers found in trailer
• Improved trailer parsing robustness by using bytes.TrimSpace for key/value parsing
• Removed redundant trimTrailingWhitespace call in parseChunkChecksum
• Removed redundant CRLF reading in trailer processing

In weed/s3api/chunked_bug_reproduction_test.go:
• Added test case for mixed format handling (unsigned headers with signed chunk data)
• Corrected checksum value in test payload

## Root Cause

The chunked reader was not properly handling unsigned streaming uploads with trailers, causing chunk headers to be stored as part of the file content.

## Testing

• All existing S3 API tests pass
• New test case validates proper handling of mixed format uploads
• Chunked encoding now correctly strips headers and stores only file content

Fixes #6847