### PR TITLE
fix: volume server healthz now checks local conditions only

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -469,6 +469,10 @@ func (s *Store) SetStopping() {
 	}
 }
 
+func (s *Store) IsStopping() bool {
+	return s.isStopping
+}
+
 func (s *Store) LoadNewVolumes() {
 	for _, location := range s.Locations {
 		location.loadExistingVolumes(s.NeedleMapKind, 0)


### PR DESCRIPTION
## Summary
Fixes #6823 - Volume server healthz now checks local conditions only to prevent cascading failures.

## Problem
When a volume server shuts down, other healthy volume servers fail their `/healthz` checks because they can't reach all required replicas. This causes Kubernetes to restart the healthy servers, leading to a complete cluster outage.

### Root Cause
The `healthzHandler` was calling `GetWritableRemoteReplications()` for each replicated volume, which fails when the master reports fewer locations than the required copy count. When one volume server goes down:

1. Master removes the dead server from volume location list
2. Other volume servers' healthz checks find `len(locations) < copyCount`
3. They return 503 → Kubernetes restarts them
4. Cascading failure ensues

## Solution
Changed the healthz endpoint to only check local server health:
- Is the store stopping?
- Is the server connected to master (heartbeating)?

Remote replication status is no longer checked in healthz, following the principle that health checks should verify THIS server's health, not the cluster state.

## Changes
- `weed/server/volume_server_handlers_admin.go`: Simplified healthzHandler to check local conditions only
- `weed/storage/store.go`: Added `IsStopping()` method

## Testing
1. Deploy 3 volume servers with replication 001
2. Shutdown one node
3. Verify remaining servers' healthz returns 200 (previously would return 503)