### PR TITLE
fix: update getVersioningState to signal non-existent buckets with Er…

### DIFF
--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -516,16 +516,16 @@ func (s3a *S3ApiServer) isVersioningConfigured(bucket string) (bool, error) {
 
 // getVersioningState returns the detailed versioning state for a bucket
 func (s3a *S3ApiServer) getVersioningState(bucket string) (string, error) {
-    config, errCode := s3a.getBucketConfig(bucket)
-    if errCode != s3err.ErrNone {
-        if errCode == s3err.ErrNoSuchBucket {
-            // Signal to callers that the bucket does not exist so they can
-            // decide whether to auto-create it (e.g., in PUT handlers).
-            return "", filer_pb.ErrNotFound
-        }
-        glog.Errorf("getVersioningState: failed to get bucket config for %s: %v", bucket, errCode)
-        return "", fmt.Errorf("failed to get bucket config: %v", errCode)
-    }
+	config, errCode := s3a.getBucketConfig(bucket)
+	if errCode != s3err.ErrNone {
+		if errCode == s3err.ErrNoSuchBucket {
+			// Signal to callers that the bucket does not exist so they can
+			// decide whether to auto-create it (e.g., in PUT handlers).
+			return "", filer_pb.ErrNotFound
+		}
+		glog.Errorf("getVersioningState: failed to get bucket config for %s: %v", bucket, errCode)
+		return "", fmt.Errorf("failed to get bucket config: %v", errCode)
+	}
 
 	// If object lock is enabled, versioning must be enabled regardless of explicit setting
 	if config.ObjectLockConfig != nil {


### PR DESCRIPTION


# What problem are we solving?
This change modifies the getVersioningState function to return filer_pb.ErrNotFound when a requested bucket does not exist, allowing callers to handle the situation appropriately, such as auto-creating the bucket in PUT handlers. This improves error handling and clarity in the API's behavior regarding bucket existence.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for bucket versioning: attempts to check versioning on a non-existent bucket now return a clear "Not Found" error instead of an empty/ambiguous result, making missing-bucket cases easier to detect and handle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->