### PR TITLE
fix: S3 GetObject/HeadObject with PartNumber should return object ETag, not part ETag

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -659,16 +659,14 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 			glog.V(3).Infof("GetObject: Set PartsCount=%d for multipart GET with PartNumber=%d", partsCount, partNumber)
 
 			// Calculate the byte range for this part
+			// Note: ETag is NOT overridden - AWS S3 returns the complete object's ETag
+			// even when requesting a specific part via PartNumber
 			var startOffset, endOffset int64
 			if partInfo != nil {
 				// Use part boundaries from metadata (accurate for multi-chunk parts)
 				startOffset = objectEntryForSSE.Chunks[partInfo.StartChunk].Offset
 				lastChunk := objectEntryForSSE.Chunks[partInfo.EndChunk-1]
 				endOffset = lastChunk.Offset + int64(lastChunk.Size) - 1
-
-				// Override ETag with the part's ETag from metadata
-				w.Header().Set("ETag", "\""+partInfo.ETag+"\"")
-				glog.V(3).Infof("GetObject: Override ETag with part %d ETag: %s (from metadata)", partNumber, partInfo.ETag)
 			} else {
 				// Fallback: assume 1:1 part-to-chunk mapping (backward compatibility)
 				chunkIndex := partNumber - 1
@@ -680,15 +678,6 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 				partChunk := objectEntryForSSE.Chunks[chunkIndex]
 				startOffset = partChunk.Offset
 				endOffset = partChunk.Offset + int64(partChunk.Size) - 1
-
-				// Override ETag with chunk's ETag (fallback)
-				if partChunk.ETag != "" {
-					if md5Bytes, decodeErr := base64.StdEncoding.DecodeString(partChunk.ETag); decodeErr == nil {
-						partETag := fmt.Sprintf("%x", md5Bytes)
-						w.Header().Set("ETag", "\""+partETag+"\"")
-						glog.V(3).Infof("GetObject: Override ETag with part %d ETag: %s (fallback from chunk)", partNumber, partETag)
-					}
-				}
 			}
 
 			// Check if client supplied a Range header - if so, apply it within the part's boundaries
@@ -2266,7 +2255,7 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 	if partNumberStr != "" {
 		if partNumber, parseErr := strconv.Atoi(partNumberStr); parseErr == nil && partNumber > 0 {
 			// Get actual parts count from metadata (not chunk count)
-			partsCount, partInfo := s3a.getMultipartInfo(objectEntryForSSE, partNumber)
+			partsCount, _ := s3a.getMultipartInfo(objectEntryForSSE, partNumber)
 
 			// Validate part number
 			if partNumber > partsCount {
@@ -2276,31 +2265,10 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 			}
 
 			// Set parts count header
+			// Note: ETag is NOT overridden - AWS S3 returns the complete object's ETag
+			// even when requesting a specific part via PartNumber
 			w.Header().Set(s3_constants.AmzMpPartsCount, strconv.Itoa(partsCount))
 			glog.V(3).Infof("HeadObject: Set PartsCount=%d for part %d", partsCount, partNumber)
-
-			// Override ETag with the part's ETag
-			if partInfo != nil {
-				// Use part ETag from metadata (accurate for multi-chunk parts)
-				w.Header().Set("ETag", "\""+partInfo.ETag+"\"")
-				glog.V(3).Infof("HeadObject: Override ETag with part %d ETag: %s (from metadata)", partNumber, partInfo.ETag)
-			} else {
-				// Fallback: use chunk's ETag (backward compatibility)
-				chunkIndex := partNumber - 1
-				if chunkIndex >= len(objectEntryForSSE.Chunks) {
-					glog.Warningf("HeadObject: Part %d chunk index %d out of range (chunks: %d)", partNumber, chunkIndex, len(objectEntryForSSE.Chunks))
-					s3err.WriteErrorResponse(w, r, s3err.ErrInvalidPart)
-					return
-				}
-				partChunk := objectEntryForSSE.Chunks[chunkIndex]
-				if partChunk.ETag != "" {
-					if md5Bytes, decodeErr := base64.StdEncoding.DecodeString(partChunk.ETag); decodeErr == nil {
-						partETag := fmt.Sprintf("%x", md5Bytes)
-						w.Header().Set("ETag", "\""+partETag+"\"")
-						glog.V(3).Infof("HeadObject: Override ETag with part %d ETag: %s (fallback from chunk)", partNumber, partETag)
-					}
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
## Problem
The `test_multipart_get_part` S3 compatibility test was failing:
```
E           assert '"07ad0945963...cd3e42469a0d"' == '"e3944eb31f9...641e3ef5ef-4"'
E             - "e3944eb31f9c5042069cd8641e3ef5ef-4"
E             + "07ad0945963379f99c2dcd3e42469a0d"
```

## Root Cause
When calling `GetObject` or `HeadObject` with the `PartNumber` query parameter, SeaweedFS was incorrectly overriding the ETag header with the individual part's ETag instead of keeping the complete object's ETag.

## AWS S3 Behavior
According to AWS S3 documentation, when using `PartNumber`:
- `ETag` should remain the **complete object's ETag** (e.g., `"e3944eb31f9c5042069cd8641e3ef5ef-4"` with `-4` suffix for 4 parts)
- `x-amz-mp-parts-count` header indicates the total number of parts
- `Content-Length` is adjusted to the specific part's size

## Fix
Remove the ETag override logic in both `GetObjectHandler` and `HeadObjectHandler` while keeping:
- `x-amz-mp-parts-count` header (correct behavior)
- Content-Length adjusted to part size (correct behavior)  
- Range calculation for part boundaries (correct behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ETag handling in multipart object requests to consistently return the full object ETag instead of overriding with per-part values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->