### PR TITLE
fix: Admin UI file browser uses https.client TLS config for filer communication

### DIFF
--- a/weed/admin/handlers/file_browser_handlers.go
+++ b/weed/admin/handlers/file_browser_handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -588,10 +589,9 @@ func (h *FileBrowserHandlers) DownloadFile(c *gin.Context) {
 
 	// Set headers for file download
 	fileName := filepath.Base(cleanFilePath)
-	// Escape quotes and backslashes in filename per RFC 2616
-	escapedFileName := strings.ReplaceAll(fileName, "\\", "\\\\")
-	escapedFileName = strings.ReplaceAll(escapedFileName, "\"", "\\\"")
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", escapedFileName))
+	// Use mime.FormatMediaType for RFC 6266 compliant Content-Disposition,
+	// properly handling non-ASCII characters and special characters
+	c.Header("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": fileName}))
 
 	// Use content type from filer response, or default to octet-stream
 	contentType := resp.Header.Get("Content-Type")


### PR DESCRIPTION
## Problem

When filer is configured with HTTPS (`https.filer` section in `security.toml`), the Admin UI file browser was still using plain HTTP for file uploads, downloads, and viewing. This caused TLS handshake errors:

```
http: TLS handshake error from 172.18.0.6:44766: client sent an HTTP request to an HTTPS server
```

## Solution

Updated `FileBrowserHandlers` in `weed/admin/handlers/file_browser_handlers.go` to use the `HTTPClient` from `weed/util/http/client` package, which:

- Reads TLS configuration from the `[https.client]` section in `security.toml`
- Automatically uses HTTPS when `https.client.enabled=true`
- Supports mTLS with client certificates

## Changes

1. Added `httpClient` field to `FileBrowserHandlers` struct
2. Initialize `HTTPClient` with TLS support in `NewFileBrowserHandlers()`
3. Updated `uploadFileToFiler()` to use TLS-aware client
4. Updated `DownloadFile()` to use proper URL scheme
5. Updated `ViewFile()` to use TLS-aware client
6. Updated `isLikelyTextFile()` to use TLS-aware client

## Testing

When `[https.client]` is configured in `security.toml`:
```toml
[https.client]
enabled = true
cert = "/path/to/client.crt"
key = "/path/to/client.key"
ca = "/path/to/ca.crt"
```

The Admin UI file browser will now use HTTPS to communicate with the filer.

Fixes #7631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File transfers now use TLS-aware connections, with per-request timeouts and proxying/streaming of downloads through the Admin UI for large files.

* **Bug Fixes**
  * Strengthened SSRF-safe URL normalization and address/path validation across uploads, downloads, and previews.
  * Centralized content fetching and improved timeout/error handling for more reliable uploads, downloads, and text previews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->