### PR TITLE
fix: normalize Windows backslash paths in weed admin file uploads

### DIFF
--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -128,7 +128,7 @@ func parseUpload(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 
 		pu.FileName = part.FileName()
 		if pu.FileName != "" {
-			pu.FileName = path.Base(pu.FileName)
+			pu.FileName = util.CleanWindowsPathBase(pu.FileName)
 		}
 
 		dataSize, e = pu.bytesBuffer.ReadFrom(io.LimitReader(part, sizeLimit+1))
@@ -169,7 +169,7 @@ func parseUpload(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 
 				// update
 				pu.Data = pu.bytesBuffer.Bytes()
-				pu.FileName = path.Base(fName)
+				pu.FileName = util.CleanWindowsPathBase(fName)
 				contentType = part.Header.Get("Content-Type")
 				part = part2
 				break
@@ -207,7 +207,7 @@ func parseUpload(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 		}
 
 		if pu.FileName != "" {
-			pu.FileName = path.Base(pu.FileName)
+			pu.FileName = util.CleanWindowsPathBase(pu.FileName)
 		} else {
 			pu.FileName = path.Base(r.URL.Path)
 		}

--- a/weed/util/fullpath.go
+++ b/weed/util/fullpath.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -84,4 +85,16 @@ func StringSplit(separatedValues string, sep string) []string {
 		return nil
 	}
 	return strings.Split(separatedValues, sep)
+}
+
+// CleanWindowsPath normalizes Windows-style backslashes to forward slashes.
+// This handles paths from Windows clients where paths use backslashes.
+func CleanWindowsPath(p string) string {
+	return strings.ReplaceAll(p, "\\", "/")
+}
+
+// CleanWindowsPathBase normalizes Windows-style backslashes to forward slashes
+// and returns the base name of the path.
+func CleanWindowsPathBase(p string) string {
+	return path.Base(strings.ReplaceAll(p, "\\", "/"))
 }


### PR DESCRIPTION
## Problem

When uploading files from a Windows `weed admin` client to a Linux server, file paths containing backslashes were not being properly interpreted as directory separators. This caused files intended for subdirectories to be created in the root directory with backslashes in their filenames.

For example, uploading to `subdir\file.zip` from Windows would create a file named `subdir\file.zip` in the root directory instead of `/subdir/file.zip`.

## Root Cause

The server-side code used `filepath.Join()` which on Linux doesn't recognize Windows backslashes (`\`) as path separators. The backslashes were treated as part of the filename rather than directory delimiters.

## Solution

1. **Normalize backslashes in uploaded filenames**: Convert `\` to `/` before processing the filename
2. **Use forward-slash path joining**: Build URL paths using forward slashes explicitly since these are URL paths, not filesystem paths
3. **Defense-in-depth in `validateAndCleanFilePath`**: Also normalize backslashes when validating/cleaning file paths
4. **Clean base filename for filer upload**: Extract the base filename from the clean path to avoid any residual backslashes

## Testing

- Verified code compiles successfully
- The fix normalizes Windows paths like `subdir\file.zip` to `subdir/file.zip` before creating the full path

Fixes #7628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved file naming consistency when uploading from different operating systems
* Enhanced path validation and sanitization during file uploads
* Increased timeout duration for large file uploads to prevent timeouts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->