### PR TITLE
fix: CompleteMultipartUpload fails for uploads with more than 1000 parts

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -187,7 +187,10 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 	sort.Ints(completedPartNumbers)
 
 	uploadDirectory := s3a.genUploadsFolder(*input.Bucket) + "/" + *input.UploadId
-	entries, _, err := s3a.list(uploadDirectory, "", "", false, 0)
+	// Use explicit limit to ensure all parts are listed (up to S3's max of 10,000 parts)
+	// Previously limit=0 relied on server's DirListingLimit default (1000 in weed server mode),
+	// which caused CompleteMultipartUpload to fail for uploads with more than 1000 parts.
+	entries, _, err := s3a.list(uploadDirectory, "", "", false, s3_constants.MaxS3MultipartParts+1)
 	if err != nil {
 		glog.Errorf("completeMultipartUpload %s %s error: %v, entries:%d", *input.Bucket, *input.UploadId, err, len(entries))
 		stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedNoSuchUpload).Inc()


### PR DESCRIPTION
## Problem

When uploading large files via S3 multipart upload in `weed server` mode, the `CompleteMultipartUpload` operation fails with:

```
An error occurred (InvalidPart) when calling the CompleteMultipartUpload operation: 
One or more of the specified parts could not be found.
```

## Root Cause

In `completeMultipartUpload()`, parts are listed with `limit=0`:
```go
entries, _, err := s3a.list(uploadDirectory, "", "", false, 0)
```

When `limit=0`, the server uses its default `DirListingLimit`:
- `weed server` mode: **1,000** (default)
- `weed filer` standalone: **100,000** (default)

For a 38GB file with AWS CLI's default 8MB part size, this creates ~4,564 parts. Only the first 1,000 are listed, causing parts 1001+ to fail validation.

## Fix

Use an explicit limit of `MaxS3MultipartParts + 1` (10,001) to ensure all parts are listed regardless of server configuration. This matches the S3 API's documented limit of 10,000 parts per upload.

## Testing

This fix ensures `CompleteMultipartUpload` works correctly for:
- Uploads with any number of parts up to the S3 maximum (10,000)
- Both `weed server` and standalone `weed filer` deployments

Fixes #7638