### PR TITLE
fix: initialize missing S3 options in filer to prevent nil pointer dereference

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -234,7 +234,7 @@ func runFiler(cmd *Command, args []string) bool {
 		}
 		// Set S3 metrics IP based on bind IP if not explicitly set
 		if *filerS3Options.metricsHttpIp == "" {
-			filerS3Options.metricsHttpIp = filerS3Options.bindIp
+			*filerS3Options.metricsHttpIp = *filerS3Options.bindIp
 		}
 		go func(delay time.Duration) {
 			time.Sleep(delay * time.Second)


### PR DESCRIPTION
Fixes https://github.com/seaweedfs/seaweedfs/discussions/7644

## Problem

When starting the S3 gateway from the filer (using the  flag), several S3Options fields were not being initialized. This caused a nil pointer dereference panic during startup, specifically around s3.go:226.

The error manifested as:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1cf9bf5]

goroutine 59 [running]:
github.com/seaweedfs/seaweedfs/weed/command.(*S3Options).startS3Server(0x3cc9860)
/go/src/github.com/seaweedfs/seaweedfs/weed/command/s3.go:226 +0x495
```

## Solution

This commit adds initialization for three missing S3Options fields in `filer.go`:
- **iamConfig**: for advanced IAM configuration support
- **metricsHttpPort**: for Prometheus metrics endpoint
- **metricsHttpIp**: for binding the metrics endpoint

Additionally, ensures `metricsHttpIp` defaults to `bindIp` when not explicitly set, matching the behavior of the standalone S3 server.

## Changes

- Added `filerS3Options.iamConfig` initialization with `-s3.iam.config` flag
- Added `filerS3Options.metricsHttpPort` initialization with `-s3.metricsPort` flag  
- Added `filerS3Options.metricsHttpIp` initialization with `-s3.metricsIp` flag
- Set default value for `metricsHttpIp` from `bindIp` if not explicitly provided

## Testing

- ✅ Code compiles successfully
- ✅ Follows the same pattern as standalone S3 server initialization
- ✅ Backward compatible with existing configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3 configuration options for advanced IAM settings, Prometheus metrics HTTP port, and metrics listening IP address.
  * Metrics listening IP now defaults to the S3 server bind address when not explicitly configured, ensuring metrics bind aligns with the S3 service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->