### PR TITLE
SFTP: support reloading user store on HUP signal

### DIFF
--- a/weed/command/sftp.go
+++ b/weed/command/sftp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/sftpd"
 	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 )
 
 var (
@@ -147,6 +148,9 @@ func (sftpOpt *SftpOptions) startSftpServer() bool {
 		ClientAliveCountMax: *sftpOpt.clientAliveCountMax,
 		UserStoreFile:       *sftpOpt.userStoreFile,
 	})
+
+	// Register reload hook for HUP signal
+	grace.OnReload(service.Reload)
 
 	// Set up Unix socket if on non-Windows platforms
 	if runtime.GOOS != "windows" {

--- a/weed/sftpd/sftp_service.go
+++ b/weed/sftpd/sftp_service.go
@@ -300,3 +300,15 @@ func (s *SFTPService) handleSFTP(channel ssh.Channel, fs *SftpServer) {
 		glog.Errorf("SFTP server finished with error: %v", err)
 	}
 }
+
+// Reload reloads the user store from disk, useful for HUP signal handling
+func (s *SFTPService) Reload() {
+	glog.V(0).Info("Reload SFTP server...")
+	if fileStore, ok := s.userStore.(*user.FileStore); ok {
+		if err := fileStore.Reload(); err != nil {
+			glog.Errorf("Failed to reload user store: %v", err)
+		} else {
+			glog.V(0).Info("Successfully reloaded SFTP user store")
+		}
+	}
+}

--- a/weed/sftpd/user/filestore.go
+++ b/weed/sftpd/user/filestore.go
@@ -264,3 +264,8 @@ func (s *FileStore) CreateUser(username, password string) (*User, error) {
 
 	return user, nil
 }
+
+// Reload reloads users from the file, useful for HUP signal handling
+func (s *FileStore) Reload() error {
+	return s.loadUsers()
+}


### PR DESCRIPTION
Fixes #7650

This PR enables the SFTP server to reload the user store configuration () when a HUP signal is sent to the process, without requiring a service restart.

## Problem

After making changes to `sftp_userstore.json` and sending a `HUP` signal, the configuration was not being reloaded. The SFTP service did not have a reload hook registered with the grace signal handler.

## Solution

This change adds reload functionality following the same pattern used by other SeaweedFS components (filer, volume server, S3, master):

### Changes:
- **`weed/sftpd/user/filestore.go`**: Added `Reload()` method to re-read users from disk
- **`weed/sftpd/sftp_service.go`**: Added `Reload()` method to handle reload requests with proper error handling and logging
- **`weed/command/sftp.go`**: Registered reload hook with `grace.OnReload()`

## Benefits

- Administrators can now add users or change access policies dynamically
- No service restart required - just edit the user store file and send a HUP signal
- Existing connections remain active during reload
- Thread-safe implementation using existing mutex locks

## Usage

After making changes to `sftp_userstore.json`:

```bash
# Send HUP signal
kill -HUP <pid>

# Or with systemd
systemctl reload seaweedfs
```

Logs will confirm the reload:
```
I1208 07:23:21 Reload SFTP server...
I1208 07:23:21 Successfully reloaded SFTP user store
```

## Testing

- Code compiles successfully
- Implementation follows existing SeaweedFS patterns
- Thread-safe with proper locking