### PR TITLE
fix: restore volume mount when VolumeConfigure fails

### DIFF
--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -137,6 +137,7 @@ func (vs *VolumeServer) VolumeConfigure(ctx context.Context, req *volume_server_
 		// Try to re-mount to restore the volume state
 		if mountErr := vs.store.MountVolume(needle.VolumeId(req.VolumeId)); mountErr != nil {
 			glog.Errorf("volume configure failed to restore mount %v: %v", req, mountErr)
+			resp.Error += fmt.Sprintf(". Also failed to restore mount: %v", mountErr)
 		}
 		return resp, nil
 	}


### PR DESCRIPTION
## Problem

When running `volume.configure.replication` command, if the `.vif` file fails to parse (e.g., corrupted or unexpected format), the volume disappears from the cluster, causing potential data loss.

### Root Cause

The `VolumeConfigure` function:
1. Calls `UnmountVolume()` which immediately notifies the master that the volume is "deleted"
2. Calls `ConfigureVolume()` to modify the `.vif` file
3. If step 2 fails, the function returns **without re-mounting the volume**
4. The volume remains unmounted and the master thinks it's deleted

## Solution

When `ConfigureVolume` fails, attempt to re-mount the volume to restore its state before returning the error. This ensures the volume remains available even if the configuration change fails.

## Changes

- Added recovery logic in `VolumeConfigure` to re-mount the volume when `ConfigureVolume` fails

Fixes #7666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced volume configuration reliability by automatically attempting to remount volumes when initial configuration fails, with improved error logging for better troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->