### PR TITLE
mount: add mutex to DirectoryHandle to fix race condition

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -130,6 +130,7 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 		signature:     util.RandomInt32(),
 		inodeToPath:   NewInodeToPath(util.FullPath(option.FilerMountRootPath), option.CacheMetaTTlSec),
 		fhMap:         NewFileHandleToInode(),
+		dhMap:         NewDirectoryHandleToInode(),
 		filerClient:   filerClient, // nil for proxy mode, initialized for direct access
 		fhLockTable:   util.NewLockTable[FileHandleId](),
 	}

--- a/weed/mount/weedfs_dir_read.go
+++ b/weed/mount/weedfs_dir_read.go
@@ -30,7 +30,12 @@ type DirectoryHandle struct {
 
 func (dh *DirectoryHandle) reset() {
 	dh.isFinished = false
-	dh.entryStream = []*filer.Entry{}
+	// Nil out pointers to allow garbage collection of old entries,
+	// then reuse the slice's capacity to avoid re-allocations.
+	for i := range dh.entryStream {
+		dh.entryStream[i] = nil
+	}
+	dh.entryStream = dh.entryStream[:0]
 	dh.entryStreamOffset = directoryStreamBaseOffset
 }
 


### PR DESCRIPTION
## Summary
When using Ganesha NFS on top of FUSE mount, `ls` operations would hang forever on directories with hundreds of files. This was caused by a race condition in `DirectoryHandle` where multiple concurrent readdir operations could modify the `entryStream` and other fields without synchronization.

## Root Cause
Ganesha NFS uses multi-threaded access patterns with parallel `READDIRPLUS` calls, which triggered this race condition. Direct FUSE access typically uses single-threaded sequential access, which is why the issue was not observed with direct `ls` on the FUSE mount.

## Fix
The fix adds a mutex to `DirectoryHandle` and acquires it at the start of `doReadDirectory` to ensure thread-safe access to the directory handle state.

## Changes
- Added `sync.Mutex` to `DirectoryHandle` struct
- Added `dh.Lock()` / `defer dh.Unlock()` in `doReadDirectory`
- Updated `reset()` method to not overwrite the mutex

Fixes #7672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for directory reads to prevent races and ensure consistent incremental listings under concurrent access.
  * More reliable handling of "." and ".." entries during directory listing.
  * Directory listings now fail fast with a clear I/O error if metadata isn’t available, reducing silent inconsistencies.
  * Reduced intermittent missing/duplicated entries and read-related failures by coalescing listing state and stabilizing offset/stream handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->