### PR TITLE
fix: prevent makeslice panic in ReadNeedleMeta with corrupted needle

### DIFF
--- a/weed/storage/needle/needle_read_page.go
+++ b/weed/storage/needle/needle_read_page.go
@@ -64,8 +64,8 @@ func (n *Needle) ReadNeedleMeta(r backend.BackendStorageFile, offset int64, size
 	dataSize := GetActualSize(size, version)
 	stopOffset := offset + dataSize
 	metaSize := stopOffset - startOffset
-	if metaSize < 0 {
-		return fmt.Errorf("invalid needle meta: metaSize=%d, DataSize=%d, size=%d, offset=%d", metaSize, n.DataSize, size, offset)
+	if metaSize < 0 || metaSize > 128*1024 {
+		return fmt.Errorf("invalid needle meta size %d: DataSize=%d, size=%d, offset=%d", metaSize, n.DataSize, size, offset)
 	}
 	metaSlice := make([]byte, int(metaSize))
 


### PR DESCRIPTION
## Problem

Fixes #7475

When running `volume.fsck` or vacuum on a volume with corrupted needle data, the operation fails with:

```
failed to AscendingVisit read needle meta with id 981704839 from volume 156: 
rpc error: code = Unknown desc = panic occurred: runtime error: makeslice: len out of range
```

## Root Cause

In `ReadNeedleMeta`, when a needle's `DataSize` in the `.dat` file is corrupted to a very large value:

1. `startOffset = offset + NeedleHeaderSize + DataSizeSize + int64(n.DataSize)` becomes very large
2. `metaSize = stopOffset - startOffset` becomes **negative**
3. `make([]byte, int(metaSize))` panics with "makeslice: len out of range"

## Fix

Add validation to check if `metaSize` is negative before creating the slice, returning a descriptive error instead of panicking. This allows fsck to continue processing other needles and report the corrupted ones.

## Changes

- Added bounds check for `metaSize` in `ReadNeedleMeta`
- Returns descriptive error with debugging info: `metaSize`, `DataSize`, `size`, `offset`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata validation with stricter checks to ensure metadata size values are non-negative. When invalid metadata is detected, the system now returns detailed error information including relevant diagnostic context instead of proceeding with potentially corrupted data. This prevents downstream processing failures and improves overall system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->