### PR TITLE
s3api: remove redundant auth verification in getRequestDataReader

### DIFF
--- a/weed/s3api/s3api_put_object_helper.go
+++ b/weed/s3api/s3api_put_object_helper.go
@@ -17,8 +17,7 @@ func getRequestDataReader(s3a *S3ApiServer, r *http.Request) (io.ReadCloser, s3e
 	dataReader := r.Body
 	rAuthType := getRequestAuthType(r)
 	if s3a.iam.isEnabled() {
-		switch rAuthType {
-		case authTypeStreamingSigned, authTypeStreamingUnsigned:
+		if rAuthType == authTypeStreamingSigned || rAuthType == authTypeStreamingUnsigned {
 			dataReader, s3ErrCode = s3a.iam.newChunkedReader(r)
 		}
 	} else {


### PR DESCRIPTION
## Summary

This PR removes redundant authentication verification in `getRequestDataReader` function.

## Problem

As reported in #7683, the handlers that use `getRequestDataReader` (e.g., `PutObjectHandler`, `PutObjectPartHandler`) are already wrapped with the `s3a.iam.Auth` middleware, which calls `authRequest` and performs signature verification (`reqSignatureV4Verify` or `isReqAuthenticatedV2`) **before** the handler is invoked.

The verification for `authTypeSignedV2`, `authTypePresignedV2`, `authTypePresigned`, and `authTypeSigned` in `getRequestDataReader` was therefore redundant - performing the same verification twice.

## Changes

- Removed redundant signature verification for non-streaming auth types in `getRequestDataReader`
- Kept the `newChunkedReader()` call for streaming auth types as it's necessary to parse the chunked transfer encoding format and extract actual data

## Testing

The existing tests continue to pass. The authentication is still properly enforced by the Auth middleware.

Fixes #7683