### PR TITLE
mount: improve read throughput by enabling parallel HTTP connections

### DIFF
--- a/weed/util/http/client/http_client.go
+++ b/weed/util/http/client/http_client.go
@@ -130,7 +130,10 @@ func NewHttpClient(clientName ClientName, opts ...HttpClientOpt) (*HTTPClient, e
 	httpClient.Transport = &http.Transport{
 		MaxIdleConns:        1024,
 		MaxIdleConnsPerHost: 1024,
-		TLSClientConfig:     tlsConfig,
+		// Allow truly parallel per-host connections and avoid HTTP/2 multiplexing
+		MaxConnsPerHost:   0,     // unlimited
+		ForceAttemptHTTP2: false, // disable HTTP/2 to avoid implicit single-connection multiplexing
+		TLSClientConfig:   tlsConfig,
 	}
 	httpClient.Client = &http.Client{
 		Transport: httpClient.Transport,


### PR DESCRIPTION
This addresses issue #7504 where a single weed mount FUSE instance does not fully utilize node network bandwidth when reading large files.

## Root Cause
HTTP GET streaming reads were getting serialized even with multiple concurrent goroutines, due to:
1. HTTP/2 multiplexing all requests over a single TCP connection
2. The streaming loop using a 64KB intermediate buffer with extra copies

## Changes

### http/client: Enable truly parallel connections
- Set `ForceAttemptHTTP2: false` to disable HTTP/2 multiplexing
- Set `MaxConnsPerHost: 0` (unlimited) to allow parallel connections per host

### filer/stream: Add direct-to-buffer fast path
- For full, uncompressed, unencrypted chunks, use `RetriedFetchChunkData` to read directly into the destination buffer
- Skips the 64KB staged streaming loop and avoids an extra memory copy
- Falls back to streaming path on partial fill or error

Closes #7504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chunk streaming performance with optimizations for direct buffer fetching of full, unencrypted chunks, with fallback to existing streaming path.
  * Enhanced HTTP client connection management by adjusting transport configuration for improved per-host concurrency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->