### PR TITLE
fix: cache successful volume lookups instead of failed ones

### DIFF
--- a/weed/operation/lookup.go
+++ b/weed/operation/lookup.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
-	"google.golang.org/grpc"
 	"math/rand/v2"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"google.golang.org/grpc"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 )
@@ -101,7 +102,7 @@ func LookupVolumeIds(masterFn GetMasterFn, grpcDialOption grpc.DialOption, vids 
 					GrpcPort:   int(loc.GrpcPort),
 				})
 			}
-			if vidLocations.Error != "" {
+			if vidLocations.Error == "" {
 				vc.Set(vidLocations.VolumeOrFileId, locations, 10*time.Minute)
 			}
 			ret[vidLocations.VolumeOrFileId] = &LookupResult{


### PR DESCRIPTION
## Problem

Users reported ~1 second latency for replicated writes with TTL volumes, while writes without TTL had ~10ms latency. Metrics showed `writeToLocalDisk` was fast but `writeToReplicas` was slow.

## Root Cause

In `weed/operation/lookup.go`, the volume location caching condition was **inverted**:

```go
// BEFORE (buggy):
if vidLocations.Error != "" {  // Only caches FAILED lookups!
    vc.Set(vidLocations.VolumeOrFileId, locations, 10*time.Minute)
}
```

This caused every replicated write to make a gRPC call to master for volume location lookup, adding ~1 second latency.

## Why TTL Volumes Were Particularly Affected

- More unique volumes are created (separate pools per TTL)
- Volumes expire and get recreated frequently
- Each new volume requires a fresh lookup (cache miss)
- Higher volume churn = more cache misses = more master lookups

## Fix

```go
// AFTER (fixed):
if vidLocations.Error == "" {  // Now caches SUCCESSFUL lookups
    vc.Set(vidLocations.VolumeOrFileId, locations, 10*time.Minute)
}
```

## Expected Improvement

- First write to a new volume: Still requires master lookup (~1s)
- Subsequent writes to same volume: Cache hit, no master lookup (~10ms)
- Overall latency should drop from ~1s to ~10ms for most replicated writes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a caching mechanism that was incorrectly storing data even when errors occurred during operations. The system now ensures data is only cached when operations complete successfully, improving accuracy and reliability of cached results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->