### PR TITLE
fix worker -admin -adminServer error

### DIFF
--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -132,9 +132,9 @@ spec:
               {{- end }}
               worker \
               {{- if .Values.worker.adminServer }}
-              -adminServer={{ .Values.worker.adminServer }} \
+              -admin={{ .Values.worker.adminServer }} \
               {{- else }}
-              -adminServer={{ template "seaweedfs.name" . }}-admin.{{ .Release.Namespace }}:{{ .Values.admin.grpcPort }} \
+              -admin={{ template "seaweedfs.name" . }}-admin.{{ .Release.Namespace }}:{{ .Values.admin.grpcPort }} \
               {{- end }}
               -capabilities={{ .Values.worker.capabilities }} \
               -maxConcurrent={{ .Values.worker.maxConcurrent }} \


### PR DESCRIPTION
# What problem are we solving?

worker-deployment.yaml use weed -adminServer in place of weed -admin

# How are we solving the problem?

changing -admin in place of -adminServer

# How is the PR tested?
Manually


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SeaweedFS worker deployment to use the correct admin server configuration flag, ensuring proper worker-to-admin communication in both explicitly configured and fallback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->