### PR TITLE
docker: add curl for HTTPS healthcheck support

### DIFF
--- a/docker/Dockerfile.foundationdb_large
+++ b/docker/Dockerfile.foundationdb_large
@@ -77,6 +77,7 @@ LABEL author="Chris Lu"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     fuse \
     wget && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -27,7 +27,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh 
 # To disable: docker run -e GODEBUG=fips140=off ...
 
 # Install dependencies and create non-root user
-RUN apk add --no-cache fuse su-exec && \
+RUN apk add --no-cache fuse curl su-exec && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed
 

--- a/docker/Dockerfile.rocksdb_large
+++ b/docker/Dockerfile.rocksdb_large
@@ -34,7 +34,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/filer_rocksdb.
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh /entrypoint.sh
 
 # Install dependencies and create non-root user
-RUN apk add --no-cache fuse snappy gflags su-exec && \
+RUN apk add --no-cache fuse snappy gflags curl su-exec && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed
 

--- a/docker/Dockerfile.rocksdb_large_local
+++ b/docker/Dockerfile.rocksdb_large_local
@@ -17,7 +17,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/filer_rocksdb.
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh /entrypoint.sh
 
 # Install dependencies and create non-root user
-RUN apk add --no-cache fuse snappy gflags tmux su-exec && \
+RUN apk add --no-cache fuse snappy gflags curl tmux su-exec && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed
 


### PR DESCRIPTION
## Summary

Add `curl` to Docker images to enable HTTPS healthchecks with client certificate authentication.

## Problem

Alpine's busybox `wget` does not support the following options required for HTTPS healthchecks:
- `--ca-cert` for HTTPS certificate verification
- `--certificate` for client authentication
- `--private-key` for client authentication

This makes it impossible to implement proper container healthchecks when HTTPS mode is enabled.

## Solution

Add `curl` package to all production Docker images:
- `Dockerfile.go_build` (main production image)
- `Dockerfile.rocksdb_large`
- `Dockerfile.rocksdb_large_local`
- `Dockerfile.foundationdb_large`

Note: `Dockerfile.local` and `Dockerfile.e2e` already include `curl`.

## Usage Example

With curl available, users can now implement HTTPS healthchecks:

```bash
curl --cacert /path/to/ca.crt --cert /path/to/client.crt --key /path/to/client.key https://localhost:8888/
```

Fixes #7707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added curl as a runtime dependency to Docker container images across multiple build environments, expanding available system utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->