### PR TITLE
s3: fix presigned POST upload missing slash between bucket and key

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -201,16 +201,6 @@ func removeDuplicateSlashes(object string) string {
 	return result.String()
 }
 
-// normalizeObjectKey ensures the object key has a leading slash and no duplicate slashes.
-// This is used to normalize keys from various sources (URL path, form values, etc.)
-// to a consistent format for path construction.
-func normalizeObjectKey(object string) string {
-	object = removeDuplicateSlashes(object)
-	if !strings.HasPrefix(object, "/") {
-		object = "/" + object
-	}
-	return object
-}
 
 // hasChildren checks if a path has any child objects (is a directory with contents)
 //

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -56,7 +56,7 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 	if fileName != "" && strings.Contains(formValues.Get("Key"), "${filename}") {
 		formValues.Set("Key", strings.Replace(formValues.Get("Key"), "${filename}", fileName, -1))
 	}
-	object := normalizeObjectKey(formValues.Get("Key"))
+	object := s3_constants.NormalizeObjectKey(formValues.Get("Key"))
 
 	successRedirect := formValues.Get("success_action_redirect")
 	successStatus := formValues.Get("success_action_status")

--- a/weed/s3api/s3api_object_handlers_postpolicy_test.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,8 +68,8 @@ func TestPostPolicyKeyNormalization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Use the actual normalizeObjectKey function
-			object := normalizeObjectKey(tt.key)
+			// Use the actual NormalizeObjectKey function
+			object := s3_constants.NormalizeObjectKey(tt.key)
 
 			// Verify the normalized object has the expected prefix
 			assert.Equal(t, tt.expectedPrefix, object,
@@ -90,7 +91,7 @@ func TestPostPolicyKeyNormalization(t *testing.T) {
 	}
 }
 
-// TestNormalizeObjectKey tests the normalizeObjectKey function directly
+// TestNormalizeObjectKey tests the NormalizeObjectKey function directly
 func TestNormalizeObjectKey(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -111,7 +112,7 @@ func TestNormalizeObjectKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeObjectKey(tt.input)
+			result := s3_constants.NormalizeObjectKey(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -160,7 +161,7 @@ func TestPostPolicyFilenameSubstitution(t *testing.T) {
 			}
 
 			// Normalize using the actual function
-			object := normalizeObjectKey(key)
+			object := s3_constants.NormalizeObjectKey(key)
 
 			assert.Equal(t, tt.expectedKey, object,
 				"Key should be correctly substituted and normalized")
@@ -287,8 +288,8 @@ func TestPostPolicyPathConstruction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Use the actual normalizeObjectKey function
-			object := normalizeObjectKey(tt.formKey)
+			// Use the actual NormalizeObjectKey function
+			object := s3_constants.NormalizeObjectKey(tt.formKey)
 
 			// Construct path as done in PostPolicyBucketHandler
 			filePath := s3a.option.BucketsPath + "/" + tt.bucket + object
@@ -370,7 +371,7 @@ func TestPostPolicyBucketHandlerKeyExtraction(t *testing.T) {
 			_, _, _, _, formValues, _ := extractPostPolicyFormValues(form)
 
 			// Apply the same normalization as PostPolicyBucketHandler
-			object := normalizeObjectKey(formValues.Get("Key"))
+			object := s3_constants.NormalizeObjectKey(formValues.Get("Key"))
 
 			// Construct path
 			filePath := s3a.option.BucketsPath + "/" + tt.bucket + object
@@ -380,4 +381,3 @@ func TestPostPolicyBucketHandlerKeyExtraction(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## Problem

When uploading a file using presigned POST (e.g., `boto3.generate_presigned_post`), the file was saved with the bucket name and object key concatenated without a slash (e.g., `my-bucketfilename` instead of `my-bucket/filename`).

## Root Cause

In `PostPolicyBucketHandler`, the object key from form values was used directly without ensuring it had a leading slash:

```go
object := formValues.Get("Key")  // e.g., "test_image.png"
// ...
filePath := fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, bucket, object)
// Result: "/buckets/my-buckettest_image.png" (wrong!)
```

Other handlers use `s3_constants.GetBucketAndObject(r)` which automatically adds a leading slash if missing, but `PostPolicyBucketHandler` gets the key from form values and wasn't applying the same normalization.

## Fix

Added the same leading slash normalization used by `GetBucketAndObject`:

```go
object := formValues.Get("Key")
if !strings.HasPrefix(object, "/") {
    object = "/" + object
}
```

Now the path is correctly constructed as `/buckets/my-bucket/test_image.png`.

Fixes #7713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved S3 POST policy object key handling to ensure proper path formatting with leading slashes.
  * Fixed path construction logic for file uploads via POST policy requests.

* **Tests**
  * Added comprehensive test coverage for S3 POST policy object key normalization and path construction workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->