### PR TITLE
test: add integration test for versioned object listing path fix

### DIFF
--- a/test/s3/versioning/s3_velero_integration_test.go
+++ b/test/s3/versioning/s3_velero_integration_test.go
@@ -306,20 +306,18 @@ func TestVeleroListVersionsWithNestedPaths(t *testing.T) {
 	}
 }
 
-// hasDoubledPath checks if a path has repeated segments indicating the path doubling bug
-// For example: "kopia/logpaste/kopia/logpaste/file.txt" would return true
+// hasDoubledPath checks if a path has a repeated pair of segments, which indicates
+// the path doubling bug. For example: "kopia/logpaste/kopia/logpaste/file.txt" would return true.
 func hasDoubledPath(path string) bool {
 	parts := strings.Split(path, "/")
 	if len(parts) < 4 {
 		return false
 	}
 
-	// Check for repeated consecutive segments
-	// The bug pattern: [prefix]/[subdir]/[prefix]/[subdir]/...
-	for i := 0; i < len(parts)-2; i++ {
-		// Check if we have a repeated pair of segments
+	// Check for repeated pairs of segments, e.g., a/b/.../a/b.
+	for i := 0; i < len(parts)-3; i++ {
 		for j := i + 2; j < len(parts)-1; j++ {
-			if parts[i] == parts[j] && i+1 < len(parts) && j+1 < len(parts) && parts[i+1] == parts[j+1] {
+			if parts[i] == parts[j] && parts[i+1] == parts[j+1] {
 				return true
 			}
 		}


### PR DESCRIPTION
## Description

Add integration test that validates the fix for GitHub discussion #7573 (Velero/Kopia compatibility with S3 versioning).

## Tests Added

`TestVersionedObjectListingPathConstruction`:
- Verifies that entry names use `path.Base()` to get base filename only
- Validates that path doubling bug is prevented when listing versioned objects  
- Tests multiple scenarios: nested directories, bucket root, deep nesting

`TestVersionedEntryCreation`:
- Verifies logical entries are created correctly with proper attributes
- Tests that versioned entries preserve metadata

`TestVersionsFolderPathHandling`:
- Tests that .versions folder paths are handled correctly

## Related

- Fixes discussed in: https://github.com/seaweedfs/seaweedfs/discussions/7573
- The actual fix is already in master (uses `path.Base(object)` in `getLatestVersionEntryForListOperation`)
- This PR adds test coverage to prevent regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for versioned S3 buckets supporting Velero/Kopia backup workflows. Tests validate object listing accuracy, multiple version handling, nested path support, and prevention of path anomalies during retrieval operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->