### PR TITLE
fix(s3): start KeepConnectedToMaster for filer discovery with filerGroup

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -115,6 +115,8 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 			masterMap[fmt.Sprintf("master%d", i)] = addr
 		}
 		masterClient := wdclient.NewMasterClient(option.GrpcDialOption, option.FilerGroup, cluster.S3Type, "", "", "", *pb.NewServiceDiscoveryFromMap(masterMap))
+		// Start the master client connection loop - required for GetMaster() to work
+		go masterClient.KeepConnectedToMaster(context.Background())
 
 		filerClient = wdclient.NewFilerClient(option.Filers, option.GrpcDialOption, option.DataCenter, &wdclient.FilerClientOption{
 			MasterClient:      masterClient,

--- a/weed/wdclient/masterclient_test.go
+++ b/weed/wdclient/masterclient_test.go
@@ -1,0 +1,104 @@
+package wdclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"google.golang.org/grpc"
+)
+
+// TestWaitUntilConnectedWithoutKeepConnected verifies that WaitUntilConnected
+// respects context cancellation when KeepConnectedToMaster is not running.
+// This tests the fix for https://github.com/seaweedfs/seaweedfs/issues/7721
+func TestWaitUntilConnectedWithoutKeepConnected(t *testing.T) {
+	mc := NewMasterClient(grpc.EmptyDialOption{}, "test-group", "test-client", "", "", "", pb.ServerDiscovery{})
+
+	// Without KeepConnectedToMaster running, WaitUntilConnected should
+	// respect context cancellation and not block forever
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	mc.WaitUntilConnected(ctx)
+	elapsed := time.Since(start)
+
+	// Should have returned due to context timeout, not blocked forever
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("WaitUntilConnected blocked for %v, expected to return on context timeout", elapsed)
+	}
+
+	// GetMaster should return empty since we never connected
+	master := mc.getCurrentMaster()
+	if master != "" {
+		t.Errorf("Expected empty master, got %s", master)
+	}
+}
+
+// TestWaitUntilConnectedReturnsImmediatelyWhenConnected verifies that
+// WaitUntilConnected returns immediately when a master is already set.
+func TestWaitUntilConnectedReturnsImmediatelyWhenConnected(t *testing.T) {
+	mc := NewMasterClient(grpc.EmptyDialOption{}, "test-group", "test-client", "", "", "", pb.ServerDiscovery{})
+
+	// Simulate that KeepConnectedToMaster has already established a connection
+	mc.setCurrentMaster("localhost:9333")
+
+	ctx := context.Background()
+	start := time.Now()
+	mc.WaitUntilConnected(ctx)
+	elapsed := time.Since(start)
+
+	// Should return almost immediately (< 10ms)
+	if elapsed > 10*time.Millisecond {
+		t.Errorf("WaitUntilConnected took %v when master was already set, expected immediate return", elapsed)
+	}
+
+	// Verify master is returned
+	master := mc.getCurrentMaster()
+	if master != "localhost:9333" {
+		t.Errorf("Expected master localhost:9333, got %s", master)
+	}
+}
+
+// TestGetMasterRespectsContextCancellation verifies that GetMaster
+// respects context cancellation and doesn't block forever.
+func TestGetMasterRespectsContextCancellation(t *testing.T) {
+	mc := NewMasterClient(grpc.EmptyDialOption{}, "test-group", "test-client", "", "", "", pb.ServerDiscovery{})
+
+	// GetMaster calls WaitUntilConnected internally
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	master := mc.GetMaster(ctx)
+	elapsed := time.Since(start)
+
+	// Should return on context timeout
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("GetMaster blocked for %v, expected to return on context timeout", elapsed)
+	}
+
+	// Master should be empty since we never connected
+	if master != "" {
+		t.Errorf("Expected empty master when not connected, got %s", master)
+	}
+}
+
+// TestMasterClientFilerGroupLogging verifies the FilerGroup is properly set
+// and would be logged correctly (regression test for issue #7721 log message format)
+func TestMasterClientFilerGroupLogging(t *testing.T) {
+	filerGroup := "filer_1"
+	clientType := "s3"
+
+	mc := NewMasterClient(grpc.EmptyDialOption{}, filerGroup, clientType, "", "", "", pb.ServerDiscovery{})
+
+	if mc.FilerGroup != filerGroup {
+		t.Errorf("Expected FilerGroup %s, got %s", filerGroup, mc.FilerGroup)
+	}
+
+	if mc.clientType != clientType {
+		t.Errorf("Expected clientType %s, got %s", clientType, mc.clientType)
+	}
+}
+


### PR DESCRIPTION
## Summary

Fixes #7721

When S3 server is configured with a `filerGroup`, it creates a `MasterClient` to enable dynamic filer discovery. However, the `KeepConnectedToMaster()` background goroutine was never started, causing `GetMaster()` to block indefinitely in `WaitUntilConnected()`.

This resulted in the log message:
```
WaitUntilConnected still waiting for master connection (attempt N)...
```
being logged repeatedly every ~20 seconds.

## Root Cause

In `s3api_server.go`, when both `Masters` and `FilerGroup` are configured:
1. A `MasterClient` is created
2. It's passed to `FilerClient` for filer discovery
3. `FilerClient.discoverFilers()` calls `masterClient.GetMaster(ctx)`
4. `GetMaster()` calls `WaitUntilConnected()` which waits for `currentMaster` to be set
5. But `currentMaster` is only set by `KeepConnectedToMaster()`, which was never started

## Fix

Add the missing `go masterClient.KeepConnectedToMaster(context.Background())` call after creating the MasterClient.

## Testing

- Added unit tests for `MasterClient.WaitUntilConnected()` to verify it respects context cancellation
- All existing tests pass
- Build verified with `go build ./weed/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for MasterClient validating connection synchronization behavior, master retrieval under various conditions, timeout handling, and client initialization configuration.

* **Bug Fixes**
  * Strengthened master client connection reliability through enhanced connection maintenance mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->