### PR TITLE
feat(iam): add SetUserStatus and UpdateAccessKey actions

### DIFF
--- a/weed/iam/constants.go
+++ b/weed/iam/constants.go
@@ -29,3 +29,9 @@ const (
 	AccessKeyIdLength     = 21
 	SecretAccessKeyLength = 42
 )
+
+// Access key status values (AWS IAM compatible)
+const (
+	AccessKeyStatusActive   = "Active"
+	AccessKeyStatusInactive = "Inactive"
+)

--- a/weed/iam/responses.go
+++ b/weed/iam/responses.go
@@ -138,3 +138,15 @@ type Policies struct {
 	Policies map[string]interface{} `json:"policies"`
 }
 
+// SetUserStatusResponse is the response for SetUserStatus action.
+// This is a SeaweedFS extension to enable/disable users without deleting them.
+type SetUserStatusResponse struct {
+	CommonResponse
+	XMLName xml.Name `xml:"https://iam.amazonaws.com/doc/2010-05-08/ SetUserStatusResponse"`
+}
+
+// UpdateAccessKeyResponse is the response for UpdateAccessKey action.
+type UpdateAccessKeyResponse struct {
+	CommonResponse
+	XMLName xml.Name `xml:"https://iam.amazonaws.com/doc/2010-05-08/ UpdateAccessKeyResponse"`
+}

--- a/weed/pb/iam.proto
+++ b/weed/pb/iam.proto
@@ -24,13 +24,13 @@ message Identity {
     repeated Credential credentials = 2;
     repeated string actions = 3;
     Account account = 4;
+    bool disabled = 5;  // User status: false = enabled (default), true = disabled
 }
 
 message Credential {
     string access_key = 1;
     string secret_key = 2;
-    // uint64 expiration = 3;
-    // bool is_disabled = 4;
+    string status = 3;  // Access key status: "Active" or "Inactive"
 }
 
 message Account {

--- a/weed/pb/iam_pb/iam.pb.go
+++ b/weed/pb/iam_pb/iam.pb.go
@@ -79,6 +79,7 @@ type Identity struct {
 	Credentials   []*Credential          `protobuf:"bytes,2,rep,name=credentials,proto3" json:"credentials,omitempty"`
 	Actions       []string               `protobuf:"bytes,3,rep,name=actions,proto3" json:"actions,omitempty"`
 	Account       *Account               `protobuf:"bytes,4,opt,name=account,proto3" json:"account,omitempty"`
+	Disabled      bool                   `protobuf:"varint,5,opt,name=disabled,proto3" json:"disabled,omitempty"` // User status: false = enabled (default), true = disabled
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -141,10 +142,18 @@ func (x *Identity) GetAccount() *Account {
 	return nil
 }
 
+func (x *Identity) GetDisabled() bool {
+	if x != nil {
+		return x.Disabled
+	}
+	return false
+}
+
 type Credential struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AccessKey     string                 `protobuf:"bytes,1,opt,name=access_key,json=accessKey,proto3" json:"access_key,omitempty"`
 	SecretKey     string                 `protobuf:"bytes,2,opt,name=secret_key,json=secretKey,proto3" json:"secret_key,omitempty"`
+	Status        string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"` // Access key status: "Active" or "Inactive"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -189,6 +198,13 @@ func (x *Credential) GetAccessKey() string {
 func (x *Credential) GetSecretKey() string {
 	if x != nil {
 		return x.SecretKey
+	}
+	return ""
+}
+
+func (x *Credential) GetStatus() string {
+	if x != nil {
+		return x.Status
 	}
 	return ""
 }
@@ -262,18 +278,20 @@ const file_iam_proto_rawDesc = "" +
 	"\n" +
 	"identities\x18\x01 \x03(\v2\x10.iam_pb.IdentityR\n" +
 	"identities\x12+\n" +
-	"\baccounts\x18\x02 \x03(\v2\x0f.iam_pb.AccountR\baccounts\"\x99\x01\n" +
+	"\baccounts\x18\x02 \x03(\v2\x0f.iam_pb.AccountR\baccounts\"\xb5\x01\n" +
 	"\bIdentity\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x124\n" +
 	"\vcredentials\x18\x02 \x03(\v2\x12.iam_pb.CredentialR\vcredentials\x12\x18\n" +
 	"\aactions\x18\x03 \x03(\tR\aactions\x12)\n" +
-	"\aaccount\x18\x04 \x01(\v2\x0f.iam_pb.AccountR\aaccount\"J\n" +
+	"\aaccount\x18\x04 \x01(\v2\x0f.iam_pb.AccountR\aaccount\x12\x1a\n" +
+	"\bdisabled\x18\x05 \x01(\bR\bdisabled\"b\n" +
 	"\n" +
 	"Credential\x12\x1d\n" +
 	"\n" +
 	"access_key\x18\x01 \x01(\tR\taccessKey\x12\x1d\n" +
 	"\n" +
-	"secret_key\x18\x02 \x01(\tR\tsecretKey\"a\n" +
+	"secret_key\x18\x02 \x01(\tR\tsecretKey\x12\x16\n" +
+	"\x06status\x18\x03 \x01(\tR\x06status\"a\n" +
 	"\aAccount\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12#\n" +

--- a/weed/s3api/auto_signature_v4_test.go
+++ b/weed/s3api/auto_signature_v4_test.go
@@ -190,7 +190,7 @@ func mustNewRequest(method string, urlStr string, contentLength int64, body io.R
 // is signed with AWS Signature V4, fails if not able to do so.
 func mustNewSignedRequest(method string, urlStr string, contentLength int64, body io.ReadSeeker, t *testing.T) *http.Request {
 	req := mustNewRequest(method, urlStr, contentLength, body, t)
-	cred := &Credential{"access_key_1", "secret_key_1"}
+	cred := &Credential{AccessKey: "access_key_1", SecretKey: "secret_key_1"}
 	if err := signRequestV4(req, cred.AccessKey, cred.SecretKey); err != nil {
 		t.Fatalf("Unable to initialized new signed http request %s", err)
 	}
@@ -201,7 +201,7 @@ func mustNewSignedRequest(method string, urlStr string, contentLength int64, bod
 // is presigned with AWS Signature V4, fails if not able to do so.
 func mustNewPresignedRequest(iam *IdentityAccessManagement, method string, urlStr string, contentLength int64, body io.ReadSeeker, t *testing.T) *http.Request {
 	req := mustNewRequest(method, urlStr, contentLength, body, t)
-	cred := &Credential{"access_key_1", "secret_key_1"}
+	cred := &Credential{AccessKey: "access_key_1", SecretKey: "secret_key_1"}
 	if err := preSignV4(iam, req, cred.AccessKey, cred.SecretKey, int64(10*time.Minute.Seconds())); err != nil {
 		t.Fatalf("Unable to initialized new signed http request %s", err)
 	}

--- a/weed/s3api/s3api_bucket_handlers_test.go
+++ b/weed/s3api/s3api_bucket_handlers_test.go
@@ -670,7 +670,7 @@ func TestListBucketsIssue7647(t *testing.T) {
 	t.Run("admin user can see their created buckets", func(t *testing.T) {
 		// Simulate the exact scenario from issue #7647:
 		// User "root" with ["Admin", "Read", "Write", "Tagging", "List"] permissions
-		
+
 		// Create identity for root user with Admin action
 		rootIdentity := &Identity{
 			Name: "root",
@@ -730,7 +730,7 @@ func TestListBucketsIssue7647(t *testing.T) {
 	t.Run("admin user sees buckets without owner metadata", func(t *testing.T) {
 		// Admin users should see buckets even if they don't have owner metadata
 		// (this can happen with legacy buckets or manual creation)
-		
+
 		rootIdentity := &Identity{
 			Name: "root",
 			Actions: []Action{
@@ -754,7 +754,7 @@ func TestListBucketsIssue7647(t *testing.T) {
 
 	t.Run("non-admin user cannot see buckets without owner", func(t *testing.T) {
 		// Non-admin users should not see buckets without owner metadata
-		
+
 		regularUser := &Identity{
 			Name: "user1",
 			Actions: []Action{


### PR DESCRIPTION
## Summary

Add ability to enable/disable users and access keys without deleting them.

Fixes #7745

## Proposed Actions

| Action          | Description                                |
| --------------- | ------------------------------------------ |
| SetUserStatus   | Enable or disable a user                   |
| UpdateAccessKey | Change access key status (Active/Inactive) |

## Use Cases

1. **Temporary suspension**: Disable user access during investigation
2. **Key rotation**: Deactivate old key before deletion
3. **Offboarding**: Disable rather than delete for audit purposes
4. **Emergency response**: Quickly disable compromised credentials

## Implementation Details

### Protocol Buffer Updates
- Added `enabled` field (bool) to Identity message for user status
- Added `status` field (string: "Active" or "Inactive") to Credential message

### New IAM Actions
- **SetUserStatus**: Enable or disable a user (requires admin rights)
- **UpdateAccessKey**: Change access key status (self-service for own keys, admin for others)

### Behavior
- Disabled users: All API requests using their credentials return AccessDenied
- Inactive access keys: Signature validation fails
- Status check happens early in auth flow for performance
- Backward compatible: existing configs without status fields default to enabled

### API Examples

**Set User Status:**
```bash
aws iam set-user-status --user-name testuser --status Inactive
aws iam set-user-status --user-name testuser --status Active
```

**Update Access Key:**
```bash
aws iam update-access-key --user-name testuser --access-key-id AKIAEXAMPLE --status Inactive
aws iam update-access-key --access-key-id AKIAEXAMPLE --status Active  # self-service
```

## Files Changed

- `weed/pb/iam.proto` - Added enabled and status fields
- `weed/pb/iam_pb/iam.pb.go` - Regenerated protobuf
- `weed/iam/constants.go` - Added AccessKeyStatusActive/Inactive constants
- `weed/iam/responses.go` - Added SetUserStatusResponse and UpdateAccessKeyResponse
- `weed/s3api/s3api_embedded_iam.go` - Implemented SetUserStatus and UpdateAccessKey
- `weed/s3api/auth_credentials.go` - Added status checking in auth flow
- Test files updated to include Enabled field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IAM: add user enable/disable and access-key Active/Inactive operations; API exposes SetUserStatus and UpdateAccessKey and returns status on key listings.
  * New access keys default to Active.

* **Behavior**
  * Authentication rejects disabled users and inactive keys; identity records include a disabled flag and credentials include a status field.
  * ListAccessKeys shows per-key status (defaults to Active when unspecified).

* **Tests**
  * Added comprehensive tests covering status changes, defaults, and error paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->