### PR TITLE
fix: default policy storeType to memory when not specified

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -653,6 +653,11 @@ func loadIAMManagerFromConfig(configPath string, filerAddressProvider func() str
 			DefaultEffect: sts.EffectDeny,
 			StoreType:     sts.StoreTypeMemory,
 		}
+	} else if configRoot.Policy.StoreType == "" {
+		// If policy config exists but storeType is not specified, use memory store
+		// This ensures JSON-defined policies are stored in memory and work correctly
+		configRoot.Policy.StoreType = sts.StoreTypeMemory
+		glog.V(1).Infof("Policy storeType not specified; using memory store for JSON config-based setup")
 	}
 
 	// Create IAM configuration


### PR DESCRIPTION
## Summary
When loading IAM config from JSON, if the policy section exists but `storeType` is not specified, default to `memory` instead of `filer`.

## Problem
`TestS3IAMPresignedURLIntegration` was failing with `AccessDenied` because policies defined in JSON config files were not being loaded correctly. The `PolicyEngine` was defaulting to `filer` as the store type, but in test environments without a filer connection, this meant policies weren't available.

## Fix
In `loadIAMManagerFromConfig`, if `configRoot.Policy.StoreType` is empty, explicitly set it to `memory`. This ensures JSON-defined policies work correctly in standalone setups and test environments.