### PR TITLE
Fix EC Volumes page header styling to match admin theme

### DIFF
--- a/weed/admin/view/app/cluster_ec_volumes.templ
+++ b/weed/admin/view/app/cluster_ec_volumes.templ
@@ -25,7 +25,7 @@ templ ClusterEcVolumes(data dash.ClusterEcVolumesData) {
                             <i class="fas fa-filter me-1"></i>Collection: {data.Collection}
                         </span>
                     }
-                    <a href="/cluster/ec-shards" class="btn btn-sm btn-outline-secondary">
+                    <a href="/cluster/ec-volumes" class="btn btn-sm btn-outline-secondary">
                         <i class="fas fa-times me-1"></i>Clear Filter
                     </a>
                 </div>

--- a/weed/admin/view/app/cluster_ec_volumes_templ.go
+++ b/weed/admin/view/app/cluster_ec_volumes_templ.go
@@ -70,7 +70,7 @@ func ClusterEcVolumes(data dash.ClusterEcVolumesData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<a href=\"/cluster/ec-shards\" class=\"btn btn-sm btn-outline-secondary\"><i class=\"fas fa-times me-1\"></i>Clear Filter</a></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<a href=\"/cluster/ec-volumes\" class=\"btn btn-sm btn-outline-secondary\"><i class=\"fas fa-times me-1\"></i>Clear Filter</a></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Fixes #7779

## Problem
The Admin GUI's EC Volumes page (Cluster -> EC Volumes) was displaying with bright Bootstrap default colors instead of the admin dark theme, as reported in the issue.

## Root Cause
The `cluster_ec_volumes.templ` template was structured as a standalone HTML document with its own `<!DOCTYPE html>`, `<head>`, and `<body>` tags, loading Bootstrap directly from CDN. This bypassed the admin layout's CSS styling.

## Solution
Converted the template to be a content fragment (matching the pattern used by other properly styled templates like `cluster_ec_shards.templ`), so it correctly renders within the layout and inherits the admin.css dark theme styling.

## Changes
- Removed full HTML document structure (`<!DOCTYPE`, `<html>`, `<head>`, `<body>` tags)
- Converted to content fragment pattern with consistent header styling
- Updated pagination and JavaScript to match other admin pages
- Regenerated the templ Go file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-page EC volume repair workflow with feedback and auto-refresh
  * Collection-aware badges with clickable filtering and Clear Filter action
  * Per-volume actions: View details and Repair

* **Enhancements**
  * Redesigned EC Volumes UI: header toolbar, page-size selector, Refresh
  * Compact neighbor-focused pagination (First/Last, ellipses) and improved sort controls
  * Consolidated statistics cards and clearer, human-friendly shard size and distribution displays

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->