### PR TITLE
Fix admin GUI list ordering on refresh

### DIFF
--- a/weed/admin/dash/admin_data.go
+++ b/weed/admin/dash/admin_data.go
@@ -109,13 +109,6 @@ func (s *AdminServer) GetAdminData(username string) (AdminData, error) {
 		glog.Errorf("Failed to get cluster volume servers: %v", err)
 		return AdminData{}, err
 	}
-	// Sort the servers so they show up in consistent order after each reload
-	sort.Slice(volumeServersData.VolumeServers, func(i, j int) bool {
-		s1Name := volumeServersData.VolumeServers[i].GetDisplayAddress()
-		s2Name := volumeServersData.VolumeServers[j].GetDisplayAddress()
-
-		return s1Name < s2Name
-	})
 
 	// Get master nodes status
 	masterNodes := s.getMasterNodesStatus()
@@ -265,6 +258,11 @@ func (s *AdminServer) getFilerNodesStatus() []FilerNode {
 		return []FilerNode{}
 	}
 
+	// Sort filer nodes by address for consistent ordering on page refresh
+	sort.Slice(filerNodes, func(i, j int) bool {
+		return filerNodes[i].Address < filerNodes[j].Address
+	})
+
 	return filerNodes
 }
 
@@ -300,6 +298,11 @@ func (s *AdminServer) getMessageBrokerNodesStatus() []MessageBrokerNode {
 		// Return empty list if we can't get broker info from master
 		return []MessageBrokerNode{}
 	}
+
+	// Sort message broker nodes by address for consistent ordering on page refresh
+	sort.Slice(messageBrokers, func(i, j int) bool {
+		return messageBrokers[i].Address < messageBrokers[j].Address
+	})
 
 	return messageBrokers
 }

--- a/weed/admin/dash/admin_server.go
+++ b/weed/admin/dash/admin_server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -720,6 +721,11 @@ func (s *AdminServer) GetClusterMasters() (*ClusterMastersData, error) {
 		masters = append(masters, *masterInfo)
 	}
 
+	// Sort masters by address for consistent ordering on page refresh
+	sort.Slice(masters, func(i, j int) bool {
+		return masters[i].Address < masters[j].Address
+	})
+
 	// If no masters found at all, add the current master as fallback
 	if len(masters) == 0 {
 		currentMaster := s.masterClient.GetMaster(context.Background())
@@ -776,6 +782,11 @@ func (s *AdminServer) GetClusterFilers() (*ClusterFilersData, error) {
 		return nil, fmt.Errorf("failed to get filer nodes from master: %w", err)
 	}
 
+	// Sort filers by address for consistent ordering on page refresh
+	sort.Slice(filers, func(i, j int) bool {
+		return filers[i].Address < filers[j].Address
+	})
+
 	return &ClusterFilersData{
 		Filers:      filers,
 		TotalFilers: len(filers),
@@ -817,6 +828,11 @@ func (s *AdminServer) GetClusterBrokers() (*ClusterBrokersData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get broker nodes from master: %w", err)
 	}
+
+	// Sort brokers by address for consistent ordering on page refresh
+	sort.Slice(brokers, func(i, j int) bool {
+		return brokers[i].Address < brokers[j].Address
+	})
 
 	return &ClusterBrokersData{
 		Brokers:      brokers,

--- a/weed/admin/dash/volume_management.go
+++ b/weed/admin/dash/volume_management.go
@@ -544,6 +544,11 @@ func (s *AdminServer) GetClusterVolumeServers() (*ClusterVolumeServersData, erro
 		volumeServers = append(volumeServers, *vs)
 	}
 
+	// Sort volume servers by address for consistent ordering on page refresh
+	sort.Slice(volumeServers, func(i, j int) bool {
+		return volumeServers[i].GetDisplayAddress() < volumeServers[j].GetDisplayAddress()
+	})
+
 	var totalCapacity int64
 	var totalVolumes int
 	for _, vs := range volumeServers {


### PR DESCRIPTION
## Summary

Fixes the issue where lists in the Admin GUI change order on refresh.

## Problem

As reported in #7781, iterating over Go maps with `range` produces non-deterministic ordering, causing lists of filers, volume servers, masters, and message brokers to shuffle on each page refresh.

## Solution

Added `sort.Slice()` calls to sort all relevant lists by address before returning them:

- **`volume_management.go`**: Sort volume servers in `GetClusterVolumeServers()`
- **`admin_data.go`**: Sort filer nodes in `getFilerNodesStatus()` and message brokers in `getMessageBrokerNodesStatus()` (affects main dashboard)
- **`admin_server.go`**: Sort masters in `GetClusterMasters()`, filers in `GetClusterFilers()`, and brokers in `GetClusterBrokers()` (affects dedicated cluster pages)

All lists are now sorted alphabetically by address for consistent ordering.

Fixes #7781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin dashboard now displays cluster masters, filers, brokers and volume servers in a consistent, stable order across page refreshes.

* **New Features**
  * Bucket/collection metadata now surfaces object-lock and versioning status so storage settings are clearer in the admin UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->