### PR TITLE
Fix uncleanable size=0 orphans with volume.fsck -forcePurging

### DIFF
--- a/weed/storage/needle_map_leveldb.go
+++ b/weed/storage/needle_map_leveldb.go
@@ -122,7 +122,7 @@ func generateLevelDbFile(dbFileName string, indexFile *os.File) error {
 		glog.V(0).Infof("generateLevelDbFile %s, watermark %d, num of entries:%d", dbFileName, watermark, (uint64(stat.Size())-watermark*NeedleMapEntrySize)/NeedleMapEntrySize)
 	}
 	return idx.WalkIndexFile(indexFile, watermark, func(key NeedleId, offset Offset, size Size) error {
-		if !offset.IsZero() && size.IsValid() {
+		if !offset.IsZero() && !size.IsDeleted() {
 			levelDbWrite(db, key, offset, size, false, 0)
 		} else {
 			levelDbDelete(db, key)
@@ -380,10 +380,10 @@ func (m *LevelDbNeedleMap) DoOffsetLoading(v *Volume, indexFile *os.File, startF
 			// needle is found
 			oldSize := BytesToSize(data[OffsetSize : OffsetSize+SizeSize])
 			oldOffset := BytesToOffset(data[0:OffsetSize])
-			if !offset.IsZero() && size.IsValid() {
+			if !offset.IsZero() && !size.IsDeleted() {
 				// updated needle
 				m.mapMetric.FileByteCounter += uint64(size)
-				if !oldOffset.IsZero() && oldSize.IsValid() {
+				if !oldOffset.IsZero() && !oldSize.IsDeleted() {
 					m.mapMetric.DeletionCounter++
 					m.mapMetric.DeletionByteCounter += uint64(oldSize)
 				}

--- a/weed/storage/needle_map_memory.go
+++ b/weed/storage/needle_map_memory.go
@@ -40,7 +40,7 @@ func doLoading(file *os.File, nm *NeedleMap) (*NeedleMap, error) {
 			nm.FileCounter++
 			nm.FileByteCounter = nm.FileByteCounter + uint64(size)
 			oldOffset, oldSize := nm.m.Set(NeedleId(key), offset, size)
-			if !oldOffset.IsZero() && oldSize.IsValid() {
+			if !oldOffset.IsZero() && !oldSize.IsDeleted() {
 				nm.DeletionCounter++
 				nm.DeletionByteCounter = nm.DeletionByteCounter + uint64(oldSize)
 			}
@@ -112,10 +112,10 @@ func (nm *NeedleMap) DoOffsetLoading(v *Volume, indexFile *os.File, startFrom ui
 	e := idx.WalkIndexFile(indexFile, startFrom, func(key NeedleId, offset Offset, size Size) error {
 		nm.MaybeSetMaxFileKey(key)
 		nm.FileCounter++
-		if !offset.IsZero() && size.IsValid() {
+		if !offset.IsZero() && !size.IsDeleted() {
 			nm.FileByteCounter = nm.FileByteCounter + uint64(size)
 			oldOffset, oldSize := nm.m.Set(NeedleId(key), offset, size)
-			if !oldOffset.IsZero() && oldSize.IsValid() {
+			if !oldOffset.IsZero() && !oldSize.IsDeleted() {
 				nm.DeletionCounter++
 				nm.DeletionByteCounter = nm.DeletionByteCounter + uint64(oldSize)
 			}

--- a/weed/storage/types/needle_types.go
+++ b/weed/storage/types/needle_types.go
@@ -14,9 +14,18 @@ type Offset struct {
 
 type Size int32
 
+// IsDeleted checks if the needle entry has been marked as deleted (tombstoned).
+// Use this when checking if an entry should exist in the needle map.
+// Returns true for negative sizes or TombstoneFileSize.
+// Note: size=0 is NOT considered deleted - it's an anomalous but active entry.
 func (s Size) IsDeleted() bool {
 	return s < 0 || s == TombstoneFileSize
 }
+
+// IsValid checks if the needle has actual readable data.
+// Use this when checking if needle data can be read or when counting data bytes.
+// Returns true only for positive sizes (size > 0).
+// Note: size=0 returns false - such needles exist in the map but have no readable data.
 func (s Size) IsValid() bool {
 	return s > 0 && s != TombstoneFileSize
 }


### PR DESCRIPTION
## Description

This is a follow-up fix to PR #7332 which partially addressed the issue reported in #7293.

### Problem

Size=0 needles are in a gray area:
- `IsValid()` returns `false` for size=0 (because size must be > 0)
- `IsDeleted()` returns `false` for size=0 (because size must be < 0 or == TombstoneFileSize)

PR #7332 only fixed 2 places (`doLoading` and `doDeleteRequest`), but several other places still had the same bug, causing size=0 orphans to persist even after running `volume.fsck -forcePurging`.

### Root Cause

1. **`needle_map_memory.go:DoOffsetLoading`** - Used during vacuum and incremental loading. Size=0 needles were not loaded into the needle map.

2. **`needle_map_leveldb.go:generateLevelDbFile`** - Used when generating LevelDB needle maps. Same issue.

3. **`needle_map_leveldb.go:DoOffsetLoading`** - Used during incremental loading for LevelDB. Same issue.

4. **`needle_map/compact_map.go:delete`** - Could not delete size=0 entries because:
   - The condition `size > 0 && size.IsValid()` failed for size=0
   - Even if it passed, negating 0 gives 0 (not marking as deleted)

### Changes

- Changed `size.IsValid()` to `!size.IsDeleted()` in `DoOffsetLoading` functions
- Fixed compact_map `delete` to use `TombstoneFileSize` for size=0 entries instead of negating

### Testing

- All existing tests pass
- `go build ./weed/storage/...` compiles successfully

Fixes #7293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deleted entries across storage layers; deleted items are now consistently recognized and recorded, with more reliable tombstone marking.
* **Refactor**
  * Standardized deletion-check logic and bookkeeping across memory, leveldb, and compact storage backends for consistent behavior and simpler maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->