### PR TITLE
fix: correctly detect missing source file during volume copy

### DIFF
--- a/weed/server/volume_grpc_copy.go
+++ b/weed/server/volume_grpc_copy.go
@@ -428,10 +428,10 @@ func (vs *VolumeServer) CopyFile(req *volume_server_pb.CopyFileRequest, stream v
 
 	}
 
-	// If the file exists but is empty (or smaller than stopOffset), we still need to
-	// send the ModifiedTsNs so the client knows the source file exists.
-	// fileModTsNs is set to 0 after the first send, so if it's still non-zero,
-	// we haven't sent anything yet.
+// If no data has been sent in the loop (e.g. for an empty file, or when stopOffset is 0),
+// we still need to send the ModifiedTsNs so the client knows the source file exists.
+// fileModTsNs is set to 0 after the first send, so if it's still non-zero,
+// we haven't sent anything yet.
 	if fileModTsNs != 0 {
 		err = stream.Send(&volume_server_pb.CopyFileResponse{
 			ModifiedTsNs: fileModTsNs,


### PR DESCRIPTION
## Problem

The previous fix (commit 5c27522) incorrectly used `progressedBytes == 0` to detect if the source file didn't exist. This was wrong because it would also delete files when the source file exists but is empty.

## Solution

1. **Server side**: Send `ModifiedTsNs` even for empty files, so the client knows the source file exists
2. **Client side**: Check `modifiedTsNs == 0` instead of `progressedBytes == 0` to determine if source file didn't exist

## Behavior now

| Scenario | `modifiedTsNs` received? | Result |
|----------|--------------------------|--------|
| Source file doesn't exist | No (0) | Remove empty file ✓ |
| Source file exists but is empty | Yes (timestamp) | Keep empty file ✓ |
| Source file exists with content | Yes (timestamp) | Keep file with content ✓ |

Fixes #7777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate handling of empty and truncated files during copy: destination-file removal now depends on whether source modification info was received, preventing unintended deletions.
  * Clients are now reliably informed of source-file existence and modification time even when no file data is transferred (e.g., empty or zero-byte transfers), improving sync correctness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->