### PR TITLE
s3: add pagination to getObjectVersionList and reduce memory

### DIFF
--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -544,8 +544,8 @@ func (s3a *S3ApiServer) getObjectVersionList(bucket, object string) ([]*ObjectVe
 	for {
 		entries, isLast, err := s3a.list(versionsDir, "", startFrom, false, pageSize)
 		if err != nil {
-			glog.V(2).Infof("getObjectVersionList: failed to list version files: %v", err)
-			return versions, nil
+			glog.Warningf("getObjectVersionList: failed to list version files in %s: %v", versionsDir, err)
+			return nil, err
 		}
 
 		totalEntries += len(entries)


### PR DESCRIPTION
## Problem

1. **Missing versions**: `getObjectVersionList` had a hardcoded limit of 1000 versions. Objects with more than 1000 versions would have some versions missing from list results.

2. **Memory bloat**: The `ObjectVersion` struct stored the full `filer_pb.Entry` including the `Chunks` array, which can be very large for big files.

## Solution

### 1. Add pagination to `getObjectVersionList`

- Use `startFrom` marker to paginate through all version files
- Continue fetching until `isLast` is true or page size is not reached
- Fixes correctness issue where objects with >1000 versions were incomplete

### 2. Reduce memory footprint

- Replace `Entry *filer_pb.Entry` with `OwnerID string` in `ObjectVersion` struct
- Extract owner ID when creating `ObjectVersion` instead of keeping full Entry
- Call `clear(seenVersionIds)` after use to help GC reclaim memory sooner

### 3. Update `getObjectOwnerFromVersion`

- Use new `OwnerID` field directly instead of accessing `Entry.Extended`
- Maintains backward compatibility with fallback lookups

## Testing

- Verified compilation: `go build ./weed/s3api/...`

## Related

This is part of a series of memory/correctness fixes for S3 versioning operations. See also #7785 and #7786.