### PR TITLE
fix: JWT validation failures during replication (#7788)

### DIFF
--- a/weed/server/volume_server_handlers.go
+++ b/weed/server/volume_server_handlers.go
@@ -363,7 +363,12 @@ func (vs *VolumeServer) maybeCheckJwtAuthorization(r *http.Request, vid, fid str
 		if sepIndex := strings.LastIndex(fid, "_"); sepIndex > 0 {
 			fid = fid[:sepIndex]
 		}
-		return sc.Fid == vid+","+fid
+		expectedFid := vid + "," + fid
+		if sc.Fid != expectedFid {
+			glog.V(1).Infof("jwt fid mismatch from %s: token has %q, request has %q", r.RemoteAddr, sc.Fid, expectedFid)
+			return false
+		}
+		return true
 	}
 	glog.V(1).Infof("unexpected jwt from %s: %v", r.RemoteAddr, tokenStr)
 	return false


### PR DESCRIPTION
## Problem

Volume servers were returning "wrong jwt" errors during replication despite identical JWT config and NTP sync, as reported in #7788.

## Root Cause

In `parseURLPath()`, the `commaIndex` and `dotIndex` were calculated relative to a substring (`path[sepIndex:]`) but then used as absolute indices into the full `path` string. This caused incorrect parsing of file IDs, especially for larger volume IDs like `69240`.

For example, with path `/69240,xxxx`:
- `sepIndex = 0` (works correctly by coincidence)

But if there was a prefix like `/prefix/69240,xxxx`:
- `sepIndex = 7`, `commaIndex = 6` (relative)
- Using `path[sepIndex+1 : commaIndex]` = `path[8:6]` would cause an error

## Changes

1. **Fixed `parseURLPath()`** in `weed/server/common.go`:
   - Convert relative indices to absolute before using them

2. **Added debug logging** in `weed/server/volume_server_handlers.go`:
   - Log when JWT file ID doesn't match the request file ID
   - This helps debug similar issues in the future

3. **Added test cases** in `weed/server/common_test.go`:
   - Tests for large volume IDs like `69240`
   - Tests for file IDs with extensions

## Testing

```bash
go test ./weed/server/... -run TestParseURL -v
```

Fixes #7788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL path parsing to properly extract volume IDs, file IDs, and extensions when using comma separators.
  * Enhanced JWT authorization validation with improved error detection and logging.

* **Tests**
  * Added test cases for URL parsing with large volume IDs and file extensions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->