### PR TITLE
fix: use unique bucket name in TestS3IAMPresignedURLIntegration to avoid flaky test

### DIFF
--- a/test/s3/iam/s3_iam_integration_test.go
+++ b/test/s3/iam/s3_iam_integration_test.go
@@ -558,13 +558,14 @@ func TestS3IAMPresignedURLIntegration(t *testing.T) {
 	adminClient, err := framework.CreateS3ClientWithJWT("admin-user", "TestAdminRole")
 	require.NoError(t, err)
 
-	// Use static bucket name but with cleanup to handle conflicts
-	err = framework.CreateBucketWithCleanup(adminClient, testBucket)
+	// Use unique bucket name to avoid conflicts with other tests
+	bucketName := framework.GenerateUniqueBucketName("test-iam-presigned")
+	err = framework.CreateBucket(adminClient, bucketName)
 	require.NoError(t, err)
 
 	// Put test object
 	_, err = adminClient.PutObject(&s3.PutObjectInput{
-		Bucket: aws.String(testBucket),
+		Bucket: aws.String(bucketName),
 		Key:    aws.String(testObjectKey),
 		Body:   strings.NewReader(testObjectData),
 	})
@@ -586,7 +587,7 @@ func TestS3IAMPresignedURLIntegration(t *testing.T) {
 
 		// Test direct object access with JWT Bearer token (recommended approach)
 		_, err := adminClient.GetObject(&s3.GetObjectInput{
-			Bucket: aws.String(testBucket),
+			Bucket: aws.String(bucketName),
 			Key:    aws.String(testObjectKey),
 		})
 		require.NoError(t, err, "Direct object access with JWT Bearer token works correctly")
@@ -597,13 +598,13 @@ func TestS3IAMPresignedURLIntegration(t *testing.T) {
 
 	// Cleanup
 	_, err = adminClient.DeleteObject(&s3.DeleteObjectInput{
-		Bucket: aws.String(testBucket),
+		Bucket: aws.String(bucketName),
 		Key:    aws.String(testObjectKey),
 	})
 	require.NoError(t, err)
 
 	_, err = adminClient.DeleteBucket(&s3.DeleteBucketInput{
-		Bucket: aws.String(testBucket),
+		Bucket: aws.String(bucketName),
 	})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Problem

The test `TestS3IAMPresignedURLIntegration` was flaky, failing with `AccessDenied` errors:

```
=== RUN   TestS3IAMPresignedURLIntegration
    s3_iam_framework.go:697: Bucket test-iam-bucket already exists, cleaning up first
    s3_iam_framework.go:705: Warning: Failed to delete existing bucket test-iam-bucket: NoSuchBucket
    s3_iam_framework.go:719: Bucket test-iam-bucket still exists after cleanup, reusing it
    s3_iam_integration_test.go:571: AccessDenied: Access Denied.
--- FAIL: TestS3IAMPresignedURLIntegration (0.56s)
```

## Root Cause

The test was using a static bucket name `test-iam-bucket` that could conflict with buckets created by other tests or previous runs:

1. Each `NewS3IAMTestFramework` creates new RSA keys for JWT signing
2. When a bucket exists from a previous test (with different RSA keys), the "admin-user" identity is different
3. The new admin cannot delete or access the old bucket (AccessDenied), even though they have the same username
4. The `CreateBucketWithCleanup` function tried to handle this but failed because the new admin can't operate on buckets owned by a different identity

## Solution

Changed the test to use `GenerateUniqueBucketName("test-iam-presigned")` instead of the static `testBucket` constant. This ensures each test run gets its own uniquely-named bucket, avoiding conflicts with other tests or previous runs.

This follows the same pattern already used by other tests in the file (e.g., `TestS3IAMBucketPolicyIntegration`).