### PR TITLE
fix: initialize missing MasterOptions fields in master.follower

### DIFF
--- a/weed/command/master_follower.go
+++ b/weed/command/master_follower.go
@@ -41,6 +41,9 @@ func init() {
 	mf.metricsAddress = aws.String("")
 	mf.metricsIntervalSec = aws.Int(0)
 	mf.raftResumeState = aws.Bool(false)
+	mf.maxParallelVacuumPerServer = aws.Int(1)
+	mf.telemetryUrl = aws.String("")
+	mf.telemetryEnabled = aws.Bool(false)
 }
 
 var cmdMasterFollower = &Command{


### PR DESCRIPTION
## Summary
Fix nil pointer dereference panic when starting `master.follower`.

## Problem
The `init()` function in `master_follower.go` was missing initialization for several fields that are dereferenced in `toMasterOption()`:
- `maxParallelVacuumPerServer`
- `telemetryUrl`
- `telemetryEnabled`

This caused a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x37e6ae6]

goroutine 1 [running]:
github.com/seaweedfs/seaweedfs/weed/command.(*MasterOptions).toMasterOption(...)
    /github/workspace/weed/command/master.go:364 +0xc6
```

## Solution
Added initialization for the missing fields with sensible defaults matching the main `master` command.

Fixes #7806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established default configuration values for master server operations, including settings for parallel vacuum operations (default: 1) and telemetry initialization (disabled by default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->