### PR TITLE
fix: use consistent telemetryUrl default in master.follower

### DIFF
--- a/weed/command/master_follower.go
+++ b/weed/command/master_follower.go
@@ -42,7 +42,7 @@ func init() {
 	mf.metricsIntervalSec = aws.Int(0)
 	mf.raftResumeState = aws.Bool(false)
 	mf.maxParallelVacuumPerServer = aws.Int(1)
-	mf.telemetryUrl = aws.String("")
+	mf.telemetryUrl = aws.String("https://telemetry.seaweedfs.com/api/collect")
 	mf.telemetryEnabled = aws.Bool(false)
 }
 


### PR DESCRIPTION
## Summary
Update `telemetryUrl` default value in `master.follower` to match the master command for consistency.

## Problem
In PR #7808, the `telemetryUrl` was initialized to an empty string, while the main `master` command defaults to `https://telemetry.seaweedfs.com/api/collect`.

## Solution
Changed the default `telemetryUrl` value to match the master command:
```go
mf.telemetryUrl = aws.String("https://telemetry.seaweedfs.com/api/collect")
```

This has no functional impact since telemetry is disabled by default, but aligns the defaults for better maintainability.

Addresses review feedback from #7808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default telemetry collection endpoint configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->