### PR TITLE
Upgrade raft to v1.1.6 to fix panic on log compaction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/seaweedfs/goexif v1.0.3
-	github.com/seaweedfs/raft v1.1.3
+	github.com/seaweedfs/raft v1.1.6
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1618,8 +1618,8 @@ github.com/seaweedfs/cockroachdb-parser v0.0.0-20251021184156-909763b17138 h1:bX
 github.com/seaweedfs/cockroachdb-parser v0.0.0-20251021184156-909763b17138/go.mod h1:JSKCh6uCHBz91lQYFYHCyTrSVIPge4SUFVn28iwMNB0=
 github.com/seaweedfs/goexif v1.0.3 h1:ve/OjI7dxPW8X9YQsv3JuVMaxEyF9Rvfd04ouL+Bz30=
 github.com/seaweedfs/goexif v1.0.3/go.mod h1:Oni780Z236sXpIQzk1XoJlTwqrJ02smEin9zQeff7Fk=
-github.com/seaweedfs/raft v1.1.3 h1:5B6hgneQ7IuU4Ceom/f6QUt8pEeqjcsRo+IxlyPZCws=
-github.com/seaweedfs/raft v1.1.3/go.mod h1:9cYlEBA+djJbnf/5tWsCybtbL7ICYpi+Uxcg3MxjuNs=
+github.com/seaweedfs/raft v1.1.6 h1:e83Xn0boscPnuSiBllUPeWRVS6JKrqJPYBozgFyBiC0=
+github.com/seaweedfs/raft v1.1.6/go.mod h1:9cYlEBA+djJbnf/5tWsCybtbL7ICYpi+Uxcg3MxjuNs=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=


### PR DESCRIPTION
## Issue

Fixes #7810

Users upgrading to 4.03_large_disk were experiencing panics on seaweed master:

```
panic: raft: Index is beyond end of log: 7 102452

goroutine 3134 [running]:
github.com/seaweedfs/raft.(*Log).getEntriesAfter(0xc00092a070, 0x19034, 0x7d0)
	/go/pkg/mod/github.com/seaweedfs/raft@v1.1.3/log.go:256 +0x73a
```

## Root Cause

The panic occurs when:
1. A server becomes leader and sets all peers' `prevLogIndex` to its current log index
2. Log compaction runs (via snapshot), reducing the number of entries and updating `startIndex`
3. When `peer.flush()` calls `getEntriesAfter(prevLogIndex)`, the stale `prevLogIndex` is now beyond the end of the compacted log
4. The check `index > (len(entries) + startIndex)` triggers a panic

## Fix

The fix in raft v1.1.6 changes the panic to return `nil, 0` instead, which triggers the snapshot fallback in `peer.flush()` - the same behavior as when `index < startIndex`.

See: https://github.com/seaweedfs/raft/commit/5770300cecb1b1997fba71a27c96324904178898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest stable versions for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->