### PR TITLE
master: enable hashicorp raft by default, deprecate seaweedfs/raft

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -96,7 +96,7 @@ func init() {
 	m.raftResumeState = cmdMaster.Flag.Bool("resumeState", false, "resume previous state on start master server")
 	m.heartbeatInterval = cmdMaster.Flag.Duration("heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	m.electionTimeout = cmdMaster.Flag.Duration("electionTimeout", 10*time.Second, "election timeout of master servers")
-	m.raftHashicorp = cmdMaster.Flag.Bool("raftHashicorp", false, "use hashicorp raft")
+	m.raftHashicorp = cmdMaster.Flag.Bool("raftHashicorp", true, "use hashicorp raft (recommended, will become the only option in future versions)")
 	m.raftBootstrap = cmdMaster.Flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	m.telemetryUrl = cmdMaster.Flag.String("telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL to send usage statistics")
 	m.telemetryEnabled = cmdMaster.Flag.Bool("telemetry", false, "enable telemetry reporting")
@@ -216,6 +216,9 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 			glog.Fatalf("NewHashicorpRaftServer: %s", err)
 		}
 	} else {
+		glog.Warningf("The legacy raft implementation (seaweedfs/raft) is deprecated and will be removed in a future version.")
+		glog.Warningf("Please migrate to hashicorp raft by adding -raftHashicorp=true flag.")
+		glog.Warningf("Migration requires: 1) stop all masters, 2) clear raft data (log/, conf/, snapshot/ dirs), 3) restart with -raftHashicorp=true -raftBootstrap")
 		raftServer, err = weed_server.NewRaftServer(raftServerOption)
 		if raftServer == nil {
 			glog.Fatalf("please verify %s is writable, see https://github.com/seaweedfs/seaweedfs/issues/717: %s", *masterOption.metaFolder, err)


### PR DESCRIPTION
## Summary

This PR enables hashicorp raft by default while keeping the legacy seaweedfs/raft available for existing deployments. This allows a smooth transition period before removing seaweedfs/raft in a future version.

## Changes

1. Change default value of `-raftHashicorp` from `false` to `true`
2. Add deprecation warning when legacy raft is used (`-raftHashicorp=false`)
3. Include migration instructions in the warning message

## Impact

### New Deployments
- Will use hashicorp raft by default
- No action required

### Existing Deployments Using Legacy Raft
- **Continue to work** with explicit `-raftHashicorp=false`
- Will see deprecation warnings at startup
- Can migrate at their convenience before the legacy implementation is removed

## Migration Instructions (for existing deployments)

When ready to migrate:

```bash
# 1. Stop all master servers

# 2. Clear old raft data on all masters
rm -rf <mdir>/m*/log <mdir>/m*/conf <mdir>/m*/snapshot

# 3. Start first master with bootstrap flag
weed master -raftHashicorp=true -raftBootstrap ...

# 4. Start remaining masters
weed master -raftHashicorp=true ...
```

Note: The MaxVolumeId state is recovered automatically from volume server heartbeats after restart.

## Future Plan

In a future version (after sufficient transition period), the legacy seaweedfs/raft implementation will be removed entirely.