### PR TITLE
fix: prevent panic on close of closed channel in worker client reconnection

### DIFF
--- a/weed/worker/client.go
+++ b/weed/worker/client.go
@@ -98,7 +98,10 @@ func NewGrpcAdminClient(adminAddress string, workerID string, dialOption grpc.Di
 	return c
 }
 
-// safeCloseChannel safely closes a channel and sets it to nil to prevent double-close panics
+// safeCloseChannel safely closes a channel and sets it to nil to prevent double-close panics.
+// NOTE: This function is NOT thread-safe. It is safe to use in this codebase because all calls
+// are serialized within the managerLoop goroutine. If this function is used in concurrent contexts
+// in the future, synchronization (e.g., sync.Mutex) should be added.
 func (c *GrpcAdminClient) safeCloseChannel(chPtr *chan struct{}) {
 	if *chPtr != nil {
 		close(*chPtr)


### PR DESCRIPTION
## Problem

A panic 'close of closed channel' occurs in the worker client when reconnecting to the admin server. The issue happens because the `streamExit` channel can be closed multiple times without proper synchronization.

## Root Cause

The `streamExit` channel was being closed in multiple places (`reconnect()` and `handleDisconnect()`) without checking if it had already been closed. This leads to a panic when attempting to close an already-closed channel.

## Solution

- Add `streamExitOnce` flag to the `grpcState` struct to prevent double-closing the `streamExit` channel
- Check the flag before closing in `reconnect()` and `handleDisconnect()` functions
- Reset the flag after cleanup to allow proper channel creation in the next connection cycle
- Also add safety check for `reconnectStop` channel close

## Testing

The fix has been verified by running `weed mini` for extended periods. Previously, the panic would occur during worker reconnection attempts. Now the application runs cleanly without any panic errors.

## Changes

- Modified `grpcState` struct: added `streamExitOnce bool` field
- Updated `reconnect()` function to check flag before closing
- Updated `handleDisconnect()` function to check flag before closing
- Added reset of `streamExitOnce` flag after cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker connection handling to prevent duplicate resource-closure errors during registration, reconnection, and disconnect flows. This reduces crashes and connection-related interruptions, improving stability, uptime, and overall reliability of worker services and service-to-service communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->