### PR TITLE
fix: enable RetryForever for active-active cluster sync to prevent out-of-sync

### DIFF
--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -2,11 +2,12 @@ package filersink
 
 import (
 	"fmt"
-	"github.com/schollz/progressbar/v3"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/schollz/progressbar/v3"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"google.golang.org/grpc"
 
@@ -114,6 +115,7 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string)
 			IsInputCompressed: "gzip" == header.Get("Content-Encoding"),
 			MimeType:          header.Get("Content-Type"),
 			PairMap:           nil,
+			RetryForever:      true,
 		},
 		func(host, fileId string) string {
 			fileUrl := fmt.Sprintf("http://%s/%s", host, fileId)


### PR DESCRIPTION
## Summary

Fixes #7230

When a cluster goes down during file replication, the chunk upload process would fail after a limited number of retries. Once the remote cluster came back online, those failed uploads were never retried, leaving the clusters out-of-sync.

## Changes

This change enables the `RetryForever` flag in the `UploadOption` when replicating chunks between filers in the FilerSink. This ensures that upload operations will keep retrying indefinitely.

## How it works

- When a remote cluster is down, chunk uploads will continue to retry
- Once the remote cluster comes back online, pending uploads will automatically succeed
- This prevents the manual workaround of running `fs.meta.save` and `fs.meta.load`

## Files Modified

- `weed/replication/sink/filersink/fetch_write.go`: Added `RetryForever: true` to UploadOption in the `fetchAndWrite` method

## Testing

This change applies the same retry mechanism that is already used elsewhere in the codebase for other critical upload operations. The change is minimal and focused on solving the specific issue of cluster sync resilience.