### PR TITLE
Support volume server ID in Helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -176,6 +176,9 @@ spec:
                 {{- if $volume.dataCenter }}
                 -dataCenter={{ $volume.dataCenter }} \
                 {{- end }}
+                {{- if $volume.id }}
+                -id={{ $volume.id }} \
+                {{- end }}
                 -ip.bind={{ $volume.ipBind }} \
                 -readMode={{ $volume.readMode }} \
                 {{- if $volume.whiteList }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -401,6 +401,10 @@ volume:
   # Volume server's rack name
   rack: null
 
+  # Stable identifier for the volume server, independent of IP address
+  # Useful for Kubernetes environments with hostPath volumes to maintain stable identity
+  id: null
+
   # Volume server's data center name
   dataCenter: null
 


### PR DESCRIPTION
# What problem are we solving?

Support for separate volume server ID in the Helm chart (added in #7609) raised in #7487

# How are we solving the problem?

Extending the chart to support the new `id` flag

# How is the PR tested?

Ran in-cluster and automated checks

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional volume server identifier configuration for SeaweedFS Kubernetes deployments. Volume servers can now maintain stable identity across restarts and scaling operations in persistent storage environments, improving overall system reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->