### PR TITLE
fix: restore TimeToFirstByte metric for S3 GetObject operations (issue #7869)

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1028,6 +1028,9 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		w.WriteHeader(http.StatusOK)
 	}
 
+	// Track time to first byte metric
+	TimeToFirstByte(r.Method, t0, r)
+
 	// Stream directly to response with counting wrapper
 	tStreamExec := time.Now()
 	glog.V(4).Infof("streamFromVolumeServers: starting streamFn, offset=%d, size=%d", offset, size)
@@ -1236,7 +1239,12 @@ func (s3a *S3ApiServer) streamFromVolumeServersWithSSE(w http.ResponseWriter, r 
 	// Now write status code (headers are all set)
 	if isRangeRequest {
 		w.WriteHeader(http.StatusPartialContent)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
+
+	// Track time to first byte metric
+	TimeToFirstByte(r.Method, t0, r)
 
 	// Full Range Optimization: Use ViewFromChunks to only fetch/decrypt needed chunks
 	tDecryptSetup := time.Now()


### PR DESCRIPTION
This PR restores the missing TimeToFirstByte() metric call that was accidentally removed in PR #7481.

## Issue
The `SeaweedFS_s3_time_to_first_byte_millisecond_bucket` Prometheus metric was missing since version 4.01, making it impossible to monitor first-byte response times for S3 GET operations.

## Changes
- Added `TimeToFirstByte()` call in `streamFromVolumeServersWithSSE` function to track TTFB for SSE-encrypted objects
- Added `TimeToFirstByte()` call in `streamFromVolumeServers` function to track TTFB for non-encrypted objects
- Both calls are made right after `WriteHeader()` to accurately record when the first byte is sent to the client

## Impact
This metric is essential for:
- Monitoring cluster performance under load
- Debugging latency issues in S3 GET operations
- Measuring response time characteristics for both encrypted and non-encrypted objects

Closes #7869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced observability by adding Time To First Byte (TTFB) metrics tracking for S3 object streaming operations
  * TTFB metrics now captured for both encrypted and standard data transfer paths
  * Improved monitoring without affecting error handling or public APIs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->