### PR TITLE
fix: Correct admin server port in Helm worker deployment

### DIFF
--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -134,7 +134,7 @@ spec:
               {{- if .Values.worker.adminServer }}
               -admin={{ .Values.worker.adminServer }} \
               {{- else }}
-              -admin={{ template "seaweedfs.name" . }}-admin.{{ .Release.Namespace }}:{{ .Values.admin.grpcPort }} \
+              -admin={{ template "seaweedfs.name" . }}-admin.{{ .Release.Namespace }}:{{ .Values.admin.port }} \
               {{- end }}
               -capabilities={{ .Values.worker.capabilities }} \
               -maxConcurrent={{ .Values.worker.maxConcurrent }} \


### PR DESCRIPTION
# What problem are we solving?

The worker deployment was incorrectly passing the admin gRPC port (33646) to the -admin flag. However, `weed worker` automatically calculates the gRPC port by adding 10000 to the HTTP port provided.

This caused workers to attempt connection to port 43646 (33646 + 10000) instead of the correct gRPC port 33646 (23646 + 10000).

# How are we solving the problem?

- Update worker-deployment.yaml to use admin.port instead of admin.grpcPort
- Workers now correctly connect to admin HTTP port, allowing the binary to calculate the gRPC port automatically

Fixes workers failing with:
"dial tcp <admin-ip>:43646: connect: no route to host"

# How is the PR tested?

In-cluster and automated tests


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker deployment admin port configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->