### PR TITLE
Fix the issue where fuse command on a node cannot specify multiple configuration directory paths

### DIFF
--- a/weed/command/fuse.go
+++ b/weed/command/fuse.go
@@ -28,3 +28,7 @@ var cmdFuse = &Command{
   To check valid options look "weed mount --help"
   `,
 }
+
+func GetFuseCommandName() string {
+	return cmdFuse.Name()
+}

--- a/weed/command/fuse_std.go
+++ b/weed/command/fuse_std.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
 type parameter struct {
@@ -219,6 +222,8 @@ func runFuse(cmd *Command, args []string) bool {
 			}
 		case "fusermount.path":
 			fusermountPath = parameter.value
+		case "config_dir":
+			util.ConfigurationFileDirectory.Set(parameter.value)
 		default:
 			t := parameter.name
 			if parameter.value != "true" {
@@ -227,6 +232,8 @@ func runFuse(cmd *Command, args []string) bool {
 			mountOptions.extraOptions = append(mountOptions.extraOptions, t)
 		}
 	}
+
+	util_http.InitGlobalHttpClient()
 
 	// the master start the child, release it then finish himself
 	if masterProcess {

--- a/weed/weed.go
+++ b/weed/weed.go
@@ -85,8 +85,9 @@ func main() {
 		}
 		return
 	}
-
-	util_http.InitGlobalHttpClient()
+	if args[0] != command.GetFuseCommandName() {
+		util_http.InitGlobalHttpClient()
+	}
 	for _, cmd := range commands {
 		if cmd.Name() == args[0] && cmd.Run != nil {
 			cmd.Flag.Usage = func() { cmd.Usage() }


### PR DESCRIPTION
Fix the issue where fuse command on a node cannot specify multiple configuration directory paths

Changes:
    Modified weed/command/fuse.go to add a function GetFuseCommandName to return the name of the fuse command.
    Modified weed/weed.go to conditionally initialize the global HTTP client only if the command is not "fuse".
    Modified weed/command/fuse_std.go to parse parameters and ensure the global HTTP client is initialized for the fuse command.

Tests:
  Use /etc/fstab like:
  fuse /repos fuse.weed filer=192.168.1.101:7202,filer.path=/hpc/repos,config_dir=/etc/seaweedfs/seaweedfs_01 0 0
  fuse /opt/ohpc/pub fuse.weed filer=192.168.1.102:7202,filer.path=/hpc_cluster/pub,config_dir=/etc/seaweedfs/seaweedfs_02 0 0

# What problem are we solving?



# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `config_dir` parameter support for the fuse command, allowing users to specify a custom configuration directory location.

* **Improvements**
  * Optimized HTTP client initialization to run only when necessary, improving startup performance for certain operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->