### PR TITLE
fix(filer): check error from FindEntry

### DIFF
--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -258,7 +258,6 @@ func (f *Filer) ensureParentDirectoryEntry(ctx context.Context, entry *Entry, di
 
 	// check the store directly
 	glog.V(4).InfofCtx(ctx, "find uncached directory: %s", dirPath)
-	dirEntry, _ := f.FindEntry(ctx, util.FullPath(dirPath))
 	dirEntry, findErr := f.FindEntry(ctx, util.FullPath(dirPath))
 	if findErr != nil && !errors.Is(findErr, filer_pb.ErrNotFound) {
 		return findErr


### PR DESCRIPTION
# What problem are we solving?
Check the error returned by FindEntry; only proceed with the subsequent flow when the error is ErrNotFound, to prevent existing records from being overwritten by an update, especially for the bucket metadata in filedata .


# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for file operations: errors occurring during directory lookups are now properly reported instead of being silently ignored, improving visibility into system issues and enabling more effective troubleshooting.
  * Expected "not found" cases remain handled separately so normal absent-directory behavior is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->