### PR TITLE
filer.backup: ignore missing volume/lookup errors when -ignore404Error is set

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -152,12 +152,10 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 				return nil
 			}
 			// also ignore missing volume/lookup errors coming from LookupFileId or vid map
-			if err != nil {
-				errStr := err.Error()
-				if strings.Contains(errStr, "LookupFileId") || (strings.Contains(errStr, "volume id") && strings.Contains(errStr, "not found")) {
-					glog.V(0).Infof("got missing-volume error, ignore it: %s", errStr)
-					return nil
-				}
+			errStr := err.Error()
+			if strings.Contains(errStr, "LookupFileId") || (strings.Contains(errStr, "volume id") && strings.Contains(errStr, "not found")) {
+				glog.V(0).Infof("got missing-volume error, ignore it: %s", errStr)
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
Fixes #7888: treat missing-volume/LookupFileId errors as ignorable when -ignore404Error is set so filer.backup doesn't stall on deleted volumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backup process now better ignores missing remote data when the "ignore errors" option is enabled: HTTP 404s and other remote-read failures that indicate missing volumes are logged as missing and no longer abort the backup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->