### PR TITLE
Fix bucket name case sensitivity in remote gateway (#7910)

### DIFF
--- a/weed/command/filer_remote_gateway_buckets.go
+++ b/weed/command/filer_remote_gateway_buckets.go
@@ -3,6 +3,12 @@ package command
 import (
 	"context"
 	"fmt"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -12,11 +18,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/replication/source"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"google.golang.org/protobuf/proto"
-	"math"
-	"math/rand"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 func (option *RemoteGatewayOptions) followBucketUpdatesAndUploadToRemote(filerSource *source.FilerSource) error {
@@ -100,7 +101,7 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 			return err
 		}
 
-		bucketName := strings.ToLower(entry.Name)
+		bucketName := entry.Name
 		if *option.include != "" {
 			if ok, _ := filepath.Match(*option.include, entry.Name); !ok {
 				return nil


### PR DESCRIPTION
## Problem

GitHub discussion #7910 reported that file names with uppercase letters (e.g., `File.svg`) don't work properly. Investigation revealed that bucket names were being converted to lowercase in the remote gateway code.

## Root Cause

In `weed/command/filer_remote_gateway_buckets.go:103`, bucket names were converted to lowercase with `strings.ToLower(entry.Name)` when creating remote storage buckets. This created a mismatch:
- Local filer path: `/buckets/MyBucket/File.svg` (case preserved)
- Remote bucket name: `mybucket` (lowercase)

## Solution

Removed the `strings.ToLower` conversion to preserve case consistency between local filer paths and remote bucket names. Cloud providers like AWS S3 support mixed-case bucket names and will enforce their own naming rules if needed.

## Testing

- Build verified successfully
- Case preservation confirmed in code review

Fixes #7910 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket names in remote storage mappings now retain their original case instead of being converted to lowercase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->