### PR TITLE
fix: correcting S3 nil cipher dereference in filer init

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -137,6 +137,7 @@ func init() {
 	filerS3Options.concurrentUploadLimitMB = cmdFiler.Flag.Int("s3.concurrentUploadLimitMB", 0, "limit total concurrent upload size for S3, 0 means unlimited")
 	filerS3Options.concurrentFileUploadLimit = cmdFiler.Flag.Int("s3.concurrentFileUploadLimit", 0, "limit number of concurrent file uploads for S3, 0 means unlimited")
 	filerS3Options.enableIam = cmdFiler.Flag.Bool("s3.iam", true, "enable embedded IAM API on the same S3 port")
+	filerS3Options.cipher = cmdFiler.Flag.Bool("s3.encryptVolumeData", false, "encrypt data on volume servers for S3 uploads")
 
 	// start webdav on filer
 	filerStartWebDav = cmdFiler.Flag.Bool("webdav", false, "whether to start webdav gateway")


### PR DESCRIPTION
# What problem are we solving?
Resolves the following error reported in #7949:
```
I0103 21:38:30.230662 s3.go:275 Starting S3 API Server with standard IAM
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x38ca961]

goroutine 102 [running]:
github.com/seaweedfs/seaweedfs/weed/command.(*S3Options).startS3Server(0x7caf840)
    /go/src/github.com/seaweedfs/seaweedfs/weed/command/s3.go:295 +0x741
github.com/seaweedfs/seaweedfs/weed/command.runFiler.func1(...)
    /go/src/github.com/seaweedfs/seaweedfs/weed/command/filer.go:244
created by github.com/seaweedfs/seaweedfs/weed/command.runFiler in goroutine 1
    /go/src/github.com/seaweedfs/seaweedfs/weed/command/filer.go:242 +0x353
```

# How are we solving the problem?
`filerS3Options.cipher` is being set during filer S3 initialization.

# How is the PR tested?
Tested manually to ensure filer starts up & gets past its S3 initialization stage:
```
$ sudo ./weed -v=4 -logtostderr filer -master=127.0.0.1:8888 -s3
...
I0103 16:47:41.205883 s3.go:244 S3 read filer buckets dir: /buckets
I0103 16:47:41.205909 s3.go:246 S3 read master addresses for discovery: [192.168.68.60:9333]
I0103 16:47:41.205922 s3.go:254 connected to filers [192.168.68.60:8888]
I0103 16:47:41.205954 s3.go:275 Starting S3 API Server with standard IAM
I0103 16:47:41.206378 config.go:53 Reading : Config File "credential" Not Found in "[~/code/seaweedfs/weed ~/.seaweedfs /usr/local/etc/seaweedfs /etc/seaweedfs]"
I0103 16:47:41.206401 config_loader.go:23 No credential.toml found, credential store disabled
I0103 16:47:41.206412 config_loader.go:122 No credential.toml found, defaulting to filer_etc store
I0103 16:47:41.206455 auth_credentials.go:148 Credential store configured with temporary filer function (will be updated after FilerClient creation)
I0103 16:47:41.206459 auth_credentials.go:169 no static config file specified... loading config from credential manager
I0103 16:47:41.206468 auth_credentials.go:870 Loading S3 API configuration from credential manager
I0103 16:47:41.206484 filer_etc_identity.go:18 Loading IAM configuration from /etc/iam/identity.json (using current active filer)
I0103 16:47:41.206493 grpc_client_server.go:119 gRPC cache hit for 192.168.68.60:18888 (version 7838711144943790842)
I0103 16:47:41.207254 filer_etc_identity.go:28 IAM identity file not found at /etc/iam/identity.json, no credentials loaded
I0103 16:47:41.207261 auth_credentials.go:878 Credential manager returned 0 identities and 0 accounts
I0103 16:47:41.207270 auth_credentials.go:395 Loaded 0 identities, 2 accounts, 0 access keys. Auth enabled: false
I0103 16:47:41.207275 auth_credentials.go:399 Access key to identity mapping:
I0103 16:47:41.207278 auth_credentials.go:886 Successfully loaded S3 API configuration from credential manager
I0103 16:47:41.207311 s3api_server.go:135 S3 API initialized FilerClient with 1 filer(s) (no discovery)
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line flag to enable encryption for volume data during S3 uploads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->