### PR TITLE
Fix unaligned 64-bit atomic operation on ARM32 (#7958)

### DIFF
--- a/weed/filer/meta_aggregator.go
+++ b/weed/filer/meta_aggregator.go
@@ -31,8 +31,8 @@ type MetaAggregator struct {
 	peerChansLock  sync.Mutex
 	// notifying clients
 	ListenersLock  sync.Mutex
-	ListenersCond  *sync.Cond
 	ListenersWaits int64 // Atomic counter
+	ListenersCond  *sync.Cond
 }
 
 // MetaAggregator only aggregates data "on the fly". The logs are not re-persisted to disk.


### PR DESCRIPTION
# What problem are we solving?

Bug: unaligned 64-bit atomic operation error on ARM32 #7958

On 64-bit systems the "*sync.Cond" pointer is 64-bits long, which means that the following atomic counter is aligned on a 64-bit boundary. 

On 32-bit systems, the "*sync.Cond" pointer is 32-bits long, which means the atomic counter is no longer aligned on a 64-bit boundary, and throws run time errors when the code is run.

# How are we solving the problem?

Re-order the fields in the structure so the atomic counter memory location is less sensitive to pointer/architecture size. 

# How is the PR tested?

Ran "make server" on ARM32, and checked the error no longer occurs.
Ran "make server" on AMD64, to check for regressions.

Ran "make test" on AMD64.
Did not run "make test" on ARM32, due to low memory on available platform.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->