### PR TITLE
storage/needle: add bounds check for WriteNeedleBlob buffer

### DIFF
--- a/weed/storage/needle/needle_write.go
+++ b/weed/storage/needle/needle_write.go
@@ -65,6 +65,10 @@ func WriteNeedleBlob(w backend.BackendStorageFile, dataSlice []byte, size Size, 
 		// compute byte offset as int to compare and slice correctly
 		tsOffset := int(NeedleHeaderSize) + int(size) + NeedleChecksumSize
 		// Ensure dataSlice has enough capacity for the timestamp
+		if tsOffset < 0 {
+			err = fmt.Errorf("invalid needle size %d results in negative timestamp offset %d", size, tsOffset)
+			return
+		}
 		if tsOffset+TimestampSize > len(dataSlice) {
 			err = fmt.Errorf("needle blob buffer too small: need %d bytes, have %d", tsOffset+TimestampSize, len(dataSlice))
 			return


### PR DESCRIPTION
Add buffer bounds validation in WriteNeedleBlob to prevent slice bounds out of range panic when writing Version3 needles with timestamp.

Fixes: panic: runtime error: slice bounds out of range [:87] with capacity 64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime safety checks to prevent out-of-bounds writes when appending timestamps to stored blobs; operations now return a clear error if the buffer is too small.
  * Improved error messages to indicate when computed timestamp offsets are invalid (negative) and to specify required versus available buffer size for easier diagnosis.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->