### PR TITLE
fix: Invalid volume mount conditional in filer template

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -229,7 +229,7 @@ spec:
             - name: seaweedfs-filer-log-volume
               mountPath: "/logs/"
             {{- end }}
-            {{- if .Values.filer.s3.enableAuth }}
+            {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
             - name: config-users
               mountPath: /etc/sw
               readOnly: true


### PR DESCRIPTION
# What problem are we solving?
There is a mistmatch in the conditionals for the definition and mounting of the `config-users` volume in the filer's template. 

Volume definition:
```
        {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
```
Mount:
```
            {{- if .Values.filer.s3.enableAuth }}
```

This leads to an invalid specification in the case where s3 is disabled but the enableAuth value is set to true, as it tries to mount in an undefined volume.


# How are we solving the problem?
I've switched updated the volume mount to use the same conditional as the volume definition, so that both s3.enabled and s3.enableAuth.


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kubernetes deployment configuration to correctly handle S3 authentication setup. The authentication configuration is now properly mounted only when both S3 and S3 authentication are enabled, preventing potential misconfiguration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->