### PR TITLE
fix: Set cipher for filerS3Options in filer.go

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -228,6 +228,7 @@ func runFiler(cmd *Command, args []string) bool {
 	filerAddress := pb.NewServerAddress(*f.ip, *f.port, *f.portGrpc).String()
 	startDelay := time.Duration(2)
 	if *filerStartS3 {
+		filerS3Options.cipher = f.cipher
 		filerS3Options.filer = &filerAddress
 		if *filerS3Options.bindIp == "" {
 			filerS3Options.bindIp = f.bindIp


### PR DESCRIPTION
Propagate filer encryption intent into the embedded S3 options:

- In `weed/command/filer.go` inside `runFiler()` when `-s3` is enabled:
  - Set `filerS3Options.cipher = f.cipher` before calling `filerS3Options.startS3Server()`.

This ensures:
- `filerS3Options.cipher` is always non-nil in the embedded S3 path
- embedded S3 inherits `-encryptVolumeData` behavior from the filer configuration

# What problem are we solving?

When running S3 embedded inside `weed filer` (i.e. `weed filer -s3 ...`), SeaweedFS can crash with a nil pointer dereference in `(*S3Options).startS3Server()` because `S3Options.cipher` is not initialized in the embedded S3 path. This is commonly triggered when operators enable volume encryption via filer (`-encryptVolumeData`), which is a reasonable expectation for production.

# How are we solving the problem?

We propagate the filer’s encryption intent into the embedded S3 options by setting `filerS3Options.cipher = f.cipher` in `runFiler()` before starting embedded S3. This prevents the nil dereference and makes embedded S3 follow the same `-encryptVolumeData` behavior as the filer.

# How is the PR tested?

Manually reproduced on a real deployment:
- Start master + volume
- Start filer with embedded S3 enabled
- Before fix: embedded S3 goroutine panics (nil pointer in `S3Options.startS3Server`)
- After fix: filer and embedded S3 start successfully and S3 is reachable

No unit tests were added because I could not find existing tests covering CLI flag wiring / option propagation for these commands.

# Checks
- [ ] I have added unit tests if possible. (Not added: no existing test harness found for CLI flag wiring here.)
- [ ] I will add related wiki document changes and link to this PR after merging.

> **Note / Attribution**
>
> Issue discovered and reproduced by GitHub user @franchb .
> The PR description and patch proposal were prepared with assistance from **GPT‑5.2 Medium**.


Closes https://github.com/seaweedfs/seaweedfs/issues/7991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cipher encryption settings not being properly applied to S3 storage on the filer, ensuring consistent encryption across storage configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->