### PR TITLE
Fix special characters in admin-generated secret keys

### DIFF
--- a/weed/iam/constants.go
+++ b/weed/iam/constants.go
@@ -3,7 +3,7 @@ package iam
 // Character sets for credential generation
 const (
 	CharsetUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	Charset      = CharsetUpper + "abcdefghijklmnopqrstuvwxyz/"
+	Charset      = CharsetUpper + "abcdefghijklmnopqrstuvwxyz"
 )
 
 // Policy document version

--- a/weed/iam/helpers_test.go
+++ b/weed/iam/helpers_test.go
@@ -58,6 +58,23 @@ func TestGenerateSecretAccessKey(t *testing.T) {
 	assert.Len(t, secretKey, SecretAccessKeyLength)
 }
 
+func TestGenerateSecretAccessKey_URLSafe(t *testing.T) {
+	// Generate multiple keys to increase probability of catching unsafe chars
+	for i := 0; i < 100; i++ {
+		secretKey, err := GenerateSecretAccessKey()
+		assert.NoError(t, err)
+
+		// Verify no URL-unsafe characters that would cause authentication issues
+		assert.NotContains(t, secretKey, "/", "Secret key should not contain /")
+		assert.NotContains(t, secretKey, "+", "Secret key should not contain +")
+
+		// Verify only expected characters are present
+		for _, char := range secretKey {
+			assert.Contains(t, Charset, string(char), "Secret key contains unexpected character: %c", char)
+		}
+	}
+}
+
 func TestStringSlicesEqual(t *testing.T) {
 	tests := []struct {
 		a        []string


### PR DESCRIPTION
Fixes #7990

## Problem
When generating secret keys via the SeaweedFS admin UI, keys containing special characters (e.g., `+`, `/`) fail to authenticate clients. The root cause is that the `Charset` constant includes `/` which is URL-unsafe. When these characters appear in secret keys, they get URL-encoded in HTTP requests, causing a mismatch during signature verification.

## Changes
- Removed `/` from the `Charset` constant in `weed/iam/constants.go`
- Added `TestGenerateSecretAccessKey_URLSafe` to verify generated keys don't contain URL-unsafe characters

## Impact
- **Non-breaking change**: Existing keys continue to work
- **Future keys**: Newly generated secret keys will be URL-safe and won't contain `/` or `+`
- **Authentication**: Resolves authentication failures for keys with special characters

## Testing
- All existing tests pass
- New test verifies URL-safety of generated keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated credential generation character restrictions to exclude URL-unsafe characters, ensuring improved compatibility with API requests and preventing potential encoding issues in authentication workflows.

* **Tests**
  * Added comprehensive test coverage to validate that generated secret access keys contain only approved URL-safe characters and properly enforce updated restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->