### PR TITLE
fix(gcs): resolve credential conflict in remote storage mount

### DIFF
--- a/weed/remote_storage/gcs/gcs_storage_client.go
+++ b/weed/remote_storage/gcs/gcs_storage_client.go
@@ -65,12 +65,12 @@ func (s gcsRemoteStorageMaker) Make(conf *remote_pb.RemoteConf) (remote_storage.
 		} else {
 			data, err = os.ReadFile(googleApplicationCredentials)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read credentials file %s: %v", googleApplicationCredentials, err)
+				return nil, fmt.Errorf("failed to read credentials file %s: %w", googleApplicationCredentials, err)
 			}
 		}
 		creds, err := google.CredentialsFromJSON(context.Background(), data, storage.ScopeFullControl)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse credentials: %v", err)
+			return nil, fmt.Errorf("failed to parse credentials: %w", err)
 		}
 		httpClient := oauth2.NewClient(context.Background(), creds.TokenSource)
 		clientOpts = append(clientOpts, option.WithHTTPClient(httpClient), option.WithoutAuthentication())


### PR DESCRIPTION
This PR resolves the 'multiple credential options provided' error in remote.mount when using GCS. It mirrors the fix previously applied in #7951 for gcs_sink.go by manually handling GCS credentials in gcs_storage_client.go. Fixes #8007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Google Cloud Storage credential handling to accept credentials provided as either JSON text or a file path, and to use dynamic client configuration. Maintains backward compatibility, adds clearer error handling for invalid or unreadable credentials, and offers more flexible authentication options for cloud storage connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->