### PR TITLE
s3api: allow-all default when no credentials are configured

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -285,13 +285,11 @@ func NewIdentityAccessManagementWithStore(option *S3ApiServerOption, explicitSto
 	// If any credentials are configured (via file, filer, or env vars), enable authentication
 	iam.m.Lock()
 	iam.isAuthEnabled = len(iam.identities) > 0
-	isAuthEnabled := iam.isAuthEnabled
-	identitiesCount := len(iam.identities)
 	iam.m.Unlock()
 
-	if isAuthEnabled {
+	if iam.isAuthEnabled {
 		// Credentials were configured - enable authentication
-		glog.V(0).Infof("S3 authentication enabled (%d identities configured)", identitiesCount)
+		glog.V(0).Infof("S3 authentication enabled (%d identities configured)", len(iam.identities))
 	} else {
 		// No credentials configured
 		if startConfigFile != "" {


### PR DESCRIPTION
This PR modifies the S3 gateway behavior to default to allow-all access when no credentials are configured. This applies globally to all S3 instances, including `weed mini`. It also ensures that adding credentials (either via flags/env vars or dynamically via Admin UI/Shell) transitions the server from "allow all" to "authentication required" mode.

### Key Changes:
- **Global Allow-All Default**: S3 gateway now defaults to allow-all mode when no identities are found.
- **Dynamic Transition**: Fixed dynamic configuration updates to allow switching from allow-all to auth-enforced mode.
- **Code Refactor**: Improved clarity and efficiency of the authentication initialization in `NewIdentityAccessManagementWithStore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication state management to ensure proper synchronization with credential presence.
  * Added informational logging for authentication state transitions and credential updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->