### PR TITLE
fix(chart): place backoffLimit correctly in resize hook

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -58,11 +58,11 @@ metadata:
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
+  backoffLimit: 1
   template:
     spec:
       serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook
       restartPolicy: Never
-      backoffLimit: 1
       containers:
         - name: resize
           image: {{ .Values.volume.resizeHook.image }}


### PR DESCRIPTION
# What problem are we solving?
Fixes #8020



# How are we solving the problem?
Moving backoffLimit to Job .spec from pod's spec which a correct placement.

# How is the PR tested?
I've run helm template with values to render resize hook, also tested on a live environment where I was resizing PVCs for volume server.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->