### PR TITLE
Fix: Fail fast on unsupported volume versions

### DIFF
--- a/weed/storage/needle/volume_version.go
+++ b/weed/storage/needle/volume_version.go
@@ -11,3 +11,7 @@ const (
 func GetCurrentVersion() Version {
 	return Version3
 }
+
+func IsSupportedVersion(v Version) bool {
+	return v >= Version1 && v <= Version3
+}

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -106,7 +106,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 	if alreadyHasSuperBlock {
 		err = v.readSuperBlock()
 		if err == nil {
-			if v.SuperBlock.Version < needle.Version1 || v.SuperBlock.Version > needle.Version3 {
+			if !needle.IsSupportedVersion(v.SuperBlock.Version) {
 				glog.Fatalf("Unsupported volume %d version %v", v.Id, v.SuperBlock.Version)
 			}
 			v.volumeInfo.Version = uint32(v.SuperBlock.Version)

--- a/weed/storage/volume_super_block.go
+++ b/weed/storage/volume_super_block.go
@@ -18,8 +18,8 @@ func (v *Volume) maybeWriteSuperBlock(ver needle.Version) error {
 		return e
 	}
 	if datSize == 0 {
-		if ver == 0 {
-			return fmt.Errorf("volume super block version 0 is not supported")
+		if !needle.IsSupportedVersion(ver) {
+			return fmt.Errorf("volume super block version %d is not supported", ver)
 		}
 		v.SuperBlock.Version = ver
 		_, e = v.DataBackend.WriteAt(v.SuperBlock.Bytes(), 0)


### PR DESCRIPTION
## Problem
When the Open Source volume server receives an AllocateVolume request with version 0 (or omitted default), it could initialize a volume with Version 0 superblock, causing "Unsupported Version! (0)" errors when the volume is later accessed.

Additionally, if the server encounters an existing volume with an unsupported version (e.g., Version 0 or Enterprise Version 4), it should stop immediately rather than attempting to operate on incompatible data.

## Changes
1. **Prevent Creation**: Modified `volume_super_block.go` to reject Version 0 (and other unsupported versions) during volume initialization, returning an explicit error.
2. **Prevent Loading**: Modified `volume_loading.go` to crash immediately (fatal exit) if an unsupported version is detected when loading existing volumes.
3. **Refactoring**: Added `IsSupportedVersion` helper function in `volume_version.go` to centralize version validation logic.

## Verification
- Tested with reproduction script that attempts to create a volume with Version 0 - now properly rejected
- Tested with crash verification script that simulates loading a corrupted volume - server exits immediately with clear error message

Fixes version corruption issues when switching between Enterprise and Open Source deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Version validation is now performed when loading and creating volumes
  * Operations with unsupported versions now fail with clear error messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->