### PR TITLE
Fix CopyObject If-Match ETag mismatch by copying Md5 attribute

### DIFF
--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1045,6 +1045,7 @@ func (s3a *S3ApiServer) validateConditionalCopyHeaders(r *http.Request, entry *f
 			Mtime:    time.Unix(entry.Attributes.Mtime, 0),
 			Crtime:   time.Unix(entry.Attributes.Crtime, 0),
 			Mime:     entry.Attributes.Mime,
+			Md5:      entry.Attributes.Md5,
 		},
 		Chunks: entry.Chunks,
 	}


### PR DESCRIPTION
This PR fixes a bug where CopyObject validation would fail for encrypted objects (or any scenario where chunk ETag differs from stored MD5).

The `validateConditionalCopyHeaders` function was constructing a temporary `filer.Entry` for ETag calculation but failed to copy the stored `Md5` attribute. This forced `filer.ETagEntry` to recalculate the ETag from chunks. 

When encryption is enabled, the chunk content is encrypted, so its MD5 differs from the original plaintext MD5 stored in `entry.Attributes.Md5` by `PutObject`. This mismatch caused correct `If-Match` headers to fail validation.

This fix explicitly copies the `Md5` attribute during validation, ensuring the ETag comparison uses the authoritative stored value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced S3 copy operations to properly include MD5 checksum values in validation checks, ensuring precondition headers are correctly evaluated during conditional copy requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->