### PR TITLE
Support for cacheMetaTtlSec option in fuse command

### DIFF
--- a/weed/command/fuse_std.go
+++ b/weed/command/fuse_std.go
@@ -150,6 +150,13 @@ func runFuse(cmd *Command, args []string) bool {
 			} else {
 				panic(fmt.Errorf("chunkSizeLimitMB: %s", err))
 			}
+		case "cacheMetaTtlSec":
+			if parsed, err := strconv.ParseInt(parameter.value, 0, 32); err == nil {
+				intValue := int(parsed)
+				mountOptions.cacheMetaTtlSec = &intValue
+			} else {
+				panic(fmt.Errorf("cacheMetaTtlSec: %s", err))
+			}
 		case "concurrentWriters":
 			i++
 			if parsed, err := strconv.ParseInt(parameter.value, 0, 32); err == nil {


### PR DESCRIPTION
# What problem are we solving?

We want to adjust the TTL of the meta cache to synchronize metadata across multiple mounted devices.
For the `weed mount` command, this can be configured using the `-cacheMetaTtlSec=0` option.
However, the `weed fuse` command does not parse this option, so it cannot be used.

# How are we solving the problem?

Modify the FUSE option parsing logic to also handle `cacheMetaTtlSec`.

# How is the PR tested?

YES

`weed` is located `/sbin/mount.weed`

`/etc/fstab`

> fuse ~~{PATH}~~ weed defaults,nodev,nosuid,x-systemd.automount,x-systemd.after=network-online.target,~~{SOME OPTIONS}~~,cacheMetaTtlSec=0 0 0

`ps -ef`

> root     123957      1  1 13:26 ?        00:00:49 /sbin/mount.weed fuse ~~{PATH}~~ -o rw,nodev,nosuid,~~{SOME OPTIONS}~~,cacheMetaTtlSec=0 -o child=123932



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable cache metadata time-to-live setting for FUSE mounts, allowing users to control how long metadata is retained in the cache.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->