### PR TITLE
Fix: S3 CORS headers missing for non-existent buckets

### DIFF
--- a/weed/s3api/cors/middleware.go
+++ b/weed/s3api/cors/middleware.go
@@ -50,6 +50,9 @@ func (m *Middleware) getCORSConfig(bucket string) (*CORSConfiguration, bool) {
 		// No bucket config, proceed to fallback.
 	case s3err.ErrNoSuchCORSConfiguration:
 		// No bucket config, proceed to fallback.
+	case s3err.ErrNoSuchBucket:
+		// Bucket doesn't exist, proceed to fallback.
+		// This ensures we don't leak existence information and returning 403 vs 200.
 	default:
 		// Any other error means we should not proceed.
 		return nil, false

--- a/weed/s3api/cors/middleware_test.go
+++ b/weed/s3api/cors/middleware_test.go
@@ -358,10 +358,10 @@ func TestMiddlewareFallbackWithError(t *testing.T) {
 			description:          "Internal errors should not expose CORS headers",
 		},
 		{
-			name:                 "ErrNoSuchBucket should not trigger fallback",
+			name:                 "ErrNoSuchBucket should trigger fallback",
 			errCode:              s3err.ErrNoSuchBucket,
-			expectedOriginHeader: "",
-			description:          "Bucket not found errors should not expose CORS headers",
+			expectedOriginHeader: "https://example.com",
+			description:          "Bucket not found errors should expose CORS headers to prevent information disclosure",
 		},
 		{
 			name:                 "ErrNoSuchCORSConfiguration should trigger fallback",


### PR DESCRIPTION
Fixes #8065. 

When an OPTIONS request is made to a non-existent bucket, SeaweedFS was returning 403 Forbidden without CORS headers, even if global CORS was configured. This change ensures that we fall back to the global CORS configuration when a bucket is not found, returning 200 OK with the appropriate CORS headers. This prevents leakage of bucket existence information and aligns with standard S3 behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Improved CORS configuration handling: When a bucket does not exist, the system now gracefully falls back to global CORS configuration and returns appropriate CORS headers to requesting clients instead of hard error responses. This ensures cross-origin requests continue to be properly handled in fallback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->