### PR TITLE
fix: propagate OIDC attributes to STS session token for IAM policies

### DIFF
--- a/weed/iam/sts/sts_service.go
+++ b/weed/iam/sts/sts_service.go
@@ -459,7 +459,7 @@ func (s *STSService) AssumeRoleWithWebIdentity(ctx context.Context, request *Ass
 	}
 
 	// Create request context from identity attributes for policy evaluation
-	requestContext := make(map[string]interface{})
+	requestContext := make(map[string]interface{}, len(externalIdentity.Attributes)+3)
 
 	// Add generic attributes (including preferred_username, etc.)
 	if externalIdentity.Attributes != nil {

--- a/weed/iam/sts/sts_service_test.go
+++ b/weed/iam/sts/sts_service_test.go
@@ -712,6 +712,7 @@ func TestAssumeRoleWithWebIdentity_PreservesAttributes(t *testing.T) {
 	// Check standard claims are also present
 	assert.Equal(t, "test-user-id", sessionInfo.RequestContext["sub"])
 	assert.Equal(t, "test@example.com", sessionInfo.RequestContext["email"])
+	assert.Equal(t, "Test User", sessionInfo.RequestContext["name"])
 }
 
 // MockIdentityProviderWithAttributes is a mock provider that returns configured attributes


### PR DESCRIPTION
Fixes an issue where OIDC claims (specifically attributes like preferred_username) were not being propagated to the internal STS Session Token. This is critical for IAM policies that rely on variable substitution like ${jwt:preferred_username}.

Fixes #8037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session tokens generated from web identity credentials now include user attributes from external identity providers, enabling authorization policies to make decisions based on custom user attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->