### PR TITLE
mount: apply UID/GID mapping in lookupEntry for cache misses

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -306,7 +306,7 @@ func (wfs *WFS) lookupEntry(fullpath util.FullPath) (*filer.Entry, fuse.Status) 
 		glog.V(1).Infof("lookupEntry GetEntry %s: %v", fullpath, err)
 		return nil, fuse.ENOENT
 	}
-	if entry != nil && wfs.option.UidGidMapper != nil {
+	if entry != nil && entry.Attributes != nil && wfs.option.UidGidMapper != nil {
 		entry.Attributes.Uid, entry.Attributes.Gid = wfs.option.UidGidMapper.FilerToLocal(entry.Attributes.Uid, entry.Attributes.Gid)
 	}
 	return filer.FromPbEntry(dir, entry), fuse.OK


### PR DESCRIPTION
Fixes #8134. Applied UID/GID mapping when fetching entries directly from the filer (cache miss) in weed mount. This prevents rsync permission errors caused by unmapped ownership info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File system entries now correctly remap user and group IDs when UID/GID mapping is configured, ensuring correct ownership display and access behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->