### PR TITLE
fix #8081: build latest container is missing latest_large_disk

### DIFF
--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -16,15 +16,7 @@ jobs:
       matrix:
         platform: [amd64, arm64, arm, 386]
         variant: [standard, large_disk]
-        include:
-          - platform: amd64
-            qemu: false
-          - platform: arm64
-            qemu: true
-          - platform: arm
-            qemu: true
-          - platform: 386
-            qemu: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -69,7 +61,7 @@ jobs:
             org.opencontainers.image.description=SeaweedFS is a distributed storage system for blobs, objects, files, and data lake, to store and serve billions of files fast!
             org.opencontainers.image.vendor=Chris Lu
       - name: Set up QEMU
-        if: matrix.qemu
+        if: matrix.platform != 'amd64'
         uses: docker/setup-qemu-action@v3
       - name: Create BuildKit config
         run: |


### PR DESCRIPTION
Fixes #8081. This PR adds the `latest_large_disk` build configuration to the `container_latest.yml` workflow, ensuring it builds and pushes alongside the standard latest tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added support for multiple container image variants (standard, large_disk) in automated builds
  * Docker image tags now include variant-specific suffixes for clearer identification
  * Optimized multi-architecture build process and manifest generation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->