### PR TITLE
Update Helm hook annotations for post-install and upgrade

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -15,14 +15,18 @@
     {{- $existingConfigSecret = or .Values.allInOne.s3.existingConfigSecret .Values.s3.existingConfigSecret .Values.filer.s3.existingConfigSecret }}
   {{- end }}
 {{- else if .Values.master.enabled }}
-  {{- /* Check standalone filer.s3 mode */}}
-  {{- if .Values.filer.s3.enabled }}
+  {{- /* Check if embedded (in filer) or standalone S3 gateway is enabled */}}
+  {{- if or .Values.filer.s3.enabled .Values.s3.enabled }}
     {{- $s3Enabled = true }}
-    {{- if .Values.filer.s3.createBuckets }}
+    {{- if .Values.s3.createBuckets }}
+      {{- $createBuckets = .Values.s3.createBuckets }}
+      {{- $enableAuth = .Values.s3.enableAuth }}
+      {{- $existingConfigSecret = .Values.s3.existingConfigSecret }}
+    {{- else if .Values.filer.s3.createBuckets }}
       {{- $createBuckets = .Values.filer.s3.createBuckets }}
+      {{- $enableAuth = .Values.filer.s3.enableAuth }}
+      {{- $existingConfigSecret = .Values.filer.s3.existingConfigSecret }}
     {{- end }}
-    {{- $enableAuth = .Values.filer.s3.enableAuth }}
-    {{- $existingConfigSecret = .Values.filer.s3.existingConfigSecret }}
   {{- end }}
 {{- end }}
 

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -891,7 +891,7 @@ filer:
     # should have a secret key called seaweedfs_s3_config with an inline json configure
     existingConfigSecret: null
     auditLogConfig: {}
-    # You may specify buckets to be created during the install process.
+    # You may specify buckets to be created during the install or upgrade process.
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # createBuckets:
     #   - name: bucket-a
@@ -916,6 +916,13 @@ s3:
   # should have a secret key called seaweedfs_s3_config with an inline json config
   existingConfigSecret: null
   auditLogConfig: {}
+  # You may specify buckets to be created during the install or upgrade process.
+  # Buckets may be exposed publicly by setting `anonymousRead` to `true`
+  # createBuckets:
+  #   - name: bucket-a
+  #     anonymousRead: true
+  #   - name: bucket-b
+  #     anonymousRead: false
 
   # Suffix of the host name, {bucket}.{domainName}
   domainName: ""


### PR DESCRIPTION
# What problem are we solving?
I believe it makes sense to allow this job to run also after installation. Assuming someone wants to add a new bucket after the initial installation, it makes sense to trigger the job again.
The subsequent commits should ensure the code is idempotent in the bucket creation
# How are we solving the problem?
Adding the post-upgrade hook

# How is the PR tested?
locally

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket initialization now runs on both upgrades and fresh installs; creation is idempotent (existing buckets skipped and logged).
  * Bucket-create settings and auth now respect the appropriate S3 configuration source, avoiding misconfiguration.

* **New Features**
  * S3 enablement treats embedded filer S3 and standalone S3 gateway equivalently, activating S3 when either is enabled.

* **Documentation**
  * Updated configuration comments and added an example for bucket creation settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->