### PR TITLE
feat(gcs): add application default credentials fallback support

### DIFF
--- a/weed/remote_storage/gcs/gcs_storage_client.go
+++ b/weed/remote_storage/gcs/gcs_storage_client.go
@@ -50,7 +50,7 @@ func (s gcsRemoteStorageMaker) Make(conf *remote_pb.RemoteConf) (remote_storage.
 		if pid, found := os.LookupEnv("GOOGLE_CLOUD_PROJECT"); found {
 			projectID = pid
 		} else {
-			glog.Warningf("need to specific GOOGLE_CLOUD_PROJECT env variable")
+			glog.Warningf("need to specify GOOGLE_CLOUD_PROJECT env variable")
 		}
 	}
 


### PR DESCRIPTION
# What problem are we solving?
Addresses problem from #8160 

# How are we solving the problem?
- When mounting GCS cloud drive, if there are no credentials from a json or from environment variables, then the Application Default Credentials (ADC) are used. 
  - This is the default behaviour of `storage.NewClient` anyway; [see here](https://pkg.go.dev/cloud.google.com/go/storage#NewClient).
- This required changing the returned error from there being no env variable to just logging a warning the ADC is being used

<!--# How is the PR tested?-->



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing Google Cloud credentials now produce a warning and allow the system to continue instead of failing.
  * Missing Google Cloud project ID now logs a warning rather than causing an error.
  * Credential path resolution is deferred and only performed when credentials are present, avoiding unnecessary resolution attempts.
  * Improved resilience during cloud configuration lookup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->