### PR TITLE
shell: allow spaces in arguments via quoting (#8157)

### DIFF
--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -187,7 +187,7 @@ func parseShellInput(line string, split bool) (args []string, unbalanced bool) {
 		args = append(args, current.String())
 	}
 
-	return args, inDoubleQuotes || inSingleQuotes
+	return args, inDoubleQuotes || inSingleQuotes || escaped
 }
 
 func printGenericHelp() {

--- a/weed/shell/shell_liner_test.go
+++ b/weed/shell/shell_liner_test.go
@@ -59,6 +59,7 @@ func TestStripQuotes(t *testing.T) {
 		{input: `"unbalanced`, expected: `"unbalanced`},
 		{input: `'unbalanced`, expected: `'unbalanced`},
 		{input: `-name="a\"b`, expected: `-name="a\"b`},
+		{input: `trailing\`, expected: `trailing\`},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes #8157 where weed shell was unable to parse arguments containing spaces even when quoted.

Summary of changes:
- Updated the argument splitting regex in weed/shell/shell_liner.go to correctly handle quoted segments within a flag.
- Added a  function to remove matching quotes from flags/values.
- Added a comprehensive unit test in weed/shell/shell_liner_test.go to verify the fix and prevent regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command parsing: more reliable tokenization, better handling of quoted and escaped arguments, and correct processing of multiple semicolon-delimited commands so flags and values are interpreted as intended.

* **Tests**
  * Added unit tests validating tokenization, quote stripping, escaped-quote handling, and flag parsing to ensure parsing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->