### PR TITLE
s3tables: add Iceberg file layout validation for table buckets

### DIFF
--- a/weed/s3api/s3tables/iceberg_layout.go
+++ b/weed/s3api/s3tables/iceberg_layout.go
@@ -296,6 +296,14 @@ func (v *TableBucketFileValidator) ValidateTableBucketUpload(fullPath string) er
 		return nil
 	}
 
+	// Reject paths with empty segments (double slashes) within the table path
+	if strings.HasPrefix(tableRelativePath, "/") || strings.Contains(tableRelativePath, "//") {
+		return &IcebergLayoutError{
+			Code:    ErrCodeInvalidIcebergLayout,
+			Message: "bucket, namespace, and table segments cannot be empty",
+		}
+	}
+
 	return v.layoutValidator.ValidateFilePath(tableRelativePath)
 }
 

--- a/weed/s3api/s3tables/iceberg_layout_test.go
+++ b/weed/s3api/s3tables/iceberg_layout_test.go
@@ -125,6 +125,7 @@ func TestTableBucketFileValidator_ValidateTableBucketUpload(t *testing.T) {
 		{"empty table", "/table-buckets/mybucket/myns//data/file.parquet", true},
 		{"empty bucket dir", "/table-buckets//", true},
 		{"empty namespace dir", "/table-buckets/mybucket//", true},
+		{"table double slash bypass", "/table-buckets/mybucket/myns/mytable//data/file.parquet", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

This PR adds file layout validation for table buckets to enforce Apache Iceberg table structure.

## Changes

Files uploaded to table buckets must conform to the expected Iceberg layout:

### metadata/ directory
Contains metadata files:
- `v*.metadata.json` (table metadata)
- `snap-*.avro` (snapshot manifests)
- `*-m*.avro` (manifest files)
- `version-hint.text`

### data/ directory
Contains data files:
- `*.parquet`, `*.orc`, `*.avro`
- Supports partition paths (e.g., `year=2024/month=01/`)
- Supports bucket subdirectories

## Exported Functions

The validator exports functions for use by the S3 API:

- `IsTableBucketPath`: checks if a path is under /table-buckets/
- `GetTableInfoFromPath`: extracts bucket/namespace/table from path
- `ValidateTableBucketUpload`: validates file layout for table bucket uploads
- `ValidateTableBucketUploadWithClient`: validates with filer client access

## Error Handling

Invalid uploads receive `InvalidIcebergLayout` error response with descriptive message.

## Testing

Added comprehensive unit tests for:
- Valid Iceberg metadata file patterns
- Valid data file patterns
- Partition path validation
- Table bucket path detection
- Path component extraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Iceberg layout validation for metadata, data, directories, partitions and filename patterns to enforce compliant uploads and reject invalid paths.
  * Added table-bucket upload validation with optional remote metadata verification to confirm ICEBERG-format tables and return clear error codes.
  * Added utilities to detect table-bucket paths and extract bucket/namespace/table information.

* **Tests**
  * Added comprehensive unit tests for layout validation, partition handling, table-bucket detection, path extraction, and upload validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->