### PR TITLE
fix: skip exhausted blocks before creating an interval

### DIFF
--- a/weed/storage/erasure_coding/ec_locate.go
+++ b/weed/storage/erasure_coding/ec_locate.go
@@ -52,14 +52,14 @@ func LocateData(largeBlockLength, smallBlockLength int64, shardDatSize int64, of
 	return
 }
 
-func moveToNextBlock(blockIndex int, isLargeBlock bool, nLargeBlockRows int64) (nextBlockIndex int, nextIsLargeBlock bool) {
-	nextBlockIndex = blockIndex + 1
-	nextIsLargeBlock = isLargeBlock
+func moveToNextBlock(blockIndex int, isLargeBlock bool, nLargeBlockRows int64) (int, bool) {
+	nextBlockIndex := blockIndex + 1
+	nextIsLargeBlock := isLargeBlock
 	if isLargeBlock && int64(nextBlockIndex) == nLargeBlockRows*DataShardsCount {
 		nextIsLargeBlock = false
 		nextBlockIndex = 0
 	}
-	return
+	return nextBlockIndex, nextIsLargeBlock
 }
 
 func locateOffset(largeBlockLength, smallBlockLength int64, shardDatSize int64, offset int64) (blockIndex int, isLargeBlock bool, nLargeBlockRows int64, innerBlockOffset int64) {

--- a/weed/storage/erasure_coding/ec_test.go
+++ b/weed/storage/erasure_coding/ec_test.go
@@ -243,8 +243,10 @@ func TestLocateData_Issue8179(t *testing.T) {
 	shardSize := int64(259092) // Resulting in nLargeBlockRows = 25 as seen in panic log
 
 	// Testing range through the large-to-small transition boundary
-	// Large Area: 25 * 10 * 10000 = 2,500,000
-	for offset := int64(2499500); offset < 2500500; offset++ {
+	nLargeBlockRows := (shardSize - 1) / large
+	largeAreaSize := nLargeBlockRows * int64(DataShardsCount) * large
+
+	for offset := largeAreaSize - 500; offset < largeAreaSize+500; offset++ {
 		intervals := LocateData(large, small, shardSize, offset, 200)
 		for _, interval := range intervals {
 			assert.True(t, interval.Size > 0, "Interval size must be positive at offset %d, got %+v", offset, interval)


### PR DESCRIPTION
Fixes #8179. Checks if blockRemaining is zero or less to skip exhausted blocks. This prevents potential infinite loops and ensures correct interval calculation for data location in erasure coded volumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block transition handling so storage advances cleanly when a block is exhausted, preventing allocation errors and incorrect interval creation.
  * Added guards against zero/negative remaining space to ensure correct sizing decisions and improve reliability during sequential writes.
  * Consolidated transition logic to eliminate duplicate boundary calculations and reduce off-by-one/edge-condition failures.

* **Tests**
  * Added a boundary test validating data-location splits around large-to-small block transitions to prevent regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->