### PR TITLE
command: fix s3 panic in filer command

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -143,6 +143,8 @@ func init() {
 	filerS3Options.concurrentFileUploadLimit = cmdFiler.Flag.Int("s3.concurrentFileUploadLimit", 0, "limit number of concurrent file uploads for S3, 0 means unlimited")
 	filerS3Options.enableIam = cmdFiler.Flag.Bool("s3.iam", true, "enable embedded IAM API on the same S3 port")
 	filerS3Options.cipher = cmdFiler.Flag.Bool("s3.encryptVolumeData", false, "encrypt data on volume servers for S3 uploads")
+	filerS3Options.iamReadOnly = cmdFiler.Flag.Bool("s3.iam.readOnly", true, "disable IAM write operations on this server")
+	filerS3Options.portIceberg = cmdFiler.Flag.Int("s3.port.iceberg", 8181, "Iceberg REST Catalog server listen port (0 to disable)")
 
 	// start webdav on filer
 	filerStartWebDav = cmdFiler.Flag.Bool("webdav", false, "whether to start webdav gateway")


### PR DESCRIPTION
This fixes a nil pointer dereference panic when starting the S3 server via the weed filer command by correctly initializing iamReadOnly and portIceberg flags. Fixes #8200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 IAM read-only mode configuration option to disable write operations
  * Added customizable port configuration for Iceberg REST Catalog server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->