### PR TITLE
s3api: fix ListObjectVersions inconsistency with delimiters

### DIFF
--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -706,16 +706,6 @@ func (vc *versionCollector) collectVersions(currentPath, relativePath string) er
 
 // processDirectory handles directory entries
 func (vc *versionCollector) processDirectory(currentPath, entryPath string, entry *filer_pb.Entry) error {
-	// Skip .uploads directory
-	if strings.HasPrefix(entry.Name, ".uploads") {
-		return nil
-	}
-
-	// Handle .versions directory
-	if strings.HasSuffix(entry.Name, s3_constants.VersionsFolder) {
-		return vc.processVersionsDirectory(entryPath)
-	}
-
 	// Handle explicit S3 directory object
 	if entry.Attributes.Mime == s3_constants.FolderMimeType {
 		vc.processExplicitDirectory(entryPath, entry)


### PR DESCRIPTION
Fixes #8206. Prioritize handling of .versions and .uploads directories before delimiter processing in collectVersions. This ensures .versions directories are processed as version containers instead of being incorrectly rolled up into CommonPrefixes when a delimiter is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Listing/enumeration now correctly skips upload marker directories and correctly surfaces version containers so object versions are managed and displayed consistently during listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->