### PR TITLE
shell: add minCacheAge flag to remote.uncache command

### DIFF
--- a/weed/shell/command_remote_uncache.go
+++ b/weed/shell/command_remote_uncache.go
@@ -136,6 +136,7 @@ type FileFilter struct {
 	minAge      *int64
 	maxAge      *int64
 	minCacheAge *int64
+	now         int64
 }
 
 func newFileFilter(remoteMountCommand *flag.FlagSet) (ff *FileFilter) {
@@ -147,6 +148,7 @@ func newFileFilter(remoteMountCommand *flag.FlagSet) (ff *FileFilter) {
 	ff.minAge = remoteMountCommand.Int64("minAge", -1, "minimum file age in seconds (created time)")
 	ff.maxAge = remoteMountCommand.Int64("maxAge", -1, "maximum file age in seconds (created time)")
 	ff.minCacheAge = remoteMountCommand.Int64("minCacheAge", -1, "minimum file cache age in seconds (last cached time)")
+	ff.now = time.Now().Unix()
 	return
 }
 
@@ -175,12 +177,12 @@ func (ff *FileFilter) matches(entry *filer_pb.Entry) bool {
 		}
 	}
 	if *ff.minAge != -1 {
-		if entry.Attributes.Crtime+*ff.minAge > time.Now().Unix() {
+		if entry.Attributes.Crtime+*ff.minAge > ff.now {
 			return false
 		}
 	}
 	if *ff.maxAge != -1 {
-		if entry.Attributes.Crtime+*ff.maxAge < time.Now().Unix() {
+		if entry.Attributes.Crtime+*ff.maxAge < ff.now {
 			return false
 		}
 	}
@@ -189,7 +191,7 @@ func (ff *FileFilter) matches(entry *filer_pb.Entry) bool {
 		if entry.RemoteEntry != nil && entry.RemoteEntry.LastLocalSyncTsNs > 0 {
 			lastCachedTime = entry.RemoteEntry.LastLocalSyncTsNs / 1e9
 		}
-		if lastCachedTime+*ff.minCacheAge > time.Now().Unix() {
+		if lastCachedTime+*ff.minCacheAge > ff.now {
 			return false
 		}
 	}

--- a/weed/shell/command_remote_uncache_test.go
+++ b/weed/shell/command_remote_uncache_test.go
@@ -93,6 +93,7 @@ func TestFileFilter_matches_minCacheAge(t *testing.T) {
 				minAge:      &defaultInt64,
 				maxAge:      &defaultInt64,
 				minCacheAge: &tt.minCacheAge,
+				now:         now,
 			}
 
 			if got := ff.matches(tt.entry); got != tt.want {


### PR DESCRIPTION
This PR adds a `minCacheAge` flag to the `remote.uncache` command to allow skipping recently cached files.

Fixes #8221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a minimum cache-age filter (minCacheAge) with a CLI flag to filter files by how long they've been cached.

* **Bug Fixes**
  * Uncache flow now respects minimum cache-age when deciding which files to skip.
  * Safely handles entries missing metadata to avoid errors.

* **Documentation**
  * Help text and examples clarify created-time vs cached-time semantics.

* **Tests**
  * New unit tests cover minCacheAge scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->