### PR TITLE
helm: add a trafficDistribution field to an s3 service

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -16,6 +16,9 @@ metadata:
 {{- end }}
 spec:
   internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
+  {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) (or .Values.s3.trafficDistribution .Values.filer.s3.trafficDistribution) }}
+  trafficDistribution: {{ include "seaweedfs.trafficDistribution" . }}
+  {{- end }}
   ports:
   - name: "swfs-s3"
     port: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -323,3 +323,12 @@ Create the name of the service account to use
 {{- define "seaweedfs.serviceAccountName" -}}
 {{- .Values.global.serviceAccountName | default "seaweedfs" -}}
 {{- end -}}
+
+{{/* Generate a compatible trafficDistribution value due to "PreferClose" fast deprecation in k8s v1.35 */}}
+{{- define "seaweedfs.trafficDistribution" -}}
+{{- if .Values.s3.trafficDistribution -}}
+{{- and (eq .Values.s3.trafficDistribution "PreferClose") (semverCompare ">=1.35-0" .Capabilities.KubeVersion.GitVersion) | ternary "PreferSameZone" .Values.s3.trafficDistribution -}}
+{{- else if .Values.filer.s3.trafficDistribution -}}
+{{- and (eq .Values.filer.s3.trafficDistribution "PreferClose") (semverCompare ">=1.35-0" .Capabilities.KubeVersion.GitVersion) | ternary "PreferSameZone" .Values.filer.s3.trafficDistribution -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
# What problem are we solving?
There is currently no way to specify a trafficDistribution field for an s3 service.
[More info on trafficDistribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
) 

# How are we solving the problem?
Adding the corresponding option to s3 and filer.s3

# How is the PR tested?
`helm template . | kubectl apply --dry-run=server -f -`

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring traffic distribution on Kubernetes 1.31 and later via chart values.
  * Automatic adjustment of traffic distribution for Kubernetes 1.35+ so legacy values (e.g., "PreferClose") are mapped to a compatible value when applicable, preserving existing ports, targets, and selectors and only applying when traffic distribution is explicitly set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->