### PR TITLE
use ReadFull (#40)

### DIFF
--- a/weed/shell/command_fs_meta_load.go
+++ b/weed/shell/command_fs_meta_load.go
@@ -98,7 +98,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 		var wg sync.WaitGroup
 
 		for {
-			if n, err := dst.Read(sizeBuf); n != 4 {
+			if _, err := io.ReadFull(dst, sizeBuf); err != nil {
 				if err == io.EOF {
 					return nil
 				}
@@ -109,7 +109,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 
 			data := make([]byte, int(size))
 
-			if n, err := dst.Read(data); n != len(data) {
+			if _, err := io.ReadFull(dst, data); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
# What problem are we solving?
restoring filer meta from a gzip file exit prematurely, due to io.Reader may read less bytes than the buffer length without error, this is rare if reading from disk but quite possible if reading from compressed stream or from network. We should use ReadFull() here.

# How are we solving the problem?
use io.ReadFull()

# How is the PR tested?
tested with this file:
[filer_metadata.meta.gz](https://github.com/user-attachments/files/25141498/filer_metadata.meta.gz)
it contains more than 2000 entries, but fs.meta.load without this fix only loads 183 entries.


# Checks
- [x] I have added unit tests if possible.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file metadata loading reliability by strengthening error handling to prevent incomplete data from being incorrectly accepted as valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->