### PR TITLE
Explicitly disable signing for public buckets.

### DIFF
--- a/weed/remote_storage/s3/s3_storage_client.go
+++ b/weed/remote_storage/s3/s3_storage_client.go
@@ -44,6 +44,9 @@ func (s s3RemoteStorageMaker) Make(conf *remote_pb.RemoteConf) (remote_storage.R
 	}
 	if conf.S3AccessKey != "" && conf.S3SecretKey != "" {
 		config.Credentials = credentials.NewStaticCredentials(conf.S3AccessKey, conf.S3SecretKey, "")
+	} else if conf.S3AccessKey == "" && conf.S3SecretKey == "" {
+		// Explicitly disable signing for public buckets.
+		config.Credentials = credentials.AnonymousCredentials
 	}
 
 	sess, err := session.NewSession(config)

--- a/weed/remote_storage/s3/s3_storage_client_test.go
+++ b/weed/remote_storage/s3/s3_storage_client_test.go
@@ -1,0 +1,57 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/pb/remote_pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3MakeUsesAnonymousCredentialsWhenKeysAreEmpty(t *testing.T) {
+	maker := s3RemoteStorageMaker{}
+	conf := &remote_pb.RemoteConf{
+		Type:             "s3",
+		S3Region:         "us-east-1",
+		S3Endpoint:       "http://localhost:8333",
+		S3ForcePathStyle: true,
+	}
+
+	remoteClient, err := maker.Make(conf)
+	require.NoError(t, err)
+
+	client, ok := remoteClient.(*s3RemoteStorageClient)
+	require.True(t, ok)
+
+	s3Client, ok := client.conn.(*awss3.S3)
+	require.True(t, ok)
+	require.Same(t, credentials.AnonymousCredentials, s3Client.Config.Credentials)
+}
+
+func TestS3MakeUsesStaticCredentialsWhenKeysAreProvided(t *testing.T) {
+	maker := s3RemoteStorageMaker{}
+	conf := &remote_pb.RemoteConf{
+		Type:             "s3",
+		S3Region:         "us-east-1",
+		S3Endpoint:       "http://localhost:8333",
+		S3ForcePathStyle: true,
+		S3AccessKey:      "test-access",
+		S3SecretKey:      "test-secret",
+	}
+
+	remoteClient, err := maker.Make(conf)
+	require.NoError(t, err)
+
+	client, ok := remoteClient.(*s3RemoteStorageClient)
+	require.True(t, ok)
+
+	s3Client, ok := client.conn.(*awss3.S3)
+	require.True(t, ok)
+	require.NotSame(t, credentials.AnonymousCredentials, s3Client.Config.Credentials)
+
+	credValue, err := s3Client.Config.Credentials.Get()
+	require.NoError(t, err)
+	require.Equal(t, conf.S3AccessKey, credValue.AccessKeyID)
+	require.Equal(t, conf.S3SecretKey, credValue.SecretAccessKey)
+}


### PR DESCRIPTION
# What problem are we solving?

fix https://github.com/seaweedfs/seaweedfs/issues/8256

# How are we solving the problem?

allow empty credentials

# How is the PR tested?

unit tests

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for public S3 bucket access without requiring credentials.

* **Tests**
  * Added tests to verify credential handling for authenticated and public S3 bucket scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->