### PR TITLE
s3api: fix multipart Complete ETag matching and lower empty-upload log noise

### DIFF
--- a/weed/operation/upload_chunked.go
+++ b/weed/operation/upload_chunked.go
@@ -113,7 +113,9 @@ uploadLoop:
 		// Only break if we've already read some data (chunkOffset > 0) or if this is truly EOF
 		if dataSize == 0 {
 			if chunkOffset == 0 {
-				glog.Warningf("UploadReaderInChunks: received 0 bytes on first read - creating empty file")
+				// Empty objects are valid for S3/HTTP uploads (e.g. zero-byte files).
+				// Keep this at verbose level to avoid warning noise in normal operation.
+				glog.V(4).Infof("UploadReaderInChunks: received 0 bytes on first read - creating empty file")
 			}
 			chunkBufferPool.Put(bytesBuffer)
 			<-bytesBufferLimitChan


### PR DESCRIPTION
## Summary
- fix `CompleteMultipartUpload` part ETag validation to compare against the canonical stored part ETag (`ExtETagKey` / `filer.ETag`) instead of only `Attributes.Md5`
- accept valid composite part ETags like `md5-partcount` (for chunked/multipart part entries) and avoid false `invalid complete etag` warnings
- downgrade `UploadReaderInChunks` first-read zero-byte message from warning to V(4), since empty object uploads are valid and common

## Why
`CompleteMultipartUpload` was rejecting/logging valid part ETags when the part entry did not have `Attributes.Md5` populated, even though the effective ETag existed in `Extended` or chunk-derived form.

## Tests
- `go test ./weed/s3api -run 'Test(InitiateMultipartUploadResult|ListPartsResult|parsePartNumber|GetEntryNameAndDir|ValidateCompletePartETag)$' -count=1`
- `go test ./weed/operation -run TestUploadReaderInChunks -count=1`
- `go test ./weed/operation -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 multipart upload reliability with enhanced ETag validation and normalization, ensuring more accurate completion verification.

* **Chores**
  * Reduced warning log noise for valid empty object uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->