### PR TITLE
Fix EC rebuild shard detection

### DIFF
--- a/weed/server/volume_grpc_erasure_coding_test.go
+++ b/weed/server/volume_grpc_erasure_coding_test.go
@@ -1,0 +1,57 @@
+package weed_server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage"
+)
+
+func TestCheckEcVolumeStatusCountOnlyDataShards(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	idxDir := filepath.Join(tempDir, "idx")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	if err := os.MkdirAll(idxDir, 0o755); err != nil {
+		t.Fatalf("mkdir idx dir: %v", err)
+	}
+
+	baseName := "7"
+	filesToCreate := []string{
+		filepath.Join(dataDir, baseName+".ec00"),
+		filepath.Join(dataDir, baseName+".ec09"),
+		filepath.Join(dataDir, baseName+".ec13"),
+		filepath.Join(idxDir, baseName+".ecx"),
+		filepath.Join(idxDir, baseName+".ecj"),
+		filepath.Join(idxDir, baseName+".idx"),
+	}
+	for _, fileName := range filesToCreate {
+		if err := os.WriteFile(fileName, []byte("x"), 0o644); err != nil {
+			t.Fatalf("create %s: %v", fileName, err)
+		}
+	}
+
+	location := &storage.DiskLocation{
+		Directory:    dataDir,
+		IdxDirectory: idxDir,
+	}
+
+	hasEcxFile, hasIdxFile, shardCount, err := checkEcVolumeStatus(baseName, location)
+	if err != nil {
+		t.Fatalf("checkEcVolumeStatus: %v", err)
+	}
+
+	if !hasEcxFile {
+		t.Fatalf("expected hasEcxFile=true")
+	}
+	if !hasIdxFile {
+		t.Fatalf("expected hasIdxFile=true")
+	}
+	if shardCount != 3 {
+		t.Fatalf("expected shardCount=3, got %d", shardCount)
+	}
+}
+


### PR DESCRIPTION
## Summary
- ignore non-data shards (.ecx, .ecj) when counting existing EC files so rebuild only runs when enough real shards exist
- add a regression test that verifies only numeric .ecNN files contribute toward the shard count
- explain why we keep `Reconstruct` for the full shard recovery path

## Testing
- go test ./weed/server -run TestCheckEcVolumeStatusCountOnlyDataShards -count=1

Fixes #8262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced erasure coding volume status detection to more accurately identify and count data shard files using improved validation patterns.

* **Tests**
  * Added comprehensive test coverage for erasure coding volume status checks, validating correct identification of data shards and index files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->