### PR TITLE
fix issue #8230: volume.fsck deletion logic to respect purgeAbsent flag

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -293,7 +293,7 @@ func (c *commandVolumeFsck) collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo m
 					}
 					fmt.Fprintf(c.writer, "%d,%x%08x %s volume not found\n", i.vid, i.fileKey, i.cookie, i.path)
 					if purgeAbsent {
-						fmt.Printf("deleting path %s after volume not found", i.path)
+						fmt.Fprintf(c.writer, "deleting path %s after volume not found\n", i.path)
 						c.httpDelete(i.path)
 					}
 				}


### PR DESCRIPTION
This PR fixes issue #8230 by ensuring that  deletion logic respects the `-reallyDeleteFilerEntries` (purgeAbsent) flag in more cases.

Specifically:
1. Missing chunks in existing volumes are now deleted if `-reallyDeleteFilerEntries` is set.
2. Missing volumes are now properly handled when a `-volumeId` filter is specified, allowing deletion of filer entries for those volumes.

Fixes #8230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purging now honors multiple purge conditions and more strictly respects volume filters, skipping unrelated volumes during cleanup.
  * Safer deletion handling: HTTP/request errors are detected and surfaced earlier to prevent incomplete or continued operations.
  * Reporting refinements to ensure orphan/missing-entry reports remain accurate under the stricter filter and error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->