### PR TITLE
Fix master leader election when grpc ports change

### DIFF
--- a/weed/command/master_test.go
+++ b/weed/command/master_test.go
@@ -43,3 +43,24 @@ func TestCheckPeersCanonicalizesSelfEntry(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckPeersDeduplicatesAliasPeers(t *testing.T) {
+	_, peers := checkPeers("127.0.0.1", 9000, 19000, "127.0.0.1:9002,127.0.0.1:9002.19002,127.0.0.1:9003")
+
+	if len(peers) != 3 {
+		t.Fatalf("expected 3 unique peers after normalization, got %d: %+v", len(peers), peers)
+	}
+
+	count9002 := 0
+	for _, peer := range peers {
+		if peer.ToHttpAddress() == "127.0.0.1:9002" {
+			count9002++
+			if string(peer) != "127.0.0.1:9002.19002" {
+				t.Fatalf("expected canonical peer 127.0.0.1:9002.19002, got %q", peer)
+			}
+		}
+	}
+	if count9002 != 1 {
+		t.Fatalf("expected one peer for 127.0.0.1:9002, got %d in %+v", count9002, peers)
+	}
+}


### PR DESCRIPTION
## Summary
- compare peers by HTTP address only so the bootstrap first-node check works even when the gRPC port component changes
- add regression tests that ensure the comparison ignores the gRPC port and that the produced peers include self by HTTP address

## Testing
- go test ./weed/command

Fixes #8270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Peer handling now deduplicates and normalizes addresses by HTTP host:port before ordering and identity checks, avoiding duplicate entries and ensuring the master is correctly identified even when gRPC ports differ.
  * Self-peer entries are canonicalized so the canonical HTTP address replaces non-canonical matches.

* **Tests**
  * Added tests verifying HTTP-based peer matching, self-canonicalization, and deduplication of alias peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->