### PR TITLE
Iceberg: make stage-create semantics explicit

### DIFF
--- a/weed/s3api/iceberg/iceberg_create_table_test.go
+++ b/weed/s3api/iceberg/iceberg_create_table_test.go
@@ -1,0 +1,27 @@
+package iceberg
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateCreateTableRequestRejectsStageCreate(t *testing.T) {
+	err := validateCreateTableRequest(CreateTableRequest{Name: "orders", StageCreate: true})
+	if !errors.Is(err, errStageCreateUnsupported) {
+		t.Fatalf("validateCreateTableRequest() error = %v, want errStageCreateUnsupported", err)
+	}
+}
+
+func TestValidateCreateTableRequestRequiresName(t *testing.T) {
+	err := validateCreateTableRequest(CreateTableRequest{})
+	if err == nil {
+		t.Fatalf("validateCreateTableRequest() expected error")
+	}
+}
+
+func TestValidateCreateTableRequestAcceptsStandardCreate(t *testing.T) {
+	err := validateCreateTableRequest(CreateTableRequest{Name: "orders"})
+	if err != nil {
+		t.Fatalf("validateCreateTableRequest() error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make `stage-create` behavior explicit in Iceberg table create: return `501 NotImplementedException` and do not create table state
- prevent partial create behavior where table metadata entry could be created without writing a metadata file
- add unit tests for create-table request validation, including stage-create rejection

## Testing
- `go test ./weed/s3api/iceberg`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for Iceberg table creation requests to ensure proper request structure.
  * Stage-create operations now return explicit "not implemented" errors with clearer messaging instead of generic validation errors.
  * Improved error handling and responses for invalid or unsupported table creation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->