### PR TITLE
Remove unsupported iceberg rest signing-region from tests and docs

### DIFF
--- a/test/s3tables/Makefile
+++ b/test/s3tables/Makefile
@@ -300,7 +300,6 @@ populate-spark: ensure-table-bucket ensure-work-dir ## Populate sample data via 
 			--conf "spark.sql.catalog.iceberg.s3.region=$(AWS_REGION)" \
 			--conf "spark.sql.catalog.iceberg.rest.sigv4-enabled=true" \
 			--conf "spark.sql.catalog.iceberg.rest.signing-name=s3tables" \
-			--conf "spark.sql.catalog.iceberg.rest.signing-region=$(AWS_REGION)" \
 			--conf "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkCatalog" \
 			--conf "spark.sql.catalog.spark_catalog.type=rest" \
 			--conf "spark.sql.catalog.spark_catalog.uri=$(CATALOG_ENDPOINT_DOCKER)" \
@@ -314,7 +313,6 @@ populate-spark: ensure-table-bucket ensure-work-dir ## Populate sample data via 
 			--conf "spark.sql.catalog.spark_catalog.s3.region=$(AWS_REGION)" \
 			--conf "spark.sql.catalog.spark_catalog.rest.sigv4-enabled=true" \
 			--conf "spark.sql.catalog.spark_catalog.rest.signing-name=s3tables" \
-			--conf "spark.sql.catalog.spark_catalog.rest.signing-region=$(AWS_REGION)" \
 			-f /work/spark_seed.sql'
 
 populate: populate-trino populate-spark ## Populate sample data through Trino and Spark

--- a/test/s3tables/catalog_spark/setup_test.go
+++ b/test/s3tables/catalog_spark/setup_test.go
@@ -326,7 +326,6 @@ spark = (SparkSession.builder
     .config("spark.sql.catalog.iceberg.rest.auth.type", "sigv4")
     .config("spark.sql.catalog.iceberg.rest.auth.sigv4.delegate-auth-type", "none")
     .config("spark.sql.catalog.iceberg.rest.sigv4-enabled", "true")
-    .config("spark.sql.catalog.iceberg.rest.signing-region", "us-west-2")
     .config("spark.sql.catalog.iceberg.rest.signing-name", "s3")
     .config("spark.sql.catalog.iceberg.rest.access-key-id", "test")
     .config("spark.sql.catalog.iceberg.rest.secret-access-key", "test")


### PR DESCRIPTION
Following user report that iceberg.rest-catalog.signing-region is not supported in Trino versions, this PR removes it and similar Spark properties from tests and docs for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Iceberg signing-region REST configuration from test files and build configuration. All other settings and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->