### PR TITLE
ci: fix container_release_unified manual dispatch and workflow parsing

### DIFF
--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -41,10 +41,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name != 'workflow_dispatch' ||
-      github.event.inputs.variant == 'all' ||
-      github.event.inputs.variant == matrix.variant
     strategy:
       # Build sequentially to avoid rate limits
       max-parallel: 2
@@ -87,9 +83,11 @@ jobs:
             
     steps:
       - name: Checkout
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: actions/checkout@v6
         
       - name: Free Disk Space
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         run: |
           echo "Available disk space before cleanup:"
           df -h
@@ -103,6 +101,7 @@ jobs:
           df -h
           
       - name: Docker meta
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
@@ -117,10 +116,11 @@ jobs:
             org.opencontainers.image.vendor=Chris Lu
             
       - name: Set up QEMU
-        if: contains(matrix.platforms, 'arm')
+        if: (github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant) && contains(matrix.platforms, 'arm')
         uses: docker/setup-qemu-action@v3
         
       - name: Create BuildKit config
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         run: |
           cat > /tmp/buildkitd.toml <<EOF
           [registry."docker.io"]
@@ -128,19 +128,20 @@ jobs:
           EOF
           
       - name: Set up Docker Buildx
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config: /tmp/buildkitd.toml
           
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: (github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant) && github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: (github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant) && github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -148,6 +149,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
           
       - name: Build and push ${{ matrix.variant }}
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: docker/build-push-action@v6
         env:
           DOCKER_BUILDKIT: 1
@@ -169,7 +171,7 @@ jobs:
             ${{ matrix.variant == 'rocksdb' && format('ROCKSDB_VERSION={0}', github.event.inputs.rocksdb_version || 'v10.10.1') || '' }}
             
       - name: Clean up build artifacts
-        if: always()
+        if: always() && (github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant)
         run: |
           sudo docker system prune -f
           sudo rm -rf /tmp/go-build*
@@ -177,13 +179,7 @@ jobs:
   copy-to-dockerhub:
     runs-on: ubuntu-latest
     needs: [build]
-    if: |
-      github.event_name != 'pull_request' &&
-      (
-        github.event_name != 'workflow_dispatch' ||
-        github.event.inputs.variant == 'all' ||
-        github.event.inputs.variant == matrix.variant
-      )
+    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         variant: [normal, large_disk, full, large_disk_full, rocksdb]
@@ -201,12 +197,14 @@ jobs:
             
     steps:
       - name: Login to Docker Hub
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
       - name: Login to GHCR
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -214,6 +212,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
           
       - name: Install crane
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         run: |
           cd $(mktemp -d)
           curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" | tar xz
@@ -221,6 +220,7 @@ jobs:
           crane version
           
       - name: Copy ${{ matrix.variant }} from GHCR to Docker Hub
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         run: |
           # Function to retry with exponential backoff
           retry_with_backoff() {


### PR DESCRIPTION
## Problem
`container_release_unified.yml` was being listed by filename and failing immediately (0s runs), so manual dispatch did not start.

## Root Cause
The workflow used `matrix` context in **job-level** `if` expressions. GitHub does not allow `matrix` there, causing workflow file evaluation errors.

## Fix
- removed `matrix` references from job-level `if`
- moved variant filtering checks to step-level `if` expressions in both `build` and `copy-to-dockerhub` jobs
- kept manual dispatch behavior the same: `variant` + required `release_tag`

## Validation
- `actionlint` no longer reports expression/context errors for this workflow file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal build and deployment workflow automation to enhance consistency and control across different build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->