### PR TITLE
s3api: fix ListObjectsV2 NextContinuationToken duplication for nested prefix

### DIFF
--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -472,6 +472,9 @@ func buildTruncatedNextMarker(requestDir, prefix, nextMarker string, lastEntryWa
 			}
 			return requestDir + "/" + lastCommonPrefixName + "/"
 		}
+		if prefix != "" {
+			return prefix + "/" + lastCommonPrefixName + "/"
+		}
 		return lastCommonPrefixName + "/"
 	}
 

--- a/weed/s3api/s3api_object_handlers_list_test.go
+++ b/weed/s3api/s3api_object_handlers_list_test.go
@@ -161,6 +161,11 @@ func TestBuildTruncatedNextMarker(t *testing.T) {
 		actual := buildTruncatedNextMarker("xemu", "export_2026-02-10_17-00-23", "", true, "nested")
 		assert.Equal(t, "xemu/export_2026-02-10_17-00-23/nested/", actual)
 	})
+
+	t.Run("includes prefix for common prefix marker when request dir is empty", func(t *testing.T) {
+		actual := buildTruncatedNextMarker("", "foo", "", true, "bar")
+		assert.Equal(t, "foo/bar/", actual)
+	})
 }
 
 func TestAllowUnorderedParameterValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a regression test for ListObjectsV2 truncated marker composition using a nested prefix path
- fix next-marker composition to avoid prepending the parsed prefix segment twice
- keep common-prefix marker behavior unchanged

## Repro from issue
For prefix \xemu/export_2026-02-10_17-00-23\, the previous token could become:
`xemu/export_2026-02-10_17-00-23/export_2026-02-10_17-00-23/4156000e.jpg`

Now it correctly returns:
`xemu/export_2026-02-10_17-00-23/4156000e.jpg`

## Testing
- `go test ./weed/s3api -run TestBuildTruncatedNextMarker -count=1` (fails before fix, passes after)
- `go test ./weed/s3api -count=1`

Closes #8287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized truncation-marker computation for object listing to simplify handling of continuation tokens and common-prefix edge cases while preserving existing behavior.

* **Tests**
  * Added unit tests covering continuation-token and common-prefix scenarios for truncated list responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->