### PR TITLE
admin: require CSRF for S3 tables EU bucket writes

### DIFF
--- a/weed/admin/dash/s3tables_management.go
+++ b/weed/admin/dash/s3tables_management.go
@@ -579,6 +579,9 @@ func (s *AdminServer) ListS3TablesBucketsAPI(c *gin.Context) {
 }
 
 func (s *AdminServer) CreateS3TablesBucket(c *gin.Context) {
+	if !requireSessionCSRFToken(c) {
+		return
+	}
 	var req struct {
 		Name  string            `json:"name"`
 		Tags  map[string]string `json:"tags"`
@@ -664,6 +667,9 @@ func (s *AdminServer) SetTableBucketOwner(ctx context.Context, bucketName, owner
 }
 
 func (s *AdminServer) DeleteS3TablesBucket(c *gin.Context) {
+	if !requireSessionCSRFToken(c) {
+		return
+	}
 	bucketArn := c.Query("bucket")
 	if bucketArn == "" {
 		c.JSON(400, gin.H{"error": "Bucket ARN is required"})


### PR DESCRIPTION
## Summary
- require the admin session CSRF token before creating or deleting S3 Tables buckets
- keep the create/delete bucket write surface aligned with the namespace handlers

## Testing
- not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for S3 Tables administrative operations by implementing additional authentication validation for API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->