### PR TITLE
filer.sync: support manifest chunks

### DIFF
--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -127,7 +127,7 @@ func (fs *FilerSink) CreateEntry(key string, entry *filer_pb.Entry, signatures [
 			}
 		}
 
-		replicatedChunks, err := fs.replicateChunks(entry.GetChunks(), key, getEntryMtime(entry))
+		replicatedChunks, err := fs.replicateChunks(context.Background(), entry.GetChunks(), key, getEntryMtime(entry))
 
 		if err != nil {
 			// only warning here since the source chunk may have been deleted already
@@ -211,7 +211,7 @@ func (fs *FilerSink) UpdateEntry(key string, oldEntry *filer_pb.Entry, newParent
 		}
 
 		// replicate the chunks that are new in the source
-		replicatedChunks, err := fs.replicateChunks(newChunks, key, getEntryMtime(newEntry))
+		replicatedChunks, err := fs.replicateChunks(context.Background(), newChunks, key, getEntryMtime(newEntry))
 		if err != nil {
 			glog.Warningf("replicate entry chunks %s: %v", key, err)
 			return true, nil


### PR DESCRIPTION
## Summary
- teach `filersink` replication to handle `is_chunk_manifest` chunks in `filer.sync`
- resolve manifest chunks, replicate referenced chunks recursively, and upload a rebuilt manifest chunk with destination-side file IDs
- preserve source chunk metadata fields used by sync logic (`SourceFileId`, offsets, timestamps) and keep SSE metadata on regular chunks
- fix concurrent error assignment in chunk replication by guarding the first error

## Validation
- `go test ./weed/replication/sink/filersink`
- `go test ./weed/command -run TestNonExistent -count=0`
- `go test ./weed/replication/... -run TestNonExistent -count=0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced file replication with full manifest support: manifest chunks are resolved, their data reassembled and uploaded as separate manifest blobs.
  * Improved upload routing to choose proxy or direct URLs for transfers.

* **Reliability**
  * Centralized error collection with early abort to reduce wasted work on failures.
  * Individual chunk retries and preservation of server-side encryption metadata during replication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->