### PR TITLE
s3api/policy_engine: use forwarded client IP for aws:SourceIp

### DIFF
--- a/weed/s3api/policy_engine/engine_test.go
+++ b/weed/s3api/policy_engine/engine_test.go
@@ -466,12 +466,12 @@ func TestExtractConditionValuesFromRequestSourceIPPrecedence(t *testing.T) {
 		expectedIP string
 	}{
 		{
-			name: "uses first valid X-Forwarded-For entry",
+			name: "uses right-most public X-Forwarded-For entry",
 			header: map[string][]string{
 				"X-Forwarded-For": {"bad-ip, 203.0.113.10, 198.51.100.5"},
 			},
 			remoteAddr: "192.168.1.100:12345",
-			expectedIP: "203.0.113.10",
+			expectedIP: "198.51.100.5",
 		},
 		{
 			name: "falls back to X-Real-Ip when X-Forwarded-For has no valid ip",
@@ -500,7 +500,15 @@ func TestExtractConditionValuesFromRequestSourceIPPrecedence(t *testing.T) {
 				"X-Forwarded-For": {"2001:db8::8, 198.51.100.7"},
 			},
 			remoteAddr: "192.168.1.100:12345",
-			expectedIP: "2001:db8::8",
+			expectedIP: "198.51.100.7",
+		},
+		{
+			name: "ignores spoofed IP when real client is public",
+			header: map[string][]string{
+				"X-Forwarded-For": {"8.8.8.8, 203.0.113.10, 10.0.0.1"},
+			},
+			remoteAddr: "192.168.1.100:12345",
+			expectedIP: "203.0.113.10",
 		},
 		{
 			name:       "handles bracketed IPv6 remote address",


### PR DESCRIPTION
## Summary
- use a dedicated source IP extraction helper for `aws:SourceIp`
- prefer `X-Forwarded-For` (first valid IP), then `X-Real-Ip`, then parsed `RemoteAddr`
- document that forwarding headers are trusted when direct exposure is not protected by a proxy
- guard against returning DNS host names and add IPv6 coverage for forwarded/remote values
- keep non-IP fallbacks (e.g. unix socket marker `@`) without parse warnings

## Testing
- `go test ./weed/s3api/policy_engine`
- `go test ./weed/s3api/...`

Fixes #8301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source IP detection for S3 API policy conditions: uses X-Forwarded-For priority, falls back to X-Real-Ip then RemoteAddr; applies trust rules for proxies, handles bracketed IPv6, skips non-IP hosts, and preserves non-IP markers.

* **New Features**
  * Added aws:RequestTime as an additional condition alongside aws:CurrentTime.

* **Tests**
  * Added tests validating source IP extraction and precedence across headers and RemoteAddr scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->