### PR TITLE
Fix inconsistent admin argument in worker pods

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-service.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-admin" (include "seaweedfs.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "seaweedfs.componentName" (list . "admin") }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -134,7 +134,7 @@ spec:
               {{- if .Values.worker.adminServer }}
               -admin={{ .Values.worker.adminServer }} \
               {{- else }}
-              -admin={{ printf "%s-admin" (include "seaweedfs.fullname" .) | trunc 63 | trimSuffix "-" }}.{{ .Release.Namespace }}:{{ .Values.admin.port }}{{ if .Values.admin.grpcPort }}.{{ .Values.admin.grpcPort }}{{ end }} \
+              -admin={{ include "seaweedfs.componentName" (list . "admin") }}.{{ .Release.Namespace }}:{{ .Values.admin.port }}{{ if .Values.admin.grpcPort }}.{{ .Values.admin.grpcPort }}{{ end }} \
               {{- end }}
               -capabilities={{ .Values.worker.capabilities }} \
               -maxConcurrent={{ .Values.worker.maxConcurrent }} \


### PR DESCRIPTION
Fixes #8314. The worker deployment now uses `seaweedfs.fullname` to construct the admin service address, matching the admin service definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored Kubernetes Helm chart templates to standardize service naming for admin endpoints, improving configuration consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->