### PR TITLE
s3api: fix AccessDenied by correctly propagating principal ARN in vended tokens

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -100,6 +100,9 @@ type Account struct {
 	Id string
 }
 
+// Default account ID for all automated SeaweedFS accounts and fallback
+const defaultAccountID = "000000000000"
+
 // Predefined Accounts
 var (
 	// AccountAdmin is used as the default account for IAM-Credentials access without Account configured
@@ -1011,9 +1014,9 @@ func generatePrincipalArn(identityName string) string {
 	case AccountAnonymous.Id:
 		return "*" // Use universal wildcard for anonymous allowed by bucket policy
 	case AccountAdmin.Id:
-		return "arn:aws:iam::000000000000:user/admin"
+		return fmt.Sprintf("arn:aws:iam::%s:user/admin", defaultAccountID)
 	default:
-		return fmt.Sprintf("arn:aws:iam::000000000000:user/%s", identityName)
+		return fmt.Sprintf("arn:aws:iam::%s:user/%s", defaultAccountID, identityName)
 	}
 }
 
@@ -1419,7 +1422,7 @@ func buildPrincipalARN(identity *Identity, r *http.Request) string {
 
 	// Build an AWS-compatible principal ARN
 	// Format: arn:aws:iam::account-id:user/user-name
-	accountID := "000000000000" // Default account ID
+	accountID := defaultAccountID // Default account ID
 	if identity.Account != nil && identity.Account.Id != "" {
 		accountID = identity.Account.Id
 	}

--- a/weed/s3api/auth_credentials_test.go
+++ b/weed/s3api/auth_credentials_test.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"sync"
@@ -294,7 +295,7 @@ func TestLoadS3ApiConfiguration(t *testing.T) {
 			expectIdent: &Identity{
 				Name:         "notSpecifyAccountId",
 				Account:      &AccountAdmin,
-				PrincipalArn: "arn:aws:iam::000000000000:user/notSpecifyAccountId",
+				PrincipalArn: fmt.Sprintf("arn:aws:iam::%s:user/notSpecifyAccountId", defaultAccountID),
 				Actions: []Action{
 					"Read",
 					"Write",
@@ -320,7 +321,7 @@ func TestLoadS3ApiConfiguration(t *testing.T) {
 			expectIdent: &Identity{
 				Name:         "specifiedAccountID",
 				Account:      &specifiedAccount,
-				PrincipalArn: "arn:aws:iam::000000000000:user/specifiedAccountID",
+				PrincipalArn: fmt.Sprintf("arn:aws:iam::%s:user/specifiedAccountID", defaultAccountID),
 				Actions: []Action{
 					"Read",
 					"Write",

--- a/weed/s3api/s3api_bucket_policy_arn_test.go
+++ b/weed/s3api/s3api_bucket_policy_arn_test.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -108,7 +109,7 @@ func TestBuildPrincipalARN(t *testing.T) {
 					Id: "",
 				},
 			},
-			expected: "arn:aws:iam::000000000000:user/test-user",
+			expected: fmt.Sprintf("arn:aws:iam::%s:user/test-user", defaultAccountID),
 		},
 		{
 			name: "identity without name",

--- a/weed/s3api/s3api_sts.go
+++ b/weed/s3api/s3api_sts.go
@@ -44,9 +44,6 @@ const (
 const (
 	minDurationSeconds = int64(900)   // 15 minutes
 	maxDurationSeconds = int64(43200) // 12 hours
-
-	// Default account ID for federated users
-	defaultAccountId = "000000000000"
 )
 
 // parseDurationSeconds parses and validates the DurationSeconds parameter
@@ -92,7 +89,7 @@ func (h *STSHandlers) getAccountID() string {
 	if h.stsService != nil && h.stsService.Config != nil && h.stsService.Config.AccountId != "" {
 		return h.stsService.Config.AccountId
 	}
-	return defaultAccountId
+	return defaultAccountID
 }
 
 // HandleSTSRequest is the main entry point for STS requests


### PR DESCRIPTION
This PR fixes an 'AccessDenied' error in Lakekeeper integration tests by ensuring that STS vended tokens correctly carry the assumed role ARN as the principal claim. It also standardizes principal ARN generation in 'auth_credentials.go' to include the account ID for consistency across S3 API operations. Fixes are verified with both unit and integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public hooks to access credential manager and install IAM integration.

* **Bug Fixes**
  * Explicit PrincipalArn now takes precedence; anonymous principals return wildcard "*" and ARN construction is nil-safe with resolved account IDs for assumed roles.
  * Improved logging and error reporting when reloading S3 API configuration.

* **Tests**
  * Updated and added tests to validate explicit PrincipalArn behavior and new ARN formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->