### PR TITLE
fix: allow overriding Enterprise image name using Helm #8361

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -135,12 +135,10 @@ Inject extra environment vars in the format key:value, if populated
 {{- $repositoryName := default .Values.image.repository .Values.global.repository | toString -}}
 {{- $name := .Values.global.imageName | toString -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag  | toString -}}
-{{- if $repositoryName -}}
-{{-   if .Values.image.repository -}}
-{{-     $name = $repositoryName -}}
-{{-   else -}}
-{{-     $name = printf "%s/%s" (trimSuffix "/" $repositoryName) (base $name) -}}
-{{-   end -}}
+{{- if .Values.image.repository -}}
+{{-   $name = $repositoryName -}}
+{{- else if $repositoryName -}}
+{{-   $name = printf "%s/%s" (trimSuffix "/" $repositoryName) (base $name) -}}
 {{- end -}}
 {{- if $registryName -}}
 {{-   printf "%s/%s:%s" $registryName $name $tag -}}


### PR DESCRIPTION
Fixes #8361. This change allows users to override the full image name (e.g., for Enterprise versions) using  while maintaining backward compatibility for  prefixing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container image name resolution for Kubernetes charts: when an explicit image repository is provided it’s used directly; otherwise, previous name-construction behavior is preserved. This makes custom repository configurations more predictable while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->