### PR TITLE
feat(k8s): added possibility to specify service.type for multiple ser…

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-service.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-service.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml .Values.filer.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.filer.service.type }}
+  clusterIP: None
   publishNotReadyAddresses: true
   ports:
   - name: "swfs-filer"

--- a/k8s/charts/seaweedfs/templates/master/master-service.yaml
+++ b/k8s/charts/seaweedfs/templates/master/master-service.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- toYaml .Values.master.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.master.service.type }}
+  clusterIP: None
   publishNotReadyAddresses: true
   ports:
   - name: "swfs-master"

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -267,10 +267,6 @@ master:
       #   sub_filter_once off;
     tls: []
 
-  # Service settings
-  service:
-    type: ClusterIP
-
   extraEnvironmentVars:
     WEED_MASTER_VOLUME_GROWTH_COPY_1: "7"
     WEED_MASTER_VOLUME_GROWTH_COPY_2: "6"
@@ -837,10 +833,6 @@ filer:
       #   sub_filter '=/' '=./';
       #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
       #   sub_filter_once off;
-
-  # Service settings
-  service:
-    type: ClusterIP
 
   # extraEnvVars is a list of extra environment variables to set with the stateful set.
   extraEnvironmentVars:


### PR DESCRIPTION
Added the possibility to specify service.type in the helm chart.

# What problem are we solving?
The services did not specify the type from the values.yaml file.

# How are we solving the problem?
This PR will import the service.type from values.yaml and insert the value into the resources.

# How is the PR tested?
By manually setting the values in my kubernetes cluster.


# Checks
- [X] I have added unit tests if possible.
- [X] I will add related wiki document changes and link to this PR after merging.
- [X] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [X] I have reviewed every line of code.
- [X] The PR is kept as minimum as possible. Large PRs would not be accepted.

No AI is used.

#first-pr :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Kubernetes Service types for S3, SFTP, and admin components are now configurable through deployment values, enabling operators to customize external accessibility and networking configuration on a per-component basis. Services default to ClusterIP (internal-only access) but can be adjusted to suit different deployment topologies and organizational requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->