### PR TITLE
Fix volume.fsck crashing on EC volumes and add multi-volume vacuum support

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -119,6 +119,7 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 	c.volumeIds = make(map[uint32]bool)
 	if *volumeIds != "" {
 		for _, volumeIdStr := range strings.Split(*volumeIds, ",") {
+			volumeIdStr = strings.TrimSpace(volumeIdStr)
 			if volumeIdInt, err := strconv.ParseUint(volumeIdStr, 10, 32); err == nil {
 				c.volumeIds[uint32(volumeIdInt)] = true
 			} else {
@@ -655,6 +656,11 @@ func (c *commandVolumeFsck) oneVolumeFileIdsSubtractFilerFileIds(dataNodeId stri
 					return nil
 				})
 		} else {
+			if vinfo.isEcVolume && (cutoffFrom > 0 || modifyFrom > 0) {
+				if *c.verbose {
+					fmt.Fprintf(c.writer, "skipping time-based filtering for EC volume %d (cutoffFrom=%d, modifyFrom=%d)\n", volumeId, cutoffFrom, modifyFrom)
+				}
+			}
 			orphanFileIds = append(orphanFileIds, n.Key.FileId(volumeId))
 			orphanFileCount++
 			orphanDataSize += uint64(n.Size)

--- a/weed/shell/command_volume_vacuum.go
+++ b/weed/shell/command_volume_vacuum.go
@@ -39,7 +39,7 @@ func (c *commandVacuum) Do(args []string, commandEnv *CommandEnv, writer io.Writ
 	volumeVacuumCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	garbageThreshold := volumeVacuumCommand.Float64("garbageThreshold", 0.3, "vacuum when garbage is more than this limit")
 	collection := volumeVacuumCommand.String("collection", "", "vacuum this collection")
-	volumeIds := volumeVacuumCommand.String("volumeId", "", "comma separated the volume id")
+	volumeIds := volumeVacuumCommand.String("volumeId", "", "comma-separated list of volume IDs")
 	if err = volumeVacuumCommand.Parse(args); err != nil {
 		return nil
 	}
@@ -51,6 +51,7 @@ func (c *commandVacuum) Do(args []string, commandEnv *CommandEnv, writer io.Writ
 	var volumeIdInts []uint32
 	if *volumeIds != "" {
 		for _, volumeIdStr := range strings.Split(*volumeIds, ",") {
+			volumeIdStr = strings.TrimSpace(volumeIdStr)
 			if volumeIdInt, err := strconv.ParseUint(volumeIdStr, 10, 32); err == nil {
 				volumeIdInts = append(volumeIdInts, uint32(volumeIdInt))
 			} else {


### PR DESCRIPTION
Fixes https://github.com/seaweedfs/seaweedfs/issues/8402.

On v4.12, `volume.fsck -collection=...` errors on EC volumes because reading needle metadata at ec shards is not supported, and aborts entirely, leaving remaining volumes unprocessed.

This PR adds an optional `-skipEcVolumes` flag and simply skips reading needle metadata from EC volumes altogether. Also this PR enhances `volume.vacuum` to accept a comma-separated list of volume IDs, making it consistent with `volume.fsck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable option to skip erasure-coded volumes during file system consistency checks, with optimized handling to reduce unnecessary processing
  * Volume maintenance command now supports processing multiple volumes in a single operation via comma-separated volume identifiers, improving batch processing efficiency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->