### PR TITLE
Worker maintenance tasks now use non-default grpcPort if configured

### DIFF
--- a/weed/plugin/worker/vacuum_handler.go
+++ b/weed/plugin/worker/vacuum_handler.go
@@ -575,7 +575,7 @@ func buildVolumeMetrics(
 						metric := &workertypes.VolumeHealthMetrics{
 							VolumeID:         volume.Id,
 							Server:           node.Id,
-							ServerAddress:    node.Address,
+							ServerAddress:    string(pb.NewServerAddressFromDataNode(node)),
 							DiskType:         diskType,
 							DiskId:           volume.DiskId,
 							DataCenter:       dc.Id,

--- a/weed/worker/tasks/util/address.go
+++ b/weed/worker/tasks/util/address.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/seaweedfs/seaweedfs/weed/admin/topology"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 )
 
 // ResolveServerAddress resolves a server ID to its network address using the active topology
@@ -16,8 +17,7 @@ func ResolveServerAddress(serverID string, activeTopology *topology.ActiveTopolo
 	if !exists {
 		return "", fmt.Errorf("server %s not found in topology", serverID)
 	}
-	if nodeInfo.Address == "" {
-		return "", fmt.Errorf("server %s has no address in topology", serverID)
-	}
-	return nodeInfo.Address, nil
+	// Note: We use NewServerAddressFromDataNode here because it encodes the GRPC port into the server address
+	// if it is non-zero, avoiding the default +10000 GRPC port offset.
+	return string(pb.NewServerAddressFromDataNode(nodeInfo)), nil
 }


### PR DESCRIPTION
Fixes #8401

When creating balance/vacuum tasks, the worker maintenance scheduler was
accidentally discarding the custom grpcPort defined on the DataNodeInfo
by using just its HTTP `Address` string, which defaults to `+10000`
during grpc dialing.

By using `pb.NewServerAddressFromDataNode`, the grpcPort suffix is correctly
encoded in the server address string, preventing `connection refused` errors
for users running volume servers with custom gRPC ports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved server address resolution in worker components to ensure more consistent identification across the distributed system
  * Enhanced volume health metrics accuracy by refining how server addresses are calculated and represented internally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->