### PR TITLE
fix(s3api): make ListObjectsV1 namespaced and prevent marker-echo pagination loops

### DIFF
--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -47,7 +47,7 @@ type ListBucketResultV2 struct {
 	StartAfter            string         `xml:"StartAfter,omitempty"`
 }
 
-type ListBucketResultV1 struct {
+type listBucketResultV1 struct {
 	XMLName        xml.Name        `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListBucketResult"`
 	Metadata       []MetadataEntry `xml:"Metadata,omitempty"`
 	Name           string          `xml:"Name"`
@@ -62,8 +62,8 @@ type ListBucketResultV1 struct {
 	EncodingType   string          `xml:"EncodingType,omitempty"`
 }
 
-func toListBucketResultV1(in ListBucketResult) ListBucketResultV1 {
-	return ListBucketResultV1{
+func toListBucketResultV1(in ListBucketResult) listBucketResultV1 {
+	return listBucketResultV1{
 		Metadata:       in.Metadata,
 		Name:           in.Name,
 		Prefix:         in.Prefix,
@@ -193,7 +193,7 @@ func (s3a *S3ApiServer) ListObjectsV1Handler(w http.ResponseWriter, r *http.Requ
 }
 
 func sanitizeV1MarkerEcho(response *ListBucketResult, marker string, encodingTypeUrl bool) {
-	if response == nil || marker == "" {
+	if marker == "" {
 		return
 	}
 

--- a/weed/s3api/s3api_object_handlers_list_test.go
+++ b/weed/s3api/s3api_object_handlers_list_test.go
@@ -70,6 +70,10 @@ type markerEchoFilerClient struct {
 	returnFollowing bool
 }
 
+// markerEchoFilerClient intentionally ignores request Limit/InclusiveStartFrom
+// and simulates a backend that may echo StartFromFileName. entriesByDir controls
+// returned entries; returnFollowing controls whether ListEntries returns only the
+// echoed marker or the echoed marker plus following entries.
 func (c *markerEchoFilerClient) ListEntries(ctx context.Context, in *filer_pb.ListEntriesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[filer_pb.ListEntriesResponse], error) {
 	entries := c.entriesByDir[in.Directory]
 	ensureEntryAttributes(entries)


### PR DESCRIPTION
## Summary
This PR fixes `ListObjectsV1` XML compatibility and hardens marker pagination in the shared listing path.

## Problem
- V1 XML root was returned without the S3 namespace.
- Marker pagination could echo the marker object and cause no-progress loops / duplicate rows.

## Changes
- Added a namespaced V1 response type:
  - `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListBucketResult"`
- Updated `ListObjectsV1Handler` to serialize through the namespaced V1 type.
- Hardened marker handling in shared `doListFilerEntries`:
  - skip `entry.Name == marker` in exclusive marker mode
  - keeps marker pagination progressing even with echoed-marker backend responses
- Added V1 sanitizer fallback for no-progress pages.

## Scope
- Primary functional fix is for **ListObjectsV1** XML compatibility.
- Marker-echo guard is in shared listing code (`doListFilerEntries`), so it also benefits V2 marker progression safety.

## Tests
Added in `weed/s3api/s3api_object_handlers_list_test.go`:
- `TestListObjectsV1NamespaceResponse`
- `TestDoListFilerEntries_ExclusiveStartSkipsMarkerEcho`
- `TestDoListFilerEntries_ExclusiveStartSkipsMarkerEchoWithSubsequentEntries`
- `TestSanitizeV1MarkerEcho_NoProgressGuard`

Validation:
- `go test ./weed/s3api -count=1` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * V1-shaped S3 list responses for improved formatting and pagination compatibility.

* **Bug Fixes**
  * Corrected marker-echo handling to prevent incorrect pagination and empty-result edge cases.
  * Ensured proper V1 XML namespace encoding.

* **Tests**
  * Added tests for V1 listing behavior, marker-echo edge cases, exclusive-start semantics, and pagination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->