### PR TITLE
fix: plural `clientType` on `ListExistingPeerUpdates`

### DIFF
--- a/weed/cluster/master_client.go
+++ b/weed/cluster/master_client.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 
+	"github.com/dustin/go-humanize/english"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
@@ -20,7 +21,7 @@ func ListExistingPeerUpdates(master pb.ServerAddress, grpcDialOption grpc.DialOp
 			return err
 		}
 
-		glog.V(0).Infof("the cluster has %d %s\n", len(resp.ClusterNodes), clientType)
+		glog.V(0).Infof("the cluster has %d %s\n", len(resp.ClusterNodes), english.PluralWord(len(resp.ClusterNodes), clientType, ""))
 		for _, node := range resp.ClusterNodes {
 			existingNodes = append(existingNodes, &master_pb.ClusterNodeUpdate{
 				NodeType:    FilerType,


### PR DESCRIPTION
# What problem are we solving?

When reading through seaweedfs logs, often the message "the cluster has 3 filer" will show up.

For a multi-filer environment, it would be better to say "the cluster has 3 filers". The same holds true for other client types such as "masters".

# How are we solving the problem?

This uses the `english.PluralWord` function that is already used in the codebase.

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cluster logging message formatting with proper singular/plural grammar based on node count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->