### PR TITLE
Use master shard sizes for EC volumes

### DIFF
--- a/weed/admin/dash/ec_shard_management.go
+++ b/weed/admin/dash/ec_shard_management.go
@@ -6,10 +6,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
-	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 )
 


### PR DESCRIPTION
## Summary
- use shard sizes from master VolumeList for EC volume list
- avoid per-volume VolumeEcShardsInfo calls that cause timeouts

## Testing
- not run (not requested)

Fixes #8419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * EC shard sizing is now driven by the cluster master when available, reducing cross-server queries and improving efficiency.
  * Shard size reporting and volume completeness calculations have been updated for more consistent and accurate status/size information.
  * Fall back handling preserved when master sizes are not provided, maintaining resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->