### PR TITLE
feat(helm): annotations for service account

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/service-account.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/service-account.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "seaweedfs.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.global.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -20,6 +20,7 @@ global:
       filerRead: false
   # we will use this serviceAccountName for all ClusterRoles/ClusterRoleBindings
   serviceAccountName: "seaweedfs"
+  serviceAccountAnnotations: {}
   automountServiceAccountToken: true
   certificates:
     duration: 87600h


### PR DESCRIPTION
# What problem are we solving?
#8428 

# How are we solving the problem?
- Adding option for service account annotations to `values.yaml`
- Adding annotations to created service account in `service-account.yaml`

# How is the PR tested?
There is currently no testing available for helm chart


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional ServiceAccount annotations configuration to the Helm chart, enabling users to customize Kubernetes ServiceAccount metadata. The new global configuration field allows annotations to be specified in Helm values, providing better integration with Kubernetes environments requiring specific annotations for security, monitoring, or infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->