### PR TITLE
fix:  unload leveldb not take effect

### DIFF
--- a/weed/storage/needle_map_leveldb.go
+++ b/weed/storage/needle_map_leveldb.go
@@ -468,6 +468,7 @@ func lazyLoadingRoutine(m *LevelDbNeedleMap) (err error) {
 				glog.V(1).Infof("reset accessRecord %s", m.dbFileName)
 				// reset accessRecord
 				accessRecord = 0
+				m.accessFlag = 0
 			}
 			continue
 		}


### PR DESCRIPTION
# What problem are we solving?
I test the index.leveldbTimeout=1. After 1 hour, unload leveldb is correct. but I upload file to unload volume, reloading leveldb is correct,but after 1 hour, the  leveldb not unload
log bellow

```shell
I0224 17:49:51.456567 volume_info.go:20 maybeLoadVolumeInfo checks /weedfs/volume-05/deepglint_123.vif
I0224 17:49:51.456590 volume_info.go:36 maybeLoadVolumeInfo reads /weedfs/volume-05/deepglint_123.vif
I0224 17:49:51.479714 volume_info.go:53 maybeLoadVolumeInfo Unmarshal volume info /weedfs/volume-05/deepglint_123.vif
I0224 17:49:51.522724 volume_loading.go:144 open to write file /weedfs/volume-05/deepglint_123.idx
I0224 17:49:51.522835 volume_loading.go:188 loading leveldb index /weedfs/volume-05/deepglint_123.ldb
I0224 17:49:51.522881 needle_map_leveldb.go:55 Opening /weedfs/volume-05/deepglint_123.ldb...
I0224 17:49:53.412098 needle_map_leveldb.go:66 Loading /weedfs/volume-05/deepglint_123.ldb... , watermark: 0
I0224 17:49:53.877196 needle_map_leveldb.go:449 lazyLoadingRoutine /weedfs/volume-05/deepglint_123.ldb
I0224 18:49:53.878215 needle_map_leveldb.go:460 timeout /weedfs/volume-05/deepglint_123.ldb
I0224 18:49:53.878239 needle_map_leveldb.go:441 reached max idle count, unload leveldb, /weedfs/volume-05/deepglint_123.ldb
I0224 18:53:07.112461 needle_map_leveldb.go:423 reloading leveldb /weedfs/volume-05/deepglint_123.ldb
I0224 19:49:53.878723 needle_map_leveldb.go:460 timeout /weedfs/volume-05/deepglint_123.ldb
I0224 19:49:53.878742 needle_map_leveldb.go:468 reset accessRecord /weedfs/volume-05/deepglint_123.ldb
I0224 20:49:53.879530 needle_map_leveldb.go:460 timeout /weedfs/volume-05/deepglint_123.ldb
I0224 20:49:53.879546 needle_map_leveldb.go:468 reset accessRecord /weedfs/volume-05/deepglint_123.ldb
```
1 hour ago the ldb is exist
```shell
root@k3s-server-192-168-2-56:/opt/dgstorage-amd64-20251209# lsof -p 1921737|grep ldb
weed    1921737 root  105uW     REG   8,96           0 102760450 /weedfs/volume-05/deepglint_123.ldb/LOCK
weed    1921737 root  242w      REG   8,96        4657 102760451 /weedfs/volume-05/deepglint_123.ldb/LOG
weed    1921737 root  243w      REG   8,96           0 102760453 /weedfs/volume-05/deepglint_123.ldb/000017.log
weed    1921737 root  326w      REG   8,96         246 102760454 /weedfs/volume-05/deepglint_123.ldb/MANIFEST-000018
weed    1921737 root  327r      REG   8,96      395487 102760456 /weedfs/volume-05/deepglint_123.ldb/000015.ldb
```


# How are we solving the problem?


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource state management during scheduled maintenance cycles to ensure proper cleanup and prevent resource allocation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->