### PR TITLE
fix(admin): release mutex before disk I/O in maintenance queue; remove per-request LoadAllTaskStates

### DIFF
--- a/weed/admin/maintenance/maintenance_queue.go
+++ b/weed/admin/maintenance/maintenance_queue.go
@@ -174,14 +174,18 @@ func (mq *MaintenanceQueue) AddTask(task *MaintenanceTask) {
 		scheduleInfo = fmt.Sprintf(", scheduled for %v", task.ScheduledAt.Format("15:04:05"))
 	}
 
+	// Snapshot task state while lock is still held to avoid data race;
+	// also capture log fields from the snapshot so the live task pointer
+	// is not accessed after mq.mutex is released.
+	taskSnapshot := snapshotTask(task)
 	mq.mutex.Unlock()
 
 	// Save task state to persistence outside the lock to avoid blocking
 	// RegisterWorker and HTTP handlers (GetTasks) during disk I/O
-	mq.saveTaskState(task)
+	mq.saveTaskState(taskSnapshot)
 
 	glog.Infof("Task queued: %s (%s) volume %d on %s, priority %d%s, reason: %s",
-		task.ID, task.Type, task.VolumeID, task.Server, task.Priority, scheduleInfo, task.Reason)
+		taskSnapshot.ID, taskSnapshot.Type, taskSnapshot.VolumeID, taskSnapshot.Server, taskSnapshot.Priority, scheduleInfo, taskSnapshot.Reason)
 }
 
 // hasDuplicateTask checks if a similar task already exists (same type, volume, and not completed)
@@ -290,9 +294,13 @@ func (mq *MaintenanceQueue) GetNextTask(workerID string, capabilities []Maintena
 	// Now acquire write lock to actually assign the task
 	mq.mutex.Lock()
 
+	// Capture ID before the re-check so it is available for logging after unlock.
+	selectedTaskID := selectedTask.ID
+
 	// Re-check that the task is still available (it might have been assigned to another worker)
-	if selectedIndex >= len(mq.pendingTasks) || mq.pendingTasks[selectedIndex].ID != selectedTask.ID {
-		glog.V(2).Infof("Task %s no longer available for worker %s: assigned to another worker", selectedTask.ID, workerID)
+	if selectedIndex >= len(mq.pendingTasks) || mq.pendingTasks[selectedIndex].ID != selectedTaskID {
+		mq.mutex.Unlock()
+		glog.V(2).Infof("Task %s no longer available for worker %s: assigned to another worker", selectedTaskID, workerID)
 		return nil
 	}
 
@@ -333,6 +341,7 @@ func (mq *MaintenanceQueue) GetNextTask(workerID string, capabilities []Maintena
 				if len(selectedTask.AssignmentHistory) > 0 {
 					selectedTask.AssignmentHistory = selectedTask.AssignmentHistory[:len(selectedTask.AssignmentHistory)-1]
 				}
+				mq.mutex.Unlock()
 				// Return nil so the task is not removed from pendingTasks and not returned to the worker
 				return nil
 			}
@@ -350,13 +359,15 @@ func (mq *MaintenanceQueue) GetNextTask(workerID string, capabilities []Maintena
 	// Track pending operation
 	mq.trackPendingOperation(selectedTask)
 
+	// Snapshot task state while lock is still held to avoid data race
+	selectedSnapshot := snapshotTask(selectedTask)
 	mq.mutex.Unlock()
 
 	// Save task state to persistence outside the lock
-	mq.saveTaskState(selectedTask)
+	mq.saveTaskState(selectedSnapshot)
 
 	glog.Infof("Task assigned: %s (%s) → worker %s (volume %d, server %s)",
-		selectedTask.ID, selectedTask.Type, workerID, selectedTask.VolumeID, selectedTask.Server)
+		selectedSnapshot.ID, selectedSnapshot.Type, workerID, selectedSnapshot.VolumeID, selectedSnapshot.Server)
 
 	return selectedTask
 }
@@ -477,11 +488,16 @@ func (mq *MaintenanceQueue) CompleteTask(taskID string, error string) {
 	}
 	taskStatus := task.Status
 	taskCount := len(mq.tasks)
+	// Snapshot task state while lock is still held to avoid data race
+	var taskToSaveSnapshot *MaintenanceTask
+	if taskToSave != nil {
+		taskToSaveSnapshot = snapshotTask(taskToSave)
+	}
 	mq.mutex.Unlock()
 
 	// Save task state to persistence outside the lock
-	if taskToSave != nil {
-		mq.saveTaskState(taskToSave)
+	if taskToSaveSnapshot != nil {
+		mq.saveTaskState(taskToSaveSnapshot)
 	}
 
 	if logFn != nil {
@@ -503,35 +519,46 @@ func (mq *MaintenanceQueue) CompleteTask(taskID string, error string) {
 
 // UpdateTaskProgress updates the progress of a running task
 func (mq *MaintenanceQueue) UpdateTaskProgress(taskID string, progress float64) {
-	mq.mutex.RLock()
-	defer mq.mutex.RUnlock()
+	mq.mutex.Lock()
 
-	if task, exists := mq.tasks[taskID]; exists {
-		oldProgress := task.Progress
-		task.Progress = progress
-		task.Status = TaskStatusInProgress
-
-		// Update pending operation status
-		mq.updatePendingOperationStatus(taskID, "in_progress")
-
-		// Log progress at significant milestones or changes
-		if progress == 0 {
-			glog.V(1).Infof("Task started: %s (%s) worker %s, volume %d",
-				taskID, task.Type, task.WorkerID, task.VolumeID)
-		} else if progress >= 100 {
-			glog.V(1).Infof("Task progress: %s (%s) worker %s, %.1f%% complete",
-				taskID, task.Type, task.WorkerID, progress)
-		} else if progress-oldProgress >= 25 { // Log every 25% increment
-			glog.V(1).Infof("Task progress: %s (%s) worker %s, %.1f%% complete",
-				taskID, task.Type, task.WorkerID, progress)
-		}
-
-		// Save task state after progress update
-		if progress == 0 || progress >= 100 || progress-oldProgress >= 10 {
-			mq.saveTaskState(task)
-		}
-	} else {
+	task, exists := mq.tasks[taskID]
+	if !exists {
+		mq.mutex.Unlock()
 		glog.V(2).Infof("Progress update for unknown task: %s (%.1f%%)", taskID, progress)
+		return
+	}
+
+	oldProgress := task.Progress
+	task.Progress = progress
+	task.Status = TaskStatusInProgress
+
+	// Update pending operation status while lock is held
+	mq.updatePendingOperationStatus(taskID, "in_progress")
+
+	// Determine whether to persist and capture log fields before unlocking
+	shouldSave := progress == 0 || progress >= 100 || progress-oldProgress >= 10
+	var taskSnapshot *MaintenanceTask
+	if shouldSave {
+		taskSnapshot = snapshotTask(task)
+	}
+	taskType, workerID, volumeID := task.Type, task.WorkerID, task.VolumeID
+	mq.mutex.Unlock()
+
+	// Log progress at significant milestones or changes
+	if progress == 0 {
+		glog.V(1).Infof("Task started: %s (%s) worker %s, volume %d",
+			taskID, taskType, workerID, volumeID)
+	} else if progress >= 100 {
+		glog.V(1).Infof("Task progress: %s (%s) worker %s, %.1f%% complete",
+			taskID, taskType, workerID, progress)
+	} else if progress-oldProgress >= 25 { // Log every 25% increment
+		glog.V(1).Infof("Task progress: %s (%s) worker %s, %.1f%% complete",
+			taskID, taskType, workerID, progress)
+	}
+
+	// Save task state outside the lock to avoid blocking readers
+	if taskSnapshot != nil {
+		mq.saveTaskState(taskSnapshot)
 	}
 }
 
@@ -1030,4 +1057,42 @@ func (mq *MaintenanceQueue) updatePendingOperationStatus(taskID string, status s
 	}
 
 	pendingOps.UpdateOperationStatus(taskID, status)
+}
+
+// snapshotTask returns a shallow copy of t with slice and map fields deep-copied
+// so that the snapshot can be safely passed to saveTaskState after mq.mutex is
+// released without racing against concurrent mutations of the live task struct.
+// Must be called with mq.mutex held.
+func snapshotTask(t *MaintenanceTask) *MaintenanceTask {
+	cp := *t // copy all scalar / pointer-sized fields
+
+	// Deep-copy AssignmentHistory: the slice header and each record pointer.
+	// Records themselves are never mutated after being appended, so copying
+	// the pointers is sufficient.
+	if t.AssignmentHistory != nil {
+		cp.AssignmentHistory = make([]*TaskAssignmentRecord, len(t.AssignmentHistory))
+		copy(cp.AssignmentHistory, t.AssignmentHistory)
+	}
+
+	// Deep-copy Tags map to avoid concurrent map read/write.
+	if t.Tags != nil {
+		cp.Tags = make(map[string]string, len(t.Tags))
+		for k, v := range t.Tags {
+			cp.Tags[k] = v
+		}
+	}
+
+	// Copy optional time pointers so a concurrent nil-assignment (e.g. retry
+	// path clearing StartedAt) does not race with maintenanceTaskToProtobuf
+	// reading the pointed-to value.
+	if t.StartedAt != nil {
+		ts := *t.StartedAt
+		cp.StartedAt = &ts
+	}
+	if t.CompletedAt != nil {
+		tc := *t.CompletedAt
+		cp.CompletedAt = &tc
+	}
+
+	return &cp
 }


### PR DESCRIPTION
## Problem

Opening the **Workers/Jobs** tab in the admin UI (`GET /maintenance`) consistently times out with `408 Request Timeout`:

```
W maintenance_handlers.go:103 ShowMaintenanceQueue: timeout waiting for data
[GIN] | 408 | 3.28s | x.x.x.x | GET "/maintenance"
```

There are two independent root causes.

---

## Root Cause 1 — `saveTaskState` called while holding `mq.mutex.Lock()`

**File:** `weed/admin/maintenance/maintenance_queue.go`
**Functions:** `AddTask`, `GetNextTask`, `CompleteTask`

`saveTaskState` delegates to `mq.persistence.SaveTaskState(task)` which performs a **synchronous BoltDB write**. All three functions call it while still holding `mq.mutex.Lock()`.

During a maintenance scan, `AddTasksFromResults` calls `AddTask` for every volume in the cluster (potentially hundreds). Each call holds the write lock for the full duration of a disk write, meaning the lock is held almost continuously throughout the scan. Meanwhile:

- `GetTasks` (called by the `/maintenance` HTTP handler) blocks on `mq.mutex.RLock()`
- `RegisterWorker` (called when a worker connects) blocks on `mq.mutex.Lock()`

The HTTP handler has a 30-second timeout (`ShowMaintenanceQueue`, `maintenance_handlers.go:64`). If the cumulative lock-hold time exceeds 30s the page returns 408.

**Fix:** Update in-memory state (`mq.tasks`, `mq.pendingTasks`) under the lock as before, then **unlock before calling `saveTaskState`**. In-memory state is the authoritative source; persistence is crash-recovery only and does not need lock protection during the write.

---

## Root Cause 2 — `LoadAllTaskStates()` on every HTTP request

**File:** `weed/admin/dash/admin_server.go`
**Function:** `getMaintenanceTasks`

```go
// Also load any persisted tasks that might not be in memory
if as.configPersistence != nil {
    persistedTasks, err := as.configPersistence.LoadAllTaskStates()
    ...
}
```

This performs a **full BoltDB scan** (all persisted task records) on every request to `/maintenance`. With many completed/historical tasks on disk this is O(n) blocking disk I/O inside the HTTP request goroutine.

This is unnecessary: tasks are already loaded into memory at startup via `LoadTasksFromPersistence()` and kept in sync via `saveTaskState()` on every state change. The in-memory `mq.tasks` map is the authoritative source.

**Fix:** Remove the `LoadAllTaskStates` fallback from `getMaintenanceTasks`. Read from the in-memory manager only.

---

## Changes

| File | Change |
|------|--------|
| `weed/admin/maintenance/maintenance_queue.go` | Unlock mutex before `saveTaskState` in `AddTask`, `GetNextTask`, `CompleteTask` |
| `weed/admin/dash/admin_server.go` | Remove `LoadAllTaskStates` call from `getMaintenanceTasks` |

## Why this is safe

- In-memory state is fully updated **before** the mutex is released — no reader can observe an inconsistent state
- `saveTaskState` is idempotent; it only provides crash-recovery durability
- Duplicate-task deduplication (`hasDuplicateTask`) still runs inside the lock
- Tasks are already guaranteed to be in memory from startup (`LoadTasksFromPersistence`)

## Tested on

SeaweedFS `4.09` cluster with 2 workers and a full volume scan running. Before fix: `/maintenance` returns 408 consistently. After fix: page loads immediately.

Confirmed present in `4.09`, `4.13`, and current `master` — `maintenance_queue.go` has not changed since commit `25bbf4c3d` ("Admin UI: Fetch task logs #7114").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced lock contention by moving persistence and logging outside critical sections and unlocking earlier on failure paths.
  * Fixed race conditions in task and config persistence with stronger serialization for filesystem operations.

* **Refactor**
  * Centralized deferred persistence and logging; introduced task snapshotting to safely persist state after unlock.
  * Adjusted periodic cleanup trigger to use total task count mod condition for cleaner scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->