### PR TITLE
s3api: preserve Host header port in signature verification

### DIFF
--- a/weed/s3api/auth_signature_v4_test.go
+++ b/weed/s3api/auth_signature_v4_test.go
@@ -208,7 +208,7 @@ func TestExtractHostHeader(t *testing.T) {
 			forwardedHost:  "example.com",
 			forwardedPort:  "80",
 			forwardedProto: "http",
-			expected:       "example.com",
+			expected:       "example.com:80",
 		},
 		{
 			name:           "X-Forwarded-Host with X-Forwarded-Port (HTTPS standard port 443)",
@@ -216,7 +216,7 @@ func TestExtractHostHeader(t *testing.T) {
 			forwardedHost:  "example.com",
 			forwardedPort:  "443",
 			forwardedProto: "https",
-			expected:       "example.com",
+			expected:       "example.com:443",
 		},
 		// Issue #6649: X-Forwarded-Host already contains port (Traefik/HAProxy style)
 		{
@@ -226,6 +226,14 @@ func TestExtractHostHeader(t *testing.T) {
 			forwardedPort:  "8433",
 			forwardedProto: "https",
 			expected:       "127.0.0.1:8433",
+		},
+		{
+			name:           "X-Forwarded-Host with standard port already included (HTTPS 443)",
+			hostHeader:     "backend:8333",
+			forwardedHost:  "example.com:443",
+			forwardedPort:  "443",
+			forwardedProto: "https",
+			expected:       "example.com:443",
 		},
 		{
 			name:           "X-Forwarded-Host with port, no X-Forwarded-Port header",
@@ -253,20 +261,20 @@ func TestExtractHostHeader(t *testing.T) {
 			expected:       "[::1]:8080",
 		},
 		{
-			name:           "IPv6 address without brackets and standard port, should strip brackets per AWS SDK",
+			name:           "IPv6 address without brackets and standard port, should include brackets and port when explicit",
 			hostHeader:     "backend:8333",
 			forwardedHost:  "::1",
 			forwardedPort:  "80",
 			forwardedProto: "http",
-			expected:       "::1",
+			expected:       "[::1]:80",
 		},
 		{
-			name:           "IPv6 address without brackets and standard HTTPS port, should strip brackets per AWS SDK",
+			name:           "IPv6 address without brackets and standard HTTPS port, should include brackets and port when explicit",
 			hostHeader:     "backend:8333",
 			forwardedHost:  "2001:db8::1",
 			forwardedPort:  "443",
 			forwardedProto: "https",
-			expected:       "2001:db8::1",
+			expected:       "[2001:db8::1]:443",
 		},
 		{
 			name:           "IPv6 address with brackets but no port, should add port",
@@ -277,12 +285,12 @@ func TestExtractHostHeader(t *testing.T) {
 			expected:       "[2001:db8::1]:8080",
 		},
 		{
-			name:           "IPv6 full address with brackets and default port (should strip port and brackets)",
+			name:           "IPv6 full address with brackets and default port (should preserve port if explicit)",
 			hostHeader:     "backend:8333",
 			forwardedHost:  "[2001:db8:85a3::8a2e:370:7334]:443",
 			forwardedPort:  "443",
 			forwardedProto: "https",
-			expected:       "2001:db8:85a3::8a2e:370:7334",
+			expected:       "[2001:db8:85a3::8a2e:370:7334]:443",
 		},
 		{
 			name:           "IPv4-mapped IPv6 address without brackets, should add brackets with port",

--- a/weed/s3api/auto_signature_v4_test.go
+++ b/weed/s3api/auto_signature_v4_test.go
@@ -415,13 +415,13 @@ func TestSignatureV4WithoutProxy(t *testing.T) {
 			name:         "HTTP with standard port",
 			host:         "backend:80",
 			proto:        "http",
-			expectedHost: "backend",
+			expectedHost: "backend:80",
 		},
 		{
 			name:         "HTTPS with standard port",
 			host:         "backend:443",
 			proto:        "https",
-			expectedHost: "backend",
+			expectedHost: "backend:443",
 		},
 		{
 			name:         "HTTP without port",
@@ -451,13 +451,13 @@ func TestSignatureV4WithoutProxy(t *testing.T) {
 			name:         "IPv6 HTTP with standard port",
 			host:         "[::1]:80",
 			proto:        "http",
-			expectedHost: "::1",
+			expectedHost: "[::1]:80",
 		},
 		{
 			name:         "IPv6 HTTPS with standard port",
 			host:         "[::1]:443",
 			proto:        "https",
-			expectedHost: "::1",
+			expectedHost: "[::1]:443",
 		},
 		{
 			name:         "IPv6 HTTP without port",


### PR DESCRIPTION
Avoid stripping default ports (80/443) from the Host header in extractHostHeader. 

This fixes SignatureDoesNotMatch errors when SeaweedFS is accessed via a proxy (like Kong Ingress) that explicitly includes the port in the Host header or X-Forwarded-Host, which S3 clients sign.

The fix aligns SeaweedFS with MinIO behavior and AWS SDK expectations.

Key changes:
- Refactored `extractHostHeader` to keep explicit ports.
- Removed unused `isDefaultPort` and variables.
- Updated unit tests to cover new port preservation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved S3 API authentication to correctly handle requests with explicit port numbers
* Enhanced IPv6 address support in S3 API authentication calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->