### PR TITLE
Remove volumePreallocate option from docker containers

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,7 +58,7 @@ isArgPassed() {
 case "$1" in
 
   'master')
-  	ARGS="-mdir=/data -volumePreallocate -volumeSizeLimitMB=1024"
+  	ARGS="-mdir=/data -volumeSizeLimitMB=1024"
   	shift
   	exec /usr/bin/weed -logtostderr=true master $ARGS $@
 	;;
@@ -73,9 +73,9 @@ case "$1" in
 	;;
 
   'server')
-  	ARGS="-dir=/data -volume.max=0 -master.volumePreallocate -master.volumeSizeLimitMB=1024"
+  	ARGS="-dir=/data -volume.max=0 -master.volumeSizeLimitMB=1024"
   	if isArgPassed "-volume.max" "$@"; then
-  	  ARGS="-dir=/data -master.volumePreallocate -master.volumeSizeLimitMB=1024"
+  	  ARGS="-dir=/data -master.volumeSizeLimitMB=1024"
   	fi
  	shift
   	exec /usr/bin/weed -logtostderr=true server $ARGS $@

--- a/docker/entrypoint_e2e.sh
+++ b/docker/entrypoint_e2e.sh
@@ -33,7 +33,7 @@ isArgPassed() {
 case "$1" in
 
   'master')
-  	ARGS="-mdir=/data -volumePreallocate -volumeSizeLimitMB=1024"
+  	ARGS="-mdir=/data -volumeSizeLimitMB=1024"
   	shift
   	exec /usr/bin/weed -logtostderr=true master $ARGS "$@"
 	;;
@@ -48,9 +48,9 @@ case "$1" in
 	;;
 
   'server')
-  	ARGS="-dir=/data -volume.max=0 -master.volumePreallocate -master.volumeSizeLimitMB=1024"
+  	ARGS="-dir=/data -volume.max=0 -master.volumeSizeLimitMB=1024"
   	if isArgPassed "-volume.max" "$@"; then
-  	  ARGS="-dir=/data -master.volumePreallocate -master.volumeSizeLimitMB=1024"
+  	  ARGS="-dir=/data -master.volumeSizeLimitMB=1024"
   	fi
  	shift
   	exec /usr/bin/weed -logtostderr=true server $ARGS "$@"


### PR DESCRIPTION
Some filesystems, such as XFS, may over-allocate disk spaces when using volume preallocation. This removes the volumePreallocate option from the default docker entrypoint scripts to allow volumes to use only the necessary disk space.

Fixes: https://github.com/seaweedfs/seaweedfs/issues/6465#issuecomment-3964174718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified volume initialization by removing preallocation flags from Docker deployment configurations for both primary and secondary node types
  * Consolidated volume management configuration to rely on size limit parameters during system startup
  * Applied to both standard production deployments and testing environments, reducing configuration complexity and startup overhead while preserving all core functionality and volume management capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->