### PR TITLE
helm: add optional parameters to COSI BucketClass

### DIFF
--- a/k8s/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ .Values.cosi.bucketClassName }}
 driverName: {{ .Values.cosi.driverName }}
 deletionPolicy: Delete
+{{- with .Values.cosi.bucketClassParameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1611,6 +1611,8 @@ cosi:
   image: "ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.1.2"
   driverName: "seaweedfs.objectstorage.k8s.io"
   bucketClassName: "seaweedfs"
+  # Optional parameters to pass to the default BucketClass (e.g., diskType for tiered storage)
+  bucketClassParameters: {}
   endpoint: ""
   region: ""
 


### PR DESCRIPTION
## What problem are we solving?

The COSI BucketClass created by the Helm chart currently has no way to pass
custom parameters. In tiered storage setups, SeaweedFS uses disk type tags
(e.g., "hdd", "ssd") to route data to specific volume servers. The COSI driver
supports a `diskType` parameter on BucketClass, but the Helm chart template
does not expose it.

## How are we solving the problem?

Add a new `cosi.bucketClassParameters` value (default: `{}`) that is rendered
as the `parameters` block on the default BucketClass when non-empty. This is a
generic map, so it supports any parameter the COSI driver accepts, not just
`diskType`.

When `bucketClassParameters` is empty (the default), the template renders
identically to the current version — no behavioral change for existing users.

Example usage:
```yaml
cosi:
  enabled: true
  bucketClassParameters:
    diskType: hdd
```

## How is the PR tested?

Verified with `helm template` that:
- Default values produce identical output (no `parameters` block)
- Setting `bucketClassParameters.diskType: hdd` adds the expected parameters block

## Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

## Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Extended Helm configuration with a new optional bucket class parameters setting. Users can now customize BucketClass configurations and specify additional storage options such as disk type specifications for tiered storage deployments. The parameter is fully optional and defaults to an empty configuration when not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->