### PR TITLE
weed/s3api/s3tables: fix dropped errors

### DIFF
--- a/weed/s3api/s3tables/handler_table.go
+++ b/weed/s3api/s3tables/handler_table.go
@@ -774,8 +774,7 @@ func (h *S3TablesHandler) listTablesInAllNamespaces(r *http.Request, client file
 
 			nsTables, nsToken, err := h.listTablesInNamespaceWithClient(r, client, bucketName, namespace, prefix, tableNameFilter, maxTables-len(tables))
 			if err != nil {
-				glog.Warningf("S3Tables: failed to list tables in namespace %s/%s: %v", bucketName, namespace, err)
-				continue
+				return nil, "", fmt.Errorf("list tables in namespace %s: %w", namespace, err)
 			}
 
 			tables = append(tables, nsTables...)


### PR DESCRIPTION
This fixes two dropped `err` variables in `weed/s3api/s3tables`.

Unit tests pass both before and after these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Table listing now surfaces failures instead of silently continuing; errors from namespace and global listings are properly reported.
  * Improved propagation and clarity of error messages so failures include contextual details (e.g., which namespace or operation failed).
  * Edge cases around pagination/continuation now return errors to callers instead of producing partial or misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->