### PR TITLE
Respect -minFreeSpace during ec.decode

### DIFF
--- a/weed/shell/command_ec_decode.go
+++ b/weed/shell/command_ec_decode.go
@@ -413,7 +413,7 @@ func (state *decodeDiskUsageState) freeVolumeCount(location pb.ServerAddress) (i
 		return 0, false
 	}
 	free := usage.maxVolumeCount - (usage.volumeCount - usage.remoteVolumeCount)
-	free -= (usage.ecShardCount + 1) / int64(erasure_coding.DataShardsCount)
+	free -= (usage.ecShardCount + int64(erasure_coding.DataShardsCount) - 1) / int64(erasure_coding.DataShardsCount)
 	return free, true
 }
 


### PR DESCRIPTION
## Summary
- add -ignoreMinFreeSpace flag to ec.decode
- skip target nodes with no free volume slots when decoding EC volumes
- fail fast with a clear error when no eligible targets remain

## Testing
- go test ./weed/shell/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a -checkMinFreeSpace option for EC decode; targets are filtered by per-node free space and decode fails if no eligible targets exist.
  * Tracks per-node disk usage and per-node shard/volume counts to enable safer decode decisions and state updates.

* **Changes**
  * Improved error messages to include disk type and free-space guidance.
  * Decode can now purge EC shards when no live entries remain, preserving behavior while enforcing eligibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->