### PR TITLE
helm: avoid duplicate env var keys in workload env lists

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -119,17 +119,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.admin.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.admin.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.admin "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -97,17 +97,9 @@ spec:
               value: /usr/local/share/ca-certificates/client/ca.crt
             {{- end }}
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.cosi.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.cosi.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.cosi "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -115,17 +115,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.filer.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.filer.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.filer "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -99,17 +99,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.master.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.master.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.master "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -91,17 +91,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.s3.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.s3.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.s3 "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -91,17 +91,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.sftp.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.sftp.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.sftp "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -60,16 +60,15 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{- define "seaweedfs.mergeExtraEnvironmentVars" -}}
-{{- $global := .global | default dict -}}
-{{- $component := .component | default dict -}}
-{{- $merged := dict -}}
+{{- $global := ((.global | default dict).extraEnvironmentVars | default dict) -}}
+{{- $component := ((.component | default dict).extraEnvironmentVars | default dict) -}}
+{{- $target := .target -}}
 {{- range $key, $value := $global }}
-{{- $_ := set $merged $key $value }}
+{{- $_ := set $target $key $value }}
 {{- end }}
 {{- range $key, $value := $component }}
-{{- $_ := set $merged $key $value }}
+{{- $_ := set $target $key $value }}
 {{- end }}
-{{- $merged -}}
 {{- end -}}
 
 {{/* Return the proper filer image */}}

--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -119,17 +119,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" $ }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if $.Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := $.Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if $volume.extraEnvironmentVars }}
-            {{- range $key, $value := $volume.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" $.Values.global "component" $volume "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -94,17 +94,9 @@ spec:
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- $mergedExtraEnvironmentVars := dict }}
-            {{- if .Values.global.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.worker.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.worker.extraEnvironmentVars }}
-            {{- $_ := set $mergedExtraEnvironmentVars $key $value }}
-            {{- end }}
-            {{- end }}
-            {{- range $key, $value := $mergedExtraEnvironmentVars }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global "component" .Values.worker "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}


### PR DESCRIPTION
## Summary
- extract a helper that merges `global.extraEnvironmentVars` and component `extraEnvironmentVars` with key-level overrides so `valueFrom` structs are not deep-merged
- share the helper across master, filer, volume, admin, worker, s3, sftp, and cosi workloads, and sort the merged keys for deterministic env lists
- keep Helm renders for filtering duplicates and avoid drift across components

## Why
`helm upgrade` can fail when the rendered container `env` list has duplicate `name` keys (for example `WEED_CLUSTER_DEFAULT`, `WEED_CLUSTER_SW_MASTER`, `WEED_CLUSTER_SW_FILER`). Rendering a single merged map once per workload guarantees unique env names, and sorting the keys keeps `helm template` outputs stable.

## Validation
- `helm lint ./k8s/charts/seaweedfs -f /tmp/issue-8480-values.yaml`
- `helm template sw ./k8s/charts/seaweedfs -f /tmp/issue-8480-values.yaml`
- `helm template sw ./k8s/charts/seaweedfs -f /tmp/issue-8480-values.yaml --show-only templates/filer/filer-statefulset.yaml` shows each `WEED_CLUSTER_*` env key once

Fixes #8480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated environment variable emission across Helm charts: global and component extra environment vars are now merged into a single map via a new helper and emitted in one unified, sorted pass, preserving string vs structured value handling and simplifying templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->