### PR TITLE
Feat: update openshift helm value to support seaweed s3

### DIFF
--- a/k8s/charts/seaweedfs/openshift-values.yaml
+++ b/k8s/charts/seaweedfs/openshift-values.yaml
@@ -100,11 +100,18 @@ filer:
 
 # S3 gateway (if enabled)
 s3:
+  enabled: true
+  replicas: 1
+  port: 8333
+  enableAuth: true
   podSecurityContext:
     enabled: true
     # On OpenShift, we omit runAsUser/runAsGroup/fsGroup to let the admission
     # controller assign them automatically based on the namespace's SCC.
     runAsNonRoot: true
+
+  logs:
+    type: "emptyDir"
 
   containerSecurityContext:
     enabled: true


### PR DESCRIPTION
Update helm values for openshift to enable/disable s3 and change log to `emptydir` instead of `hostpath`

# What problem are we solving?
Helm chart for openshift missing s3 part.


# How are we solving the problem?
adding values in openshift-values for enable/disable seaweed-s3 and change log to `emprydir` instead of `hostpath` to pass openshift scc.

# How is the PR tested?
use helm install with the openshift-values install on openshift 4.20.14 


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added and enabled S3 gateway support for OpenShift environment deployments with authentication security features enabled and logging configuration. S3 gateway service configured to operate as a single replica instance listening on port 8333.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->