### PR TITLE
s3api: add IAM policy fallback authorization tests

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1667,11 +1667,13 @@ func (iam *IdentityAccessManagement) evaluateIAMPolicies(r *http.Request, identi
 	}
 
 	resource := buildResourceARN(bucket, object)
+	principal := buildPrincipalARN(identity, r)
 	s3Action := ResolveS3Action(r, string(action), bucket, object)
-
-	// AWS IAM semantics: explicit deny overrides explicit allow.
-	explicitDeny := false
 	explicitAllow := false
+	conditions := policy_engine.ExtractConditionValuesFromRequest(r)
+	for k, v := range policy_engine.ExtractPrincipalVariables(principal) {
+		conditions[k] = v
+	}
 
 	for _, policyName := range identity.PolicyNames {
 		policy, err := iam.GetPolicy(policyName)
@@ -1679,48 +1681,25 @@ func (iam *IdentityAccessManagement) evaluateIAMPolicies(r *http.Request, identi
 			continue
 		}
 
-		var policyDoc policy_engine.PolicyDocument
-		if err := json.Unmarshal([]byte(policy.Content), &policyDoc); err != nil {
+		engine := policy_engine.NewPolicyEngine()
+		if err := engine.SetBucketPolicy(policyName, policy.Content); err != nil {
 			continue
 		}
 
-		for _, statement := range policyDoc.Statement {
-			actionMatches := false
-			for _, policyAction := range statement.Action.Strings() {
-				if wildcard.MatchesWildcard(policyAction, s3Action) {
-					actionMatches = true
-					break
-				}
-			}
-			if !actionMatches {
-				continue
-			}
+		result := engine.EvaluatePolicy(policyName, &policy_engine.PolicyEvaluationArgs{
+			Action:     s3Action,
+			Resource:   resource,
+			Principal:  principal,
+			Conditions: conditions,
+			Claims:     identity.Claims,
+		})
 
-			resourceMatches := false
-			if len(statement.Resource.Strings()) == 0 {
-				resourceMatches = true
-			} else {
-				for _, policyResource := range statement.Resource.Strings() {
-					if wildcard.MatchesWildcard(policyResource, resource) {
-						resourceMatches = true
-						break
-					}
-				}
-			}
-			if !resourceMatches {
-				continue
-			}
-
-			if statement.Effect == policy_engine.PolicyEffectDeny {
-				explicitDeny = true
-			} else if statement.Effect == policy_engine.PolicyEffectAllow {
-				explicitAllow = true
-			}
+		if result == policy_engine.PolicyResultDeny {
+			return false
 		}
-	}
-
-	if explicitDeny {
-		return false
+		if result == policy_engine.PolicyResultAllow {
+			explicitAllow = true
+		}
 	}
 
 	return explicitAllow

--- a/weed/s3api/auth_credentials_test.go
+++ b/weed/s3api/auth_credentials_test.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -330,6 +331,47 @@ func TestVerifyActionPermissionPolicyFallback(t *testing.T) {
 
 		errCode := iam.VerifyActionPermission(buildRequest(t, http.MethodGet), identity, Action(ACTION_READ), "test-bucket", "test-object")
 		assert.Equal(t, s3err.ErrAccessDenied, errCode)
+	})
+
+	t.Run("notresource excludes denied object", func(t *testing.T) {
+		iam := &IdentityAccessManagement{}
+		err := iam.PutPolicy("denyNotResource", `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:GetObject","NotResource":"arn:aws:s3:::test-bucket/public/*"}]}`)
+		assert.NoError(t, err)
+		err = iam.PutPolicy("allowAllGet", `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::test-bucket/*"}]}`)
+		assert.NoError(t, err)
+
+		identity := &Identity{
+			Name:        "policy-user",
+			Account:     &AccountAdmin,
+			PolicyNames: []string{"allowAllGet", "denyNotResource"},
+		}
+
+		errCode := iam.VerifyActionPermission(buildRequest(t, http.MethodGet), identity, Action(ACTION_READ), "test-bucket", "private/secret.txt")
+		assert.Equal(t, s3err.ErrAccessDenied, errCode)
+
+		errCode = iam.VerifyActionPermission(buildRequest(t, http.MethodGet), identity, Action(ACTION_READ), "test-bucket", "public/readme.txt")
+		assert.Equal(t, s3err.ErrNone, errCode)
+	})
+
+	t.Run("condition securetransport enforced", func(t *testing.T) {
+		iam := &IdentityAccessManagement{}
+		err := iam.PutPolicy("allowTLSOnly", `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::test-bucket/*","Condition":{"Bool":{"aws:SecureTransport":"true"}}}]}`)
+		assert.NoError(t, err)
+
+		identity := &Identity{
+			Name:        "policy-user",
+			Account:     &AccountAdmin,
+			PolicyNames: []string{"allowTLSOnly"},
+		}
+
+		httpReq := buildRequest(t, http.MethodGet)
+		errCode := iam.VerifyActionPermission(httpReq, identity, Action(ACTION_READ), "test-bucket", "test-object")
+		assert.Equal(t, s3err.ErrAccessDenied, errCode)
+
+		httpsReq := buildRequest(t, http.MethodGet)
+		httpsReq.TLS = &tls.ConnectionState{}
+		errCode = iam.VerifyActionPermission(httpsReq, identity, Action(ACTION_READ), "test-bucket", "test-object")
+		assert.Equal(t, s3err.ErrNone, errCode)
 	})
 
 	t.Run("actions based path still works", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Possible fix for #8518

- add IAM policy fallback evaluation in `VerifyActionPermission` when `Actions` are empty and `iamIntegration` is not configured
- keep existing `Actions`-based behavior unchanged for legacy identities
- remove noisy debug logs from the new fallback path
- add unit tests for allow, deny precedence, implicit deny, invalid policy handling, and actions-path regression

## Testing
- `go test ./weed/s3api -run TestVerifyActionPermissionPolicyFallback -v`
- `go test -run TestNonExistent ./weed/s3api/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy-based authorization fallback for identities with attached policies, honoring explicit Deny precedence and applying implicit-deny when no policy matches.

* **Tests**
  * Added comprehensive tests covering allow, explicit deny overriding allow, implicit deny, invalid-policy handling, and legacy behavior validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->