### PR TITLE
Add before-hook-creation delete policy to bucket-hook Job

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -51,7 +51,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
# What problem are we solving?
The bucket-hook Job currently sets `hook-delete-policy: hook-succeeded`,  which only deletes the Job after successful completion. If a helm install or upgrade is interrupted before the hook completes, the Job persists and blocks subsequent attempts with:  `jobs.batch "seaweedfs-bucket-hook" already exists`

## Context
We use SeaweedFS as an embedded S3-compatible store in [Replicated Embedded Cluster](https://github.com/replicatedhq/embedded-cluster). When enabling high availability, users can interrupt and retry the operation at any point. Without `before-hook-creation`, a cancelled install leaves the bucket-hook Job behind, and subsequent retries fail permanently until the Job is manually deleted.

# How are we solving the problem?
This PR adds `before-hook-creation` alongside `hook-succeeded` so that:
  - Successful hooks are still cleaned up immediately (hook-succeeded)
  - Leftover hooks from interrupted operations are cleaned up before
    the next attempt (before-hook-creation)

Per the Helm docs, `before-hook-creation` is the default behavior when no delete policy is set — it deletes the previous resource before a new hook is launched. The current explicit `hook-succeeded` overrides that default and removes the idempotency guarantee.
  > If no hook deletion policy annotation is specified, the
  > before-hook-creation behavior applies by default.
  >
  > — https://helm.sh/docs/topics/charts_hooks/

# How is the PR tested?

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes post-install hook lifecycle management to delete hooks before new ones are created, in addition to deletion upon success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->