### PR TITLE
Fix YAML parse error in post-install-bucket-hook template

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -92,6 +92,7 @@ spec:
           - "/bin/sh"
           - "-ec"
           - |
+            set -o pipefail
             wait_for_service() {
               local url=$1
               local max_attempts=60  # 5 minutes total (5s * 60)
@@ -117,8 +118,7 @@ spec:
             wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.master.readinessProbe.httpGet.path }}"
             wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
             {{- end }}
-          set -o pipefail
-          {{- range $createBuckets }}
+            {{- range $createBuckets }}
             {{- $bucketName := .name }}
             {{- $bucketLock := or .lock .objectLock .withLock }}
             bucket_list=$(/bin/echo 's3.bucket.list' | /usr/bin/weed shell) || { echo "Error listing s3 buckets"; exit 1; }


### PR DESCRIPTION
## Summary
- Fixed incorrect indentation of `set -o pipefail` line that was outside the YAML block scalar
- The line is now properly included at the beginning of the shell script with correct 12-space indentation
- Resolves YAML parse error when `s3.enabled=true` and `s3.createBuckets` are populated

## Test plan
- Run the helm template command with the fixed chart:
  ```
  helm template seaweedfs seaweedfs/seaweedfs --version 4.15.0 \
    --set "s3.enabled=true" \
    --set "s3.createBuckets[0].name=test-bucket"
  ```
- Verify no YAML parse errors occur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in the deployment initialization process. Enhanced failure detection mechanisms during system setup ensure that critical issues are properly identified and reported, increasing overall deployment reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->