### PR TITLE
ci: build _full and _large_disk_full images for arm64

### DIFF
--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -60,16 +60,16 @@ jobs:
             build_args: TAGS=5BytesOffset
             tag_suffix: _large_disk
             
-          # Full tags - amd64 only
+          # Full tags - multi-arch
           - variant: full
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             dockerfile: ./docker/Dockerfile.go_build
             build_args: TAGS=elastic,gocdk,rclone,sqlite,tarantool,tikv,ydb
             tag_suffix: _full
-            
-          # Large disk + full tags - amd64 only
+
+          # Large disk + full tags - multi-arch
           - variant: large_disk_full
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             dockerfile: ./docker/Dockerfile.go_build
             build_args: TAGS=5BytesOffset,elastic,gocdk,rclone,sqlite,tarantool,tikv,ydb
             tag_suffix: _large_disk_full


### PR DESCRIPTION
## Summary
- Add `linux/arm64` platform target to `_full` and `_large_disk_full` Docker image variants in the unified release workflow
- These variants were previously `linux/amd64` only, which prevented ARM64 users from using features that require extra build tags (e.g. `gocdk` for RabbitMQ notifications)

Ref: https://github.com/seaweedfs/seaweedfs/discussions/8546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ARM64 architecture support for container images alongside existing x86-64 support for full and large disk release variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->