### PR TITLE
fix(s3api): ListObjects with trailing-slash prefix matches sibling directories

### DIFF
--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -632,6 +632,10 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 
 		// Set nextMarker only when we have quota to process this entry
 		nextMarker = entry.Name
+		// Track whether this entry is the exact directory targeted by a trailing-slash prefix
+		// (e.g., prefix "foo" from original prefix "foo/"). After recursing into this directory,
+		// we must stop processing siblings to avoid matching unrelated entries like "foo1000".
+		matchedPrefixDir := cursor.prefixEndsOnDelimiter && entry.Name == prefix && entry.IsDirectory
 		if cursor.prefixEndsOnDelimiter {
 			if entry.Name == prefix && entry.IsDirectory {
 				if delimiter != "/" {
@@ -690,6 +694,9 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 				// println("doListFilerEntries2 dir", dir+"/"+entry.Name, "subNextMarker", subNextMarker)
 				nextMarker = entry.Name + "/" + subNextMarker
 				if cursor.isTruncated {
+					return
+				}
+				if matchedPrefixDir {
 					return
 				}
 				// println("doListFilerEntries2 nextMarker", nextMarker)

--- a/weed/s3api/s3api_object_handlers_list_test.go
+++ b/weed/s3api/s3api_object_handlers_list_test.go
@@ -814,3 +814,74 @@ func TestListObjectsV2_Regression_Sorting(t *testing.T) {
 	// With fix, it sees both and processes "reports"
 	assert.Contains(t, results, "file1", "Should return the nested file even if 'reports' directory is not the first match")
 }
+
+func TestListObjectsV2_PrefixEndingWithSlash_DoesNotMatchSiblings(t *testing.T) {
+	// Regression test: listing with prefix "1/" should only return objects under
+	// directory "1", not objects under "1000" or any other sibling whose name
+	// shares the same prefix string.
+
+	s3a := &S3ApiServer{}
+	client := &testFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/buckets/bucket/path/to/list": {
+				{Name: "1", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{}},
+				{Name: "1000", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{}},
+				{Name: "2500", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{}},
+			},
+			"/buckets/bucket/path/to/list/1": {
+				{Name: "fileA", IsDirectory: false, Attributes: &filer_pb.FuseAttributes{}},
+			},
+			"/buckets/bucket/path/to/list/1000": {
+				{Name: "fileB", IsDirectory: false, Attributes: &filer_pb.FuseAttributes{}},
+				{Name: "fileC", IsDirectory: false, Attributes: &filer_pb.FuseAttributes{}},
+			},
+			"/buckets/bucket/path/to/list/2500": {
+				{Name: "fileD", IsDirectory: false, Attributes: &filer_pb.FuseAttributes{}},
+			},
+		},
+	}
+
+	// Simulate listing with prefix "path/to/list/1/" (no delimiter).
+	// normalizePrefixMarker("path/to/list/1/", "") returns dir="path/to/list", prefix="1"
+	cursor := &ListingCursor{maxKeys: 1000, prefixEndsOnDelimiter: true}
+	var results []string
+
+	_, err := s3a.doListFilerEntries(client, "/buckets/bucket/path/to/list", "1", cursor, "", "", false, "bucket", func(dir string, entry *filer_pb.Entry) {
+		if !entry.IsDirectory {
+			results = append(results, entry.Name)
+		}
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"fileA"}, results, "Should only return files under directory '1', not '1000' or '2500'")
+}
+
+func TestListObjectsV2_PrefixEndingWithSlash_WithDelimiter(t *testing.T) {
+	// Same scenario but with delimiter="/", verifying the fix works for both cases.
+
+	s3a := &S3ApiServer{}
+	client := &testFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/buckets/bucket/path/to/list": {
+				{Name: "1", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{}},
+				{Name: "1000", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{}},
+			},
+			"/buckets/bucket/path/to/list/1": {
+				{Name: "fileA", IsDirectory: false, Attributes: &filer_pb.FuseAttributes{}},
+			},
+			"/buckets/bucket/path/to/list/1000": {
+				{Name: "fileB", IsDirectory: false, Attributes: &filer_pb.FuseAttributes{}},
+			},
+		},
+	}
+
+	cursor := &ListingCursor{maxKeys: 1000, prefixEndsOnDelimiter: true}
+	var results []string
+
+	_, err := s3a.doListFilerEntries(client, "/buckets/bucket/path/to/list", "1", cursor, "", "/", false, "bucket", func(dir string, entry *filer_pb.Entry) {
+		results = append(results, entry.Name)
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"fileA"}, results, "Should only return files under directory '1', not '1000'")
+}


### PR DESCRIPTION
## Summary

- Fix S3 `ListObjectsV2` returning objects from wrong directories when prefix ends with `/`
- When prefix is `path/to/list/1/`, the listing incorrectly also returns objects under `path/to/list/1000/` and other siblings sharing the same name prefix
- After recursing into the exact target directory, return immediately instead of continuing to process sibling entries

## Root cause

`normalizePrefixMarker("path/to/list/1/", "")` strips the trailing `/` and returns `dir="path/to/list", prefix="1"`. The filer lists entries matching prefix `"1"`, returning both directories `"1"` and `"1000"`. The `prefixEndsOnDelimiter` guard correctly identifies `"1"` as the target, but resets itself after processing, allowing `"1000"` to be incorrectly recursed into as well.

## Test plan

- Added `TestListObjectsV2_PrefixEndingWithSlash_DoesNotMatchSiblings` — verifies listing with prefix `1/` (no delimiter) only returns objects under directory `1`
- Added `TestListObjectsV2_PrefixEndingWithSlash_WithDelimiter` — same scenario with `delimiter=/`
- All existing listing regression tests pass (`TestListObjectsV2_Regression`, `TestListObjectsV2_Regression_Sorting`)
- Verified end-to-end with Apache Iceberg's S3FileIO integration tests (`testPrefixList` with parallel writes to `1/`, `1000/`, `2500/` prefixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 object listing with slash-delimited prefixes to correctly return only objects under the specified directory without including similarly named objects from adjacent directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->