### PR TITLE
Fix topologySpreadConstraints key in sftp-deployment.yaml

### DIFF
--- a/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       {{- if .Values.sftp.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{ tpl .Values.sftp.topologySpreadConstraint . | nindent 8 | trim }}
+        {{ tpl .Values.sftp.topologySpreadConstraints . | nindent 8 | trim }}
       {{- end }}
       {{- if .Values.sftp.tolerations }}
       tolerations:


### PR DESCRIPTION
# What problem are we solving?

there is was a typo on the sftp deployement where the topologySpreadConstraints refers to a wrong key on values

# How are we solving the problem?


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration variable naming issue in the Kubernetes deployment template that ensures topology spread constraints are properly applied during cluster deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->