### PR TITLE
Reduce task logger glog noise and remove per-write fsync

### DIFF
--- a/weed/worker/tasks/task_logger.go
+++ b/weed/worker/tasks/task_logger.go
@@ -322,9 +322,9 @@ func (l *FileTaskLogger) writeLogEntry(entry TaskLogEntry) {
 		formattedMsg := fmt.Sprintf("[TASK-%s] %s: %s", l.taskID, entry.Level, entry.Message)
 		switch entry.Level {
 		case "ERROR":
-			glog.ErrorDepth(3, formattedMsg)
+			glog.ErrorDepth(4, formattedMsg)
 		case "WARNING":
-			glog.WarningDepth(3, formattedMsg)
+			glog.WarningDepth(4, formattedMsg)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Stop forwarding INFO/DEBUG task log entries to glog — only ERROR and WARNING are forwarded now
- Remove stderr echo of every task log line
- Remove `fsync()` on every single log write (unnecessary for log files, major I/O overhead)

Every task log entry was being tripled: written to the JSON task log file, forwarded to glog (which writes to `/tmp` by default with no rotation), and echoed to stderr. On long-running workers this caused glog files to fill `/tmp`, leading to crashes like:

```
glog: existing because of error: log: cannot create log: open /tmp/weed...log.INFO...: no space left on device
```

Task log files in `BaseLogDir` remain the authoritative source for task execution details. Errors and warnings still surface in glog for operational visibility.

## Test plan
- [ ] Run a worker with `erasure_coding` job type and verify `/tmp` glog files stay small
- [ ] Verify task log files still contain all INFO/DEBUG/WARNING/ERROR entries
- [ ] Verify ERROR and WARNING entries still appear in glog output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized console logging to display only errors and warnings, reducing log verbosity
  * Improved logging performance by adjusting file I/O behavior
  * Removed duplicate stderr output in console mode
<!-- end of auto-generated comment: release notes by coderabbit.ai -->