### PR TITLE
fix(shell): set LastLocalSyncTsNs in remote.copy.local so remote.uncache works

### DIFF
--- a/weed/shell/command_remote_copy_local.go
+++ b/weed/shell/command_remote_copy_local.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -253,6 +254,7 @@ func syncFileToRemote(commandEnv *CommandEnv, remoteStorage remote_storage.Remot
 		ctx := context.Background()
 
 		// Update local entry with remote information
+		remoteEntry.LastLocalSyncTsNs = time.Now().UnixNano()
 		localEntry.RemoteEntry = remoteEntry
 
 		// Update the entry


### PR DESCRIPTION
## Summary

- `remote.copy.local` was not setting `LastLocalSyncTsNs` on the `RemoteEntry` after uploading a file to remote storage, leaving it at `0`
- `remote.uncache` checks `LastLocalSyncTsNs < Mtime` to decide if a file is synced — since `0 < Mtime` is always true, it skipped all files uploaded via `remote.copy.local`
- Set `LastLocalSyncTsNs = time.Now().UnixNano()` before updating the entry, matching what `filer.remote.sync` already does in `updateLocalEntry()`

Fixes #8602

## Test plan

- [ ] Mount a local bucket to remote storage
- [ ] Upload a file and run `remote.copy.local -dir=/buckets/test-bucket`
- [ ] Run `remote.uncache -dir=/buckets/test-bucket` and verify the file is uncached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp tracking during remote file synchronization operations to accurately record when files are synced to remote locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->