### PR TITLE
fix(s3api): allow bucket recreation when orphaned collection exists

### DIFF
--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -297,6 +297,13 @@ func (s3a *S3ApiServer) PutBucketHandler(w http.ResponseWriter, r *http.Request)
 			}
 		}
 	}); err != nil {
+		// If mkdir failed because another request created the bucket concurrently,
+		// return BucketAlreadyExists instead of InternalError.
+		if exist, checkErr := s3a.exists(s3a.option.BucketsPath, bucket, true); checkErr == nil && exist {
+			glog.V(3).Infof("PutBucketHandler: bucket %s was created concurrently", bucket)
+			s3err.WriteErrorResponse(w, r, s3err.ErrBucketAlreadyExists)
+			return
+		}
 		glog.Errorf("PutBucketHandler mkdir: %v", err)
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return


### PR DESCRIPTION
## Summary
- Fixes #8601
- When a bucket is deleted and immediately recreated, the underlying collection may still exist (volumes not yet cleaned up). `PutBucketHandler` was treating this orphaned state as a hard error (`ErrBucketAlreadyExists`), blocking bucket recreation and causing subsequent uploads via pre-signed URLs to fail with `InternalError`.
- Changed the orphaned collection check from a blocking error to a warning, allowing the bucket directory to be recreated. The orphaned collection is harmlessly reused.

## Test plan
- [ ] Delete a bucket with objects, immediately recreate it, and upload via pre-signed URL — should succeed without `InternalError`
- [ ] Normal bucket creation (no orphaned collection) still works
- [ ] Creating a bucket that already fully exists still returns `BucketAlreadyExists`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket recreation now succeeds when the bucket directory is missing but collection exists, improving resilience in recovery scenarios
  * Enhanced handling of concurrent bucket creation requests to prevent race condition errors and provide consistent responses
  * Improved error logging during bucket directory recovery
<!-- end of auto-generated comment: release notes by coderabbit.ai -->