### PR TITLE
Fix misuse of $__interval instead of $__rate_interval in Grafana panels

### DIFF
--- a/k8s/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
+++ b/k8s/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
@@ -1539,7 +1539,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$NAMESPACE\"}[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1584,7 +1584,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$NAMESPACE\"}[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1679,7 +1679,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_request_total{namespace=\"$NAMESPACE\"}[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_request_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,

--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -1182,7 +1182,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1275,7 +1275,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1368,7 +1368,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_request_total[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_request_total[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,

--- a/other/metrics/grafana_seaweedfs_heartbeat.json
+++ b/other/metrics/grafana_seaweedfs_heartbeat.json
@@ -754,7 +754,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total[$__interval])) by (bucket)",
+              "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total[$__rate_interval])) by (bucket)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -835,7 +835,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total[$__interval])) by (bucket)",
+              "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total[$__rate_interval])) by (bucket)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -914,7 +914,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(SeaweedFS_s3_request_total[$__interval])) by (bucket)",
+              "expr": "sum(rate(SeaweedFS_s3_request_total[$__rate_interval])) by (bucket)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,

--- a/other/metrics/grafana_seaweedfs_k8s.json
+++ b/other/metrics/grafana_seaweedfs_k8s.json
@@ -310,7 +310,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -403,7 +403,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -496,7 +496,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(SeaweedFS_s3_request_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__interval])) by (bucket)",
+          "expr": "sum(rate(SeaweedFS_s3_request_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__rate_interval])) by (bucket)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,


### PR DESCRIPTION
# What problem are we solving?

Grafana dashboards provided used `$__interval` with `rate` on some panels. This caused the panel to show no data when relatively short period are selected (<3 hours).

# How are we solving the problem?

Replaced `$__interval` with `$__rate_interval` on panels causing the problem. This is the recommended usage from [Grafana](https://grafana.com/docs/grafana/latest/datasources/prometheus/template-variables/#use-__rate_interval.)

# How is the PR tested?

I have deployed the fixes on my own installation and checked that dashboards display the data properly for short rages.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana dashboard configurations to improve rate interval calculations for S3 metrics, including bucket traffic received, bucket traffic sent, and request counts across multiple monitoring dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->