### PR TITLE
feat(balance): add volume state filter (ALL/ACTIVE/FULL)

### DIFF
--- a/weed/plugin/worker/volume_balance_handler.go
+++ b/weed/plugin/worker/volume_balance_handler.go
@@ -94,9 +94,13 @@ func (h *VolumeBalanceHandler) Descriptor() *plugin_pb.JobTypeDescriptor {
 							Name:        "volume_state",
 							Label:       "Volume State Filter",
 							Description: "Filter volumes by state: ALL (default), ACTIVE (writable volumes below size limit), or FULL (read-only volumes above size limit).",
-							Placeholder: "ALL",
-							FieldType:   plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_STRING,
-							Widget:      plugin_pb.ConfigWidget_CONFIG_WIDGET_TEXT,
+							FieldType:   plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_ENUM,
+							Widget:      plugin_pb.ConfigWidget_CONFIG_WIDGET_SELECT,
+							Options: []*plugin_pb.ConfigOption{
+								{Value: "ALL", Label: "All Volumes"},
+								{Value: "ACTIVE", Label: "Active (writable)"},
+								{Value: "FULL", Label: "Full (read-only)"},
+							},
 						},
 					},
 				},
@@ -563,14 +567,28 @@ func emitVolumeBalanceDetectionDecisionTrace(
 // "FULL" keeps volumes with FullnessRatio >= 1.01 (read-only, above size limit).
 // "ALL" or any other value returns all metrics unfiltered.
 func filterMetricsByVolumeState(metrics []*workertypes.VolumeHealthMetrics, volumeState string) []*workertypes.VolumeHealthMetrics {
-	if volumeState != "ACTIVE" && volumeState != "FULL" {
+	const fullnessThreshold = 1.01
+
+	var predicate func(m *workertypes.VolumeHealthMetrics) bool
+	switch volumeState {
+	case "ACTIVE":
+		predicate = func(m *workertypes.VolumeHealthMetrics) bool {
+			return m.FullnessRatio < fullnessThreshold
+		}
+	case "FULL":
+		predicate = func(m *workertypes.VolumeHealthMetrics) bool {
+			return m.FullnessRatio >= fullnessThreshold
+		}
+	default:
 		return metrics
 	}
-	const fullnessThreshold = 1.01
+
 	filtered := make([]*workertypes.VolumeHealthMetrics, 0, len(metrics))
 	for _, m := range metrics {
-		isActive := m.FullnessRatio < fullnessThreshold
-		if (volumeState == "ACTIVE" && isActive) || (volumeState == "FULL" && !isActive) {
+		if m == nil {
+			continue
+		}
+		if predicate(m) {
 			filtered = append(filtered, m)
 		}
 	}

--- a/weed/plugin/worker/volume_balance_handler_test.go
+++ b/weed/plugin/worker/volume_balance_handler_test.go
@@ -686,6 +686,23 @@ func TestFilterMetricsByVolumeState(t *testing.T) {
 	}
 }
 
+func TestFilterMetricsByVolumeState_NilElement(t *testing.T) {
+	metrics := []*workertypes.VolumeHealthMetrics{
+		nil,
+		{VolumeID: 1, FullnessRatio: 0.5},
+		nil,
+		{VolumeID: 2, FullnessRatio: 1.5},
+	}
+	result := filterMetricsByVolumeState(metrics, "ACTIVE")
+	if len(result) != 1 || result[0].VolumeID != 1 {
+		t.Fatalf("expected [vol 1] for ACTIVE with nil elements, got %d results", len(result))
+	}
+	result = filterMetricsByVolumeState(metrics, "FULL")
+	if len(result) != 1 || result[0].VolumeID != 2 {
+		t.Fatalf("expected [vol 2] for FULL with nil elements, got %d results", len(result))
+	}
+}
+
 func TestFilterMetricsByVolumeState_EmptyInput(t *testing.T) {
 	result := filterMetricsByVolumeState(nil, "ACTIVE")
 	if len(result) != 0 {


### PR DESCRIPTION
## Summary

- Adds a `volume_state` admin config field to the plugin worker volume balance handler, mirroring the shell's `-volumeBy` flag
- Supports three modes: `ALL` (default, all volumes), `ACTIVE` (writable volumes with FullnessRatio < 1.01), and `FULL` (read-only volumes with FullnessRatio >= 1.01)
- The 1.01 threshold matches the shell's `thresholdVolumeSize` constant at `weed/shell/command_volume_balance.go:26`

## Test plan

- [x] `go build ./weed/...` compiles successfully
- [x] `TestFilterMetricsByVolumeState` verifies ALL/ACTIVE/FULL/empty/unknown filtering
- [x] `TestFilterMetricsByVolumeState_EmptyInput` verifies nil and empty slice handling
- [x] `TestVolumeBalanceDescriptorHasVolumeStateField` verifies the field and default value exist in the descriptor
- [x] All existing balance handler tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added volume state filtering option in admin configuration to filter volumes by operational status (ALL, ACTIVE, FULL).

* **Tests**
  * Added comprehensive tests for volume state filtering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->