### PR TITLE
fix(mount): return dropped error

### DIFF
--- a/weed/mount/rdma_client.go
+++ b/weed/mount/rdma_client.go
@@ -226,6 +226,7 @@ func (c *RDMAMountClient) ReadNeedle(ctx context.Context, fileID string, offset,
 
 	var data []byte
 
+	var n int
 	if useTempFile && tempFilePath != "" {
 		// Zero-copy path: read from temp file (page cache)
 		glog.V(4).Infof("🔥 Using zero-copy temp file: %s", tempFilePath)
@@ -237,7 +238,7 @@ func (c *RDMAMountClient) ReadNeedle(ctx context.Context, fileID string, offset,
 		}
 		buffer := make([]byte, bufferSize)
 
-		n, err := c.readFromTempFile(tempFilePath, buffer)
+		n, err = c.readFromTempFile(tempFilePath, buffer)
 		if err != nil {
 			glog.V(2).Infof("Zero-copy failed, falling back to HTTP body: %v", err)
 			// Fall back to reading HTTP body


### PR DESCRIPTION
This fixes an `err` variable in `mount` that was being redeclared with an ':=` inside an `if` block and not making it to the return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized variable handling in the RDMA client's read operation to improve code clarity and reduce overhead in the zero-copy path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->