### PR TITLE
Fix ec.rebuild failing on unrepairable volumes instead of skipping

### DIFF
--- a/weed/shell/command_ec_rebuild.go
+++ b/weed/shell/command_ec_rebuild.go
@@ -231,7 +231,7 @@ func (erb *ecRebuilder) rebuildEcVolumes(collection string) {
 			continue
 		}
 		if shardCount < erasure_coding.DataShardsCount {
-			erb.write("%.2d: ec volume %d is unrepairable with %d shards (need %d), skipping\n", vid, vid, shardCount, erasure_coding.DataShardsCount)
+			erb.write("ec volume %d is unrepairable with %d shards (need %d), skipping\n", vid, shardCount, erasure_coding.DataShardsCount)
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- When an EC volume has fewer shards than `DataShardsCount`, `ec.rebuild` was returning an error via `ErrorWaitGroup`, causing the entire rebuild operation to abort
- Changed to log a warning and skip the unrepairable volume, allowing the remaining volumes to be rebuilt

Fixes #8630

## Test plan
- [ ] Run `ec.rebuild -force` with a mix of repairable and unrepairable EC volumes
- [ ] Verify unrepairable volumes are logged and skipped
- [ ] Verify repairable volumes are still rebuilt successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EC volume rebuild behavior: volumes with insufficient data shards are now skipped with a log message instead of causing the entire rebuild operation to fail.
  * Skipped volumes no longer propagate errors that halt the overall rebuild; rebuild continues for eligible volumes.
  * Per-volume rebuild handling for volumes with sufficient shards remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->