### PR TITLE
fix(mini): use "all" job type for plugin worker

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -45,7 +45,7 @@ const (
 	defaultMiniVolumeSizeMB       = 128         // Default volume size for mini mode
 	maxVolumeSizeMB               = 1024        // Maximum volume size in MB (1GB)
 	GrpcPortOffset                = 10000       // Offset used to calculate gRPC port from HTTP port
-	defaultMiniPluginJobTypes     = "vacuum,volume_balance,erasure_coding,admin_script"
+	defaultMiniPluginJobTypes     = "all"
 )
 
 var (


### PR DESCRIPTION
## Summary
- Replace hardcoded job type list (`vacuum,volume_balance,erasure_coding,admin_script`) with the `"all"` category in `weed mini`'s plugin worker startup
- New handlers (e.g. `ec_balance`) will be automatically picked up without needing to update this list

## Test plan
- [ ] Verify `weed mini` starts and the plugin worker logs `job types: all`
- [ ] Confirm all registered handlers are resolved via `ResolveHandlerFactories("all")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded the default task types executed by the mini plugin to include all available job categories, broadening the scope of operations that are enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->