### PR TITLE
fix(grafana): unify `datasource` usage in `grafana_seaweedfs.json`

### DIFF
--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -465,7 +465,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 6,
@@ -547,7 +547,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 6,
@@ -649,7 +649,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 6,
@@ -731,7 +731,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 6,


### PR DESCRIPTION
# What problem are we solving?

Some panels were using `Prometheus` instead of `${DS_PROMETHEUS}` which caused missing data when other sources (e.g. VictoriaMetrics) are in use.


# How are we solving the problem?

Setting datasource to `${DS_PROMETHEUS}` for all panels.


# How is the PR tested?

I have imported the changed dashboard into Grafana and all panels are now active.


# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana monitoring configuration to use dynamic datasource references instead of hard-coded values, improving portability and maintainability of the monitoring setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->