### PR TITLE
Change iceberg compaction target file size config from bytes to MB

### DIFF
--- a/weed/plugin/worker/iceberg/config.go
+++ b/weed/plugin/worker/iceberg/config.go
@@ -16,7 +16,7 @@ const (
 	defaultMaxSnapshotsToKeep     = 5
 	defaultOrphanOlderThanHours   = 72
 	defaultMaxCommitRetries       = 5
-	defaultTargetFileSizeBytes    = 256 * 1024 * 1024
+	defaultTargetFileSizeMB       = 256
 	defaultMinInputFiles          = 5
 	defaultMinManifestsToRewrite  = 5
 	defaultOperations             = "all"
@@ -42,7 +42,7 @@ func ParseConfig(values map[string]*plugin_pb.ConfigValue) Config {
 		MaxSnapshotsToKeep:     readInt64Config(values, "max_snapshots_to_keep", defaultMaxSnapshotsToKeep),
 		OrphanOlderThanHours:   readInt64Config(values, "orphan_older_than_hours", defaultOrphanOlderThanHours),
 		MaxCommitRetries:       readInt64Config(values, "max_commit_retries", defaultMaxCommitRetries),
-		TargetFileSizeBytes:    readInt64Config(values, "target_file_size_bytes", defaultTargetFileSizeBytes),
+		TargetFileSizeBytes:    readInt64Config(values, "target_file_size_mb", defaultTargetFileSizeMB) * 1024 * 1024,
 		MinInputFiles:          readInt64Config(values, "min_input_files", defaultMinInputFiles),
 		MinManifestsToRewrite:  readInt64Config(values, "min_manifests_to_rewrite", defaultMinManifestsToRewrite),
 		Operations:             readStringConfig(values, "operations", defaultOperations),
@@ -62,7 +62,7 @@ func ParseConfig(values map[string]*plugin_pb.ConfigValue) Config {
 		cfg.MaxCommitRetries = defaultMaxCommitRetries
 	}
 	if cfg.TargetFileSizeBytes <= 0 {
-		cfg.TargetFileSizeBytes = defaultTargetFileSizeBytes
+		cfg.TargetFileSizeBytes = defaultTargetFileSizeMB * 1024 * 1024
 	}
 	if cfg.MinInputFiles < 2 {
 		cfg.MinInputFiles = defaultMinInputFiles

--- a/weed/plugin/worker/iceberg/handler.go
+++ b/weed/plugin/worker/iceberg/handler.go
@@ -133,12 +133,12 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 					Description: "Controls for bin-packing small Parquet data files.",
 					Fields: []*plugin_pb.ConfigField{
 						{
-							Name:        "target_file_size_bytes",
-							Label:       "Target File Size (bytes)",
-							Description: "Files smaller than this are candidates for compaction.",
+							Name:        "target_file_size_mb",
+							Label:       "Target File Size (MB)",
+							Description: "Files smaller than this (in megabytes) are candidates for compaction.",
 							FieldType:   plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_INT64,
 							Widget:      plugin_pb.ConfigWidget_CONFIG_WIDGET_NUMBER,
-							MinValue:    &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 1024 * 1024}},
+							MinValue:    &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 1}},
 						},
 						{
 							Name:        "min_input_files",
@@ -205,7 +205,7 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 				},
 			},
 			DefaultValues: map[string]*plugin_pb.ConfigValue{
-				"target_file_size_bytes":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeBytes}},
+				"target_file_size_mb":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeMB}},
 				"min_input_files":          {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMinInputFiles}},
 				"min_manifests_to_rewrite": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMinManifestsToRewrite}},
 				"snapshot_retention_hours": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultSnapshotRetentionHours}},
@@ -227,7 +227,7 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 			JobTypeMaxRuntimeSeconds:      3600, // 1 hour max
 		},
 		WorkerDefaultValues: map[string]*plugin_pb.ConfigValue{
-			"target_file_size_bytes":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeBytes}},
+			"target_file_size_mb":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeMB}},
 			"min_input_files":          {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMinInputFiles}},
 			"snapshot_retention_hours": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultSnapshotRetentionHours}},
 			"max_snapshots_to_keep":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMaxSnapshotsToKeep}},


### PR DESCRIPTION
## Summary
- Rename config field from `target_file_size_bytes` to `target_file_size_mb`
- Default value is now `256` (MB) instead of `268435456` (bytes)
- Value is converted to bytes internally — no behavior change
- UI label and min value updated accordingly (min: 1 MB)

## Test plan
- [x] Unit tests pass (`weed/plugin/worker/iceberg/...`)
- [x] Integration tests pass (`test/s3tables/maintenance/...`)
- [ ] Verify admin UI renders the field correctly with the new label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Changed target file size configuration parameter from bytes to megabytes for simplification.
  * Updated minimum allowed value to 1 MB.
  * Adjusted default configuration values accordingly.
  * Configuration labels and descriptions updated to reflect megabyte units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->