### PR TITLE
Add multi-spec and delete-aware compaction to iceberg maintenance (Phase 3)

### DIFF
--- a/weed/plugin/worker/iceberg/compact.go
+++ b/weed/plugin/worker/iceberg/compact.go
@@ -22,10 +22,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// compactionBin groups small data files from the same partition for merging.
+// compactionBin groups small data files from the same partition and spec for merging.
 type compactionBin struct {
 	PartitionKey string
 	Partition    map[int]any
+	SpecID       int32
 	Entries      []iceberg.ManifestEntry
 	TotalSize    int64
 }
@@ -38,64 +39,117 @@ func (h *Handler) compactDataFiles(
 	filerClient filer_pb.SeaweedFilerClient,
 	bucketName, tablePath string,
 	config Config,
-) (string, error) {
+	onProgress func(binIdx, totalBins int),
+) (string, map[string]int64, error) {
+	start := time.Now()
 	meta, metadataFileName, err := loadCurrentMetadata(ctx, filerClient, bucketName, tablePath)
 	if err != nil {
-		return "", fmt.Errorf("load metadata: %w", err)
+		return "", nil, fmt.Errorf("load metadata: %w", err)
 	}
 
 	currentSnap := meta.CurrentSnapshot()
 	if currentSnap == nil || currentSnap.ManifestList == "" {
-		return "no current snapshot", nil
+		return "no current snapshot", nil, nil
 	}
 
 	// Read manifest list
 	manifestListData, err := loadFileByIcebergPath(ctx, filerClient, bucketName, tablePath, currentSnap.ManifestList)
 	if err != nil {
-		return "", fmt.Errorf("read manifest list: %w", err)
+		return "", nil, fmt.Errorf("read manifest list: %w", err)
 	}
 	manifests, err := iceberg.ReadManifestList(bytes.NewReader(manifestListData))
 	if err != nil {
-		return "", fmt.Errorf("parse manifest list: %w", err)
+		return "", nil, fmt.Errorf("parse manifest list: %w", err)
 	}
 
-	// Abort if delete manifests exist — the compactor does not apply deletes,
-	// so carrying them through could produce incorrect results.
-	// Also detect multiple partition specs — the compactor writes a single
-	// manifest under the current spec which is invalid for spec-evolved tables.
-	specIDs := make(map[int32]struct{})
+	// Separate data manifests from delete manifests.
+	var dataManifests, deleteManifests []iceberg.ManifestFile
 	for _, mf := range manifests {
-		if mf.ManifestContent() != iceberg.ManifestContentData {
-			return "compaction skipped: delete manifests present (not yet supported)", nil
+		if mf.ManifestContent() == iceberg.ManifestContentData {
+			dataManifests = append(dataManifests, mf)
+		} else {
+			deleteManifests = append(deleteManifests, mf)
 		}
-		specIDs[mf.PartitionSpecID()] = struct{}{}
 	}
-	if len(specIDs) > 1 {
-		return "compaction skipped: multiple partition specs present (not yet supported)", nil
+
+	// If delete manifests exist and apply_deletes is disabled (or not yet
+	// implemented for this code path), skip compaction to avoid producing
+	// incorrect results by dropping deletes.
+	if len(deleteManifests) > 0 && !config.ApplyDeletes {
+		return "compaction skipped: delete manifests present and apply_deletes is disabled", nil, nil
 	}
 
 	// Collect data file entries from data manifests
 	var allEntries []iceberg.ManifestEntry
-	for _, mf := range manifests {
+	for _, mf := range dataManifests {
 		manifestData, err := loadFileByIcebergPath(ctx, filerClient, bucketName, tablePath, mf.FilePath())
 		if err != nil {
-			return "", fmt.Errorf("read manifest %s: %w", mf.FilePath(), err)
+			return "", nil, fmt.Errorf("read manifest %s: %w", mf.FilePath(), err)
 		}
 		entries, err := iceberg.ReadManifest(mf, bytes.NewReader(manifestData), true)
 		if err != nil {
-			return "", fmt.Errorf("parse manifest %s: %w", mf.FilePath(), err)
+			return "", nil, fmt.Errorf("parse manifest %s: %w", mf.FilePath(), err)
 		}
 		allEntries = append(allEntries, entries...)
+	}
+
+	// Collect delete entries if we need to apply deletes
+	var positionDeletes map[string][]int64
+	var equalityDeletes map[string]struct{}
+	var equalityFieldIDs []int
+	if config.ApplyDeletes && len(deleteManifests) > 0 {
+		var allDeleteEntries []iceberg.ManifestEntry
+		for _, mf := range deleteManifests {
+			manifestData, err := loadFileByIcebergPath(ctx, filerClient, bucketName, tablePath, mf.FilePath())
+			if err != nil {
+				return "", nil, fmt.Errorf("read delete manifest %s: %w", mf.FilePath(), err)
+			}
+			entries, err := iceberg.ReadManifest(mf, bytes.NewReader(manifestData), true)
+			if err != nil {
+				return "", nil, fmt.Errorf("parse delete manifest %s: %w", mf.FilePath(), err)
+			}
+			allDeleteEntries = append(allDeleteEntries, entries...)
+		}
+
+		// Separate position and equality deletes
+		var posDeleteEntries, eqDeleteEntries []iceberg.ManifestEntry
+		for _, entry := range allDeleteEntries {
+			switch entry.DataFile().ContentType() {
+			case iceberg.EntryContentPosDeletes:
+				posDeleteEntries = append(posDeleteEntries, entry)
+			case iceberg.EntryContentEqDeletes:
+				eqDeleteEntries = append(eqDeleteEntries, entry)
+			}
+		}
+
+		if len(posDeleteEntries) > 0 {
+			positionDeletes, err = collectPositionDeletes(ctx, filerClient, bucketName, tablePath, posDeleteEntries)
+			if err != nil {
+				return "", nil, fmt.Errorf("collect position deletes: %w", err)
+			}
+		}
+
+		if len(eqDeleteEntries) > 0 {
+			equalityDeletes, equalityFieldIDs, err = collectEqualityDeletes(ctx, filerClient, bucketName, tablePath, eqDeleteEntries, meta.CurrentSchema())
+			if err != nil {
+				return "", nil, fmt.Errorf("collect equality deletes: %w", err)
+			}
+		}
 	}
 
 	// Build compaction bins: group small files by partition
 	// MinInputFiles is clamped by ParseConfig to [2, ...] so int conversion is safe.
 	bins := buildCompactionBins(allEntries, config.TargetFileSizeBytes, int(config.MinInputFiles))
 	if len(bins) == 0 {
-		return "no files eligible for compaction", nil
+		return "no files eligible for compaction", nil, nil
 	}
 
-	spec := meta.PartitionSpec()
+	// Build a lookup from spec ID to PartitionSpec for per-bin manifest writing.
+	specByID := make(map[int]iceberg.PartitionSpec)
+	for _, ps := range meta.PartitionSpecs() {
+		specByID[ps.ID()] = ps
+	}
+
 	schema := meta.CurrentSchema()
 	version := meta.Version()
 	snapshotID := currentSnap.SnapshotID
@@ -136,14 +190,14 @@ func (h *Handler) compactDataFiles(
 	for binIdx, bin := range bins {
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return "", nil, ctx.Err()
 		default:
 		}
 
 		mergedFileName := fmt.Sprintf("compact-%d-%d-%d.parquet", snapshotID, newSnapID, binIdx)
 		mergedFilePath := path.Join("data", mergedFileName)
 
-		mergedData, recordCount, err := mergeParquetFiles(ctx, filerClient, bucketName, tablePath, bin.Entries)
+		mergedData, recordCount, err := mergeParquetFiles(ctx, filerClient, bucketName, tablePath, bin.Entries, positionDeletes, equalityDeletes, equalityFieldIDs, schema)
 		if err != nil {
 			glog.Warningf("iceberg compact: failed to merge bin %d (%d files): %v", binIdx, len(bin.Entries), err)
 			continue
@@ -151,15 +205,23 @@ func (h *Handler) compactDataFiles(
 
 		// Write merged file to filer
 		if err := ensureFilerDir(ctx, filerClient, dataDir); err != nil {
-			return "", fmt.Errorf("ensure data dir: %w", err)
+			return "", nil, fmt.Errorf("ensure data dir: %w", err)
 		}
 		if err := saveFilerFile(ctx, filerClient, dataDir, mergedFileName, mergedData); err != nil {
-			return "", fmt.Errorf("save merged file: %w", err)
+			return "", nil, fmt.Errorf("save merged file: %w", err)
+		}
+
+		// Use the partition spec matching this bin's spec ID
+		binSpec, ok := specByID[int(bin.SpecID)]
+		if !ok {
+			glog.Warningf("iceberg compact: spec %d not found for bin %d, skipping", bin.SpecID, binIdx)
+			_ = deleteFilerFile(ctx, filerClient, dataDir, mergedFileName)
+			continue
 		}
 
 		// Create new DataFile entry for the merged file
 		dfBuilder, err := iceberg.NewDataFileBuilder(
-			spec,
+			binSpec,
 			iceberg.EntryContentData,
 			mergedFilePath,
 			iceberg.ParquetFile,
@@ -186,23 +248,28 @@ func (h *Handler) compactDataFiles(
 
 		// Mark original entries as deleted
 		for _, entry := range bin.Entries {
+			seqNum := entry.SequenceNum()
+			fileSeqNum := entry.FileSequenceNum()
 			delEntry := iceberg.NewManifestEntry(
 				iceberg.EntryStatusDELETED,
 				&newSnapID,
-				nil, nil,
+				&seqNum, fileSeqNum,
 				entry.DataFile(),
 			)
 			deletedManifestEntries = append(deletedManifestEntries, delEntry)
 		}
 
 		totalMerged += len(bin.Entries)
+		if onProgress != nil {
+			onProgress(binIdx, len(bins))
+		}
 	}
 
 	if len(newManifestEntries) == 0 {
-		return "no bins successfully compacted", nil
+		return "no bins successfully compacted", nil, nil
 	}
 
-	// Build entries for the new manifest:
+	// Build entries for the new manifests:
 	// - ADDED entries for merged files
 	// - DELETED entries for original files
 	// - EXISTING entries for files that weren't compacted
@@ -211,59 +278,114 @@ func (h *Handler) compactDataFiles(
 		compactedPaths[entry.DataFile().FilePath()] = struct{}{}
 	}
 
-	var manifestEntries []iceberg.ManifestEntry
-	manifestEntries = append(manifestEntries, newManifestEntries...)
-	manifestEntries = append(manifestEntries, deletedManifestEntries...)
+	// Group all manifest entries by spec ID for per-spec manifest writing.
+	type specEntries struct {
+		specID  int32
+		entries []iceberg.ManifestEntry
+	}
+	specEntriesMap := make(map[int32]*specEntries)
 
-	// Keep existing entries that weren't compacted
+	addToSpec := func(specID int32, entry iceberg.ManifestEntry) {
+		se, ok := specEntriesMap[specID]
+		if !ok {
+			se = &specEntries{specID: specID}
+			specEntriesMap[specID] = se
+		}
+		se.entries = append(se.entries, entry)
+	}
+
+	// New and deleted entries carry the spec ID from their bin
+	for _, entry := range newManifestEntries {
+		addToSpec(entry.DataFile().SpecID(), entry)
+	}
+	for _, entry := range deletedManifestEntries {
+		addToSpec(entry.DataFile().SpecID(), entry)
+	}
+
+	// Existing entries that weren't compacted
 	for _, entry := range allEntries {
 		if _, compacted := compactedPaths[entry.DataFile().FilePath()]; !compacted {
+			seqNum := entry.SequenceNum()
+			fileSeqNum := entry.FileSequenceNum()
 			existingEntry := iceberg.NewManifestEntry(
 				iceberg.EntryStatusEXISTING,
 				func() *int64 { id := entry.SnapshotID(); return &id }(),
-				nil, nil,
+				&seqNum, fileSeqNum,
 				entry.DataFile(),
 			)
-			manifestEntries = append(manifestEntries, existingEntry)
+			addToSpec(entry.DataFile().SpecID(), existingEntry)
 		}
 	}
 
-	// Write new manifest
-	var manifestBuf bytes.Buffer
-	manifestFileName := fmt.Sprintf("compact-%d.avro", newSnapID)
-	newManifest, err := iceberg.WriteManifest(
-		path.Join("metadata", manifestFileName),
-		&manifestBuf,
-		version,
-		spec,
-		schema,
-		newSnapID,
-		manifestEntries,
-	)
-	if err != nil {
-		return "", fmt.Errorf("write compact manifest: %w", err)
+	// Write one manifest per spec ID
+	var allManifests []iceberg.ManifestFile
+	for _, se := range specEntriesMap {
+		ps, ok := specByID[int(se.specID)]
+		if !ok {
+			return "", nil, fmt.Errorf("partition spec %d not found in table metadata", se.specID)
+		}
+
+		var manifestBuf bytes.Buffer
+		manifestFileName := fmt.Sprintf("compact-%d-spec%d.avro", newSnapID, se.specID)
+		newManifest, err := iceberg.WriteManifest(
+			path.Join("metadata", manifestFileName),
+			&manifestBuf,
+			version,
+			ps,
+			schema,
+			newSnapID,
+			se.entries,
+		)
+		if err != nil {
+			return "", nil, fmt.Errorf("write compact manifest for spec %d: %w", se.specID, err)
+		}
+
+		if err := saveFilerFile(ctx, filerClient, metaDir, manifestFileName, manifestBuf.Bytes()); err != nil {
+			return "", nil, fmt.Errorf("save compact manifest for spec %d: %w", se.specID, err)
+		}
+		writtenArtifacts = append(writtenArtifacts, artifact{dir: metaDir, fileName: manifestFileName})
+		allManifests = append(allManifests, newManifest)
 	}
 
-	if err := saveFilerFile(ctx, filerClient, metaDir, manifestFileName, manifestBuf.Bytes()); err != nil {
-		return "", fmt.Errorf("save compact manifest: %w", err)
+	// Carry forward delete manifests only if deletes were NOT applied.
+	// When deletes were applied, they've been consumed during the merge.
+	// Position deletes reference specific data files — if all those files
+	// were compacted, the deletes are fully consumed. Equality deletes
+	// apply broadly, so they're only consumed if all data files were compacted.
+	if !config.ApplyDeletes || (len(positionDeletes) == 0 && len(equalityDeletes) == 0) {
+		for _, mf := range deleteManifests {
+			allManifests = append(allManifests, mf)
+		}
+	} else {
+		// Check if any non-compacted data files remain
+		hasUncompactedFiles := false
+		for _, entry := range allEntries {
+			if _, compacted := compactedPaths[entry.DataFile().FilePath()]; !compacted {
+				hasUncompactedFiles = true
+				break
+			}
+		}
+		if hasUncompactedFiles {
+			// Some files weren't compacted — carry forward delete manifests
+			// since deletes may still apply to those files.
+			for _, mf := range deleteManifests {
+				allManifests = append(allManifests, mf)
+			}
+		}
+		// If all files were compacted, deletes are fully consumed — don't carry forward.
 	}
-	writtenArtifacts = append(writtenArtifacts, artifact{dir: metaDir, fileName: manifestFileName})
-
-	// Build manifest list with only the new manifest (the early abort at the
-	// top of this function guarantees no delete manifests are present).
-	allManifests := []iceberg.ManifestFile{newManifest}
 
 	// Write new manifest list
 	var manifestListBuf bytes.Buffer
 	seqNum := currentSnap.SequenceNumber + 1
 	err = iceberg.WriteManifestList(version, &manifestListBuf, newSnapID, &snapshotID, &seqNum, 0, allManifests)
 	if err != nil {
-		return "", fmt.Errorf("write compact manifest list: %w", err)
+		return "", nil, fmt.Errorf("write compact manifest list: %w", err)
 	}
 
 	manifestListFileName := fmt.Sprintf("snap-%d.avro", newSnapID)
 	if err := saveFilerFile(ctx, filerClient, metaDir, manifestListFileName, manifestListBuf.Bytes()); err != nil {
-		return "", fmt.Errorf("save compact manifest list: %w", err)
+		return "", nil, fmt.Errorf("save compact manifest list: %w", err)
 	}
 	writtenArtifacts = append(writtenArtifacts, artifact{dir: metaDir, fileName: manifestListFileName})
 
@@ -302,11 +424,17 @@ func (h *Handler) compactDataFiles(
 		return builder.SetSnapshotRef(table.MainBranch, newSnapID, table.BranchRef)
 	})
 	if err != nil {
-		return "", fmt.Errorf("commit compaction: %w", err)
+		return "", nil, fmt.Errorf("commit compaction: %w", err)
 	}
 
 	committed = true
-	return fmt.Sprintf("compacted %d files into %d (across %d bins)", totalMerged, len(newManifestEntries), len(bins)), nil
+	metrics := map[string]int64{
+		"files_merged":  int64(totalMerged),
+		"files_written": int64(len(newManifestEntries)),
+		"bins":          int64(len(bins)),
+		"duration_ms":   time.Since(start).Milliseconds(),
+	}
+	return fmt.Sprintf("compacted %d files into %d (across %d bins)", totalMerged, len(newManifestEntries), len(bins)), metrics, nil
 }
 
 // buildCompactionBins groups small data files by partition for bin-packing.
@@ -317,7 +445,8 @@ func buildCompactionBins(entries []iceberg.ManifestEntry, targetSize int64, minF
 		minFiles = 2
 	}
 
-	// Group entries by partition key
+	// Group entries by spec ID + partition key so that files from different
+	// partition specs are never mixed in the same compaction bin.
 	groups := make(map[string]*compactionBin)
 	for _, entry := range entries {
 		df := entry.DataFile()
@@ -329,13 +458,15 @@ func buildCompactionBins(entries []iceberg.ManifestEntry, targetSize int64, minF
 		}
 
 		partKey := partitionKey(df.Partition())
-		bin, ok := groups[partKey]
+		groupKey := fmt.Sprintf("spec%d\x00%s", df.SpecID(), partKey)
+		bin, ok := groups[groupKey]
 		if !ok {
 			bin = &compactionBin{
 				PartitionKey: partKey,
 				Partition:    df.Partition(),
+				SpecID:       df.SpecID(),
 			}
-			groups[partKey] = bin
+			groups[groupKey] = bin
 		}
 		bin.Entries = append(bin.Entries, entry)
 		bin.TotalSize += df.FileSizeBytes()
@@ -378,6 +509,7 @@ func splitOversizedBin(bin compactionBin, targetSize int64, minFiles int) []comp
 	current := compactionBin{
 		PartitionKey: bin.PartitionKey,
 		Partition:    bin.Partition,
+		SpecID:       bin.SpecID,
 	}
 	for _, entry := range sorted {
 		if current.TotalSize > 0 && current.TotalSize+entry.DataFile().FileSizeBytes() > targetSize {
@@ -385,6 +517,7 @@ func splitOversizedBin(bin compactionBin, targetSize int64, minFiles int) []comp
 			current = compactionBin{
 				PartitionKey: bin.PartitionKey,
 				Partition:    bin.Partition,
+				SpecID:       bin.SpecID,
 			}
 		}
 		current.Entries = append(current.Entries, entry)
@@ -456,17 +589,245 @@ func partitionKey(partition map[int]any) string {
 	return strings.Join(parts, "\x00")
 }
 
+// collectPositionDeletes reads position delete Parquet files and returns a map
+// from data file path to sorted row positions that should be deleted.
+func collectPositionDeletes(
+	ctx context.Context,
+	filerClient filer_pb.SeaweedFilerClient,
+	bucketName, tablePath string,
+	deleteEntries []iceberg.ManifestEntry,
+) (map[string][]int64, error) {
+	result := make(map[string][]int64)
+	for _, entry := range deleteEntries {
+		if entry.DataFile().ContentType() != iceberg.EntryContentPosDeletes {
+			continue
+		}
+		fileDeletes, err := readPositionDeleteFile(ctx, filerClient, bucketName, tablePath, entry.DataFile().FilePath())
+		if err != nil {
+			return nil, fmt.Errorf("read position delete file %s: %w", entry.DataFile().FilePath(), err)
+		}
+		for filePath, positions := range fileDeletes {
+			result[filePath] = append(result[filePath], positions...)
+		}
+	}
+	// Sort positions for each file (binary search during filtering)
+	for filePath := range result {
+		sort.Slice(result[filePath], func(i, j int) bool {
+			return result[filePath][i] < result[filePath][j]
+		})
+	}
+	return result, nil
+}
+
+// readPositionDeleteFile reads a position delete Parquet file and returns a map
+// from data file path to row positions. The file must have columns "file_path"
+// (string) and "pos" (int32 or int64).
+func readPositionDeleteFile(
+	ctx context.Context,
+	filerClient filer_pb.SeaweedFilerClient,
+	bucketName, tablePath, filePath string,
+) (map[string][]int64, error) {
+	data, err := loadFileByIcebergPath(ctx, filerClient, bucketName, tablePath, filePath)
+	if err != nil {
+		return nil, err
+	}
+	reader := parquet.NewReader(bytes.NewReader(data))
+	defer reader.Close()
+
+	pqSchema := reader.Schema()
+	filePathIdx := -1
+	posIdx := -1
+	for i, col := range pqSchema.Columns() {
+		name := strings.Join(col, ".")
+		switch name {
+		case "file_path":
+			filePathIdx = i
+		case "pos":
+			posIdx = i
+		}
+	}
+	if filePathIdx < 0 || posIdx < 0 {
+		return nil, fmt.Errorf("position delete file %s missing required columns (file_path=%d, pos=%d)", filePath, filePathIdx, posIdx)
+	}
+
+	result := make(map[string][]int64)
+	rows := make([]parquet.Row, 256)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		n, readErr := reader.ReadRows(rows)
+		for i := 0; i < n; i++ {
+			row := rows[i]
+			fp := row[filePathIdx].String()
+			var pos int64
+			if row[posIdx].Column() == posIdx {
+				pos = row[posIdx].Int64()
+			}
+			result[fp] = append(result[fp], pos)
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return nil, readErr
+		}
+	}
+	return result, nil
+}
+
+// collectEqualityDeletes reads equality delete Parquet files and returns a set
+// of composite keys that should be deleted. Each key is built from the equality
+// field values of a row. Also returns the field IDs used for equality comparison.
+func collectEqualityDeletes(
+	ctx context.Context,
+	filerClient filer_pb.SeaweedFilerClient,
+	bucketName, tablePath string,
+	deleteEntries []iceberg.ManifestEntry,
+	schema *iceberg.Schema,
+) (map[string]struct{}, []int, error) {
+	result := make(map[string]struct{})
+	var fieldIDs []int
+
+	for _, entry := range deleteEntries {
+		if entry.DataFile().ContentType() != iceberg.EntryContentEqDeletes {
+			continue
+		}
+		eqFieldIDs := entry.DataFile().EqualityFieldIDs()
+		if len(eqFieldIDs) == 0 {
+			continue
+		}
+		if len(fieldIDs) == 0 {
+			fieldIDs = eqFieldIDs
+		}
+
+		keys, err := readEqualityDeleteFile(ctx, filerClient, bucketName, tablePath, entry.DataFile().FilePath(), eqFieldIDs, schema)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read equality delete file %s: %w", entry.DataFile().FilePath(), err)
+		}
+		for k := range keys {
+			result[k] = struct{}{}
+		}
+	}
+	return result, fieldIDs, nil
+}
+
+// readEqualityDeleteFile reads an equality delete Parquet file and returns a set
+// of composite keys built from the specified field IDs. The Iceberg schema is used
+// to map field IDs to column names, which are then looked up in the Parquet schema.
+func readEqualityDeleteFile(
+	ctx context.Context,
+	filerClient filer_pb.SeaweedFilerClient,
+	bucketName, tablePath, filePath string,
+	fieldIDs []int,
+	icebergSchema *iceberg.Schema,
+) (map[string]struct{}, error) {
+	data, err := loadFileByIcebergPath(ctx, filerClient, bucketName, tablePath, filePath)
+	if err != nil {
+		return nil, err
+	}
+	reader := parquet.NewReader(bytes.NewReader(data))
+	defer reader.Close()
+
+	// Map Iceberg field IDs → column names → Parquet column indices
+	pqSchema := reader.Schema()
+	colNameToIdx := make(map[string]int)
+	for i, col := range pqSchema.Columns() {
+		colNameToIdx[strings.Join(col, ".")] = i
+	}
+
+	colIndices := make([]int, len(fieldIDs))
+	for i, fid := range fieldIDs {
+		field, ok := icebergSchema.FindFieldByID(fid)
+		if !ok {
+			return nil, fmt.Errorf("field ID %d not found in iceberg schema", fid)
+		}
+		idx, ok := colNameToIdx[field.Name]
+		if !ok {
+			return nil, fmt.Errorf("column %q (field ID %d) not found in parquet schema of %s", field.Name, fid, filePath)
+		}
+		colIndices[i] = idx
+	}
+
+	result := make(map[string]struct{})
+	rows := make([]parquet.Row, 256)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		n, readErr := reader.ReadRows(rows)
+		for i := 0; i < n; i++ {
+			key := buildEqualityKey(rows[i], colIndices)
+			result[key] = struct{}{}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return nil, readErr
+		}
+	}
+	return result, nil
+}
+
+// buildEqualityKey builds a composite string key from specific column values in a row.
+func buildEqualityKey(row parquet.Row, colIndices []int) string {
+	if len(colIndices) == 1 {
+		return row[colIndices[0]].String()
+	}
+	var b strings.Builder
+	for i, idx := range colIndices {
+		if i > 0 {
+			b.WriteByte(0)
+		}
+		b.WriteString(row[idx].String())
+	}
+	return b.String()
+}
+
+// resolveEqualityColIndices maps Iceberg field IDs to Parquet column indices.
+func resolveEqualityColIndices(pqSchema *parquet.Schema, fieldIDs []int, icebergSchema *iceberg.Schema) ([]int, error) {
+	if len(fieldIDs) == 0 {
+		return nil, nil
+	}
+
+	colNameToIdx := make(map[string]int)
+	for i, col := range pqSchema.Columns() {
+		colNameToIdx[strings.Join(col, ".")] = i
+	}
+
+	indices := make([]int, len(fieldIDs))
+	for i, fid := range fieldIDs {
+		field, ok := icebergSchema.FindFieldByID(fid)
+		if !ok {
+			return nil, fmt.Errorf("field ID %d not found in iceberg schema", fid)
+		}
+		idx, ok := colNameToIdx[field.Name]
+		if !ok {
+			return nil, fmt.Errorf("column %q (field ID %d) not found in parquet schema", field.Name, fid)
+		}
+		indices[i] = idx
+	}
+	return indices, nil
+}
+
 // mergeParquetFiles reads multiple small Parquet files and merges them into
-// a single Parquet file. Files are processed one at a time: each source file
-// is loaded, its rows are streamed into the output writer, and then its data
-// is released before the next file is loaded. This keeps peak memory
-// proportional to the size of a single input file plus the output buffer,
-// rather than the sum of all inputs.
+// a single Parquet file, optionally filtering out rows matching position or
+// equality deletes. Files are processed one at a time to keep memory usage
+// proportional to a single input file plus the output buffer.
 func mergeParquetFiles(
 	ctx context.Context,
 	filerClient filer_pb.SeaweedFilerClient,
 	bucketName, tablePath string,
 	entries []iceberg.ManifestEntry,
+	positionDeletes map[string][]int64,
+	equalityDeletes map[string]struct{},
+	equalityFieldIDs []int,
+	icebergSchema *iceberg.Schema,
 ) ([]byte, int64, error) {
 	if len(entries) == 0 {
 		return nil, 0, fmt.Errorf("no entries to merge")
@@ -484,15 +845,32 @@ func mergeParquetFiles(
 		return nil, 0, fmt.Errorf("no parquet schema found in %s", entries[0].DataFile().FilePath())
 	}
 
+	// Resolve equality delete column indices from the Parquet schema.
+	var eqColIndices []int
+	if len(equalityDeletes) > 0 && len(equalityFieldIDs) > 0 && icebergSchema != nil {
+		eqColIndices, err = resolveEqualityColIndices(parquetSchema, equalityFieldIDs, icebergSchema)
+		if err != nil {
+			firstReader.Close()
+			return nil, 0, fmt.Errorf("resolve equality columns: %w", err)
+		}
+	}
+
 	var outputBuf bytes.Buffer
 	writer := parquet.NewWriter(&outputBuf, parquetSchema)
 
-	// drainReader streams all rows from reader into writer, then closes reader.
-	// source identifies the input file for error messages.
 	var totalRows int64
 	rows := make([]parquet.Row, 256)
+
+	// drainReader streams rows from reader into writer, filtering out deleted
+	// rows. source is the data file path (used for error messages and
+	// position delete lookups).
 	drainReader := func(reader *parquet.Reader, source string) error {
 		defer reader.Close()
+
+		posDeletes := positionDeletes[source]
+		posDeleteIdx := 0
+		var absolutePos int64
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -501,10 +879,47 @@ func mergeParquetFiles(
 			}
 			n, readErr := reader.ReadRows(rows)
 			if n > 0 {
-				if _, writeErr := writer.WriteRows(rows[:n]); writeErr != nil {
-					return fmt.Errorf("write rows from %s: %w", source, writeErr)
+				// Filter rows if we have any deletes
+				if len(posDeletes) > 0 || len(equalityDeletes) > 0 {
+					writeIdx := 0
+					for i := 0; i < n; i++ {
+						rowPos := absolutePos + int64(i)
+
+						// Check position deletes (sorted, so advance index)
+						if len(posDeletes) > 0 {
+							for posDeleteIdx < len(posDeletes) && posDeletes[posDeleteIdx] < rowPos {
+								posDeleteIdx++
+							}
+							if posDeleteIdx < len(posDeletes) && posDeletes[posDeleteIdx] == rowPos {
+								posDeleteIdx++
+								continue // skip this row
+							}
+						}
+
+						// Check equality deletes
+						if len(equalityDeletes) > 0 && len(eqColIndices) > 0 {
+							key := buildEqualityKey(rows[i], eqColIndices)
+							if _, deleted := equalityDeletes[key]; deleted {
+								continue // skip this row
+							}
+						}
+
+						rows[writeIdx] = rows[i]
+						writeIdx++
+					}
+					absolutePos += int64(n)
+					if writeIdx > 0 {
+						if _, writeErr := writer.WriteRows(rows[:writeIdx]); writeErr != nil {
+							return fmt.Errorf("write rows from %s: %w", source, writeErr)
+						}
+						totalRows += int64(writeIdx)
+					}
+				} else {
+					if _, writeErr := writer.WriteRows(rows[:n]); writeErr != nil {
+						return fmt.Errorf("write rows from %s: %w", source, writeErr)
+					}
+					totalRows += int64(n)
 				}
-				totalRows += int64(n)
 			}
 			if readErr != nil {
 				if readErr == io.EOF {

--- a/weed/plugin/worker/iceberg/config.go
+++ b/weed/plugin/worker/iceberg/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	MinInputFiles          int64
 	MinManifestsToRewrite  int64
 	Operations             string
+	ApplyDeletes           bool
 }
 
 // ParseConfig extracts an iceberg maintenance Config from plugin config values.
@@ -46,6 +47,7 @@ func ParseConfig(values map[string]*plugin_pb.ConfigValue) Config {
 		MinInputFiles:          readInt64Config(values, "min_input_files", defaultMinInputFiles),
 		MinManifestsToRewrite:  readInt64Config(values, "min_manifests_to_rewrite", defaultMinManifestsToRewrite),
 		Operations:             readStringConfig(values, "operations", defaultOperations),
+		ApplyDeletes:           readBoolConfig(values, "apply_deletes", true),
 	}
 
 	// Clamp to safe minimums using the default constants
@@ -149,6 +151,34 @@ func readStringConfig(values map[string]*plugin_pb.ConfigValue, field string, fa
 		return strconv.FormatBool(kind.BoolValue)
 	default:
 		glog.V(1).Infof("readStringConfig: unexpected config value type %T for field %q, using fallback", value.Kind, field)
+	}
+	return fallback
+}
+
+// readBoolConfig reads a bool value from plugin config, with fallback.
+func readBoolConfig(values map[string]*plugin_pb.ConfigValue, field string, fallback bool) bool {
+	if values == nil {
+		return fallback
+	}
+	value := values[field]
+	if value == nil {
+		return fallback
+	}
+	switch kind := value.Kind.(type) {
+	case *plugin_pb.ConfigValue_BoolValue:
+		return kind.BoolValue
+	case *plugin_pb.ConfigValue_StringValue:
+		s := strings.TrimSpace(strings.ToLower(kind.StringValue))
+		if s == "true" || s == "1" || s == "yes" {
+			return true
+		}
+		if s == "false" || s == "0" || s == "no" {
+			return false
+		}
+	case *plugin_pb.ConfigValue_Int64Value:
+		return kind.Int64Value != 0
+	default:
+		glog.V(1).Infof("readBoolConfig: unexpected config value type %T for field %q, using fallback", value.Kind, field)
 	}
 	return fallback
 }

--- a/weed/plugin/worker/iceberg/exec_test.go
+++ b/weed/plugin/worker/iceberg/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"path"
 	"sort"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
+	"github.com/parquet-go/parquet-go"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/plugin_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3tables"
@@ -386,7 +388,7 @@ func TestExpireSnapshotsExecution(t *testing.T) {
 		Operations:             "expire_snapshots",
 	}
 
-	result, err := handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	result, _, err := handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), config)
 	if err != nil {
 		t.Fatalf("expireSnapshots failed: %v", err)
 	}
@@ -426,7 +428,7 @@ func TestExpireSnapshotsNothingToExpire(t *testing.T) {
 		MaxCommitRetries:       3,
 	}
 
-	result, err := handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	result, _, err := handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), config)
 	if err != nil {
 		t.Fatalf("expireSnapshots failed: %v", err)
 	}
@@ -474,7 +476,7 @@ func TestRemoveOrphansExecution(t *testing.T) {
 		MaxCommitRetries:     3,
 	}
 
-	result, err := handler.removeOrphans(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	result, _, err := handler.removeOrphans(context.Background(), client, setup.BucketName, setup.tablePath(), config)
 	if err != nil {
 		t.Fatalf("removeOrphans failed: %v", err)
 	}
@@ -516,7 +518,7 @@ func TestRemoveOrphansPreservesReferencedFiles(t *testing.T) {
 		MaxCommitRetries:     3,
 	}
 
-	result, err := handler.removeOrphans(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	result, _, err := handler.removeOrphans(context.Background(), client, setup.BucketName, setup.tablePath(), config)
 	if err != nil {
 		t.Fatalf("removeOrphans failed: %v", err)
 	}
@@ -608,7 +610,7 @@ func TestRewriteManifestsExecution(t *testing.T) {
 		MaxCommitRetries: 3,
 	}
 
-	result, err := handler.rewriteManifests(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	result, _, err := handler.rewriteManifests(context.Background(), client, setup.BucketName, setup.tablePath(), config)
 	if err != nil {
 		t.Fatalf("rewriteManifests failed: %v", err)
 	}
@@ -654,7 +656,7 @@ func TestRewriteManifestsBelowThreshold(t *testing.T) {
 		MaxCommitRetries:      3,
 	}
 
-	result, err := handler.rewriteManifests(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	result, _, err := handler.rewriteManifests(context.Background(), client, setup.BucketName, setup.tablePath(), config)
 	if err != nil {
 		t.Fatalf("rewriteManifests failed: %v", err)
 	}
@@ -728,11 +730,11 @@ func TestFullExecuteFlow(t *testing.T) {
 		var opErr error
 		switch op {
 		case "expire_snapshots":
-			opResult, opErr = handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), workerConfig)
+			opResult, _, opErr = handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), workerConfig)
 		case "remove_orphans":
-			opResult, opErr = handler.removeOrphans(context.Background(), client, setup.BucketName, setup.tablePath(), workerConfig)
+			opResult, _, opErr = handler.removeOrphans(context.Background(), client, setup.BucketName, setup.tablePath(), workerConfig)
 		case "rewrite_manifests":
-			opResult, opErr = handler.rewriteManifests(context.Background(), client, setup.BucketName, setup.tablePath(), workerConfig)
+			opResult, _, opErr = handler.rewriteManifests(context.Background(), client, setup.BucketName, setup.tablePath(), workerConfig)
 		}
 		if opErr != nil {
 			t.Fatalf("operation %s failed: %v", op, opErr)
@@ -941,5 +943,788 @@ func TestMetadataVersionCAS(t *testing.T) {
 	}
 	if version != 2 {
 		t.Errorf("expected version 2 after update, got %d", version)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Avro manifest content patching for tests
+// ---------------------------------------------------------------------------
+
+// patchManifestContentToDeletes performs a binary patch on an Avro manifest
+// file to change the "content" metadata value from "data" to "deletes".
+// In Avro OCF encoding, strings are stored as zigzag-encoded length + bytes.
+// "content" (7 chars) = \x0e + "content", "data" (4 chars) = \x08 + "data",
+// "deletes" (7 chars) = \x0e + "deletes".
+func patchManifestContentToDeletes(t *testing.T, manifestBytes []byte) []byte {
+	t.Helper()
+
+	// Pattern: zigzag(7)="content" zigzag(4)="data"
+	old := append([]byte{0x0e}, []byte("content")...)
+	old = append(old, 0x08)
+	old = append(old, []byte("data")...)
+
+	// Replacement: zigzag(7)="content" zigzag(7)="deletes"
+	new := append([]byte{0x0e}, []byte("content")...)
+	new = append(new, 0x0e)
+	new = append(new, []byte("deletes")...)
+
+	result := bytes.Replace(manifestBytes, old, new, 1)
+	if bytes.Equal(result, manifestBytes) {
+		t.Fatal("patchManifestContentToDeletes: pattern not found in manifest bytes")
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end compaction tests with deletes
+// ---------------------------------------------------------------------------
+
+// writeTestParquetFile creates a Parquet file with id/name columns in the fake filer.
+func writeTestParquetFile(t *testing.T, fs *fakeFilerServer, dir, name string, rows []struct {
+	ID   int64
+	Name string
+}) []byte {
+	t.Helper()
+	type dataRow struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+	var buf bytes.Buffer
+	w := parquet.NewWriter(&buf, parquet.SchemaOf(new(dataRow)))
+	for _, r := range rows {
+		if err := w.Write(&dataRow{r.ID, r.Name}); err != nil {
+			t.Fatalf("write parquet row: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close parquet writer: %v", err)
+	}
+	data := buf.Bytes()
+	fs.putEntry(dir, name, &filer_pb.Entry{
+		Name:       name,
+		Content:    data,
+		Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(len(data))},
+	})
+	return data
+}
+
+// populateTableWithDeleteFiles sets up a table with data files and delete manifest(s)
+// for compaction testing. Returns the table metadata.
+func populateTableWithDeleteFiles(
+	t *testing.T,
+	fs *fakeFilerServer,
+	setup tableSetup,
+	dataFiles []struct {
+		Name string
+		Rows []struct {
+			ID   int64
+			Name string
+		}
+	},
+	posDeleteFiles []struct {
+		Name string
+		Rows []struct {
+			FilePath string
+			Pos      int64
+		}
+	},
+	eqDeleteFiles []struct {
+		Name     string
+		FieldIDs []int
+		Rows     []struct {
+			ID   int64
+			Name string
+		}
+	},
+) table.Metadata {
+	t.Helper()
+
+	schema := newTestSchema()
+	spec := *iceberg.UnpartitionedSpec
+
+	meta, err := table.NewMetadata(schema, &spec, table.UnsortedSortOrder, "s3://"+setup.BucketName+"/"+setup.tablePath(), nil)
+	if err != nil {
+		t.Fatalf("create metadata: %v", err)
+	}
+
+	bucketsPath := s3tables.TablesPath
+	bucketPath := path.Join(bucketsPath, setup.BucketName)
+	nsPath := path.Join(bucketPath, setup.Namespace)
+	tableFilerPath := path.Join(nsPath, setup.TableName)
+	metaDir := path.Join(tableFilerPath, "metadata")
+	dataDir := path.Join(tableFilerPath, "data")
+
+	version := meta.Version()
+
+	// Write data files
+	var dataManifestEntries []iceberg.ManifestEntry
+	for _, df := range dataFiles {
+		data := writeTestParquetFile(t, fs, dataDir, df.Name, df.Rows)
+		dfb, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData, "data/"+df.Name, iceberg.ParquetFile, map[int]any{}, nil, nil, int64(len(df.Rows)), int64(len(data)))
+		if err != nil {
+			t.Fatalf("build data file %s: %v", df.Name, err)
+		}
+		snapID := int64(1)
+		dataManifestEntries = append(dataManifestEntries, iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfb.Build()))
+	}
+
+	// Write data manifest
+	var dataManifestBuf bytes.Buffer
+	dataManifestName := "data-manifest-1.avro"
+	dataMf, err := iceberg.WriteManifest(path.Join("metadata", dataManifestName), &dataManifestBuf, version, spec, schema, 1, dataManifestEntries)
+	if err != nil {
+		t.Fatalf("write data manifest: %v", err)
+	}
+	fs.putEntry(metaDir, dataManifestName, &filer_pb.Entry{
+		Name: dataManifestName, Content: dataManifestBuf.Bytes(),
+		Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(dataManifestBuf.Len())},
+	})
+
+	allManifests := []iceberg.ManifestFile{dataMf}
+
+	// Write position delete files and manifests
+	if len(posDeleteFiles) > 0 {
+		var posDeleteEntries []iceberg.ManifestEntry
+		for _, pdf := range posDeleteFiles {
+			type posRow struct {
+				FilePath string `parquet:"file_path"`
+				Pos      int64  `parquet:"pos"`
+			}
+			var buf bytes.Buffer
+			w := parquet.NewWriter(&buf, parquet.SchemaOf(new(posRow)))
+			for _, r := range pdf.Rows {
+				if err := w.Write(&posRow{r.FilePath, r.Pos}); err != nil {
+					t.Fatalf("write pos delete: %v", err)
+				}
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close pos delete: %v", err)
+			}
+			fs.putEntry(dataDir, pdf.Name, &filer_pb.Entry{
+				Name: pdf.Name, Content: buf.Bytes(),
+				Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(buf.Len())},
+			})
+			dfb, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentPosDeletes, "data/"+pdf.Name, iceberg.ParquetFile, map[int]any{}, nil, nil, int64(len(pdf.Rows)), int64(buf.Len()))
+			if err != nil {
+				t.Fatalf("build pos delete file: %v", err)
+			}
+			snapID := int64(1)
+			posDeleteEntries = append(posDeleteEntries, iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfb.Build()))
+		}
+
+		// WriteManifest always sets content="data", so we patch the Avro
+		// metadata to "deletes" and build a ManifestFile with the right content type.
+		var posManifestBuf bytes.Buffer
+		posManifestName := "pos-delete-manifest-1.avro"
+		posManifestPath := path.Join("metadata", posManifestName)
+		_, err := iceberg.WriteManifest(posManifestPath, &posManifestBuf, version, spec, schema, 1, posDeleteEntries)
+		if err != nil {
+			t.Fatalf("write pos delete manifest: %v", err)
+		}
+		patchedBytes := patchManifestContentToDeletes(t, posManifestBuf.Bytes())
+		fs.putEntry(metaDir, posManifestName, &filer_pb.Entry{
+			Name: posManifestName, Content: patchedBytes,
+			Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(len(patchedBytes))},
+		})
+		posMf := iceberg.NewManifestFile(version, posManifestPath, int64(len(patchedBytes)), int32(spec.ID()), 1).
+			Content(iceberg.ManifestContentDeletes).
+			AddedFiles(int32(len(posDeleteEntries))).
+			AddedRows(int64(len(posDeleteFiles[0].Rows))).
+			Build()
+		allManifests = append(allManifests, posMf)
+	}
+
+	// Write equality delete files and manifests
+	if len(eqDeleteFiles) > 0 {
+		var eqDeleteEntries []iceberg.ManifestEntry
+		for _, edf := range eqDeleteFiles {
+			type eqRow struct {
+				ID   int64  `parquet:"id"`
+				Name string `parquet:"name"`
+			}
+			var buf bytes.Buffer
+			w := parquet.NewWriter(&buf, parquet.SchemaOf(new(eqRow)))
+			for _, r := range edf.Rows {
+				if err := w.Write(&eqRow{r.ID, r.Name}); err != nil {
+					t.Fatalf("write eq delete: %v", err)
+				}
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close eq delete: %v", err)
+			}
+			fs.putEntry(dataDir, edf.Name, &filer_pb.Entry{
+				Name: edf.Name, Content: buf.Bytes(),
+				Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(buf.Len())},
+			})
+			dfb, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentEqDeletes, "data/"+edf.Name, iceberg.ParquetFile, map[int]any{}, nil, nil, int64(len(edf.Rows)), int64(buf.Len()))
+			if err != nil {
+				t.Fatalf("build eq delete file: %v", err)
+			}
+			dfb.EqualityFieldIDs(edf.FieldIDs)
+			snapID := int64(1)
+			eqDeleteEntries = append(eqDeleteEntries, iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfb.Build()))
+		}
+
+		var eqManifestBuf bytes.Buffer
+		eqManifestName := "eq-delete-manifest-1.avro"
+		eqManifestPath := path.Join("metadata", eqManifestName)
+		_, err := iceberg.WriteManifest(eqManifestPath, &eqManifestBuf, version, spec, schema, 1, eqDeleteEntries)
+		if err != nil {
+			t.Fatalf("write eq delete manifest: %v", err)
+		}
+		patchedBytes := patchManifestContentToDeletes(t, eqManifestBuf.Bytes())
+		fs.putEntry(metaDir, eqManifestName, &filer_pb.Entry{
+			Name: eqManifestName, Content: patchedBytes,
+			Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(len(patchedBytes))},
+		})
+		eqMf := iceberg.NewManifestFile(version, eqManifestPath, int64(len(patchedBytes)), int32(spec.ID()), 1).
+			Content(iceberg.ManifestContentDeletes).
+			AddedFiles(int32(len(eqDeleteEntries))).
+			AddedRows(int64(len(eqDeleteFiles[0].Rows))).
+			Build()
+		allManifests = append(allManifests, eqMf)
+	}
+
+	// Write manifest list
+	var mlBuf bytes.Buffer
+	seqNum := int64(1)
+	if err := iceberg.WriteManifestList(version, &mlBuf, 1, nil, &seqNum, 0, allManifests); err != nil {
+		t.Fatalf("write manifest list: %v", err)
+	}
+	fs.putEntry(metaDir, "snap-1.avro", &filer_pb.Entry{
+		Name: "snap-1.avro", Content: mlBuf.Bytes(),
+		Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix(), FileSize: uint64(mlBuf.Len())},
+	})
+
+	// Build final metadata with snapshot
+	now := time.Now().UnixMilli()
+	snap := table.Snapshot{SnapshotID: 1, TimestampMs: now, ManifestList: "metadata/snap-1.avro"}
+	meta = buildTestMetadata(t, []table.Snapshot{snap})
+
+	// Register table structure
+	fullMetadataJSON, _ := json.Marshal(meta)
+	internalMeta := map[string]interface{}{
+		"metadataVersion": 1,
+		"metadata":        map[string]interface{}{"fullMetadata": json.RawMessage(fullMetadataJSON)},
+	}
+	xattr, _ := json.Marshal(internalMeta)
+
+	fs.putEntry(bucketsPath, setup.BucketName, &filer_pb.Entry{
+		Name: setup.BucketName, IsDirectory: true,
+		Extended: map[string][]byte{s3tables.ExtendedKeyTableBucket: []byte("true")},
+	})
+	fs.putEntry(bucketPath, setup.Namespace, &filer_pb.Entry{Name: setup.Namespace, IsDirectory: true})
+	fs.putEntry(nsPath, setup.TableName, &filer_pb.Entry{
+		Name: setup.TableName, IsDirectory: true,
+		Extended: map[string][]byte{s3tables.ExtendedKeyMetadata: xattr},
+	})
+
+	return meta
+}
+
+func TestCompactDataFilesMetrics(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	setup := tableSetup{BucketName: "tb", Namespace: "ns", TableName: "tbl"}
+	populateTableWithDeleteFiles(t, fs, setup,
+		[]struct {
+			Name string
+			Rows []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"d1.parquet", []struct {
+				ID   int64
+				Name string
+			}{{1, "a"}, {2, "b"}}},
+			{"d2.parquet", []struct {
+				ID   int64
+				Name string
+			}{{3, "c"}}},
+		},
+		nil, nil,
+	)
+
+	handler := NewHandler(nil)
+	config := Config{
+		TargetFileSizeBytes: 256 * 1024 * 1024,
+		MinInputFiles:       2,
+		MaxCommitRetries:    3,
+		ApplyDeletes:        true,
+	}
+
+	// Track progress callbacks
+	var progressCalls []int
+	result, metrics, err := handler.compactDataFiles(context.Background(), client, setup.BucketName, setup.tablePath(), config, func(binIdx, totalBins int) {
+		progressCalls = append(progressCalls, binIdx)
+	})
+	if err != nil {
+		t.Fatalf("compactDataFiles: %v", err)
+	}
+
+	if !strings.Contains(result, "compacted") {
+		t.Errorf("expected compaction result, got %q", result)
+	}
+
+	// Verify metrics
+	if metrics == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+	if metrics["files_merged"] != 2 {
+		t.Errorf("expected files_merged=2, got %d", metrics["files_merged"])
+	}
+	if metrics["files_written"] != 1 {
+		t.Errorf("expected files_written=1, got %d", metrics["files_written"])
+	}
+	if metrics["bins"] != 1 {
+		t.Errorf("expected bins=1, got %d", metrics["bins"])
+	}
+	if metrics["duration_ms"] < 0 {
+		t.Errorf("expected non-negative duration_ms, got %d", metrics["duration_ms"])
+	}
+
+	// Verify progress callback was invoked
+	if len(progressCalls) != 1 {
+		t.Errorf("expected 1 progress call, got %d", len(progressCalls))
+	}
+}
+
+func TestExpireSnapshotsMetrics(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	now := time.Now().UnixMilli()
+	setup := tableSetup{
+		BucketName: "test-bucket",
+		Namespace:  "ns",
+		TableName:  "tbl",
+		Snapshots: []table.Snapshot{
+			{SnapshotID: 1, TimestampMs: now, ManifestList: "metadata/snap-1.avro"},
+			{SnapshotID: 2, TimestampMs: now + 1, ManifestList: "metadata/snap-2.avro"},
+			{SnapshotID: 3, TimestampMs: now + 2, ManifestList: "metadata/snap-3.avro"},
+		},
+	}
+	populateTable(t, fs, setup)
+
+	handler := NewHandler(nil)
+	config := Config{
+		SnapshotRetentionHours: 0,
+		MaxSnapshotsToKeep:     1,
+		MaxCommitRetries:       3,
+	}
+
+	_, metrics, err := handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	if err != nil {
+		t.Fatalf("expireSnapshots: %v", err)
+	}
+
+	if metrics == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+	if metrics["snapshots_expired"] == 0 {
+		t.Error("expected snapshots_expired > 0")
+	}
+	if metrics["duration_ms"] < 0 {
+		t.Errorf("expected non-negative duration_ms, got %d", metrics["duration_ms"])
+	}
+}
+
+func TestExecuteCompletionOutputValues(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	now := time.Now().UnixMilli()
+	setup := tableSetup{
+		BucketName: "test-bucket",
+		Namespace:  "ns",
+		TableName:  "tbl",
+		Snapshots: []table.Snapshot{
+			{SnapshotID: 1, TimestampMs: now, ManifestList: "metadata/snap-1.avro"},
+			{SnapshotID: 2, TimestampMs: now + 1, ManifestList: "metadata/snap-2.avro"},
+			{SnapshotID: 3, TimestampMs: now + 2, ManifestList: "metadata/snap-3.avro"},
+		},
+	}
+	populateTable(t, fs, setup)
+
+	handler := NewHandler(nil)
+	config := Config{
+		SnapshotRetentionHours: 0,
+		MaxSnapshotsToKeep:     1,
+		MaxCommitRetries:       3,
+	}
+
+	_, metrics, err := handler.expireSnapshots(context.Background(), client, setup.BucketName, setup.tablePath(), config)
+	if err != nil {
+		t.Fatalf("expireSnapshots: %v", err)
+	}
+
+	// Verify metrics have the expected keys
+	if _, ok := metrics["snapshots_expired"]; !ok {
+		t.Error("expected 'snapshots_expired' key in metrics")
+	}
+	if _, ok := metrics["files_deleted"]; !ok {
+		t.Error("expected 'files_deleted' key in metrics")
+	}
+	if _, ok := metrics["duration_ms"]; !ok {
+		t.Error("expected 'duration_ms' key in metrics")
+	}
+}
+
+func TestCompactDataFilesWithPositionDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	setup := tableSetup{BucketName: "tb", Namespace: "ns", TableName: "tbl"}
+	populateTableWithDeleteFiles(t, fs, setup,
+		// 3 small data files (to meet min_input_files=2)
+		[]struct {
+			Name string
+			Rows []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"d1.parquet", []struct {
+				ID   int64
+				Name string
+			}{{1, "alice"}, {2, "bob"}, {3, "charlie"}}},
+			{"d2.parquet", []struct {
+				ID   int64
+				Name string
+			}{{4, "dave"}, {5, "eve"}}},
+		},
+		// Position deletes: delete row 1 (bob) from d1
+		[]struct {
+			Name string
+			Rows []struct {
+				FilePath string
+				Pos      int64
+			}
+		}{
+			{"pd1.parquet", []struct {
+				FilePath string
+				Pos      int64
+			}{{"data/d1.parquet", 1}}},
+		},
+		nil, // no equality deletes
+	)
+
+	handler := NewHandler(nil)
+	config := Config{
+		TargetFileSizeBytes: 256 * 1024 * 1024,
+		MinInputFiles:       2,
+		MaxCommitRetries:    3,
+		ApplyDeletes:        true,
+	}
+
+	result, _, err := handler.compactDataFiles(context.Background(), client, setup.BucketName, setup.tablePath(), config, nil)
+	if err != nil {
+		t.Fatalf("compactDataFiles: %v", err)
+	}
+
+	if !strings.Contains(result, "compacted") {
+		t.Errorf("expected compaction result, got %q", result)
+	}
+	t.Logf("result: %s", result)
+
+	// Verify: read the merged output and count rows
+	// The merged file should have 4 rows (5 total - 1 position delete)
+	dataDir := path.Join(s3tables.TablesPath, setup.BucketName, setup.tablePath(), "data")
+	entries := fs.listDir(dataDir)
+	var mergedContent []byte
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name, "compact-") {
+			mergedContent = e.Content
+			break
+		}
+	}
+	if mergedContent == nil {
+		t.Fatal("no merged file found")
+	}
+
+	reader := parquet.NewReader(bytes.NewReader(mergedContent))
+	defer reader.Close()
+	type row struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+	var outputRows []row
+	for {
+		var r row
+		if err := reader.Read(&r); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("read: %v", err)
+		}
+		outputRows = append(outputRows, r)
+	}
+
+	if len(outputRows) != 4 {
+		t.Errorf("expected 4 rows (5 - 1 pos delete), got %d", len(outputRows))
+	}
+	for _, r := range outputRows {
+		if r.Name == "bob" {
+			t.Error("bob should have been deleted by position delete")
+		}
+	}
+}
+
+func TestCompactDataFilesWithEqualityDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	setup := tableSetup{BucketName: "tb", Namespace: "ns", TableName: "tbl"}
+	populateTableWithDeleteFiles(t, fs, setup,
+		[]struct {
+			Name string
+			Rows []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"d1.parquet", []struct {
+				ID   int64
+				Name string
+			}{{1, "alice"}, {2, "bob"}}},
+			{"d2.parquet", []struct {
+				ID   int64
+				Name string
+			}{{3, "charlie"}, {4, "dave"}}},
+		},
+		nil, // no position deletes
+		// Equality deletes: delete rows where name="bob" or name="dave"
+		[]struct {
+			Name     string
+			FieldIDs []int
+			Rows     []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"ed1.parquet", []int{2}, []struct {
+				ID   int64
+				Name string
+			}{{0, "bob"}, {0, "dave"}}},
+		},
+	)
+
+	handler := NewHandler(nil)
+	config := Config{
+		TargetFileSizeBytes: 256 * 1024 * 1024,
+		MinInputFiles:       2,
+		MaxCommitRetries:    3,
+		ApplyDeletes:        true,
+	}
+
+	result, _, err := handler.compactDataFiles(context.Background(), client, setup.BucketName, setup.tablePath(), config, nil)
+	if err != nil {
+		t.Fatalf("compactDataFiles: %v", err)
+	}
+
+	if !strings.Contains(result, "compacted") {
+		t.Errorf("expected compaction result, got %q", result)
+	}
+	t.Logf("result: %s", result)
+
+	// Verify merged output
+	dataDir := path.Join(s3tables.TablesPath, setup.BucketName, setup.tablePath(), "data")
+	entries := fs.listDir(dataDir)
+	var mergedContent []byte
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name, "compact-") {
+			mergedContent = e.Content
+			break
+		}
+	}
+	if mergedContent == nil {
+		t.Fatal("no merged file found")
+	}
+
+	reader := parquet.NewReader(bytes.NewReader(mergedContent))
+	defer reader.Close()
+	type row struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+	var outputRows []row
+	for {
+		var r row
+		if err := reader.Read(&r); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("read: %v", err)
+		}
+		outputRows = append(outputRows, r)
+	}
+
+	if len(outputRows) != 2 {
+		t.Errorf("expected 2 rows (4 - 2 eq deletes), got %d", len(outputRows))
+	}
+	for _, r := range outputRows {
+		if r.Name == "bob" || r.Name == "dave" {
+			t.Errorf("row %q should have been deleted by equality delete", r.Name)
+		}
+	}
+}
+
+func TestCompactDataFilesApplyDeletesDisabled(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	setup := tableSetup{BucketName: "tb", Namespace: "ns", TableName: "tbl"}
+	populateTableWithDeleteFiles(t, fs, setup,
+		[]struct {
+			Name string
+			Rows []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"d1.parquet", []struct {
+				ID   int64
+				Name string
+			}{{1, "a"}, {2, "b"}}},
+			{"d2.parquet", []struct {
+				ID   int64
+				Name string
+			}{{3, "c"}}},
+		},
+		[]struct {
+			Name string
+			Rows []struct {
+				FilePath string
+				Pos      int64
+			}
+		}{
+			{"pd1.parquet", []struct {
+				FilePath string
+				Pos      int64
+			}{{"data/d1.parquet", 0}}},
+		},
+		nil,
+	)
+
+	handler := NewHandler(nil)
+	config := Config{
+		TargetFileSizeBytes: 256 * 1024 * 1024,
+		MinInputFiles:       2,
+		MaxCommitRetries:    3,
+		ApplyDeletes:        false, // disabled
+	}
+
+	result, _, err := handler.compactDataFiles(context.Background(), client, setup.BucketName, setup.tablePath(), config, nil)
+	if err != nil {
+		t.Fatalf("compactDataFiles: %v", err)
+	}
+
+	if !strings.Contains(result, "skipped") {
+		t.Errorf("expected skip when apply_deletes=false, got %q", result)
+	}
+}
+
+func TestCompactDataFilesWithMixedDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	setup := tableSetup{BucketName: "tb", Namespace: "ns", TableName: "tbl"}
+	populateTableWithDeleteFiles(t, fs, setup,
+		[]struct {
+			Name string
+			Rows []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"d1.parquet", []struct {
+				ID   int64
+				Name string
+			}{{1, "alice"}, {2, "bob"}, {3, "charlie"}}},
+			{"d2.parquet", []struct {
+				ID   int64
+				Name string
+			}{{4, "dave"}, {5, "eve"}}},
+		},
+		// Position delete: row 0 (alice) from d1
+		[]struct {
+			Name string
+			Rows []struct {
+				FilePath string
+				Pos      int64
+			}
+		}{
+			{"pd1.parquet", []struct {
+				FilePath string
+				Pos      int64
+			}{{"data/d1.parquet", 0}}},
+		},
+		// Equality delete: name="eve"
+		[]struct {
+			Name     string
+			FieldIDs []int
+			Rows     []struct {
+				ID   int64
+				Name string
+			}
+		}{
+			{"ed1.parquet", []int{2}, []struct {
+				ID   int64
+				Name string
+			}{{0, "eve"}}},
+		},
+	)
+
+	handler := NewHandler(nil)
+	config := Config{
+		TargetFileSizeBytes: 256 * 1024 * 1024,
+		MinInputFiles:       2,
+		MaxCommitRetries:    3,
+		ApplyDeletes:        true,
+	}
+
+	result, _, err := handler.compactDataFiles(context.Background(), client, setup.BucketName, setup.tablePath(), config, nil)
+	if err != nil {
+		t.Fatalf("compactDataFiles: %v", err)
+	}
+
+	if !strings.Contains(result, "compacted") {
+		t.Errorf("expected compaction, got %q", result)
+	}
+
+	// Verify: 5 total - 1 pos delete (alice) - 1 eq delete (eve) = 3 rows
+	dataDir := path.Join(s3tables.TablesPath, setup.BucketName, setup.tablePath(), "data")
+	entries := fs.listDir(dataDir)
+	var mergedContent []byte
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name, "compact-") {
+			mergedContent = e.Content
+			break
+		}
+	}
+	if mergedContent == nil {
+		t.Fatal("no merged file found")
+	}
+
+	reader := parquet.NewReader(bytes.NewReader(mergedContent))
+	defer reader.Close()
+	type row struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+	var outputRows []row
+	for {
+		var r row
+		if err := reader.Read(&r); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("read: %v", err)
+		}
+		outputRows = append(outputRows, r)
+	}
+
+	if len(outputRows) != 3 {
+		t.Errorf("expected 3 rows (5 - 1 pos - 1 eq), got %d", len(outputRows))
+	}
+	for _, r := range outputRows {
+		if r.Name == "alice" || r.Name == "eve" {
+			t.Errorf("%q should have been deleted", r.Name)
+		}
 	}
 }

--- a/weed/plugin/worker/iceberg/handler.go
+++ b/weed/plugin/worker/iceberg/handler.go
@@ -148,6 +148,13 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 							Widget:      plugin_pb.ConfigWidget_CONFIG_WIDGET_NUMBER,
 							MinValue:    &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 2}},
 						},
+						{
+							Name:        "apply_deletes",
+							Label:       "Apply Deletes",
+							Description: "When true, compaction applies position and equality deletes to data files. When false, tables with delete manifests are skipped.",
+							FieldType:   plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_BOOL,
+							Widget:      plugin_pb.ConfigWidget_CONFIG_WIDGET_TOGGLE,
+						},
 					},
 				},
 				{
@@ -205,7 +212,7 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 				},
 			},
 			DefaultValues: map[string]*plugin_pb.ConfigValue{
-				"target_file_size_mb":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeMB}},
+				"target_file_size_mb":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeMB}},
 				"min_input_files":          {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMinInputFiles}},
 				"min_manifests_to_rewrite": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMinManifestsToRewrite}},
 				"snapshot_retention_hours": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultSnapshotRetentionHours}},
@@ -213,6 +220,7 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 				"orphan_older_than_hours":  {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultOrphanOlderThanHours}},
 				"max_commit_retries":       {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMaxCommitRetries}},
 				"operations":               {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: defaultOperations}},
+				"apply_deletes":            {Kind: &plugin_pb.ConfigValue_BoolValue{BoolValue: true}},
 			},
 		},
 		AdminRuntimeDefaults: &plugin_pb.AdminRuntimeDefaults{
@@ -227,13 +235,14 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 			JobTypeMaxRuntimeSeconds:      3600, // 1 hour max
 		},
 		WorkerDefaultValues: map[string]*plugin_pb.ConfigValue{
-			"target_file_size_mb":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeMB}},
+			"target_file_size_mb":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultTargetFileSizeMB}},
 			"min_input_files":          {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMinInputFiles}},
 			"snapshot_retention_hours": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultSnapshotRetentionHours}},
 			"max_snapshots_to_keep":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMaxSnapshotsToKeep}},
 			"orphan_older_than_hours":  {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultOrphanOlderThanHours}},
 			"max_commit_retries":       {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMaxCommitRetries}},
 			"operations":               {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: defaultOperations}},
+			"apply_deletes":            {Kind: &plugin_pb.ConfigValue_BoolValue{BoolValue: true}},
 		},
 	}
 }
@@ -393,6 +402,7 @@ func (h *Handler) Execute(ctx context.Context, request *plugin_pb.ExecuteJobRequ
 	var lastErr error
 	totalOps := len(ops)
 	completedOps := 0
+	allMetrics := make(map[string]int64)
 
 	// Execute operations in correct Iceberg maintenance order:
 	// expire_snapshots → remove_orphans → rewrite_manifests
@@ -420,19 +430,35 @@ func (h *Handler) Execute(ctx context.Context, request *plugin_pb.ExecuteJobRequ
 
 		var opResult string
 		var opErr error
+		var opMetrics map[string]int64
 
 		switch op {
 		case "compact":
-			opResult, opErr = h.compactDataFiles(ctx, filerClient, bucketName, tablePath, workerConfig)
+			opResult, opMetrics, opErr = h.compactDataFiles(ctx, filerClient, bucketName, tablePath, workerConfig, func(binIdx, totalBins int) {
+				binProgress := progress + float64(binIdx+1)/float64(totalBins)*(100.0/float64(totalOps))
+				_ = sender.SendProgress(&plugin_pb.JobProgressUpdate{
+					JobId:           request.Job.JobId,
+					JobType:         canonicalJobType,
+					State:           plugin_pb.JobState_JOB_STATE_RUNNING,
+					ProgressPercent: binProgress,
+					Stage:           fmt.Sprintf("compact bin %d/%d", binIdx+1, totalBins),
+					Message:         fmt.Sprintf("compacting bin %d of %d", binIdx+1, totalBins),
+				})
+			})
 		case "expire_snapshots":
-			opResult, opErr = h.expireSnapshots(ctx, filerClient, bucketName, tablePath, workerConfig)
+			opResult, opMetrics, opErr = h.expireSnapshots(ctx, filerClient, bucketName, tablePath, workerConfig)
 		case "remove_orphans":
-			opResult, opErr = h.removeOrphans(ctx, filerClient, bucketName, tablePath, workerConfig)
+			opResult, opMetrics, opErr = h.removeOrphans(ctx, filerClient, bucketName, tablePath, workerConfig)
 		case "rewrite_manifests":
-			opResult, opErr = h.rewriteManifests(ctx, filerClient, bucketName, tablePath, workerConfig)
+			opResult, opMetrics, opErr = h.rewriteManifests(ctx, filerClient, bucketName, tablePath, workerConfig)
 		default:
 			glog.Warningf("unknown maintenance operation: %s", op)
 			continue
+		}
+
+		// Accumulate per-operation metrics with dot-prefixed keys
+		for k, v := range opMetrics {
+			allMetrics[op+"."+k] = v
 		}
 
 		completedOps++
@@ -448,6 +474,16 @@ func (h *Handler) Execute(ctx context.Context, request *plugin_pb.ExecuteJobRequ
 	resultSummary := strings.Join(results, "; ")
 	success := lastErr == nil
 
+	// Build OutputValues with base table info + per-operation metrics
+	outputValues := map[string]*plugin_pb.ConfigValue{
+		"bucket":    {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: bucketName}},
+		"namespace": {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: namespace}},
+		"table":     {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: tableName}},
+	}
+	for k, v := range allMetrics {
+		outputValues[k] = &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: v}}
+	}
+
 	return sender.SendCompleted(&plugin_pb.JobCompleted{
 		JobId:   request.Job.JobId,
 		JobType: canonicalJobType,
@@ -459,12 +495,8 @@ func (h *Handler) Execute(ctx context.Context, request *plugin_pb.ExecuteJobRequ
 			return ""
 		}(),
 		Result: &plugin_pb.JobResult{
-			Summary: resultSummary,
-			OutputValues: map[string]*plugin_pb.ConfigValue{
-				"bucket":    {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: bucketName}},
-				"namespace": {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: namespace}},
-				"table":     {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: tableName}},
-			},
+			Summary:      resultSummary,
+			OutputValues: outputValues,
 		},
 		Activities: []*plugin_pb.ActivityEvent{
 			pluginworker.BuildExecutorActivity("completed", resultSummary),

--- a/weed/plugin/worker/iceberg/handler_test.go
+++ b/weed/plugin/worker/iceberg/handler_test.go
@@ -2,13 +2,18 @@ package iceberg
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"path"
 	"testing"
 	"time"
 
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/table"
+	"github.com/parquet-go/parquet-go"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/plugin_pb"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -519,14 +524,16 @@ type testEntrySpec struct {
 	path      string
 	size      int64
 	partition map[int]any
+	specID    int32 // partition spec ID; 0 uses UnpartitionedSpec
 }
 
 func makeTestEntries(t *testing.T, specs []testEntrySpec) []iceberg.ManifestEntry {
 	t.Helper()
 	entries := make([]iceberg.ManifestEntry, 0, len(specs))
 	for _, spec := range specs {
+		partSpec := *iceberg.UnpartitionedSpec
 		dfBuilder, err := iceberg.NewDataFileBuilder(
-			*iceberg.UnpartitionedSpec,
+			partSpec,
 			iceberg.EntryContentData,
 			spec.path,
 			iceberg.ParquetFile,
@@ -543,6 +550,439 @@ func makeTestEntries(t *testing.T, specs []testEntrySpec) []iceberg.ManifestEntr
 		entries = append(entries, entry)
 	}
 	return entries
+}
+
+// makeTestEntriesWithSpec creates manifest entries using specific partition specs.
+// Each spec in the specs slice can specify a specID; the entry is built using
+// a PartitionSpec with that ID.
+func makeTestEntriesWithSpec(t *testing.T, specs []testEntrySpec, partSpecs map[int32]iceberg.PartitionSpec) []iceberg.ManifestEntry {
+	t.Helper()
+	entries := make([]iceberg.ManifestEntry, 0, len(specs))
+	for _, s := range specs {
+		ps, ok := partSpecs[s.specID]
+		if !ok {
+			t.Fatalf("spec ID %d not found in partSpecs map", s.specID)
+		}
+		dfBuilder, err := iceberg.NewDataFileBuilder(
+			ps,
+			iceberg.EntryContentData,
+			s.path,
+			iceberg.ParquetFile,
+			s.partition,
+			nil, nil,
+			1,
+			s.size,
+		)
+		if err != nil {
+			t.Fatalf("failed to build data file %s: %v", s.path, err)
+		}
+		snapID := int64(1)
+		entry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfBuilder.Build())
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func TestBuildCompactionBinsMultipleSpecs(t *testing.T) {
+	targetSize := int64(256 * 1024 * 1024)
+	minFiles := 2
+
+	// Two partition specs with different IDs
+	spec0 := iceberg.NewPartitionSpecID(0)
+	spec1 := iceberg.NewPartitionSpecID(1)
+	partSpecs := map[int32]iceberg.PartitionSpec{
+		0: spec0,
+		1: spec1,
+	}
+
+	// Entries from two different specs with same partition values should go
+	// to separate bins.
+	entries := makeTestEntriesWithSpec(t, []testEntrySpec{
+		{path: "data/s0-f1.parquet", size: 1024, partition: map[int]any{}, specID: 0},
+		{path: "data/s0-f2.parquet", size: 2048, partition: map[int]any{}, specID: 0},
+		{path: "data/s1-f1.parquet", size: 1024, partition: map[int]any{}, specID: 1},
+		{path: "data/s1-f2.parquet", size: 2048, partition: map[int]any{}, specID: 1},
+	}, partSpecs)
+
+	bins := buildCompactionBins(entries, targetSize, minFiles)
+	if len(bins) != 2 {
+		t.Fatalf("expected 2 bins (one per spec), got %d", len(bins))
+	}
+
+	// Verify each bin has entries from only one spec
+	specsSeen := make(map[int32]bool)
+	for _, bin := range bins {
+		specsSeen[bin.SpecID] = true
+		for _, entry := range bin.Entries {
+			if entry.DataFile().SpecID() != bin.SpecID {
+				t.Errorf("bin specID=%d contains entry with specID=%d", bin.SpecID, entry.DataFile().SpecID())
+			}
+		}
+	}
+	if !specsSeen[0] || !specsSeen[1] {
+		t.Errorf("expected bins for spec 0 and 1, got specs %v", specsSeen)
+	}
+}
+
+func TestBuildCompactionBinsSingleSpec(t *testing.T) {
+	// Verify existing behavior: all entries with spec 0 still group correctly.
+	targetSize := int64(256 * 1024 * 1024)
+	minFiles := 2
+
+	spec0 := iceberg.NewPartitionSpecID(0)
+	partSpecs := map[int32]iceberg.PartitionSpec{0: spec0}
+
+	entries := makeTestEntriesWithSpec(t, []testEntrySpec{
+		{path: "data/f1.parquet", size: 1024, partition: map[int]any{}, specID: 0},
+		{path: "data/f2.parquet", size: 2048, partition: map[int]any{}, specID: 0},
+		{path: "data/f3.parquet", size: 4096, partition: map[int]any{}, specID: 0},
+	}, partSpecs)
+
+	bins := buildCompactionBins(entries, targetSize, minFiles)
+	if len(bins) != 1 {
+		t.Fatalf("expected 1 bin, got %d", len(bins))
+	}
+	if len(bins[0].Entries) != 3 {
+		t.Errorf("expected 3 entries in bin, got %d", len(bins[0].Entries))
+	}
+	if bins[0].SpecID != 0 {
+		t.Errorf("expected specID=0, got %d", bins[0].SpecID)
+	}
+}
+
+func TestParseConfigApplyDeletes(t *testing.T) {
+	// Default: true
+	config := ParseConfig(nil)
+	if !config.ApplyDeletes {
+		t.Error("expected ApplyDeletes=true by default")
+	}
+
+	// Explicit false
+	config = ParseConfig(map[string]*plugin_pb.ConfigValue{
+		"apply_deletes": {Kind: &plugin_pb.ConfigValue_BoolValue{BoolValue: false}},
+	})
+	if config.ApplyDeletes {
+		t.Error("expected ApplyDeletes=false when explicitly set")
+	}
+
+	// String "false"
+	config = ParseConfig(map[string]*plugin_pb.ConfigValue{
+		"apply_deletes": {Kind: &plugin_pb.ConfigValue_StringValue{StringValue: "false"}},
+	})
+	if config.ApplyDeletes {
+		t.Error("expected ApplyDeletes=false when set via string 'false'")
+	}
+}
+
+func TestCollectPositionDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	// Create a position delete Parquet file with file_path + pos columns
+	type posDeleteRow struct {
+		FilePath string `parquet:"file_path"`
+		Pos      int64  `parquet:"pos"`
+	}
+	var buf bytes.Buffer
+	writer := parquet.NewWriter(&buf, parquet.SchemaOf(new(posDeleteRow)))
+	rows := []posDeleteRow{
+		{"data/file1.parquet", 0},
+		{"data/file1.parquet", 5},
+		{"data/file1.parquet", 10},
+		{"data/file2.parquet", 3},
+	}
+	for _, r := range rows {
+		if err := writer.Write(&r); err != nil {
+			t.Fatalf("write pos delete row: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close pos delete writer: %v", err)
+	}
+
+	// Store in fake filer
+	dataDir := "/buckets/test-bucket/ns/tbl/data"
+	fs.putEntry(dataDir, "pos-delete-1.parquet", &filer_pb.Entry{
+		Name:    "pos-delete-1.parquet",
+		Content: buf.Bytes(),
+	})
+
+	// Create a manifest entry for the position delete file
+	spec := *iceberg.UnpartitionedSpec
+	dfBuilder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentPosDeletes,
+		"data/pos-delete-1.parquet",
+		iceberg.ParquetFile,
+		map[int]any{},
+		nil, nil,
+		int64(len(rows)),
+		int64(buf.Len()),
+	)
+	if err != nil {
+		t.Fatalf("build pos delete data file: %v", err)
+	}
+	snapID := int64(1)
+	entry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfBuilder.Build())
+
+	result, err := collectPositionDeletes(context.Background(), client, "test-bucket", "ns/tbl", []iceberg.ManifestEntry{entry})
+	if err != nil {
+		t.Fatalf("collectPositionDeletes: %v", err)
+	}
+
+	// Verify results
+	if len(result["data/file1.parquet"]) != 3 {
+		t.Errorf("expected 3 positions for file1, got %d", len(result["data/file1.parquet"]))
+	}
+	if len(result["data/file2.parquet"]) != 1 {
+		t.Errorf("expected 1 position for file2, got %d", len(result["data/file2.parquet"]))
+	}
+
+	// Verify sorted
+	positions := result["data/file1.parquet"]
+	for i := 1; i < len(positions); i++ {
+		if positions[i] <= positions[i-1] {
+			t.Errorf("positions not sorted: %v", positions)
+			break
+		}
+	}
+}
+
+func TestCollectEqualityDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	// Create an equality delete Parquet file with id + name columns
+	type eqDeleteRow struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+	var buf bytes.Buffer
+	writer := parquet.NewWriter(&buf, parquet.SchemaOf(new(eqDeleteRow)))
+	deleteRows := []eqDeleteRow{
+		{1, "alice"},
+		{2, "bob"},
+		{3, "charlie"},
+	}
+	for _, r := range deleteRows {
+		if err := writer.Write(&r); err != nil {
+			t.Fatalf("write eq delete row: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close eq delete writer: %v", err)
+	}
+
+	dataDir := "/buckets/test-bucket/ns/tbl/data"
+	fs.putEntry(dataDir, "eq-delete-1.parquet", &filer_pb.Entry{
+		Name:    "eq-delete-1.parquet",
+		Content: buf.Bytes(),
+	})
+
+	// Create manifest entry with equality field IDs
+	schema := newTestSchema() // has field 1=id, 2=name
+	spec := *iceberg.UnpartitionedSpec
+	dfBuilder, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentEqDeletes,
+		"data/eq-delete-1.parquet",
+		iceberg.ParquetFile,
+		map[int]any{},
+		nil, nil,
+		int64(len(deleteRows)),
+		int64(buf.Len()),
+	)
+	if err != nil {
+		t.Fatalf("build eq delete data file: %v", err)
+	}
+	dfBuilder.EqualityFieldIDs([]int{1, 2}) // id + name
+	snapID := int64(1)
+	entry := iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfBuilder.Build())
+
+	result, fieldIDs, err := collectEqualityDeletes(context.Background(), client, "test-bucket", "ns/tbl", []iceberg.ManifestEntry{entry}, schema)
+	if err != nil {
+		t.Fatalf("collectEqualityDeletes: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 equality delete keys, got %d", len(result))
+	}
+	if len(fieldIDs) != 2 {
+		t.Errorf("expected 2 field IDs, got %d", len(fieldIDs))
+	}
+}
+
+func TestMergeParquetFilesWithPositionDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	// Create two data files with known rows
+	type dataRow struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+
+	writeDataFile := func(name string, rows []dataRow) {
+		var buf bytes.Buffer
+		w := parquet.NewWriter(&buf, parquet.SchemaOf(new(dataRow)))
+		for _, r := range rows {
+			if err := w.Write(&r); err != nil {
+				t.Fatalf("write row: %v", err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		dataDir := "/buckets/test-bucket/ns/tbl/data"
+		fs.putEntry(dataDir, name, &filer_pb.Entry{
+			Name:    name,
+			Content: buf.Bytes(),
+		})
+	}
+
+	writeDataFile("file1.parquet", []dataRow{
+		{1, "alice"}, {2, "bob"}, {3, "charlie"}, {4, "dave"}, {5, "eve"},
+	})
+	writeDataFile("file2.parquet", []dataRow{
+		{6, "frank"}, {7, "grace"},
+	})
+
+	spec := *iceberg.UnpartitionedSpec
+	makeEntry := func(path string, size int64) iceberg.ManifestEntry {
+		dfb, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData, path, iceberg.ParquetFile, map[int]any{}, nil, nil, 1, size)
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		snapID := int64(1)
+		return iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfb.Build())
+	}
+
+	entries := []iceberg.ManifestEntry{
+		makeEntry("data/file1.parquet", 1024),
+		makeEntry("data/file2.parquet", 512),
+	}
+
+	// Delete rows 1 (bob) and 3 (dave) from file1
+	posDeletes := map[string][]int64{
+		"data/file1.parquet": {1, 3},
+	}
+
+	merged, count, err := mergeParquetFiles(
+		context.Background(), client, "test-bucket", "ns/tbl",
+		entries, posDeletes, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("mergeParquetFiles: %v", err)
+	}
+
+	// Original: 5 + 2 = 7 rows, deleted 2 = 5 rows
+	if count != 5 {
+		t.Errorf("expected 5 rows after position deletes, got %d", count)
+	}
+
+	// Verify merged output is valid Parquet
+	reader := parquet.NewReader(bytes.NewReader(merged))
+	defer reader.Close()
+	var outputRows []dataRow
+	for {
+		var r dataRow
+		err := reader.Read(&r)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read merged row: %v", err)
+		}
+		outputRows = append(outputRows, r)
+	}
+
+	if len(outputRows) != 5 {
+		t.Fatalf("expected 5 output rows, got %d", len(outputRows))
+	}
+
+	// Verify bob (id=2) and dave (id=4) are NOT in output
+	for _, r := range outputRows {
+		if r.ID == 2 || r.ID == 4 {
+			t.Errorf("row with id=%d should have been deleted", r.ID)
+		}
+	}
+}
+
+func TestMergeParquetFilesWithEqualityDeletes(t *testing.T) {
+	fs, client := startFakeFiler(t)
+
+	type dataRow struct {
+		ID   int64  `parquet:"id"`
+		Name string `parquet:"name"`
+	}
+
+	var buf bytes.Buffer
+	w := parquet.NewWriter(&buf, parquet.SchemaOf(new(dataRow)))
+	dataRows := []dataRow{
+		{1, "alice"}, {2, "bob"}, {3, "charlie"}, {4, "dave"},
+	}
+	for _, r := range dataRows {
+		if err := w.Write(&r); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	dataDir := "/buckets/test-bucket/ns/tbl/data"
+	fs.putEntry(dataDir, "data1.parquet", &filer_pb.Entry{
+		Name:    "data1.parquet",
+		Content: buf.Bytes(),
+	})
+
+	spec := *iceberg.UnpartitionedSpec
+	dfb, err := iceberg.NewDataFileBuilder(spec, iceberg.EntryContentData, "data/data1.parquet", iceberg.ParquetFile, map[int]any{}, nil, nil, 4, int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	snapID := int64(1)
+	entries := []iceberg.ManifestEntry{
+		iceberg.NewManifestEntry(iceberg.EntryStatusADDED, &snapID, nil, nil, dfb.Build()),
+	}
+
+	// Build equality deletes: delete rows where name="bob" or name="dave"
+	// Build the composite key the same way buildEqualityKey does
+	eqDeletes := map[string]struct{}{
+		"bob":  {},
+		"dave": {},
+	}
+
+	schema := newTestSchema() // field 1=id, field 2=name
+	merged, count, err := mergeParquetFiles(
+		context.Background(), client, "test-bucket", "ns/tbl",
+		entries, nil, eqDeletes, []int{2}, schema, // field 2 = name
+	)
+	if err != nil {
+		t.Fatalf("mergeParquetFiles: %v", err)
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 rows after equality deletes, got %d", count)
+	}
+
+	reader := parquet.NewReader(bytes.NewReader(merged))
+	defer reader.Close()
+	var outputRows []dataRow
+	for {
+		var r dataRow
+		err := reader.Read(&r)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		outputRows = append(outputRows, r)
+	}
+
+	for _, r := range outputRows {
+		if r.Name == "bob" || r.Name == "dave" {
+			t.Errorf("row %q should have been deleted", r.Name)
+		}
+	}
 }
 
 func TestDetectNilRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Multi-partition-spec compaction**: Removes the `len(specIDs) > 1` skip that blocked compaction on spec-evolved tables. Adds `SpecID` to compaction bins, groups by spec+partition, writes per-spec manifests, and uses the correct `PartitionSpec` per bin when building data file entries.
- **Delete-aware compaction**: Removes the delete manifest skip. Adds `apply_deletes` config (default: true). Implements position delete collection (`file_path` + `pos` Parquet columns) and equality delete collection (field ID → column mapping with composite key hash set). Updates `mergeParquetFiles` to filter deleted rows via binary search (position) and hash lookup (equality). Smart carry-forward of delete manifests: dropped only when all data files were compacted.
- Fixes EXISTING/DELETED manifest entries to include sequence numbers (required by iceberg-go `WriteManifest`).

## Test plan

- [x] `TestBuildCompactionBinsMultipleSpecs` — entries with different spec IDs go to separate bins
- [x] `TestBuildCompactionBinsSingleSpec` — existing single-spec behavior unchanged
- [x] `TestParseConfigApplyDeletes` — default true, explicit false, string "false"
- [x] `TestCollectPositionDeletes` — parse position delete Parquet, verify file→positions map
- [x] `TestCollectEqualityDeletes` — parse equality delete Parquet, verify composite key set
- [x] `TestMergeParquetFilesWithPositionDeletes` — known rows + position deletes, verify output
- [x] `TestMergeParquetFilesWithEqualityDeletes` — known rows + equality deletes, verify output
- [x] `TestCompactDataFilesWithPositionDeletes` — end-to-end with fake filer
- [x] `TestCompactDataFilesWithEqualityDeletes` — end-to-end with fake filer
- [x] `TestCompactDataFilesWithMixedDeletes` — both position and equality deletes
- [x] `TestCompactDataFilesApplyDeletesDisabled` — old skip behavior when config is false
- [x] `go build ./weed/...` passes
- [x] `go vet ./weed/plugin/worker/iceberg/` clean
- [x] All existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `apply_deletes` setting to control delete manifest handling during compaction operations
  * Enhanced progress and metrics reporting with detailed operation statistics (files merged, files written, bins processed, duration)

* **Tests**
  * Expanded test coverage for compaction workflows and delete manifest scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->