### PR TITLE
fix(remote): don't send empty StorageClass in S3 uploads

### DIFF
--- a/weed/remote_storage/s3/s3_storage_client.go
+++ b/weed/remote_storage/s3/s3_storage_client.go
@@ -275,13 +275,16 @@ func (s *s3RemoteStorageClient) WriteFile(loc *remote_pb.RemoteStorageLocation, 
 	}
 
 	// Upload the file to S3.
-	_, err = uploader.Upload(&s3manager.UploadInput{
-		Bucket:       aws.String(loc.Bucket),
-		Key:          aws.String(loc.Path[1:]),
-		Body:         reader,
-		Tagging:      awsTags,
-		StorageClass: aws.String(s.conf.S3StorageClass),
-	})
+	uploadInput := &s3manager.UploadInput{
+		Bucket:  aws.String(loc.Bucket),
+		Key:     aws.String(loc.Path[1:]),
+		Body:    reader,
+		Tagging: awsTags,
+	}
+	if s.conf.S3StorageClass != "" {
+		uploadInput.StorageClass = aws.String(s.conf.S3StorageClass)
+	}
+	_, err = uploader.Upload(uploadInput)
 
 	//in case it fails to upload
 	if err != nil {


### PR DESCRIPTION
## Summary

- When `S3StorageClass` is empty (the default), `aws.String("")` was passed as the `StorageClass` in S3 upload requests. While AWS S3 treats this as "use default," S3-compatible providers (e.g. SharkTech) reject it with `InvalidStorageClass: The storage class you specified is not valid`.
- Only set `StorageClass` on the upload input when a non-empty value is configured, letting the provider use its bucket default.

Fixes https://github.com/seaweedfs/seaweedfs/discussions/8644

## Test plan

- [ ] Verify `filer.remote.sync` works with S3-compatible providers that don't support storage classes (e.g. SharkTech)
- [ ] Verify `filer.remote.sync` still respects `S3StorageClass` when explicitly configured (e.g. `STANDARD_IA`)
- [ ] Verify uploads to AWS S3 with default (empty) config still use the bucket's default storage class