### PR TITLE
docs: add s3tables maintenance roadmap

### DIFF
--- a/docs/design/s3tables-maintenance-roadmap.md
+++ b/docs/design/s3tables-maintenance-roadmap.md
@@ -14,7 +14,7 @@ This document captures the comparison against common open source table-maintenan
 
 Reference docs used for comparison:
 
-- [Apache Iceberg Spark procedures](https://iceberg.apache.org/docs/1.10.0/spark-procedures/)
+- [Apache Iceberg Spark procedures](https://iceberg.apache.org/docs/latest/spark-procedures/)
 - [Apache Iceberg Flink table maintenance](https://iceberg.apache.org/docs/nightly/flink-maintenance/)
 - [Delta Lake optimizations](https://docs.delta.io/latest/optimizations-oss.html)
 - [Delta Lake utility commands](https://docs.delta.io/latest/delta-utility.html)


### PR DESCRIPTION
# What problem are we solving?

The s3tables maintenance review and execution plan only existed in chat. The repo needed a durable design document covering the current feature set, the OSS comparison, the remaining gaps, and the next PR split.

# How are we solving the problem?

- add a roadmap document under docs/design
- capture the current feature matrix against Iceberg, Delta, Hudi, and Amoro
- document the current stacked PRs and the remaining parity and non-parity designs
- include a phased execution plan and recommended future PR split

# How is the PR tested?

- not run (docs only)

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.
