### PR TITLE
fix(admin): show anonymous user in Object Store Users UI

### DIFF
--- a/weed/admin/dash/admin_server.go
+++ b/weed/admin/dash/admin_server.go
@@ -882,11 +882,6 @@ func (s *AdminServer) GetObjectStoreUsers(ctx context.Context) ([]ObjectStoreUse
 
 	// Convert IAM identities to ObjectStoreUser format
 	for _, identity := range s3cfg.Identities {
-		// Skip anonymous identity
-		if identity.Name == "anonymous" {
-			continue
-		}
-
 		// Skip service accounts - they should not be parent users
 		if strings.HasPrefix(identity.Name, serviceAccountPrefix) {
 			continue

--- a/weed/admin/dash/user_management.go
+++ b/weed/admin/dash/user_management.go
@@ -153,6 +153,13 @@ func (s *AdminServer) DeleteObjectStoreUser(username string) error {
 		return fmt.Errorf("credential manager not available")
 	}
 
+	// Prevent deletion of the anonymous identity — it is a system identity
+	// used for unauthenticated S3 access. Removing it would break anonymous
+	// request handling in the IAM layer.
+	if username == "anonymous" {
+		return fmt.Errorf("cannot delete the system identity 'anonymous'")
+	}
+
 	ctx := context.Background()
 
 	// Delete user using credential manager


### PR DESCRIPTION
## Summary
- Remove the filter that explicitly skipped the `anonymous` identity in `GetObjectStoreUsers()`, so it now appears in the admin console like any other user
- Add a deletion guard in `DeleteObjectStoreUser()` to prevent removing the `anonymous` system identity, which would break unauthenticated S3 request handling in the IAM layer
- Other operations (view details, edit permissions, manage access keys) work correctly for the anonymous user without changes

## Context
The `anonymous` identity is used for unauthenticated S3 access. It was being hidden from the UI, so users who configured permissions on it had no way to view or modify those permissions afterward. Attempting to recreate the user failed with "already exists" (`user_handlers.go:74`).

Fixes #8466

## Test plan
- [ ] Verify anonymous user appears in the Object Store Users list
- [ ] Verify anonymous user permissions can be viewed and edited
- [ ] Verify attempting to delete the anonymous user returns an error
- [ ] Verify other users are unaffected by the change
- [ ] Run `go test ./weed/admin/dash/` — all existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous user is now properly included in user listings.

* **Chores**
  * Added protection to prevent deletion of the anonymous user account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->