### PR TITLE
fix: clean up orphaned needles on remote.cache partial download failure

### DIFF
--- a/weed/server/filer_grpc_server_remote.go
+++ b/weed/server/filer_grpc_server_remote.go
@@ -241,6 +241,12 @@ func (fs *FilerServer) doCacheRemoteObjectToLocalCluster(ctx context.Context, re
 	})
 	chunksMu.Unlock()
 	if err != nil {
+		// Clean up any chunks that were successfully written before the error.
+		// Without this, partial downloads leave orphaned needles in volume servers
+		// that accumulate across retry cycles and cannot be reclaimed by vacuum.
+		if len(chunks) > 0 {
+			fs.filer.DeleteUncommittedChunks(ctx, chunks)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- When `remote.cache` downloads a file in parallel chunks and a gRPC connection drops mid-transfer, chunks already written to volume servers were not cleaned up on the error path
- These orphaned needles accumulate across retry cycles (`DeleteCount: 0`, so `volume.vacuum` cannot reclaim them), causing edge nodes to use significantly more storage than the remote source
- Added `DeleteUncommittedChunks` to the download-error path in `doCacheRemoteObjectToLocalCluster`, matching the cleanup already present for the metadata-update-failure path

Fixes #8481

## Test plan
- [ ] Simulate a gRPC connection drop during `remote.cache` of a large file (e.g., kill the volume server mid-transfer)
- [ ] Verify that successfully-written chunks from the failed attempt are cleaned up (check volume `DeleteCount`)
- [ ] Run `volume.vacuum` and confirm space is reclaimed
- [ ] Verify that a subsequent `remote.cache` cycle completes successfully without duplicate needles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling during remote storage operations to properly clean up incomplete uploads and prevent leftover data from accumulating, improving system reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->