### PR TITLE
fix(chart): bucket hook

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -189,7 +189,7 @@ spec:
           {{- end }}
           - containerPort: {{ .Values.master.grpcPort }}
             #name: swfs-master-grpc
-        {{- with .Values.s3.createBucketsHook.resources }}
+        {{- with coalesce .Values.allInOne.s3.createBucketsHook.resources .Values.s3.createBucketsHook.resources .Values.filer.s3.createBucketsHook.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -909,6 +909,8 @@ filer:
     #     versioning: Enabled
     #   - name: bucket-b
     #     anonymousRead: false
+    createBucketsHook:
+      resources: {}
 
 s3:
   enabled: false
@@ -1477,6 +1479,8 @@ allInOne:
     #     versioning: Enabled
     #   - name: bucket-b
     #     anonymousRead: false
+    createBucketsHook:
+      resources: {}
 
   # SFTP server configuration
   # Note: Most parameters below default to null, which means they inherit from


### PR DESCRIPTION
# What problem are we solving?

We have kyverno rules in our clusters checking for imagePullPolicy, imagePullSecret and resources. These fields are currently missing or not configurable for the bucket hook.

# How are we solving the problem?

Use values `global.imagePullPolicy` and `global.imagePullSecrets` and add `s3.bucketHook.resources`.

# How is the PR tested?

- Deploy seaweedfs with the new values and check if they are present

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved image pulling for the post-install bucket setup: supports image pull secrets and an explicit pull policy.
  * Added configurable resource settings for the bucket-creation hook so resource limits/requests can be provided.
  * Made the bucket-creation hook conditionally configurable across deployment modes (all-in-one, filer, and top-level S3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->