### PR TITLE
fix(chart): all in one maxVolumes value

### DIFF
--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -168,9 +168,11 @@ spec:
               {{- if .Values.allInOne.disableHttp }}
               -disableHttp={{ .Values.allInOne.disableHttp }} \
               {{- end }}
+              {{- if .Values.volume.dataDirs }}
               {{- with (first .Values.volume.dataDirs) }}
               {{- if and (hasKey . "maxVolumes") (ne .maxVolumes nil) }}
               -volume.max={{ .maxVolumes }} \
+              {{- end }}
               {{- end }}
               {{- end }}
               -master.port={{ .Values.master.port }} \


### PR DESCRIPTION
# What problem are we solving?

Due to [the following lines](https://github.com/seaweedfs/seaweedfs/blob/248a92dce0bd8a3e14800603aca2acb4593e8f19/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml#L171-L173) I expected to be able to set the value `volume.dataDirs[0].maxVolumes=0` which would set the command line argument `volume.max=0`:

```
              {{- if and (.Values.volume.dataDirs) (index .Values.volume.dataDirs 0 "maxVolumes") }}
              -volume.max={{ index .Values.volume.dataDirs 0 "maxVolumes" }} \
              {{- end }}
```

However, the condition evaluates to `false` if `volume.dataDirs[0].maxVolumes=0`.

# How are we solving the problem?

Replace the `index .Values.volume.dataDirs 0 "maxVolumes"` with `hasKey (index .Values.volume.dataDirs 0) "maxVolumes"`

# How is the PR tested?

- Deploy seaweedfs with `allInOne.enabled=true` and `volume.dataDirs[0].maxVolumes=0`. This should add the `volume.max` argument to the all-in-one deployment

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment templates more safely handle optional volume settings: when multiple data directories exist, the first is used and optional max-volume values are checked before applying. Missing or nil max-volume entries are ignored, reducing template rendering failures and preventing deployment-time errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->