### PR TITLE
glog: add --log_max_size_mb and --log_max_files runtime flags

### DIFF
--- a/weed/glog/glog_file.go
+++ b/weed/glog/glog_file.go
@@ -33,7 +33,11 @@ import (
 )
 
 // MaxSize is the maximum size of a log file in bytes.
+// It is initialized from the --log_max_size_mb flag when the first log file is created.
 var MaxSize uint64 = 1024 * 1024 * 1800
+
+// MaxFileCount is the maximum number of log files retained per severity level.
+// It is initialized from the --log_max_files flag when the first log file is created.
 var MaxFileCount = 5
 
 // logDirs lists the candidate directories for new log files.
@@ -43,7 +47,25 @@ var logDirs []string
 // See createLogDirs for the full list of possible destinations.
 var logDir = flag.String("logdir", "", "If non-empty, write log files in this directory")
 
+// logMaxSizeMB controls the maximum size of each log file in megabytes.
+// When a log file reaches this size it is closed and a new file is created.
+// Defaults to 1800 MB. Set to 0 to use the compiled-in default.
+var logMaxSizeMB = flag.Uint64("log_max_size_mb", 1800, "Maximum size in megabytes of each log file before it is rotated (0 = use default of 1800 MB)")
+
+// logMaxFiles controls how many log files are kept per severity level.
+// Older files are deleted when the limit is exceeded.
+// Defaults to 5.
+var logMaxFiles = flag.Int("log_max_files", 5, "Maximum number of log files to keep per severity level before older ones are deleted (0 = use default of 5)")
+
 func createLogDirs() {
+	// Apply flag values now that flags have been parsed.
+	if *logMaxSizeMB > 0 {
+		MaxSize = *logMaxSizeMB * 1024 * 1024
+	}
+	if *logMaxFiles > 0 {
+		MaxFileCount = *logMaxFiles
+	}
+
 	if *logDir != "" {
 		logDirs = append(logDirs, *logDir)
 	} else {


### PR DESCRIPTION
## Problem

`MaxSize` (1800 MB) and `MaxFileCount` (5) are variables in `weed/glog/glog_file.go` but there are no corresponding CLI flags to configure them. Users who need to reduce disk usage by keeping smaller or fewer log files must recompile SeaweedFS from source.

This causes real operational problems: log files fill up `/tmp` with no way to bound the total size at deploy time (see #5763).

## Solution

Expose two new flags:

| Flag | Default | Description |
|------|---------|-------------|
| `--log_max_size_mb` | `1800` | Maximum size in MB of each log file before rotation |
| `--log_max_files` | `5` | Maximum number of log files kept per severity level |

Both flags are applied inside `createLogDirs()`, which is invoked exactly once (via `sync.Once`) before the first log file is created — after `flag.Parse()` has already run. Existing behaviour is unchanged when the flags are not provided.

## Usage

```bash
# Keep log files small and retain only 3 per severity level
weed master --log_max_size_mb=100 --log_max_files=3

# Unlimited retention with very small files (e.g. for log-shipping sidecars)
weed volume --log_max_size_mb=50 --log_max_files=10
```

## Testing

The existing `glog_test.go` suite passes without changes. The flags can be exercised by setting them before calling any logging function (the test suite already manipulates `MaxSize` directly in the same way).

Fixes #5763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime configurability for log rotation. New options enable users to set the per-log-file maximum size (default: 1800 MB) and configure the maximum number of retained log files per severity level (default: 5 files), allowing fine-grained control over disk space usage and retention policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->