### PR TITLE
feat(ci): publish helm chart to ghcr

### DIFF
--- a/.github/workflows/helm_manual_release.yml
+++ b/.github/workflows/helm_manual_release.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pages: write
+  packages: write
 
 jobs:
   helm-release:
@@ -15,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Publish Helm charts
+      - name: Publish Helm charts to github pages
         uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,3 +24,15 @@ jobs:
           target_dir: helm
           branch: gh-pages
           helm_version: "3.18.4"
+
+      - name: Publish Helm charts to github container registry (ghcr.io)
+        uses: bitdeps/helm-oci-charts-releaser@v0.1.5
+        with:
+          charts_dir: k8s/charts
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          oci_registry: ghcr.io/${{ github.repository_owner }}
+          oci_username: github-actions
+          oci_password: ${{ secrets.GITHUB_TOKEN }}
+          skip_dependencies: true
+          skip_helm_install: true
+          skip_gh_release: true


### PR DESCRIPTION
# What problem are we solving?

Publish helm chart as OCI registry artifact (https://github.com/seaweedfs/seaweedfs/issues/6296)

# How are we solving the problem?

Add a step to the "helm: manual release" workflow. Publish helm chart to ghcr.io with [bitdeps/helm-oci-charts-releaser](https://github.com/bitdeps/helm-oci-charts-releaser). The resulting OCI artifact will be available under:

`ghcr.io/seaweedfs/seaweedfs:<tag>`

This might be confusing, if in the future the container image should also be pushed to ghcr.io. As an alternative, the parameter `tag_name_pattern` can be set in order to rename the helm packages before pushing. For example, setting `tag_name_pattern: {chartName}-chart` would result in the following OCI artifact:

`ghcr.io/seaweedfs/seaweedfs-chart:<tag>`

# How is the PR tested?

I tested this change on my fork:
- Repo: https://github.com/hoppla20/seaweedfs/tree/master
- Registry artifact: https://github.com/hoppla20/seaweedfs/pkgs/container/seaweedfs

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.