### PR TITLE
fix(ci): install Claude Code via npm to avoid install.sh 403

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,11 +31,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: claude
           allowed_bots: "*"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Summary

The `claude-code-action`'s built-in installer uses `curl -fsSL https://claude.ai/install.sh | bash` which can intermittently fail with a 403. Due to the pipe, `bash` receives empty input and exits 0, masking the curl failure. The action then reports "Claude Code installed successfully" but the `claude` binary is missing, causing a later failure.

This works around the issue by:
1. Installing Claude Code via `npm install -g @anthropic-ai/claude-code` in a separate step (with proper error handling)
2. Passing `path_to_claude_code_executable: claude` to skip the action's built-in installer

## Test plan

- [ ] Verify the Claude Code Review job passes on subsequent PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance code review automation infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->