### PR TITLE
fix(mount): correct operator precedence in shared lock wait condition

### DIFF
--- a/weed/util/lock_table.go
+++ b/weed/util/lock_table.go
@@ -85,7 +85,7 @@ func (lt *LockTable[T]) AcquireLock(intention string, key T, lockType LockType) 
 				entry.cond.Wait()
 			}
 		} else {
-			for !lock.isDeleted && (len(entry.waiters) > 0 && lock.ID != entry.waiters[0].ID) || entry.activeExclusiveLockOwnerCount > 0 {
+			for !lock.isDeleted && ((len(entry.waiters) > 0 && lock.ID != entry.waiters[0].ID) || entry.activeExclusiveLockOwnerCount > 0) {
 				entry.cond.Wait()
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes operator precedence bug in `weed/util/lock_table.go:88` where the shared lock wait condition had misplaced parentheses, causing `|| activeExclusiveLockOwnerCount > 0` to bypass the `!lock.isDeleted` guard
- A cancelled shared lock waiter could spin forever in `cond.Wait()` when any exclusive lock was active on the same key, leaking the goroutine and cascading to block other FUSE mount operations

## Details

Due to Go operator precedence (`&&` binds tighter than `||`), the condition:

```go
for !lock.isDeleted && (len(entry.waiters) > 0 && lock.ID != entry.waiters[0].ID) || entry.activeExclusiveLockOwnerCount > 0 {
```

evaluated as:

```go
for (!lock.isDeleted && (waiters_check)) || exclusiveCount > 0 {
```

The fix adds parentheses to match the correctly-written exclusive lock condition on line 84:

```go
for !lock.isDeleted && ((len(entry.waiters) > 0 && lock.ID != entry.waiters[0].ID) || entry.activeExclusiveLockOwnerCount > 0) {
```

This bug has existed since commit c43238b30 but became more likely to trigger in recent versions due to increased lock contention from parallel chunk fetching (#7569), directory handle mutex (#7674), and metadata cache snapshot consistency (#8531).

Fixes #8696

## Test plan

- [x] Existing `TestOrderedLock` passes
- [ ] Verify mount stability under concurrent read/write workload with multiple filers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a condition evaluation issue in lock acquisition logic for shared lock scenarios, improving consistency and reliability of concurrent resource access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->