### PR TITLE
feat(shell): add volume.tier.compact command to reclaim cloud storage space

### DIFF
--- a/weed/shell/command_volume_tier_compact.go
+++ b/weed/shell/command_volume_tier_compact.go
@@ -83,7 +83,10 @@ func (c *commandVolumeTierCompact) Do(args []string, commandEnv *CommandEnv, wri
 	// find remote volumes
 	var remoteVolumes []remoteVolumeInfo
 	if vid != 0 {
-		rv, found := findRemoteVolumeInTopology(topologyInfo, vid, *collection)
+		rv, found, findErr := findRemoteVolumeInTopology(topologyInfo, vid, *collection)
+		if findErr != nil {
+			return findErr
+		}
 		if !found {
 			return fmt.Errorf("remote volume %d not found", vid)
 		}
@@ -102,16 +105,33 @@ func (c *commandVolumeTierCompact) Do(args []string, commandEnv *CommandEnv, wri
 
 	fmt.Fprintf(writer, "found %d remote volume(s) to check for compaction\n", len(remoteVolumes))
 
+	var failedCount int
 	for _, rv := range remoteVolumes {
 		if err = doVolumeTierCompact(commandEnv, writer, rv, *garbageThreshold); err != nil {
 			fmt.Fprintf(writer, "error compacting volume %d: %v\n", rv.vid, err)
+			failedCount++
 		}
 	}
 
+	if failedCount > 0 {
+		return fmt.Errorf("%d of %d volume(s) failed to compact", failedCount, len(remoteVolumes))
+	}
 	return nil
 }
 
-func findRemoteVolumeInTopology(topoInfo *master_pb.TopologyInfo, vid needle.VolumeId, collection string) (remoteVolumeInfo, bool) {
+func findRemoteVolumeInTopology(topoInfo *master_pb.TopologyInfo, vid needle.VolumeId, collectionPattern string) (remoteVolumeInfo, bool, error) {
+	// when collectionPattern is provided, compile and use as regex filter
+	var matchesCollection func(string) bool
+	if collectionPattern != "" {
+		collectionRegex, err := compileCollectionPattern(collectionPattern)
+		if err != nil {
+			return remoteVolumeInfo{}, false, fmt.Errorf("invalid collection pattern '%s': %v", collectionPattern, err)
+		}
+		matchesCollection = collectionRegex.MatchString
+	} else {
+		matchesCollection = func(string) bool { return true }
+	}
+
 	var result remoteVolumeInfo
 	found := false
 	eachDataNode(topoInfo, func(dc DataCenterId, rack RackId, dn *master_pb.DataNodeInfo) {
@@ -121,7 +141,7 @@ func findRemoteVolumeInTopology(topoInfo *master_pb.TopologyInfo, vid needle.Vol
 		for _, diskInfo := range dn.DiskInfos {
 			for _, v := range diskInfo.VolumeInfos {
 				if needle.VolumeId(v.Id) == vid && v.RemoteStorageName != "" && v.RemoteStorageKey != "" {
-					if collection != "" && v.Collection != collection {
+					if !matchesCollection(v.Collection) {
 						continue
 					}
 					result = remoteVolumeInfo{
@@ -137,7 +157,7 @@ func findRemoteVolumeInTopology(topoInfo *master_pb.TopologyInfo, vid needle.Vol
 			}
 		}
 	})
-	return result, found
+	return result, found, nil
 }
 
 func collectRemoteVolumesWithInfo(topoInfo *master_pb.TopologyInfo, collectionPattern string) ([]remoteVolumeInfo, error) {

--- a/weed/shell/command_volume_tier_compact_test.go
+++ b/weed/shell/command_volume_tier_compact_test.go
@@ -127,23 +127,31 @@ func TestFindRemoteVolumeInTopology(t *testing.T) {
 			wantFound: false,
 		},
 		{
-			name:       "filter by matching collection",
+			name:       "filter by matching collection exact",
 			vid:        1,
-			collection: "col1",
+			collection: "^col1$",
+			wantFound:  true,
+			wantDest:   "s3.default",
+		},
+		{
+			name:       "filter by matching collection regex",
+			vid:        1,
+			collection: "col.*",
 			wantFound:  true,
 			wantDest:   "s3.default",
 		},
 		{
 			name:       "filter by non-matching collection",
 			vid:        1,
-			collection: "col2",
+			collection: "^col2$",
 			wantFound:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rv, found := findRemoteVolumeInTopology(topo, tt.vid, tt.collection)
+			rv, found, err := findRemoteVolumeInTopology(topo, tt.vid, tt.collection)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.wantFound, found)
 			if found {
 				assert.Equal(t, tt.vid, rv.vid)
@@ -151,6 +159,13 @@ func TestFindRemoteVolumeInTopology(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindRemoteVolumeInTopologyInvalidPattern(t *testing.T) {
+	topo := buildTestTopologyWithRemoteVolumes()
+
+	_, _, err := findRemoteVolumeInTopology(topo, 1, "[invalid")
+	assert.Error(t, err)
 }
 
 func TestCollectRemoteVolumesWithInfo(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `volume.tier.compact` shell command that automates garbage collection for cloud tier volumes
- When files are deleted from remote-tiered volumes, the cloud storage space is not reclaimed; users currently must manually download, compact, and re-upload each volume
- This command orchestrates all three steps automatically: download `.dat` from remote → compact locally to remove deleted data → upload compacted `.dat` back to remote
- Supports single volume (`-volumeId=7`) and batch operation (`-collection="mybucket"` with regex)
- Includes garbage threshold check (`-garbageThreshold=0.3`) to skip volumes with little deleted data
- Error recovery: if compaction fails mid-operation, attempts to re-upload the uncompacted volume to restore cloud tier state
- Reuses existing `downloadDatFromRemoteTier`, `uploadDatToRemoteTier`, and vacuum gRPC calls — no new server-side code needed

Closes #8563

## Usage

```
# compact a specific remote volume
volume.tier.compact -volumeId=7

# compact all remote volumes in a collection with >20% garbage
volume.tier.compact -collection="mybucket" -garbageThreshold=0.2

# compact all remote volumes across all collections
volume.tier.compact -collection=".*"
```

## Test plan

- [x] Unit tests for topology scanning functions (`findRemoteVolumeInTopology`, `collectRemoteVolumesWithInfo`)
- [x] All existing shell tests pass
- [x] `go vet` and `go build` clean
- [ ] Manual testing with a SeaweedFS cluster using S3 cloud tier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new shell command to compact remote tier volumes and reclaim unused cloud storage space. Enables filtering by volume ID, collection name patterns, and configurable garbage collection thresholds for selective compaction.

* **Tests**
  * Added comprehensive test coverage for remote volume discovery and collection-based filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->