### PR TITLE
admin/plugin: migrate inline job details asynchronously to avoid slow startup

### DIFF
--- a/weed/admin/plugin/plugin_monitor.go
+++ b/weed/admin/plugin/plugin_monitor.go
@@ -63,6 +63,12 @@ func (r *Plugin) loadPersistedMonitorState() error {
 	}
 
 	if len(trackedJobs) > 0 {
+		// Collect jobs that still carry inline rich details (old format) so we
+		// can migrate them to dedicated per-job detail files asynchronously.
+		// Writing many files synchronously during startup can be extremely slow
+		// on distributed storage (e.g. Longhorn), so we defer those writes.
+		var jobsToMigrate []TrackedJob
+
 		r.jobsMu.Lock()
 		for i := range trackedJobs {
 			job := trackedJobs[i]
@@ -78,10 +84,9 @@ func (r *Plugin) loadPersistedMonitorState() error {
 			}
 			// Backward compatibility: migrate older inline detail payloads
 			// out of tracked_jobs.json into dedicated per-job detail files.
+			// Collect for async migration instead of writing synchronously.
 			if hasTrackedJobRichDetails(job) {
-				if err := r.store.SaveJobDetail(job); err != nil {
-					glog.Warningf("Plugin failed to migrate detail snapshot for job %s: %v", job.JobID, err)
-				}
+				jobsToMigrate = append(jobsToMigrate, job)
 			}
 			stripTrackedJobDetailFields(&job)
 			jobCopy := job
@@ -89,6 +94,10 @@ func (r *Plugin) loadPersistedMonitorState() error {
 		}
 		r.pruneTrackedJobsLocked()
 		r.jobsMu.Unlock()
+
+		if len(jobsToMigrate) > 0 {
+			go r.migrateInlineJobDetails(jobsToMigrate)
+		}
 	}
 
 	if len(activities) > maxActivityRecords {
@@ -101,6 +110,23 @@ func (r *Plugin) loadPersistedMonitorState() error {
 	}
 
 	return nil
+}
+
+// migrateInlineJobDetails writes inline detail payloads from old-format
+// tracked_jobs.json entries to dedicated per-job detail files. It is called
+// asynchronously during startup to avoid blocking plugin initialisation.
+func (r *Plugin) migrateInlineJobDetails(jobs []TrackedJob) {
+	migrated := 0
+	for _, job := range jobs {
+		if err := r.store.SaveJobDetail(job); err != nil {
+			glog.Warningf("Plugin failed to migrate detail snapshot for job %s: %v", job.JobID, err)
+		} else {
+			migrated++
+		}
+	}
+	if migrated > 0 {
+		glog.V(1).Infof("Plugin migrated %d inline job details to dedicated files", migrated)
+	}
 }
 
 // ExpireJob marks an active job as failed so it no longer blocks scheduling.


### PR DESCRIPTION
## Problem

`loadPersistedMonitorState` performed a backward-compatibility migration that wrote every job still carrying inline rich detail fields to a dedicated per-job detail file **synchronously during startup**.

On deployments with many historical jobs (e.g. 1000+) stored on distributed block storage such as Longhorn, each individual `os.WriteFile` requires an fsync round-trip through the distributed storage stack. Observed startup times of **3.5+ minutes** with ~1162 jobs, causing readiness and liveness probe failures and putting the admin pod into a crash loop.

## Fix

Collect jobs that need migration into a slice during the loading loop, then write them to disk in a background goroutine after the plugin is fully initialised.

The in-memory state is unaffected: `stripTrackedJobDetailFields` is still called in-place immediately, so the scheduler and monitor see correct data from the first tick. A `glog.V(1)` message is emitted when the migration completes.

## Impact

- Startup time drops from O(N × fsync-latency) back to a single JSON parse
- No change to the on-disk format or migration correctness
- The migration is idempotent: if the admin restarts before the goroutine finishes, the remaining jobs will be migrated on the next startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved job detail migration process to run asynchronously, reducing contention during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->