### PR TITLE
wdclient/exclusive_locks: replace println with glog in ExclusiveLocker

### DIFF
--- a/weed/wdclient/exclusive_locks/exclusive_locker.go
+++ b/weed/wdclient/exclusive_locks/exclusive_locker.go
@@ -70,7 +70,7 @@ func (l *ExclusiveLocker) RequestLock(clientName string) {
 			}
 			return err
 		}); err != nil {
-			println("lock:", err.Error())
+			glog.V(2).Infof("Failed to acquire lock %s: %v", l.lockName, err)
 			time.Sleep(InitLockInterval)
 		} else {
 			break
@@ -79,6 +79,7 @@ func (l *ExclusiveLocker) RequestLock(clientName string) {
 
 	l.isLocked.Store(true)
 	l.clientName = clientName
+	glog.V(1).Infof("Acquired lock %s", l.lockName)
 
 	// Each lock has and only has one goroutine
 	if l.renewGoroutineRunning.CompareAndSwap(false, true) {
@@ -100,11 +101,11 @@ func (l *ExclusiveLocker) RequestLock(clientName string) {
 						if err == nil {
 							atomic.StoreInt64(&l.token, resp.Token)
 							atomic.StoreInt64(&l.lockTsNs, resp.LockTsNs)
-							// println("ts", l.lockTsNs, "token", l.token)
+							glog.V(2).Infof("Renewed lock %s: ts %d token %d", l.lockName, l.lockTsNs, l.token)
 						}
 						return err
 					}); err != nil {
-						glog.Errorf("failed to renew lock: %v", err)
+						glog.Warningf("Failed to renew lock %s: %v", l.lockName, err)
 						l.isLocked.Store(false)
 						return
 					} else {


### PR DESCRIPTION
## Problem

`ExclusiveLocker.RequestLock` used a bare `println` to report transient lock acquisition failures:

```go
println("lock:", err.Error())
```

This writes directly to **stdout** instead of going through the structured `glog` logging pipeline. Consequences:

- The message cannot be filtered with `-v` flags or suppressed at higher verbosity
- Output bypasses any log redirection/aggregation configured for the process
- On restart when a previous lock is still held (TTL=10s), this prints once per second (~10 times) polluting stdout with `lock: rpc error: code = Unknown desc = already locked by ...`
- The renewal failure used `glog.Errorf` which suggests the goroutine is in a fatal state, but the caller recovers by re-acquiring via `RequestLock`

## Fix

- `println("lock:", err)` → `glog.V(2).Infof` for per-retry acquisition errors (transient, high-frequency during startup overlap)
- Add `glog.V(1).Infof` when lock is successfully acquired
- Add `glog.V(2).Infof` for successful renewals (replaces the commented-out `println` debug line)
- `glog.Errorf` → `glog.Warningf` for renewal failures (the goroutine exits cleanly and the caller re-acquires; this is not a fatal error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced logging for exclusive lock operations with improved diagnostics during lock acquisition and renewal processes. Lock acquisition now includes informational logging, and renewal failures are logged with warning-level severity instead of error, providing better visibility into lock management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->