### PR TITLE
fix: resolve CORS cache race condition causing stale 404 responses

### DIFF
--- a/test/s3/cors/s3_cors_test.go
+++ b/test/s3/cors/s3_cors_test.go
@@ -590,17 +590,14 @@ func TestCORSCaching(t *testing.T) {
 		Bucket:            aws.String(bucketName),
 		CORSConfiguration: corsConfig1,
 	})
-	assert.NoError(t, err, "Should be able to put initial CORS configuration")
-
-	// Wait for metadata subscription to update cache
-	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, err, "Should be able to put initial CORS configuration")
 
 	// Get the configuration
 	getResp1, err := client.GetBucketCors(context.TODO(), &s3.GetBucketCorsInput{
 		Bucket: aws.String(bucketName),
 	})
-	assert.NoError(t, err, "Should be able to get initial CORS configuration")
-	assert.Len(t, getResp1.CORSRules, 1, "Should have one CORS rule")
+	require.NoError(t, err, "Should be able to get initial CORS configuration")
+	require.Len(t, getResp1.CORSRules, 1, "Should have one CORS rule")
 
 	// Update the configuration
 	corsConfig2 := &types.CORSConfiguration{
@@ -618,17 +615,14 @@ func TestCORSCaching(t *testing.T) {
 		Bucket:            aws.String(bucketName),
 		CORSConfiguration: corsConfig2,
 	})
-	assert.NoError(t, err, "Should be able to update CORS configuration")
-
-	// Wait for metadata subscription to update cache
-	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, err, "Should be able to update CORS configuration")
 
 	// Get the updated configuration (should reflect the changes)
 	getResp2, err := client.GetBucketCors(context.TODO(), &s3.GetBucketCorsInput{
 		Bucket: aws.String(bucketName),
 	})
-	assert.NoError(t, err, "Should be able to get updated CORS configuration")
-	assert.Len(t, getResp2.CORSRules, 1, "Should have one CORS rule")
+	require.NoError(t, err, "Should be able to get updated CORS configuration")
+	require.Len(t, getResp2.CORSRules, 1, "Should have one CORS rule")
 
 	rule := getResp2.CORSRules[0]
 	assert.Equal(t, []string{"Content-Type"}, rule.AllowedHeaders, "Should have updated headers")

--- a/weed/s3api/auth_credentials_subscribe.go
+++ b/weed/s3api/auth_credentials_subscribe.go
@@ -1,7 +1,6 @@
 package s3api
 
 import (
-	"errors"
 	"strings"
 	"time"
 
@@ -224,14 +223,13 @@ func (s3a *S3ApiServer) updateBucketConfigCacheFromEntry(entry *filer_pb.Entry) 
 	// Sync bucket policy to the policy engine for evaluation
 	s3a.syncBucketPolicyToEngine(bucket, config.BucketPolicy)
 
-	// Load CORS configuration from bucket directory content
-	if corsConfig, err := s3a.loadCORSFromBucketContent(bucket); err != nil {
-		if !errors.Is(err, filer_pb.ErrNotFound) {
-			glog.Errorf("updateBucketConfigCacheFromEntry: failed to load CORS configuration for bucket %s: %v", bucket, err)
-		}
-	} else {
-		config.CORS = corsConfig
-		glog.V(2).Infof("updateBucketConfigCacheFromEntry: loaded CORS config for bucket %s", bucket)
+	// Parse CORS configuration directly from the subscription entry's Content field.
+	// This avoids a separate RPC call that could return stale data when racing with
+	// concurrent metadata updates (e.g., PutBucketCors clearing the cache while this
+	// handler is still processing an older event).
+	config.CORS = parseCORSFromEntryContent(entry.Content)
+	if config.CORS != nil {
+		glog.V(2).Infof("updateBucketConfigCacheFromEntry: parsed CORS config for bucket %s from entry content", bucket)
 	}
 
 	// Update timestamp

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -408,18 +408,9 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 	// Sync bucket policy to the policy engine for evaluation
 	s3a.syncBucketPolicyToEngine(bucket, config.BucketPolicy)
 
-	// Load CORS configuration from bucket directory content
-	if corsConfig, err := s3a.loadCORSFromBucketContent(bucket); err != nil {
-		if errors.Is(err, filer_pb.ErrNotFound) {
-			// Missing metadata is not an error; fall back cleanly
-			glog.V(2).Infof("CORS metadata not found for bucket %s, falling back to default behavior", bucket)
-		} else {
-			// Log parsing or validation errors
-			glog.Errorf("Failed to load CORS configuration for bucket %s: %v", bucket, err)
-		}
-	} else {
-		config.CORS = corsConfig
-	}
+	// Parse CORS configuration directly from the entry's Content field.
+	// This avoids a redundant RPC call since we already have the entry.
+	config.CORS = parseCORSFromEntryContent(entry.Content)
 
 	// Cache the result
 	s3a.bucketConfigCache.Set(bucket, config)
@@ -588,15 +579,19 @@ func (s3a *S3ApiServer) setBucketOwnership(bucket, ownership string) s3err.Error
 	})
 }
 
-// loadCORSFromBucketContent loads CORS configuration from bucket directory content
-func (s3a *S3ApiServer) loadCORSFromBucketContent(bucket string) (*cors.CORSConfiguration, error) {
-	metadata, err := s3a.GetBucketMetadata(bucket)
-	if err != nil {
-		return nil, err
+// parseCORSFromEntryContent parses CORS configuration directly from an entry's Content field.
+// This avoids a separate RPC call when the entry is already available (e.g., from a
+// subscription event or a prior getBucketEntry call).
+func parseCORSFromEntryContent(content []byte) *cors.CORSConfiguration {
+	if len(content) == 0 {
+		return nil
 	}
-
-	// Note: corsConfig can be nil if no CORS configuration is set, which is valid
-	return metadata.CORS, nil
+	var protoMetadata s3_pb.BucketMetadata
+	if err := proto.Unmarshal(content, &protoMetadata); err != nil {
+		glog.Errorf("parseCORSFromEntryContent: failed to unmarshal protobuf metadata: %v", err)
+		return nil
+	}
+	return corsConfigFromProto(protoMetadata.Cors)
 }
 
 // getCORSConfiguration retrieves CORS configuration with caching


### PR DESCRIPTION
## Summary

- Fix race condition where the metadata subscription handler could re-cache stale CORS data after `PutBucketCors` cleared the cache, causing `GetBucketCors` to return 404 `NoSuchCORSConfiguration`
- Parse CORS directly from the entry's protobuf `Content` field instead of making separate RPC calls, eliminating both the race window and redundant filer RPCs
- Fix `TestCORSCaching` to use `require.NoError`/`require.Len` to prevent nil pointer dereference panics on failure

## Root Cause

`updateBucketConfigCacheFromEntry` (subscription handler) called `loadCORSFromBucketContent()` which made a **separate RPC** to the filer. This slow RPC created a race window:

1. CreateBucket fires subscription event E1
2. E1 starts processing, calls `loadCORSFromBucketContent()` (slow RPC to filer)
3. PutBucketCors updates filer, calls `cache.Remove(bucket)` to clear cache
4. E1 finishes its slow RPC, calls `cache.Set(bucket, staleConfig)` — overwrites the removal
5. GetBucketCors hits cache, gets stale data with nil CORS → **404**

The same redundant RPC existed in `getBucketConfig`, which fetched the entry from filer then called `loadCORSFromBucketContent` to fetch it again.

## Test plan

- [x] `go build ./weed/s3api/...` compiles cleanly
- [x] `go test ./weed/s3api/...` all pass
- [ ] CI CORS integration tests pass (`TestCORSCaching` no longer panics or returns stale 404)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CORS configuration tests with stricter validation checks.

* **Refactor**
  * Optimized CORS configuration loading process by streamlining parsing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->