### PR TITLE
Add -filerExcludePathPattern flag and fix nil panic in -filerExcludeFileName

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -15,23 +15,25 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/util/http"
+	"github.com/seaweedfs/seaweedfs/weed/util/wildcard"
 	"google.golang.org/grpc"
 )
 
 type FilerBackupOptions struct {
-	isActivePassive    *bool
-	filer              *string
-	path               *string
-	excludePaths       *string
-	excludeFileName    *string
-	excludePathPattern *string
-	debug              *bool
-	proxyByFiler       *bool
-	doDeleteFiles      *bool
-	disableErrorRetry  *bool
-	ignore404Error     *bool
-	timeAgo            *time.Duration
-	retentionDays      *int
+	isActivePassive     *bool
+	filer               *string
+	path                *string
+	excludePaths        *string
+	excludeFileName     *string // deprecated: use excludeFileNames
+	excludeFileNames    *string
+	excludePathPatterns *string
+	debug               *bool
+	proxyByFiler        *bool
+	doDeleteFiles       *bool
+	disableErrorRetry   *bool
+	ignore404Error      *bool
+	timeAgo             *time.Duration
+	retentionDays       *int
 }
 
 var (
@@ -44,8 +46,9 @@ func init() {
 	filerBackupOptions.filer = cmdFilerBackup.Flag.String("filer", "localhost:8888", "filer of one SeaweedFS cluster")
 	filerBackupOptions.path = cmdFilerBackup.Flag.String("filerPath", "/", "directory to sync on filer")
 	filerBackupOptions.excludePaths = cmdFilerBackup.Flag.String("filerExcludePaths", "", "exclude directories to sync on filer")
-	filerBackupOptions.excludeFileName = cmdFilerBackup.Flag.String("filerExcludeFileName", "", "exclude file names that match the regexp to sync on filer")
-	filerBackupOptions.excludePathPattern = cmdFilerBackup.Flag.String("filerExcludePathPattern", "", "exclude paths where any component matches the regexp")
+	filerBackupOptions.excludeFileName = cmdFilerBackup.Flag.String("filerExcludeFileName", "", "[DEPRECATED: use -filerExcludeFileNames] exclude file names that match the regexp")
+	filerBackupOptions.excludeFileNames = cmdFilerBackup.Flag.String("filerExcludeFileNames", "", "comma-separated wildcard patterns to exclude file names, e.g., \"*.tmp,._*\"")
+	filerBackupOptions.excludePathPatterns = cmdFilerBackup.Flag.String("filerExcludePathPatterns", "", "comma-separated wildcard patterns to exclude paths where any component matches, e.g., \".snapshot,temp*\"")
 	filerBackupOptions.proxyByFiler = cmdFilerBackup.Flag.Bool("filerProxy", false, "read and write file chunks by filer instead of volume servers")
 	filerBackupOptions.doDeleteFiles = cmdFilerBackup.Flag.Bool("doDeleteFiles", false, "delete files on the destination")
 	filerBackupOptions.debug = cmdFilerBackup.Flag.Bool("debug", false, "debug mode to print out received files")
@@ -80,10 +83,8 @@ func runFilerBackup(cmd *Command, args []string) bool {
 	if err != nil {
 		glog.Fatalf("invalid -filerExcludeFileName: %v", err)
 	}
-	reExcludePathPattern, err := compileExcludePattern(*filerBackupOptions.excludePathPattern, "exclude path pattern")
-	if err != nil {
-		glog.Fatalf("invalid -filerExcludePathPattern: %v", err)
-	}
+	excludeFileNames := wildcard.CompileWildcardMatchers(*filerBackupOptions.excludeFileNames)
+	excludePathPatterns := wildcard.CompileWildcardMatchers(*filerBackupOptions.excludePathPatterns)
 
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 
@@ -92,7 +93,7 @@ func runFilerBackup(cmd *Command, args []string) bool {
 
 	for {
 		clientEpoch++
-		err := doFilerBackup(grpcDialOption, &filerBackupOptions, reExcludeFileName, reExcludePathPattern, clientId, clientEpoch)
+		err := doFilerBackup(grpcDialOption, &filerBackupOptions, reExcludeFileName, excludeFileNames, excludePathPatterns, clientId, clientEpoch)
 		if err != nil {
 			glog.Errorf("backup from %s: %v", *filerBackupOptions.filer, err)
 			time.Sleep(1747 * time.Millisecond)
@@ -104,7 +105,7 @@ const (
 	BackupKeyPrefix = "backup."
 )
 
-func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOptions, reExcludeFileName *regexp.Regexp, reExcludePathPattern *regexp.Regexp, clientId int32, clientEpoch int32) error {
+func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOptions, reExcludeFileName *regexp.Regexp, excludeFileNames []*wildcard.WildcardMatcher, excludePathPatterns []*wildcard.WildcardMatcher, clientId int32, clientEpoch int32) error {
 
 	// find data sink
 	dataSink := findSink(util.GetViper())
@@ -146,7 +147,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 
 	var processEventFn func(*filer_pb.SubscribeMetadataResponse) error
 	if *backupOption.ignore404Error {
-		processEventFnGenerated := genProcessFunction(sourcePath, targetPath, excludePaths, reExcludeFileName, reExcludePathPattern, dataSink, *backupOption.doDeleteFiles, debug)
+		processEventFnGenerated := genProcessFunction(sourcePath, targetPath, excludePaths, reExcludeFileName, excludeFileNames, excludePathPatterns, dataSink, *backupOption.doDeleteFiles, debug)
 		processEventFn = func(resp *filer_pb.SubscribeMetadataResponse) error {
 			err := processEventFnGenerated(resp)
 			if err == nil {
@@ -159,7 +160,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 			return err
 		}
 	} else {
-		processEventFn = genProcessFunction(sourcePath, targetPath, excludePaths, reExcludeFileName, reExcludePathPattern, dataSink, *backupOption.doDeleteFiles, debug)
+		processEventFn = genProcessFunction(sourcePath, targetPath, excludePaths, reExcludeFileName, excludeFileNames, excludePathPatterns, dataSink, *backupOption.doDeleteFiles, debug)
 	}
 
 	processEventFnWithOffset := pb.AddOffsetFunc(processEventFn, 3*time.Second, func(counter int64, lastTsNs int64) error {

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -305,7 +305,7 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, grpcDialOpti
 	filerSink.SetChunkConcurrency(chunkConcurrency)
 	filerSink.SetSourceFiler(filerSource)
 
-	persistEventFn := genProcessFunction(sourcePath, targetPath, sourceExcludePaths, nil, nil, filerSink, doDeleteFiles, debug)
+	persistEventFn := genProcessFunction(sourcePath, targetPath, sourceExcludePaths, nil, nil, nil, filerSink, doDeleteFiles, debug)
 
 	processEventFn := func(resp *filer_pb.SubscribeMetadataResponse) error {
 		message := resp.EventNotification
@@ -440,7 +440,7 @@ func setOffset(grpcDialOption grpc.DialOption, filer pb.ServerAddress, signature
 
 }
 
-func genProcessFunction(sourcePath string, targetPath string, excludePaths []string, reExcludeFileName *regexp.Regexp, reExcludePathPattern *regexp.Regexp, dataSink sink.ReplicationSink, doDeleteFiles bool, debug bool) func(resp *filer_pb.SubscribeMetadataResponse) error {
+func genProcessFunction(sourcePath string, targetPath string, excludePaths []string, reExcludeFileName *regexp.Regexp, excludeFileNames []*wildcard.WildcardMatcher, excludePathPatterns []*wildcard.WildcardMatcher, dataSink sink.ReplicationSink, doDeleteFiles bool, debug bool) func(resp *filer_pb.SubscribeMetadataResponse) error {
 	// process function
 	processEventFn := func(resp *filer_pb.SubscribeMetadataResponse) error {
 		message := resp.EventNotification
@@ -472,8 +472,8 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 		// Compute per-side exclusion so that rename events crossing an
 		// exclude boundary are handled as delete + create rather than
 		// being entirely skipped.
-		oldExcluded := isEntryExcluded(resp.Directory, message.OldEntry, reExcludeFileName, reExcludePathPattern)
-		newExcluded := isEntryExcluded(message.NewParentPath, message.NewEntry, reExcludeFileName, reExcludePathPattern)
+		oldExcluded := isEntryExcluded(resp.Directory, message.OldEntry, reExcludeFileName, excludeFileNames, excludePathPatterns)
+		newExcluded := isEntryExcluded(message.NewParentPath, message.NewEntry, reExcludeFileName, excludeFileNames, excludePathPatterns)
 
 		if oldExcluded && newExcluded {
 			return nil
@@ -596,19 +596,27 @@ func buildKey(dataSink sink.ReplicationSink, message *filer_pb.EventNotification
 }
 
 // isEntryExcluded checks whether a single side (old or new) of an event is excluded
-// by either the filename regexp or the path-pattern regexp.
-func isEntryExcluded(dir string, entry *filer_pb.Entry, reExcludeFileName *regexp.Regexp, reExcludePathPattern *regexp.Regexp) bool {
+// by the deprecated filename regexp, the wildcard file-name matchers, or the
+// wildcard path-pattern matchers.
+func isEntryExcluded(dir string, entry *filer_pb.Entry, reExcludeFileName *regexp.Regexp, excludeFileNames []*wildcard.WildcardMatcher, excludePathPatterns []*wildcard.WildcardMatcher) bool {
 	if entry == nil {
 		return false
 	}
+	// deprecated regexp-based filename exclusion
 	if reExcludeFileName != nil && reExcludeFileName.MatchString(entry.Name) {
 		return true
 	}
-	if reExcludePathPattern != nil {
-		if pathContainsMatch(dir, reExcludePathPattern) {
+	// wildcard-based filename exclusion
+	if len(excludeFileNames) > 0 && matchesAnyWildcard(excludeFileNames, entry.Name) {
+		return true
+	}
+	// wildcard-based path-pattern exclusion: match against each directory
+	// component and the entry name itself
+	if len(excludePathPatterns) > 0 {
+		if pathContainsWildcardMatch(dir, excludePathPatterns) {
 			return true
 		}
-		if reExcludePathPattern.MatchString(entry.Name) {
+		if matchesAnyWildcard(excludePathPatterns, entry.Name) {
 			return true
 		}
 	}
@@ -625,26 +633,6 @@ func compileExcludePattern(pattern string, label string) (*regexp.Regexp, error)
 		return nil, fmt.Errorf("error compile regexp %v for %s: %+v", pattern, label, err)
 	}
 	return re, nil
-}
-
-// pathContainsMatch checks if any component of the given path matches the regexp,
-// without allocating a slice (unlike strings.Split).
-func pathContainsMatch(path string, re *regexp.Regexp) bool {
-	for path != "" {
-		i := strings.IndexByte(path, '/')
-		var component string
-		if i < 0 {
-			component = path
-			path = ""
-		} else {
-			component = path[:i]
-			path = path[i+1:]
-		}
-		if component != "" && re.MatchString(component) {
-			return true
-		}
-	}
-	return false
 }
 
 // matchesAnyWildcard returns true if any matcher matches the value.


### PR DESCRIPTION
# What problem are we solving?

fix #8755

# How are we solving the problem?

Add a new `-filerExcludePathPattern` flag to `filer.backup` that excludes events where any path component matches the given regexp, and fix a nil pointer panic in the existing `-filerExcludeFileName` logic.

## 1. Fix nil panic in `-filerExcludeFileName`

Add nil guards before accessing `message.NewEntry.Name` and also check `message.OldEntry.Name` for delete/rename events.

## 2. Add `-filerExcludePathPattern` flag

Introduce a new flag that takes a regexp and checks it against:
- Every component of `resp.Directory` (split by `/`)
- `message.NewEntry.Name` (if not nil)
- `message.OldEntry.Name` (if not nil)

This keeps `-filerExcludeFileName` semantically clean (leaf name only) while providing a way to exclude entire directory trees by name pattern.

# How is the PR tested?

- Exclude tests: Created ftjob-* directories and files on DFS mount, verified they did not appear in the backup destination.
- Include tests: Created normal (non-matching) directories and files, verified they were backed up correctly.
- Delete safety: Created and then deleted a ftjob-* directory, verified the service remained running with no panic.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI/config options for excluding file names and per-path-component patterns; patterns are validated and precompiled up-front. Old single-file-name option marked deprecated.

* **Bug Fixes**
  * Improved sync handling when entries are excluded on one side: events are skipped or converted to create/delete as appropriate.
  * Exclusion logic applied consistently and avoids repeated pattern compilation for each operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->