### PR TITLE
chore:(weed/worker/tasks/erasure_coding): Prune Unused and Untested Functions

### DIFF
--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -826,25 +826,6 @@ func diskInfosToCandidates(disks []*topology.DiskInfo) []*placement.DiskCandidat
 	return candidates
 }
 
-// candidatesToDiskInfos converts placement results back to topology.DiskInfo
-func candidatesToDiskInfos(candidates []*placement.DiskCandidate, originalDisks []*topology.DiskInfo) []*topology.DiskInfo {
-	// Create a map for quick lookup
-	diskMap := make(map[string]*topology.DiskInfo)
-	for _, disk := range originalDisks {
-		key := fmt.Sprintf("%s:%d", disk.NodeID, disk.DiskID)
-		diskMap[key] = disk
-	}
-
-	var result []*topology.DiskInfo
-	for _, candidate := range candidates {
-		key := fmt.Sprintf("%s:%d", candidate.NodeID, candidate.DiskID)
-		if disk, ok := diskMap[key]; ok {
-			result = append(result, disk)
-		}
-	}
-	return result
-}
-
 // calculateECScoreCandidate calculates placement score for EC operations.
 // Used for logging and plan metadata.
 func calculateECScoreCandidate(disk *placement.DiskCandidate, sourceRack, sourceDC string) float64 {


### PR DESCRIPTION
This removes unused functions from `weed/worker/tasks/erasure_coding`. Each removal is its own commit, in case the project wants me to drop one of these removals. I can squash this into a single commit, if preferred.

Unit tests pass both before and after these changes.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal code organization by consolidating erasure coding detection logic. Removed redundant helper functions and unified placement logic with existing components for improved maintainability.

**Note:** No user-facing changes in this update. This is an internal code optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->