### PR TITLE
weed/mount: simplify metadata flush retry returns

### DIFF
--- a/weed/mount/metadata_flush_retry.go
+++ b/weed/mount/metadata_flush_retry.go
@@ -12,10 +12,10 @@ func retryMetadataFlush(flush func() error, onRetry func(nextAttempt, totalAttem
 	for attempt := 1; attempt <= totalAttempts; attempt++ {
 		err = flush()
 		if err == nil {
-			return nil
+			break
 		}
 		if attempt == totalAttempts {
-			return err
+			break
 		}
 
 		backoff := time.Duration(1<<uint(attempt-1)) * time.Second


### PR DESCRIPTION
## Summary
- remove the dead return from `retryMetadataFlush`
- make the helper exit through a single `return err` path without changing behavior

## Testing
- go test ./weed/mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to metadata synchronization retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->