### PR TITLE
S3: add s3: prefix to x-amz-* condition keys for AWS compatibility

### DIFF
--- a/weed/s3api/policy_engine/engine.go
+++ b/weed/s3api/policy_engine/engine.go
@@ -427,10 +427,11 @@ func ExtractConditionValuesFromRequest(r *http.Request) map[string][]string {
 	// HTTP method
 	values["s3:RequestMethod"] = []string{r.Method}
 
-	// Extract custom headers
+	// Extract custom headers with s3: prefix for AWS-compatible condition keys
 	for key, headerValues := range r.Header {
-		if strings.HasPrefix(strings.ToLower(key), "x-amz-") {
-			values[strings.ToLower(key)] = headerValues
+		lowerKey := strings.ToLower(key)
+		if strings.HasPrefix(lowerKey, "x-amz-") {
+			values["s3:"+lowerKey] = headerValues
 		}
 	}
 

--- a/weed/s3api/policy_engine/engine_test.go
+++ b/weed/s3api/policy_engine/engine_test.go
@@ -444,8 +444,8 @@ func TestExtractConditionValuesFromRequest(t *testing.T) {
 		t.Errorf("Expected RequestMethod to be GET, got %v", values["s3:RequestMethod"])
 	}
 
-	if len(values["x-amz-copy-source"]) != 1 || values["x-amz-copy-source"][0] != "source-bucket/source-object" {
-		t.Errorf("Expected X-Amz-Copy-Source header to be extracted, got %v", values["x-amz-copy-source"])
+	if len(values["s3:x-amz-copy-source"]) != 1 || values["s3:x-amz-copy-source"][0] != "source-bucket/source-object" {
+		t.Errorf("Expected X-Amz-Copy-Source header to be extracted with s3: prefix, got %v", values["s3:x-amz-copy-source"])
 	}
 
 	// Check that aws:CurrentTime is properly set


### PR DESCRIPTION
## Summary

- AWS S3 policy conditions reference request headers with the `s3:` namespace prefix (e.g., `s3:x-amz-server-side-encryption`), but `ExtractConditionValuesFromRequest` was storing them without the prefix (e.g., `x-amz-server-side-encryption`)
- This meant bucket policy conditions using the standard AWS key format would never match
- Adds the `s3:` prefix when extracting `x-amz-*` headers as condition keys

Fixes https://github.com/seaweedfs/seaweedfs/discussions/8751

## Test plan

- [x] Existing `TestExtractConditionValuesFromRequest` updated and passes
- [x] All `policy_engine`, `s3api`, and `iam/policy` tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced S3 policy engine's condition key extraction to properly format custom AWS headers with the `s3:` namespace prefix, ensuring correct alignment with AWS S3 policy standards and improving the accuracy of access control policy evaluation for requests using custom AWS headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->