### PR TITLE
filer.sync: replace O(n) conflict check with O(depth) index lookups

### DIFF
--- a/weed/command/filer_sync_jobs.go
+++ b/weed/command/filer_sync_jobs.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"container/heap"
 	"path"
 	"sync"
 	"sync/atomic"
@@ -10,6 +11,21 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
+
+// tsMinHeap implements heap.Interface for int64 timestamps.
+type tsMinHeap []int64
+
+func (h tsMinHeap) Len() int            { return len(h) }
+func (h tsMinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h tsMinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *tsMinHeap) Push(x any)         { *h = append(*h, x.(int64)) }
+func (h *tsMinHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
 
 type syncJobPaths struct {
 	path        util.FullPath
@@ -33,8 +49,9 @@ type MetadataProcessor struct {
 	// descendantCount counts active jobs (file or dir) strictly under each directory.
 	descendantCount map[util.FullPath]int
 
-	// minActiveTs tracks the smallest TsNs in activeJobs for O(1) watermark checks.
-	minActiveTs int64
+	// tsHeap is a min-heap of active job timestamps with lazy deletion,
+	// used for O(log n) amortized watermark tracking.
+	tsHeap tsMinHeap
 }
 
 func NewMetadataProcessor(fn pb.ProcessMetadataFunc, concurrency int, offsetTsNs int64) *MetadataProcessor {
@@ -164,9 +181,7 @@ func (t *MetadataProcessor) AddSyncJob(resp *filer_pb.SubscribeMetadataResponse)
 		t.addPathToIndex(newPath, isDirectory)
 	}
 
-	if t.minActiveTs == 0 || resp.TsNs < t.minActiveTs {
-		t.minActiveTs = resp.TsNs
-	}
+	heap.Push(&t.tsHeap, resp.TsNs)
 
 	go func() {
 
@@ -185,15 +200,17 @@ func (t *MetadataProcessor) AddSyncJob(resp *filer_pb.SubscribeMetadataResponse)
 			t.removePathFromIndex(jobPaths.newPath, jobPaths.isDirectory)
 		}
 
-		// if is the oldest job, write down the watermark
-		if resp.TsNs == t.minActiveTs {
-			t.processedTsWatermark.Store(resp.TsNs)
-			t.minActiveTs = 0
-			for ts := range t.activeJobs {
-				if t.minActiveTs == 0 || ts < t.minActiveTs {
-					t.minActiveTs = ts
-				}
+		// Lazy-clean stale entries from heap top (already-completed jobs).
+		// Each entry is pushed once and popped once: O(log n) amortized.
+		for t.tsHeap.Len() > 0 {
+			if _, active := t.activeJobs[t.tsHeap[0]]; active {
+				break
 			}
+			heap.Pop(&t.tsHeap)
+		}
+		// If this was the oldest job, advance the watermark.
+		if t.tsHeap.Len() == 0 || resp.TsNs < t.tsHeap[0] {
+			t.processedTsWatermark.Store(resp.TsNs)
 		}
 		t.activeJobsCond.Signal()
 	}()

--- a/weed/command/filer_sync_jobs_test.go
+++ b/weed/command/filer_sync_jobs_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"container/heap"
 	"fmt"
 	"testing"
 
@@ -307,8 +308,8 @@ func TestIndexCleanup(t *testing.T) {
 	}
 }
 
-// TestMinActiveTsTracking verifies watermark advancement.
-func TestMinActiveTsTracking(t *testing.T) {
+// TestWatermarkWithHeap verifies watermark advancement using the min-heap.
+func TestWatermarkWithHeap(t *testing.T) {
 	noop := func(resp *filer_pb.SubscribeMetadataResponse) error { return nil }
 	p := NewMetadataProcessor(noop, 100, 0)
 
@@ -317,39 +318,43 @@ func TestMinActiveTsTracking(t *testing.T) {
 		jobPath := util.FullPath("/file" + string(rune('0'+ts/10)))
 		p.activeJobs[ts] = &syncJobPaths{path: jobPath, isDirectory: false}
 		p.addPathToIndex(jobPath, false)
-		if p.minActiveTs == 0 || ts < p.minActiveTs {
-			p.minActiveTs = ts
-		}
+		heap.Push(&p.tsHeap, ts)
 	}
 
-	if p.minActiveTs != 10 {
-		t.Errorf("expected minActiveTs=10, got %d", p.minActiveTs)
+	if p.tsHeap[0] != 10 {
+		t.Errorf("expected heap min=10, got %d", p.tsHeap[0])
 	}
 
-	// Remove non-oldest (ts=20) — minActiveTs should stay 10
+	// Remove non-oldest (ts=20) — heap top should stay 10
 	delete(p.activeJobs, 20)
 	p.removePathFromIndex("/file2", false)
-	// Simulate watermark check: not the oldest, no update
-	if 20 == p.minActiveTs {
-		t.Error("ts=20 should not be minActiveTs")
+	// Lazy clean: top is 10 which is still active, so no pop
+	for p.tsHeap.Len() > 0 {
+		if _, active := p.activeJobs[p.tsHeap[0]]; active {
+			break
+		}
+		heap.Pop(&p.tsHeap)
+	}
+	if p.tsHeap[0] != 10 {
+		t.Errorf("expected heap min=10 after removing 20, got %d", p.tsHeap[0])
 	}
 
-	// Remove oldest (ts=10) — should find new min (30)
+	// Remove oldest (ts=10) — lazy clean should find 30
 	delete(p.activeJobs, 10)
 	p.removePathFromIndex("/file1", false)
-	if 10 == p.minActiveTs {
-		p.processedTsWatermark.Store(10)
-		p.minActiveTs = 0
-		for ts := range p.activeJobs {
-			if p.minActiveTs == 0 || ts < p.minActiveTs {
-				p.minActiveTs = ts
-			}
+	for p.tsHeap.Len() > 0 {
+		if _, active := p.activeJobs[p.tsHeap[0]]; active {
+			break
 		}
+		heap.Pop(&p.tsHeap)
 	}
-	if p.minActiveTs != 30 {
-		t.Errorf("expected minActiveTs=30, got %d", p.minActiveTs)
+	if p.tsHeap.Len() != 1 || p.tsHeap[0] != 30 {
+		t.Errorf("expected heap min=30 after removing 10 and 20, got len=%d", p.tsHeap.Len())
 	}
 }
+
+// benchResult prevents the compiler from optimizing away the conflict check.
+var benchResult bool
 
 // BenchmarkConflictCheck measures conflict check cost with varying active job counts.
 // With the index-based approach, cost should be O(depth) regardless of job count.
@@ -360,7 +365,7 @@ func BenchmarkConflictCheck(b *testing.B) {
 			p := NewMetadataProcessor(noop, numJobs+1, 0)
 
 			// Fill with active jobs in different directories
-			for i := 0; i < numJobs; i++ {
+			for i := range numJobs {
 				dir := fmt.Sprintf("/dir%d/sub%d", i/100, i%100)
 				name := fmt.Sprintf("file%d.txt", i)
 				resp := makeResp(dir, name, false, int64(i+1), true)
@@ -371,10 +376,12 @@ func BenchmarkConflictCheck(b *testing.B) {
 
 			// Benchmark conflict check for a non-conflicting event
 			probe := makeResp("/other/path", "test.txt", false, int64(numJobs+1), true)
+			var r bool
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				p.conflictsWith(probe)
+				r = p.conflictsWith(probe)
 			}
+			benchResult = r
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the O(n) linear scan in `MetadataProcessor.conflictsWith()` with three index maps that provide O(depth) lookups, where depth is the path depth (typically 3-6 levels)
- Replace the O(n) watermark scan with `minActiveTs` tracking for O(1) non-oldest job completions
- Add comprehensive tests covering all conflict scenarios (file-vs-file, file-vs-dir, dir-vs-dir, renames, index cleanup, watermark tracking)

Addresses #8771 — at high `-concurrency` values (256-1024), the per-event O(n) conflict scan under the lock was throttling event dispatch, negating the benefit of more workers. Benchmark shows constant ~81ns/op whether there are 32 or 1024 active jobs.

## Test plan

- [x] All new unit tests pass (10 test cases covering conflict semantics)
- [x] Benchmark confirms constant time: `jobs=32` 81ns, `jobs=256` 81ns, `jobs=1024` 81ns
- [x] `go build ./weed/command/` compiles cleanly
- [ ] Manual test with `filer.sync -concurrency=1024` to verify higher concurrency values now improve throughput

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized conflict detection for file synchronization jobs, improving performance when handling multiple concurrent sync operations.

* **Tests**
  * Added comprehensive test coverage for sync job conflict detection and rename handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->