### PR TITLE
test: restore coverage removed in PR #8360

### DIFF
--- a/test/volume_server/framework/volume_fixture.go
+++ b/test/volume_server/framework/volume_fixture.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -43,6 +45,39 @@ func UploadBytes(t testing.TB, client *http.Client, volumeURL, fid string, data 
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(data)))
 	return DoRequest(t, client, req)
+}
+
+// CorruptIndexFile appends garbage bytes to a volume's .idx file on disk so
+// that CheckIndexFile detects a size mismatch during scrub.
+func CorruptIndexFile(t testing.TB, baseDir string, volumeID uint32) {
+	t.Helper()
+	idxPath := filepath.Join(baseDir, "volume", fmt.Sprintf("%d.idx", volumeID))
+	f, err := os.OpenFile(idxPath, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatalf("open idx file for corruption: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte{0xDE, 0xAD}); err != nil {
+		t.Fatalf("corrupt idx file: %v", err)
+	}
+}
+
+// EnableMaintenanceMode puts the volume server into maintenance mode.
+func EnableMaintenanceMode(t testing.TB, ctx context.Context, client volume_server_pb.VolumeServerClient) {
+	t.Helper()
+	stateResp, err := client.GetState(ctx, &volume_server_pb.GetStateRequest{})
+	if err != nil {
+		t.Fatalf("GetState failed: %v", err)
+	}
+	_, err = client.SetState(ctx, &volume_server_pb.SetStateRequest{
+		State: &volume_server_pb.VolumeServerState{
+			Maintenance: true,
+			Version:     stateResp.GetState().GetVersion(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetState maintenance=true failed: %v", err)
+	}
 }
 
 func ReadBytes(t testing.TB, client *http.Client, volumeURL, fid string) *http.Response {

--- a/test/volume_server/grpc/admin_readonly_collection_test.go
+++ b/test/volume_server/grpc/admin_readonly_collection_test.go
@@ -115,19 +115,7 @@ func TestVolumeMarkReadonlyWritableErrorPaths(t *testing.T) {
 	}
 
 	// enter maintenance mode
-	stateResp, err := grpcClient.GetState(ctx, &volume_server_pb.GetStateRequest{})
-	if err != nil {
-		t.Fatalf("GetState failed: %v", err)
-	}
-	_, err = grpcClient.SetState(ctx, &volume_server_pb.SetStateRequest{
-		State: &volume_server_pb.VolumeServerState{
-			Maintenance: true,
-			Version:     stateResp.GetState().GetVersion(),
-		},
-	})
-	if err != nil {
-		t.Fatalf("SetState maintenance=true failed: %v", err)
-	}
+	framework.EnableMaintenanceMode(t, ctx, grpcClient)
 
 	// existing volume in maintenance mode should return "maintenance mode" error
 	_, err = grpcClient.VolumeMarkReadonly(ctx, &volume_server_pb.VolumeMarkReadonlyRequest{VolumeId: volumeID, Persist: true})

--- a/test/volume_server/grpc/scrub_query_test.go
+++ b/test/volume_server/grpc/scrub_query_test.go
@@ -2,10 +2,7 @@ package volume_server_grpc_test
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -443,17 +440,7 @@ func TestScrubVolumeMarkBrokenReadonlyCorruptVolume(t *testing.T) {
 	httpClient := framework.NewHTTPClient()
 	framework.UploadBytes(t, httpClient, clusterHarness.VolumeAdminURL(), framework.NewFileID(volumeID, 1, 1), []byte("test data"))
 
-	// corrupt the index file by appending garbage bytes so CheckIndexFile detects a size mismatch
-	idxPath := filepath.Join(clusterHarness.BaseDir(), "volume", fmt.Sprintf("%d.idx", volumeID))
-	f, err := os.OpenFile(idxPath, os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		t.Fatalf("open idx file for corruption: %v", err)
-	}
-	if _, err := f.Write([]byte{0xDE, 0xAD}); err != nil {
-		f.Close()
-		t.Fatalf("corrupt idx file: %v", err)
-	}
-	f.Close()
+	framework.CorruptIndexFile(t, clusterHarness.BaseDir(), volumeID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -526,39 +513,16 @@ func TestScrubVolumeMarkBrokenReadonlyInMaintenanceMode(t *testing.T) {
 	httpClient := framework.NewHTTPClient()
 	framework.UploadBytes(t, httpClient, clusterHarness.VolumeAdminURL(), framework.NewFileID(volumeID, 1, 1), []byte("test data"))
 
-	// corrupt the index file
-	idxPath := filepath.Join(clusterHarness.BaseDir(), "volume", fmt.Sprintf("%d.idx", volumeID))
-	f, err := os.OpenFile(idxPath, os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		t.Fatalf("open idx file for corruption: %v", err)
-	}
-	if _, err := f.Write([]byte{0xDE, 0xAD}); err != nil {
-		f.Close()
-		t.Fatalf("corrupt idx file: %v", err)
-	}
-	f.Close()
+	framework.CorruptIndexFile(t, clusterHarness.BaseDir(), volumeID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// enter maintenance mode
-	stateResp, err := grpcClient.GetState(ctx, &volume_server_pb.GetStateRequest{})
-	if err != nil {
-		t.Fatalf("GetState failed: %v", err)
-	}
-	_, err = grpcClient.SetState(ctx, &volume_server_pb.SetStateRequest{
-		State: &volume_server_pb.VolumeServerState{
-			Maintenance: true,
-			Version:     stateResp.GetState().GetVersion(),
-		},
-	})
-	if err != nil {
-		t.Fatalf("SetState maintenance=true failed: %v", err)
-	}
+	framework.EnableMaintenanceMode(t, ctx, grpcClient)
 
 	// scrub with the flag in maintenance mode: makeVolumeReadonly should fail
 	// and ScrubVolume should propagate the error
-	_, err = grpcClient.ScrubVolume(ctx, &volume_server_pb.ScrubVolumeRequest{
+	_, err := grpcClient.ScrubVolume(ctx, &volume_server_pb.ScrubVolumeRequest{
 		VolumeIds:                 []uint32{volumeID},
 		Mode:                      volume_server_pb.VolumeScrubMode_INDEX,
 		MarkBrokenVolumesReadonly: true,


### PR DESCRIPTION
## Summary

PR #8360 removed `TestVolumeMarkReadonlyWritableErrorPaths` assertions and added the `mark_broken_volumes_readonly` flag to `ScrubVolume` without corresponding test coverage. This PR restores and extends the tests:

- **Restore maintenance mode assertions for `VolumeMarkReadonly`/`VolumeMarkWritable`**: the original test used a non-existent volume ID, so the refactored check ordering (volume lookup before maintenance check) broke it. Fixed by allocating a real volume and also validating the new ordering (non-existent volumes return "not found" even in maintenance mode).
- **Add `MarkBrokenVolumesReadonly` integration tests**: healthy volume (flag is no-op), corrupt volume (flag=false keeps writable, flag=true marks read-only), and maintenance mode (error propagated from `makeVolumeReadonly` via `errors.Join`).

## Test plan

- [ ] `go vet ./test/volume_server/grpc/...` passes
- [ ] `TestVolumeMarkReadonlyWritableErrorPaths` — maintenance mode rejection + check ordering
- [ ] `TestScrubVolumeMarkBrokenReadonlyHealthyVolume` — flag no-op on clean volumes
- [ ] `TestScrubVolumeMarkBrokenReadonlyCorruptVolume` — corrupt .idx triggers broken detection and read-only marking
- [ ] `TestScrubVolumeMarkBrokenReadonlyInMaintenanceMode` — error propagation from maintenance mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tests covering maintenance mode: verify readonly/writable transitions, error messages for existing volumes, and consistent "not found" behavior for non-existent volumes during maintenance.
  * Added integration tests for scrub behavior: detect broken volumes, auto-mark broken volumes read-only when enabled, and ensure scrubbing fails with maintenance mode enabled; introduced test helpers to corrupt on-disk index and toggle maintenance mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->