### PR TITLE
fix(weed/filer/store_test): fix dropped errors

### DIFF
--- a/weed/filer/store_test/test_suite.go
+++ b/weed/filer/store_test/test_suite.go
@@ -47,11 +47,13 @@ func TestFilerStore(t *testing.T, store filer.FilerStore) {
 	err := store.KvPut(ctx, testKey, testValue1)
 	assert.Nil(t, err, "KV put")
 	value, err := store.KvGet(ctx, testKey)
+	assert.NoError(t, err)
 	assert.Equal(t, value, testValue1, "KV get")
 
 	err = store.KvPut(ctx, testKey, testValue2)
 	assert.Nil(t, err, "KV update")
 	value, err = store.KvGet(ctx, testKey)
+	assert.NoError(t, err)
 	assert.Equal(t, value, testValue2, "KV get after update")
 }
 


### PR DESCRIPTION
This fixes two dropped `err` variables in `weed/filer/store_test`. Unit tests pass both before and after the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened error handling validation in key-value store retrieval operations by adding explicit assertions to test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->