### PR TITLE
sftpd: use global TLS-aware HTTP client for filer uploads

### DIFF
--- a/weed/sftpd/sftp_filer.go
+++ b/weed/sftpd/sftp_filer.go
@@ -324,9 +324,11 @@ func (fs *SftpServer) putFile(filepath string, reader io.Reader, user *user.User
 	dir, filename := util.FullPath(filepath).DirAndName()
 	uploadUrl := fmt.Sprintf("http://%s%s", fs.filerAddr, filepath)
 	// Let the global HTTP client normalize the scheme to https:// when TLS is configured
-	if normalizedUrl, err := util_http.NormalizeUrl(uploadUrl); err == nil {
-		uploadUrl = normalizedUrl
+	normalizedUrl, err := util_http.NormalizeUrl(uploadUrl)
+	if err != nil {
+		return fmt.Errorf("normalize upload url %q: %w", uploadUrl, err)
 	}
+	uploadUrl = normalizedUrl
 
 	// Compute MD5 while uploading
 	hash := md5.New()


### PR DESCRIPTION
Fixes #8794

## Summary
- `putFile()` hardcoded `http://` and used `http.DefaultClient`, so SFTP file uploads failed when the filer had HTTPS/TLS enabled
- Switch to the global HTTP client (`util_http.Do`) which reads `[https.client]` from `security.toml`, automatically normalizes the URL scheme to `https://` when TLS is configured, and uses the proper TLS transport

## Test plan
- [ ] Verify SFTP uploads work with a filer that has `[https.filer]` configured in `security.toml`
- [ ] Verify SFTP uploads still work with plain HTTP filer (no TLS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable file uploads: upload URLs are now normalized and handled more robustly, improving compatibility with secure/insecure endpoints and reducing failed transfers. HTTP upload handling has been adjusted for greater stability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->