### PR TITLE
chore(feed/worker): prune unused registerWorker()

### DIFF
--- a/weed/worker/worker.go
+++ b/weed/worker/worker.go
@@ -833,24 +833,6 @@ func (w *Worker) GetTaskRegistry() *tasks.TaskRegistry {
 	return w.registry
 }
 
-// registerWorker registers the worker with the admin server
-func (w *Worker) registerWorker() {
-	workerInfo := &types.WorkerData{
-		ID:            w.id,
-		Capabilities:  w.config.Capabilities,
-		MaxConcurrent: w.config.MaxConcurrent,
-		Status:        "active",
-		CurrentLoad:   0,
-		LastHeartbeat: time.Now(),
-	}
-
-	if err := w.getAdmin().RegisterWorker(workerInfo); err != nil {
-		glog.Warningf("Failed to register worker (will retry on next heartbeat): %v", err)
-	} else {
-		glog.Infof("Worker %s registered successfully with admin server", w.id)
-	}
-}
-
 // connectionMonitorLoop monitors connection status
 func (w *Worker) connectionMonitorLoop() {
 	ticker := time.NewTicker(30 * time.Second) // Check every 30 seconds


### PR DESCRIPTION
This prunes the unused function `Worker.registerWorker()`, unused in both code and tests. The tests in `feed/worker` continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal worker registration code to streamline the worker initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->