### PR TITLE
s3: support s3:x-amz-server-side-encryption policy condition

### DIFF
--- a/weed/s3api/policy_engine/engine.go
+++ b/weed/s3api/policy_engine/engine.go
@@ -213,10 +213,10 @@ func (engine *PolicyEngine) evaluateStatement(stmt *CompiledStatement, args *Pol
 		condCtx := args.Conditions
 		// Multipart continuation actions (UploadPart, UploadPartCopy) inherit SSE
 		// from CreateMultipartUpload and do not carry their own SSE header.
-		// Treat the SSE header as "present" so Null("true") conditions do not
-		// accidentally deny these operations.
-		if isMultipartContinuationAction(args.Action) {
-			condCtx = injectSSEForMultipart(args.Conditions)
+		// Inject the real inherited algorithm so Null/StringEquals conditions
+		// evaluate against the value that was set at upload initiation.
+		if IsMultipartContinuationAction(args.Action) {
+			condCtx = injectSSEForMultipart(args.Conditions, args.InheritedSSEAlgorithm)
 		}
 		match := EvaluateConditions(stmt.Statement.Condition, condCtx, args.ObjectEntry, args.Claims)
 		if !match {
@@ -465,33 +465,37 @@ func ExtractConditionValuesFromRequest(r *http.Request) map[string][]string {
 	return values
 }
 
-// isMultipartContinuationAction returns true for actions that do not carry
+// IsMultipartContinuationAction returns true for actions that do not carry
 // their own SSE header because SSE is inherited from CreateMultipartUpload.
-func isMultipartContinuationAction(action string) bool {
+func IsMultipartContinuationAction(action string) bool {
 	return action == "s3:UploadPart" || action == "s3:UploadPartCopy"
 }
 
-// injectSSEForMultipart returns a condition context with
-// "s3:x-amz-server-side-encryption" set to "AES256" when the key is absent.
-// UploadPart and UploadPartCopy inherit their SSE algorithm from the original
-// CreateMultipartUpload request and therefore do not re-send the SSE header.
-// Injecting "AES256" makes Null("true") evaluate to false (SSE is treated as
-// present), preventing those actions from being incorrectly denied.
+// injectSSEForMultipart returns a condition context augmented with the
+// inherited SSE algorithm for multipart continuation actions.
 //
-// TODO: look up the actual SSE algorithm stored with the upload ID and inject
-// that value instead. Until then, StringEquals("aws:kms") conditions on
-// s3:x-amz-server-side-encryption will not match KMS-encrypted multipart
-// uploads because "AES256" is used as the stand-in value.
-func injectSSEForMultipart(conditions map[string][]string) map[string][]string {
+// UploadPart and UploadPartCopy do not re-send the SSE header because
+// encryption is set once at CreateMultipartUpload. The caller supplies
+// inheritedSSE (the canonical algorithm, e.g. "AES256" or "aws:kms") so
+// that Null/StringEquals conditions on s3:x-amz-server-side-encryption
+// evaluate against the real value.
+//
+// If inheritedSSE is empty (no SSE was requested at initiation), the
+// conditions map is returned unchanged so Null("true") will correctly
+// match and deny the request.
+func injectSSEForMultipart(conditions map[string][]string, inheritedSSE string) map[string][]string {
 	const sseKey = "s3:x-amz-server-side-encryption"
+	if inheritedSSE == "" {
+		return conditions // no SSE at upload initiation; let Null("true") fire
+	}
 	if _, exists := conditions[sseKey]; exists {
-		return conditions // SSE header was actually sent; no injection needed
+		return conditions // SSE header was actually sent on this request
 	}
 	modified := make(map[string][]string, len(conditions)+1)
 	for k, v := range conditions {
 		modified[k] = v
 	}
-	modified[sseKey] = []string{"AES256"}
+	modified[sseKey] = []string{inheritedSSE}
 	return modified
 }
 

--- a/weed/s3api/policy_engine/sse_condition_test.go
+++ b/weed/s3api/policy_engine/sse_condition_test.go
@@ -100,6 +100,16 @@ func evalArgs(action string, conditions map[string][]string) *PolicyEvaluationAr
 	}
 }
 
+func evalArgsWithSSE(action, inheritedSSE string) *PolicyEvaluationArgs {
+	return &PolicyEvaluationArgs{
+		Action:                action,
+		Resource:              "arn:aws:s3:::test-bucket/object.txt",
+		Principal:             "*",
+		Conditions:            map[string][]string{},
+		InheritedSSEAlgorithm: inheritedSSE,
+	}
+}
+
 // TestSSEStringEqualsPresent – StringEquals with AES256 header present should Allow.
 func TestSSEStringEqualsPresent(t *testing.T) {
 	engine := newEngineWithPolicy(t, requiresAES256Policy)
@@ -184,24 +194,47 @@ func TestSSECaseInsensitiveNormalizationKMS(t *testing.T) {
 	}
 }
 
-// TestSSEMultipartContinuationExempt – UploadPart should not be blocked by SSE Null condition.
-func TestSSEMultipartContinuationExempt(t *testing.T) {
+// TestSSEMultipartAES256Exempt – UploadPart with AES256 inherited from
+// CreateMultipartUpload is not blocked by the Null("true") deny condition.
+func TestSSEMultipartAES256Exempt(t *testing.T) {
 	engine := newEngineWithPolicy(t, multipartPolicy)
 
-	// UploadPart carries no SSE header (inherited from CreateMultipartUpload)
-	result := engine.EvaluatePolicy("test-bucket", evalArgs("s3:UploadPart", map[string][]string{}))
+	result := engine.EvaluatePolicy("test-bucket", evalArgsWithSSE("s3:UploadPart", "AES256"))
 	if result == PolicyResultDeny {
-		t.Errorf("UploadPart should not be denied by SSE Null condition, got Deny")
+		t.Errorf("UploadPart with inherited AES256 should not be Deny, got Deny")
 	}
 }
 
-// TestSSEUploadPartCopyExempt – UploadPartCopy should also be exempt.
-func TestSSEUploadPartCopyExempt(t *testing.T) {
+// TestSSEMultipartKMSExempt – UploadPart with aws:kms inherited from
+// CreateMultipartUpload is not blocked by the Null("true") deny condition.
+func TestSSEMultipartKMSExempt(t *testing.T) {
 	engine := newEngineWithPolicy(t, multipartPolicy)
 
-	result := engine.EvaluatePolicy("test-bucket", evalArgs("s3:UploadPartCopy", map[string][]string{}))
+	result := engine.EvaluatePolicy("test-bucket", evalArgsWithSSE("s3:UploadPart", "aws:kms"))
 	if result == PolicyResultDeny {
-		t.Errorf("UploadPartCopy should not be denied by SSE Null condition, got Deny")
+		t.Errorf("UploadPart with inherited aws:kms should not be Deny, got Deny")
+	}
+}
+
+// TestSSEMultipartNoSSEDenied – UploadPart for an upload that had no SSE
+// must still be denied by the Null("true") deny condition.
+func TestSSEMultipartNoSSEDenied(t *testing.T) {
+	engine := newEngineWithPolicy(t, multipartPolicy)
+
+	// inheritedSSE="" means CreateMultipartUpload was sent without SSE
+	result := engine.EvaluatePolicy("test-bucket", evalArgsWithSSE("s3:UploadPart", ""))
+	if result != PolicyResultDeny {
+		t.Errorf("UploadPart with no inherited SSE should be Deny, got %v", result)
+	}
+}
+
+// TestSSEUploadPartCopyKMSExempt – UploadPartCopy with aws:kms is also exempt.
+func TestSSEUploadPartCopyKMSExempt(t *testing.T) {
+	engine := newEngineWithPolicy(t, multipartPolicy)
+
+	result := engine.EvaluatePolicy("test-bucket", evalArgsWithSSE("s3:UploadPartCopy", "aws:kms"))
+	if result == PolicyResultDeny {
+		t.Errorf("UploadPartCopy with inherited aws:kms should not be Deny, got Deny")
 	}
 }
 

--- a/weed/s3api/policy_engine/types.go
+++ b/weed/s3api/policy_engine/types.go
@@ -172,6 +172,10 @@ type PolicyEvaluationArgs struct {
 	ObjectEntry map[string][]byte
 	// Claims are JWT claims for jwt:* policy variables (can be nil)
 	Claims map[string]interface{}
+	// InheritedSSEAlgorithm is the canonical SSE algorithm ("AES256" or "aws:kms")
+	// inherited from the CreateMultipartUpload request for UploadPart and
+	// UploadPartCopy actions. The empty string means no SSE was used.
+	InheritedSSEAlgorithm string
 }
 
 // PolicyCache for caching compiled policies

--- a/weed/s3api/s3api_bucket_policy_engine.go
+++ b/weed/s3api/s3api_bucket_policy_engine.go
@@ -13,6 +13,11 @@ import (
 // BucketPolicyEngine wraps the policy_engine to provide bucket policy evaluation
 type BucketPolicyEngine struct {
 	engine *policy_engine.PolicyEngine
+	// MultipartSSELookup retrieves the canonical SSE algorithm ("AES256" or
+	// "aws:kms") that was stored when a multipart upload was initiated.
+	// Returns "" when the upload had no SSE or when the entry cannot be found.
+	// Set by S3ApiServer after construction to give the engine filer access.
+	MultipartSSELookup func(bucket, uploadID string) string
 }
 
 // NewBucketPolicyEngine creates a new bucket policy engine
@@ -155,6 +160,16 @@ func (bpe *BucketPolicyEngine) EvaluatePolicy(bucket, object, action, principal 
 			// If claims were not provided directly, try to get them from context Identity?
 			// But the caller is responsible for passing them.
 			// Falling back to empty claims if not provided.
+		}
+
+		// For multipart continuation actions look up the SSE algorithm that was
+		// set at CreateMultipartUpload time. UploadPart/UploadPartCopy do not
+		// re-send the SSE header, so we inject the stored value so that bucket
+		// policy conditions on s3:x-amz-server-side-encryption evaluate correctly.
+		if policy_engine.IsMultipartContinuationAction(s3Action) && bpe.MultipartSSELookup != nil {
+			if uploadID := r.URL.Query().Get("uploadId"); uploadID != "" {
+				args.InheritedSSEAlgorithm = bpe.MultipartSSELookup(bucket, uploadID)
+			}
 		}
 	}
 

--- a/weed/s3api/s3api_object_handlers_multipart.go
+++ b/weed/s3api/s3api_object_handlers_multipart.go
@@ -471,6 +471,25 @@ func (s3a *S3ApiServer) genUploadsFolder(bucket string) string {
 	return fmt.Sprintf("%s/%s", s3a.bucketDir(bucket), s3_constants.MultipartUploadsFolder)
 }
 
+// getMultipartSSEAlgorithm returns the canonical SSE algorithm ("AES256" or
+// "aws:kms") that was stored when the multipart upload was initiated, or ""
+// if the upload entry is not found or had no SSE. It is used by the bucket
+// policy engine to evaluate s3:x-amz-server-side-encryption conditions for
+// UploadPart and UploadPartCopy, which do not re-send the SSE header.
+func (s3a *S3ApiServer) getMultipartSSEAlgorithm(bucket, uploadID string) string {
+	entry, err := s3a.getEntry(s3a.genUploadsFolder(bucket), uploadID)
+	if err != nil || entry == nil || entry.Extended == nil {
+		return ""
+	}
+	if _, ok := entry.Extended[s3_constants.SeaweedFSSSEKMSKeyID]; ok {
+		return "aws:kms"
+	}
+	if _, ok := entry.Extended[s3_constants.SeaweedFSSSES3Encryption]; ok {
+		return "AES256"
+	}
+	return ""
+}
+
 func (s3a *S3ApiServer) genPartUploadPath(bucket, uploadID string, partID int) string {
 	// Returns just the file path - no filer address needed
 	// Upload traffic goes directly to volume servers, not through filer

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -189,6 +189,11 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 	// This avoids circular dependency by not passing the entire S3ApiServer
 	iam.policyEngine = policyEngine
 
+	// Give the policy engine a way to look up the SSE algorithm that was
+	// stored at CreateMultipartUpload time, so that UploadPart/UploadPartCopy
+	// policy conditions on s3:x-amz-server-side-encryption evaluate correctly.
+	policyEngine.MultipartSSELookup = s3ApiServer.getMultipartSSEAlgorithm
+
 	// Initialize advanced IAM system if config is provided or explicitly enabled
 	if option.IamConfig != "" || option.EnableIam {
 		configSource := "defaults"


### PR DESCRIPTION
Closes #7680

## Summary

- **Value normalisation**: `ExtractConditionValuesFromRequest` now normalises the `s3:x-amz-server-side-encryption` condition key to canonical uppercase form (`aes256` → `AES256`, `aws:kms` in any case → `aws:kms`). This ensures `StringEquals` policy conditions work regardless of how the client capitalises the header.

- **Multipart continuation exemption**: `UploadPart` and `UploadPartCopy` do not carry their own SSE header — encryption is inherited from the initial `CreateMultipartUpload`. A new helper `injectSSEForMultipart` injects a synthetic SSE value into the condition evaluation context so that `Null: {s3:x-amz-server-side-encryption: "true"}` deny policies do not block in-progress multipart uploads.

- **Tests** (`sse_condition_test.go`): covers `StringEquals` with correct/wrong value, `Null` condition when header is absent vs present, case-insensitive normalisation, and the multipart continuation exemption for both `UploadPart` and `UploadPartCopy`.

## Test plan

- [ ] `go test ./weed/s3api/policy_engine/...` passes (7 new tests green)
- [ ] `go build ./...` passes
- [ ] Manually verify: bucket policy with `Deny + Null: {s3:x-amz-server-side-encryption: true}` allows `PutObject` with `AES256` header and blocks `PutObject` without it, while `UploadPart` is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * S3 multipart uploads now properly inherit and respect the server-side encryption algorithm set at `CreateMultipartUpload` time, ensuring encryption policies are consistently enforced for `UploadPart` and `UploadPartCopy` operations.
  * SSE header values are normalized for case-insensitive policy matching, allowing policy conditions to evaluate correctly regardless of client capitalization.

* **Tests**
  * Added comprehensive test coverage for encryption-related policy conditions and multipart upload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->