### PR TITLE
lifecycle worker: scan-time rule evaluation for object expiration

### DIFF
--- a/weed/plugin/worker/lifecycle/execution.go
+++ b/weed/plugin/worker/lifecycle/execution.go
@@ -349,6 +349,9 @@ func nowUnix() int64 {
 
 // listExpiredObjectsByRules scans a bucket directory tree and evaluates
 // lifecycle rules against each object using the s3lifecycle evaluator.
+// This function handles non-versioned objects (IsLatest=true). Versioned
+// objects in .versions directories are handled by processVersionsDirectory
+// (added in a separate change for NoncurrentVersionExpiration support).
 func listExpiredObjectsByRules(
 	ctx context.Context,
 	client filer_pb.SeaweedFilerClient,

--- a/weed/plugin/worker/lifecycle/rules.go
+++ b/weed/plugin/worker/lifecycle/rules.go
@@ -116,6 +116,8 @@ func parseLifecycleXML(data []byte) ([]s3lifecycle.Rule, error) {
 		case r.Filter.Tag.Key != "":
 			rule.Prefix = r.Filter.Prefix
 			rule.FilterTags = map[string]string{r.Filter.Tag.Key: r.Filter.Tag.Value}
+			rule.FilterSizeGreaterThan = r.Filter.ObjectSizeGreaterThan
+			rule.FilterSizeLessThan = r.Filter.ObjectSizeLessThan
 		default:
 			if r.Filter.Prefix != "" {
 				rule.Prefix = r.Filter.Prefix

--- a/weed/plugin/worker/lifecycle/rules_test.go
+++ b/weed/plugin/worker/lifecycle/rules_test.go
@@ -65,6 +65,9 @@ func TestParseLifecycleXML_PrefixFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseLifecycleXML: %v", err)
 	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
 	if rules[0].Prefix != "logs/" {
 		t.Errorf("expected Prefix='logs/', got %q", rules[0].Prefix)
 	}
@@ -84,6 +87,9 @@ func TestParseLifecycleXML_LegacyPrefix(t *testing.T) {
 	rules, err := parseLifecycleXML(xml)
 	if err != nil {
 		t.Fatalf("parseLifecycleXML: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
 	}
 	if rules[0].Prefix != "archive/" {
 		t.Errorf("expected Prefix='archive/', got %q", rules[0].Prefix)
@@ -105,6 +111,9 @@ func TestParseLifecycleXML_TagFilter(t *testing.T) {
 	rules, err := parseLifecycleXML(xml)
 	if err != nil {
 		t.Fatalf("parseLifecycleXML: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
 	}
 	r := rules[0]
 	if len(r.FilterTags) != 1 || r.FilterTags["env"] != "dev" {
@@ -131,6 +140,9 @@ func TestParseLifecycleXML_AndFilter(t *testing.T) {
 	rules, err := parseLifecycleXML(xml)
 	if err != nil {
 		t.Fatalf("parseLifecycleXML: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
 	}
 	r := rules[0]
 	if r.Prefix != "data/" {


### PR DESCRIPTION
## Summary
- Add lifecycle XML parsing and conversion to evaluator rules (`rules.go`)
- Update execution to try lifecycle XML evaluation first, with TTL fallback
- New `listExpiredObjectsByRules()` evaluates rules against each object during scan
- Supports Expiration.Days, Expiration.Date, Filter.Prefix, Filter.Tag, Filter.And, Filter.ObjectSize*
- Skip objects already handled by TTL fast path (optimization)
- Extract tags only when rules need them (optimization)

Depends on #8807 and #8808.

## Test plan
- [x] XML parsing tests for all rule types and filter variants
- [x] Date parsing tests (RFC3339, ISO 8601)
- [x] All existing lifecycle tests pass
- [ ] `go test ./weed/plugin/worker/lifecycle/... ./weed/s3api/s3lifecycle/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added S3 lifecycle rules support with automatic loading and evaluation from bucket metadata
  - Implemented intelligent fallback to TTL-based object expiration when lifecycle rules are unavailable
  - Updated expired object scanning with improved progress reporting

* **Tests**
  - Added comprehensive test coverage for lifecycle rules parsing and date handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->