### PR TITLE
lifecycle worker: fix ExpiredObjectDeleteMarker to match AWS semantics

### DIFF
--- a/weed/plugin/worker/lifecycle/execution.go
+++ b/weed/plugin/worker/lifecycle/execution.go
@@ -345,7 +345,7 @@ func isDeleteMarker(entry *filer_pb.Entry) bool {
 }
 
 // matchesDeleteMarkerRule checks if any enabled ExpiredObjectDeleteMarker rule
-// matches the given object key (respecting the rule's prefix filter).
+// matches the given object key using the full filter model (prefix, tags, size).
 // When no lifecycle rules are provided (nil means no XML configured),
 // falls back to legacy behavior (returns true to allow cleanup).
 // A non-nil empty slice means XML was present but had no matching rules,
@@ -354,8 +354,10 @@ func matchesDeleteMarkerRule(rules []s3lifecycle.Rule, objKey string) bool {
 	if rules == nil {
 		return true // legacy fallback: no lifecycle XML configured
 	}
+	// Delete markers have no size or tags, so build a minimal ObjectInfo.
+	obj := s3lifecycle.ObjectInfo{Key: objKey}
 	for _, r := range rules {
-		if r.Status == "Enabled" && r.ExpiredObjectDeleteMarker && strings.HasPrefix(objKey, r.Prefix) {
+		if r.Status == "Enabled" && r.ExpiredObjectDeleteMarker && s3lifecycle.MatchesFilter(r, obj) {
 			return true
 		}
 	}

--- a/weed/plugin/worker/lifecycle/execution_test.go
+++ b/weed/plugin/worker/lifecycle/execution_test.go
@@ -1,0 +1,72 @@
+package lifecycle
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+func TestMatchesDeleteMarkerRule(t *testing.T) {
+	t.Run("nil_rules_legacy_fallback", func(t *testing.T) {
+		if !matchesDeleteMarkerRule(nil, "any/key") {
+			t.Error("nil rules should return true (legacy fallback)")
+		}
+	})
+
+	t.Run("empty_rules_xml_present_no_match", func(t *testing.T) {
+		rules := []s3lifecycle.Rule{}
+		if matchesDeleteMarkerRule(rules, "any/key") {
+			t.Error("empty rules (XML present) should return false")
+		}
+	})
+
+	t.Run("matching_prefix_rule", func(t *testing.T) {
+		rules := []s3lifecycle.Rule{
+			{ID: "cleanup", Status: "Enabled", Prefix: "logs/", ExpiredObjectDeleteMarker: true},
+		}
+		if !matchesDeleteMarkerRule(rules, "logs/app.log") {
+			t.Error("should match rule with matching prefix")
+		}
+	})
+
+	t.Run("non_matching_prefix", func(t *testing.T) {
+		rules := []s3lifecycle.Rule{
+			{ID: "cleanup", Status: "Enabled", Prefix: "logs/", ExpiredObjectDeleteMarker: true},
+		}
+		if matchesDeleteMarkerRule(rules, "data/file.txt") {
+			t.Error("should not match rule with non-matching prefix")
+		}
+	})
+
+	t.Run("disabled_rule", func(t *testing.T) {
+		rules := []s3lifecycle.Rule{
+			{ID: "cleanup", Status: "Disabled", ExpiredObjectDeleteMarker: true},
+		}
+		if matchesDeleteMarkerRule(rules, "any/key") {
+			t.Error("disabled rule should not match")
+		}
+	})
+
+	t.Run("rule_without_delete_marker_flag", func(t *testing.T) {
+		rules := []s3lifecycle.Rule{
+			{ID: "expire", Status: "Enabled", ExpirationDays: 30},
+		}
+		if matchesDeleteMarkerRule(rules, "any/key") {
+			t.Error("rule without ExpiredObjectDeleteMarker should not match")
+		}
+	})
+
+	t.Run("tag_filtered_rule_no_tags_on_marker", func(t *testing.T) {
+		rules := []s3lifecycle.Rule{
+			{
+				ID: "tagged", Status: "Enabled",
+				ExpiredObjectDeleteMarker: true,
+				FilterTags:               map[string]string{"env": "dev"},
+			},
+		}
+		// Delete markers have no tags, so a tag-filtered rule should not match.
+		if matchesDeleteMarkerRule(rules, "any/key") {
+			t.Error("tag-filtered rule should not match delete marker (no tags)")
+		}
+	})
+}

--- a/weed/s3api/s3lifecycle/evaluator.go
+++ b/weed/s3api/s3lifecycle/evaluator.go
@@ -18,7 +18,7 @@ func Evaluate(rules []Rule, obj ObjectInfo, now time.Time) EvalResult {
 			if rule.Status != "Enabled" {
 				continue
 			}
-			if !matchesFilter(rule, obj) {
+			if !MatchesFilter(rule, obj) {
 				continue
 			}
 			if rule.ExpiredObjectDeleteMarker {
@@ -42,7 +42,7 @@ func Evaluate(rules []Rule, obj ObjectInfo, now time.Time) EvalResult {
 			if rule.Status != "Enabled" {
 				continue
 			}
-			if !matchesFilter(rule, obj) {
+			if !MatchesFilter(rule, obj) {
 				continue
 			}
 			// Date-based expiration
@@ -76,7 +76,7 @@ func ShouldExpireNoncurrentVersion(rule Rule, obj ObjectInfo, noncurrentIndex in
 	if obj.IsLatest || obj.SuccessorModTime.IsZero() {
 		return false
 	}
-	if !matchesFilter(rule, obj) {
+	if !MatchesFilter(rule, obj) {
 		return false
 	}
 

--- a/weed/s3api/s3lifecycle/filter.go
+++ b/weed/s3api/s3lifecycle/filter.go
@@ -2,9 +2,9 @@ package s3lifecycle
 
 import "strings"
 
-// matchesFilter checks if an object matches the rule's filter criteria
+// MatchesFilter checks if an object matches the rule's filter criteria
 // (prefix, tags, and size constraints).
-func matchesFilter(rule Rule, obj ObjectInfo) bool {
+func MatchesFilter(rule Rule, obj ObjectInfo) bool {
 	if !matchesPrefix(rule.Prefix, obj.Key) {
 		return false
 	}


### PR DESCRIPTION
## Summary
- Rewrite `cleanupDeleteMarkers()` to only remove delete markers that are the **sole remaining version** of an object
- Previously delete markers were removed unconditionally, which could resurface older versions in versioned buckets (known bug with NOTE comment)
- New algorithm checks `.versions` directory metadata and version count before removal
- Requires `ExpiredObjectDeleteMarker=true` rule when lifecycle XML is present
- Cleans up empty `.versions` directories after marker removal

Depends on #8807, #8808, #8809, #8810.

## Test plan
- [x] Existing tests pass
- [ ] `go test ./weed/plugin/worker/lifecycle/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced S3 lifecycle delete marker cleanup behavior to align with AWS ExpiredObjectDeleteMarker rules, ensuring delete markers are only removed when lifecycle rules match and specific conditions are met.

* **Tests**
  * Added comprehensive test coverage for delete marker rule matching logic across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->