### PR TITLE
ci: add Trivy CVE scan to container release workflow

### DIFF
--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -172,8 +172,8 @@ jobs:
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Run Trivy vulnerability scanner
-        # Pin to specific release to avoid unexpected upstream changes
-        uses: aquasecurity/trivy-action@0.28.0
+        # Pin to SHA — mutable tags were compromised (GHSA-69fq-xp46-6x23)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           # Scan amd64 only — OS packages are identical across architectures
           # since they all use the same alpine base, so a single-arch scan


### PR DESCRIPTION
## Summary
- Adds a Trivy vulnerability scan job to the `container_latest.yml` workflow that scans built images for HIGH and CRITICAL CVEs before publishing
- Uploads scan results as SARIF to GitHub Security tab for visibility
- Gates the `create-manifest` job on scan completion so vulnerable images aren't published without review

Closes #8817

## Test plan
- [ ] Trigger a manual workflow dispatch and verify the `trivy-scan` job runs after `build`
- [ ] Verify SARIF results appear in the repository's Security > Code scanning tab
- [ ] Verify `create-manifest` waits for `trivy-scan` to complete before running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated automated container image vulnerability scanning into the CI/CD pipeline.
  * Scan results are captured and uploaded to GitHub's security reporting so issues are visible in security tooling.
  * The build flow now includes a security verification step before release manifest creation, and workflow permissions were extended to allow security-event reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->