### PR TITLE
lifecycle worker: expire latest version in versioned buckets

### DIFF
--- a/weed/plugin/worker/lifecycle/execution.go
+++ b/weed/plugin/worker/lifecycle/execution.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -173,6 +174,9 @@ func (h *Handler) executeLifecycleForBucket(
 				Message:         fmt.Sprintf("deleted %d/%d expired objects", result.objectsExpired, len(expired)),
 			})
 		}
+
+		// Clean up .versions directories left empty after version deletion.
+		cleanupEmptyVersionsDirectories(ctx, filerClient, expired)
 
 		remaining -= result.objectsExpired + result.errors
 		if remaining < 0 {
@@ -541,8 +545,22 @@ func listExpiredObjectsByRules(
 					return nil // skip .uploads at bucket root only
 				}
 				if strings.HasSuffix(entry.Name, s3_constants.VersionsFolder) {
-					// Process versioned object.
 					versionsDir := path.Join(dir, entry.Name)
+
+					// Evaluate Expiration rules against the latest version.
+					// In versioned buckets, data lives in .versions/ directories,
+					// so we must evaluate the latest version here — it is never
+					// seen as a regular file entry in the parent directory.
+					if obj, ok := latestVersionExpiredByRules(entry, versionsDir, bucketPath, rules, now, needTags); ok {
+						expired = append(expired, obj)
+						scanned++
+						if limit > 0 && int64(len(expired)) >= limit {
+							limitReached = true
+							return errLimitReached
+						}
+					}
+
+					// Process noncurrent versions.
 					vExpired, vScanned, vErr := processVersionsDirectory(ctx, client, versionsDir, bucketPath, rules, now, needTags, limit-int64(len(expired)))
 					if vErr != nil {
 						glog.V(1).Infof("s3_lifecycle: %v", vErr)
@@ -716,6 +734,119 @@ func processVersionsDirectory(
 	}
 
 	return expired, scanned, nil
+}
+
+// latestVersionExpiredByRules evaluates Expiration rules (Days/Date) against
+// the latest version in a .versions directory. In versioned buckets all data
+// lives inside .versions/ directories, so the latest version is never seen as
+// a regular file entry during the bucket walk. Without this check, Expiration
+// rules would never fire for versioned objects (issue #8757).
+//
+// The .versions directory entry caches metadata about the latest version in
+// its Extended attributes, so we can evaluate expiration without an extra
+// filer round-trip.
+func latestVersionExpiredByRules(
+	dirEntry *filer_pb.Entry,
+	versionsDir, bucketPath string,
+	rules []s3lifecycle.Rule,
+	now time.Time,
+	needTags bool,
+) (expiredObject, bool) {
+	if dirEntry.Extended == nil {
+		return expiredObject{}, false
+	}
+
+	// Skip if the latest version is a delete marker — those are handled
+	// by the ExpiredObjectDeleteMarker rule in cleanupDeleteMarkers.
+	if string(dirEntry.Extended[s3_constants.ExtLatestVersionIsDeleteMarker]) == "true" {
+		return expiredObject{}, false
+	}
+
+	latestFileName := string(dirEntry.Extended[s3_constants.ExtLatestVersionFileNameKey])
+	if latestFileName == "" {
+		return expiredObject{}, false
+	}
+
+	// Derive the object key: /buckets/b/path/key.versions → path/key
+	relDir := strings.TrimPrefix(versionsDir, bucketPath+"/")
+	objKey := strings.TrimSuffix(relDir, s3_constants.VersionsFolder)
+
+	objInfo := s3lifecycle.ObjectInfo{
+		Key:      objKey,
+		IsLatest: true,
+	}
+
+	// Populate ModTime from cached metadata.
+	if mtimeStr := string(dirEntry.Extended[s3_constants.ExtLatestVersionMtimeKey]); mtimeStr != "" {
+		if mtime, err := strconv.ParseInt(mtimeStr, 10, 64); err == nil {
+			objInfo.ModTime = time.Unix(mtime, 0)
+		}
+	}
+	if objInfo.ModTime.IsZero() && dirEntry.Attributes != nil && dirEntry.Attributes.Mtime > 0 {
+		objInfo.ModTime = time.Unix(dirEntry.Attributes.Mtime, 0)
+	}
+
+	// Populate Size from cached metadata.
+	if sizeStr := string(dirEntry.Extended[s3_constants.ExtLatestVersionSizeKey]); sizeStr != "" {
+		if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
+			objInfo.Size = size
+		}
+	}
+
+	if needTags {
+		objInfo.Tags = s3lifecycle.ExtractTags(dirEntry.Extended)
+	}
+
+	result := s3lifecycle.Evaluate(rules, objInfo, now)
+	if result.Action == s3lifecycle.ActionDeleteObject {
+		return expiredObject{dir: versionsDir, name: latestFileName}, true
+	}
+
+	return expiredObject{}, false
+}
+
+// cleanupEmptyVersionsDirectories removes .versions directories that became
+// empty after their contents were deleted. This is called after
+// deleteExpiredObjects to avoid leaving orphaned directories.
+func cleanupEmptyVersionsDirectories(
+	ctx context.Context,
+	client filer_pb.SeaweedFilerClient,
+	deleted []expiredObject,
+) int {
+	// Collect unique .versions directories that had entries deleted.
+	versionsDirs := map[string]struct{}{}
+	for _, obj := range deleted {
+		if strings.HasSuffix(obj.dir, s3_constants.VersionsFolder) {
+			versionsDirs[obj.dir] = struct{}{}
+		}
+	}
+
+	cleaned := 0
+	for vDir := range versionsDirs {
+		if ctx.Err() != nil {
+			break
+		}
+		// Check if the directory is now empty.
+		empty := true
+		_ = filer_pb.SeaweedList(ctx, client, vDir, "", func(entry *filer_pb.Entry, isLast bool) error {
+			empty = false
+			return errLimitReached // stop after first entry
+		}, "", false, 1)
+
+		if !empty {
+			continue
+		}
+
+		// Remove the empty .versions directory.
+		parentDir, dirName := path.Split(vDir)
+		parentDir = strings.TrimSuffix(parentDir, "/")
+		if err := filer_pb.DoRemove(ctx, client, parentDir, dirName, false, true, true, false, nil); err != nil {
+			glog.V(1).Infof("s3_lifecycle: failed to clean up empty versions dir %s: %v", vDir, err)
+		} else {
+			cleaned++
+		}
+	}
+	return cleaned
 }
 
 // sortVersionsByVersionId sorts version entries newest-first using full

--- a/weed/plugin/worker/lifecycle/integration_test.go
+++ b/weed/plugin/worker/lifecycle/integration_test.go
@@ -527,3 +527,249 @@ func TestIntegration_DeleteExpiredObjects(t *testing.T) {
 		t.Error("to-keep.txt should still exist")
 	}
 }
+
+// TestIntegration_VersionedBucket_ExpirationDays verifies that Expiration.Days
+// rules correctly detect and delete the latest version in a versioned bucket
+// where all data lives in .versions/ directories (issue #8757).
+func TestIntegration_VersionedBucket_ExpirationDays(t *testing.T) {
+	server, client := startTestFiler(t)
+	bucketsPath := "/buckets"
+	bucket := "versioned-expire"
+	bucketDir := bucketsPath + "/" + bucket
+
+	now := time.Now()
+	old := now.Add(-60 * 24 * time.Hour)    // 60 days ago — should expire
+	recent := now.Add(-5 * 24 * time.Hour)  // 5 days ago — should NOT expire
+
+	vidOld := testVersionId(old)
+	vidRecent := testVersionId(recent)
+
+	server.putEntry(bucketsPath, &filer_pb.Entry{Name: bucket, IsDirectory: true})
+
+	// --- Single-version object (old, should expire) ---
+	server.putEntry(bucketDir, &filer_pb.Entry{
+		Name: "old-file.txt" + s3_constants.VersionsFolder, IsDirectory: true,
+		Extended: map[string][]byte{
+			s3_constants.ExtLatestVersionIdKey:         []byte(vidOld),
+			s3_constants.ExtLatestVersionFileNameKey:    []byte("v_" + vidOld),
+			s3_constants.ExtLatestVersionMtimeKey:       []byte(strconv.FormatInt(old.Unix(), 10)),
+			s3_constants.ExtLatestVersionSizeKey:        []byte("3400000000"),
+			s3_constants.ExtLatestVersionIsDeleteMarker: []byte("false"),
+		},
+	})
+	oldVersionsDir := bucketDir + "/old-file.txt" + s3_constants.VersionsFolder
+	server.putEntry(oldVersionsDir, &filer_pb.Entry{
+		Name:       "v_" + vidOld,
+		Attributes: &filer_pb.FuseAttributes{Mtime: old.Unix(), FileSize: 3400000000},
+		Extended: map[string][]byte{
+			s3_constants.ExtVersionIdKey: []byte(vidOld),
+		},
+	})
+
+	// --- Single-version object (recent, should NOT expire) ---
+	server.putEntry(bucketDir, &filer_pb.Entry{
+		Name: "recent-file.txt" + s3_constants.VersionsFolder, IsDirectory: true,
+		Extended: map[string][]byte{
+			s3_constants.ExtLatestVersionIdKey:         []byte(vidRecent),
+			s3_constants.ExtLatestVersionFileNameKey:    []byte("v_" + vidRecent),
+			s3_constants.ExtLatestVersionMtimeKey:       []byte(strconv.FormatInt(recent.Unix(), 10)),
+			s3_constants.ExtLatestVersionSizeKey:        []byte("3400000000"),
+			s3_constants.ExtLatestVersionIsDeleteMarker: []byte("false"),
+		},
+	})
+	recentVersionsDir := bucketDir + "/recent-file.txt" + s3_constants.VersionsFolder
+	server.putEntry(recentVersionsDir, &filer_pb.Entry{
+		Name:       "v_" + vidRecent,
+		Attributes: &filer_pb.FuseAttributes{Mtime: recent.Unix(), FileSize: 3400000000},
+		Extended: map[string][]byte{
+			s3_constants.ExtVersionIdKey: []byte(vidRecent),
+		},
+	})
+
+	// --- Object with delete marker as latest (should NOT be expired by Expiration.Days) ---
+	vidMarker := testVersionId(old)
+	server.putEntry(bucketDir, &filer_pb.Entry{
+		Name: "deleted-obj.txt" + s3_constants.VersionsFolder, IsDirectory: true,
+		Extended: map[string][]byte{
+			s3_constants.ExtLatestVersionIdKey:         []byte(vidMarker),
+			s3_constants.ExtLatestVersionFileNameKey:    []byte("v_" + vidMarker),
+			s3_constants.ExtLatestVersionMtimeKey:       []byte(strconv.FormatInt(old.Unix(), 10)),
+			s3_constants.ExtLatestVersionIsDeleteMarker: []byte("true"),
+		},
+	})
+
+	rules := []s3lifecycle.Rule{{
+		ID: "expire-30d", Status: "Enabled",
+		ExpirationDays: 30,
+	}}
+
+	expired, scanned, err := listExpiredObjectsByRules(context.Background(), client, bucketsPath, bucket, rules, 100)
+	if err != nil {
+		t.Fatalf("listExpiredObjectsByRules: %v", err)
+	}
+
+	// Only old-file.txt's latest version should be expired.
+	// recent-file.txt is too young; deleted-obj.txt is a delete marker.
+	if len(expired) != 1 {
+		t.Fatalf("expected 1 expired, got %d: %+v", len(expired), expired)
+	}
+	if expired[0].dir != oldVersionsDir {
+		t.Errorf("expected dir=%s, got %s", oldVersionsDir, expired[0].dir)
+	}
+	if expired[0].name != "v_"+vidOld {
+		t.Errorf("expected name=v_%s, got %s", vidOld, expired[0].name)
+	}
+	// The old-file.txt latest version should count as scanned.
+	if scanned < 1 {
+		t.Errorf("expected at least 1 scanned, got %d", scanned)
+	}
+}
+
+// TestIntegration_VersionedBucket_ExpirationDays_DeleteAndCleanup verifies
+// end-to-end deletion and .versions directory cleanup for a single-version
+// versioned object expired by Expiration.Days.
+func TestIntegration_VersionedBucket_ExpirationDays_DeleteAndCleanup(t *testing.T) {
+	server, client := startTestFiler(t)
+	bucketsPath := "/buckets"
+	bucket := "versioned-cleanup"
+	bucketDir := bucketsPath + "/" + bucket
+
+	now := time.Now()
+	old := now.Add(-60 * 24 * time.Hour)
+	vidOld := testVersionId(old)
+
+	server.putEntry(bucketsPath, &filer_pb.Entry{Name: bucket, IsDirectory: true})
+
+	// Single-version object that should expire.
+	versionsDir := bucketDir + "/data.bin" + s3_constants.VersionsFolder
+	server.putEntry(bucketDir, &filer_pb.Entry{
+		Name: "data.bin" + s3_constants.VersionsFolder, IsDirectory: true,
+		Extended: map[string][]byte{
+			s3_constants.ExtLatestVersionIdKey:         []byte(vidOld),
+			s3_constants.ExtLatestVersionFileNameKey:    []byte("v_" + vidOld),
+			s3_constants.ExtLatestVersionMtimeKey:       []byte(strconv.FormatInt(old.Unix(), 10)),
+			s3_constants.ExtLatestVersionSizeKey:        []byte("1024"),
+			s3_constants.ExtLatestVersionIsDeleteMarker: []byte("false"),
+		},
+	})
+	server.putEntry(versionsDir, &filer_pb.Entry{
+		Name:       "v_" + vidOld,
+		Attributes: &filer_pb.FuseAttributes{Mtime: old.Unix(), FileSize: 1024},
+		Extended: map[string][]byte{
+			s3_constants.ExtVersionIdKey: []byte(vidOld),
+		},
+	})
+
+	rules := []s3lifecycle.Rule{{
+		ID: "expire-30d", Status: "Enabled",
+		ExpirationDays: 30,
+	}}
+
+	// Step 1: Detect expired.
+	expired, _, err := listExpiredObjectsByRules(context.Background(), client, bucketsPath, bucket, rules, 100)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(expired) != 1 {
+		t.Fatalf("expected 1 expired, got %d", len(expired))
+	}
+
+	// Step 2: Delete the expired version file.
+	deleted, errs, delErr := deleteExpiredObjects(context.Background(), client, expired)
+	if delErr != nil {
+		t.Fatalf("delete: %v", delErr)
+	}
+	if deleted != 1 || errs != 0 {
+		t.Errorf("expected 1 deleted 0 errors, got %d deleted %d errors", deleted, errs)
+	}
+
+	// Version file should be gone.
+	if server.hasEntry(versionsDir, "v_"+vidOld) {
+		t.Error("version file should have been removed")
+	}
+
+	// Step 3: Cleanup empty .versions directory.
+	cleaned := cleanupEmptyVersionsDirectories(context.Background(), client, expired)
+	if cleaned != 1 {
+		t.Errorf("expected 1 directory cleaned, got %d", cleaned)
+	}
+
+	// The .versions directory itself should be gone.
+	if server.hasEntry(bucketDir, "data.bin"+s3_constants.VersionsFolder) {
+		t.Error(".versions directory should have been removed after cleanup")
+	}
+}
+
+// TestIntegration_VersionedBucket_MultiVersion_ExpirationDays verifies that
+// when a multi-version object's latest version expires, only the latest
+// version is deleted and noncurrent versions remain.
+func TestIntegration_VersionedBucket_MultiVersion_ExpirationDays(t *testing.T) {
+	server, client := startTestFiler(t)
+	bucketsPath := "/buckets"
+	bucket := "versioned-multi"
+	bucketDir := bucketsPath + "/" + bucket
+
+	now := time.Now()
+	tOld := now.Add(-60 * 24 * time.Hour)
+	tNoncurrent := now.Add(-90 * 24 * time.Hour)
+	vidLatest := testVersionId(tOld)
+	vidNoncurrent := testVersionId(tNoncurrent)
+
+	server.putEntry(bucketsPath, &filer_pb.Entry{Name: bucket, IsDirectory: true})
+
+	versionsDir := bucketDir + "/multi.txt" + s3_constants.VersionsFolder
+	server.putEntry(bucketDir, &filer_pb.Entry{
+		Name: "multi.txt" + s3_constants.VersionsFolder, IsDirectory: true,
+		Extended: map[string][]byte{
+			s3_constants.ExtLatestVersionIdKey:         []byte(vidLatest),
+			s3_constants.ExtLatestVersionFileNameKey:    []byte("v_" + vidLatest),
+			s3_constants.ExtLatestVersionMtimeKey:       []byte(strconv.FormatInt(tOld.Unix(), 10)),
+			s3_constants.ExtLatestVersionSizeKey:        []byte("500"),
+			s3_constants.ExtLatestVersionIsDeleteMarker: []byte("false"),
+		},
+	})
+	server.putEntry(versionsDir, &filer_pb.Entry{
+		Name:       "v_" + vidLatest,
+		Attributes: &filer_pb.FuseAttributes{Mtime: tOld.Unix(), FileSize: 500},
+		Extended:   map[string][]byte{s3_constants.ExtVersionIdKey: []byte(vidLatest)},
+	})
+	server.putEntry(versionsDir, &filer_pb.Entry{
+		Name:       "v_" + vidNoncurrent,
+		Attributes: &filer_pb.FuseAttributes{Mtime: tNoncurrent.Unix(), FileSize: 500},
+		Extended:   map[string][]byte{s3_constants.ExtVersionIdKey: []byte(vidNoncurrent)},
+	})
+
+	rules := []s3lifecycle.Rule{{
+		ID: "expire-30d", Status: "Enabled",
+		ExpirationDays: 30,
+	}}
+
+	expired, _, err := listExpiredObjectsByRules(context.Background(), client, bucketsPath, bucket, rules, 100)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// Only the latest version should be detected as expired.
+	if len(expired) != 1 {
+		t.Fatalf("expected 1 expired (latest only), got %d", len(expired))
+	}
+	if expired[0].name != "v_"+vidLatest {
+		t.Errorf("expected latest version expired, got %s", expired[0].name)
+	}
+
+	// Delete it.
+	deleteExpiredObjects(context.Background(), client, expired)
+
+	// Noncurrent version should still exist.
+	if !server.hasEntry(versionsDir, "v_"+vidNoncurrent) {
+		t.Error("noncurrent version should still exist")
+	}
+
+	// .versions directory should NOT be cleaned up (not empty).
+	cleaned := cleanupEmptyVersionsDirectories(context.Background(), client, expired)
+	if cleaned != 0 {
+		t.Errorf("expected 0 directories cleaned (not empty), got %d", cleaned)
+	}
+	if !server.hasEntry(bucketDir, "multi.txt"+s3_constants.VersionsFolder) {
+		t.Error(".versions directory should still exist (has noncurrent version)")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #8757 — disk space not reclaimed when using S3 lifecycle policy on a versioned bucket with TTL volumes.

- In versioned buckets, `putVersionedObject` stores all data directly in `.versions/` directories — no entry exists at the main object path
- The lifecycle worker's `listExpiredObjectsByRules` only routed `.versions` directories to `processVersionsDirectory` (for `NoncurrentVersionExpiration`), so the **latest version was never evaluated** against `Expiration.Days` rules
- This caused expired objects to remain on disk with 0 deleted bytes at the volume level, since chunk deletion was never triggered

**Fix:** Evaluate the latest version's cached metadata from the `.versions` directory entry against `Expiration` rules during the bucket scan. After deletion, clean up `.versions` directories that became empty (single-version objects).

### Changes

- `latestVersionExpiredByRules()` — new function that reads cached metadata (`ExtLatestVersionMtimeKey`, `ExtLatestVersionSizeKey`, etc.) from the `.versions` directory entry and evaluates `Expiration.Days`/`Expiration.Date` rules against it, skipping delete markers
- `cleanupEmptyVersionsDirectories()` — removes `.versions` directories left empty after their sole version was deleted
- Wired into `listExpiredObjectsByRules` (detection) and `executeLifecycleForBucket` (cleanup)

## Test plan

- [x] `TestIntegration_VersionedBucket_ExpirationDays` — verifies detection: old versioned object expires, recent one doesn't, delete marker is skipped
- [x] `TestIntegration_VersionedBucket_ExpirationDays_DeleteAndCleanup` — end-to-end: detect → delete version file → cleanup empty `.versions` directory
- [x] `TestIntegration_VersionedBucket_MultiVersion_ExpirationDays` — multi-version object: only latest version deleted, noncurrent version preserved, `.versions` directory kept
- [x] All existing lifecycle tests pass (24/24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced versioned bucket lifecycle management with improved expiration rule evaluation for latest version metadata
  * Automatic cleanup of empty version directories after batch deletion of expired objects

* **Tests**
  * Added comprehensive integration tests for versioned bucket lifecycle behavior, including latest version expiration, delete markers, and multi-version object handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->