### PR TITLE
s3api: skip TTL fast-path for versioned buckets

### DIFF
--- a/weed/plugin/worker/lifecycle/execution.go
+++ b/weed/plugin/worker/lifecycle/execution.go
@@ -551,7 +551,7 @@ func listExpiredObjectsByRules(
 					// In versioned buckets, data lives in .versions/ directories,
 					// so we must evaluate the latest version here — it is never
 					// seen as a regular file entry in the parent directory.
-					if obj, ok := latestVersionExpiredByRules(entry, versionsDir, bucketPath, rules, now, needTags); ok {
+					if obj, ok := latestVersionExpiredByRules(ctx, client, entry, versionsDir, bucketPath, rules, now, needTags); ok {
 						expired = append(expired, obj)
 						scanned++
 						if limit > 0 && int64(len(expired)) >= limit {
@@ -746,6 +746,8 @@ func processVersionsDirectory(
 // its Extended attributes, so we can evaluate expiration without an extra
 // filer round-trip.
 func latestVersionExpiredByRules(
+	ctx context.Context,
+	client filer_pb.SeaweedFilerClient,
 	dirEntry *filer_pb.Entry,
 	versionsDir, bucketPath string,
 	rules []s3lifecycle.Rule,
@@ -794,7 +796,15 @@ func latestVersionExpiredByRules(
 	}
 
 	if needTags {
-		objInfo.Tags = s3lifecycle.ExtractTags(dirEntry.Extended)
+		// Tags are stored on the version file entry, not the .versions
+		// directory. Fetch the actual version file to get them.
+		resp, err := client.LookupDirectoryEntry(ctx, &filer_pb.LookupDirectoryEntryRequest{
+			Directory: versionsDir,
+			Name:      latestFileName,
+		})
+		if err == nil && resp.Entry != nil {
+			objInfo.Tags = s3lifecycle.ExtractTags(resp.Entry.Extended)
+		}
 	}
 
 	result := s3lifecycle.Evaluate(rules, objInfo, now)

--- a/weed/plugin/worker/lifecycle/integration_test.go
+++ b/weed/plugin/worker/lifecycle/integration_test.go
@@ -757,7 +757,13 @@ func TestIntegration_VersionedBucket_MultiVersion_ExpirationDays(t *testing.T) {
 	}
 
 	// Delete it.
-	deleteExpiredObjects(context.Background(), client, expired)
+	deleted, errs, delErr := deleteExpiredObjects(context.Background(), client, expired)
+	if delErr != nil {
+		t.Fatalf("delete: %v", delErr)
+	}
+	if deleted != 1 || errs != 0 {
+		t.Errorf("expected 1 deleted 0 errors, got %d deleted %d errors", deleted, errs)
+	}
 
 	// Noncurrent version should still exist.
 	if !server.hasEntry(versionsDir, "v_"+vidNoncurrent) {

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -962,8 +962,15 @@ func (s3a *S3ApiServer) PutBucketLifecycleConfigurationHandler(w http.ResponseWr
 	//     marker — it does not delete data. TTL has no such nuance.
 	// For versioned buckets the lifecycle worker handles all rule evaluation
 	// at scan time, which correctly operates on individual versions.
-	bucketVersioning, _ := s3a.getBucketVersioningStatus(bucket)
-	isVersioned := bucketVersioning == s3_constants.VersioningEnabled ||
+	bucketVersioning, versioningErr := s3a.getBucketVersioningStatus(bucket)
+	if versioningErr != s3err.ErrNone {
+		// Fail closed: if we cannot determine versioning status, treat the
+		// bucket as versioned to avoid creating TTL entries that would
+		// destroy noncurrent versions.
+		glog.V(1).Infof("PutBucketLifecycleConfigurationHandler: could not determine versioning status for %s (err %v), skipping TTL fast-path", bucket, versioningErr)
+	}
+	isVersioned := versioningErr != s3err.ErrNone ||
+		bucketVersioning == s3_constants.VersioningEnabled ||
 		bucketVersioning == s3_constants.VersioningSuspended
 
 	for _, rule := range lifeCycleConfig.Rules {

--- a/weed/s3api/s3api_bucket_lifecycle_response_test.go
+++ b/weed/s3api/s3api_bucket_lifecycle_response_test.go
@@ -126,24 +126,35 @@ func (f failingReadCloser) Close() error {
 	return nil
 }
 
-// TestShouldSkipTTLFastPathForVersionedBuckets verifies that the TTL
-// fast-path (filer.conf TTL entries + updateEntriesTTL) is skipped for
-// versioned buckets. On AWS S3, Expiration.Days on a versioned bucket
-// creates a delete marker — it does not delete data. TTL volumes would
-// destroy all versions indiscriminately, so the lifecycle worker must
+// TestShouldSkipTTLFastPathForVersionedBuckets verifies the versioning guard
+// logic that PutBucketLifecycleConfigurationHandler uses to decide whether
+// to create filer.conf TTL entries. On AWS S3, Expiration.Days on a versioned
+// bucket creates a delete marker — it does not delete data. TTL volumes
+// would destroy all versions indiscriminately, so the lifecycle worker must
 // handle versioned buckets at scan time instead. (issue #8757)
+//
+// Note: an integration test that invokes PutBucketLifecycleConfigurationHandler
+// directly is not feasible here because the handler requires filer gRPC
+// connectivity (ReadFilerConfFromFilers, WithFilerClient) before it reaches
+// the versioning check. The lifecycle worker integration tests in
+// weed/plugin/worker/lifecycle/ cover the end-to-end versioned-bucket behavior.
 func TestShouldSkipTTLFastPathForVersionedBuckets(t *testing.T) {
 	tests := []struct {
 		name       string
 		versioning string
 		expectSkip bool
 	}{
-		{"versioning_enabled", s3_constants.VersioningEnabled, true},
-		{"versioning_suspended", s3_constants.VersioningSuspended, true},
-		{"no_versioning", "", false},
+		{"versioning_enabled_skips_ttl", s3_constants.VersioningEnabled, true},
+		{"versioning_suspended_skips_ttl", s3_constants.VersioningSuspended, true},
+		{"unversioned_allows_ttl", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// This mirrors the guard in PutBucketLifecycleConfigurationHandler:
+			//   isVersioned := versioningErr != s3err.ErrNone ||
+			//       bucketVersioning == s3_constants.VersioningEnabled ||
+			//       bucketVersioning == s3_constants.VersioningSuspended
+			// When isVersioned is true, the TTL fast-path is skipped entirely.
 			isVersioned := tt.versioning == s3_constants.VersioningEnabled ||
 				tt.versioning == s3_constants.VersioningSuspended
 			assert.Equal(t, tt.expectSkip, isVersioned)


### PR DESCRIPTION
## Summary

`PutBucketLifecycleConfiguration` was translating `Expiration.Days` into filer.conf TTL entries for all buckets, including versioned ones. This is incompatible with versioning because:

1. **TTL volumes expire as a unit**, destroying all data — including noncurrent versions that should be preserved
2. **Filer-backend TTL** (RocksDB compaction filter, Redis key expiry) removes entries without triggering chunk deletion, leaving orphaned volume data with 0 deleted bytes
3. **On AWS S3**, `Expiration.Days` on a versioned bucket creates a delete marker — it does not hard-delete data. TTL has no such nuance

### Changes

**`s3api_bucket_handlers.go`** — Skip the TTL fast-path (filer.conf TTL entries + `updateEntriesTTL`) when the bucket has versioning enabled or suspended. The lifecycle XML is still stored in bucket metadata; all rule evaluation is deferred to the lifecycle worker.

**`execution.go`** — Fix the lifecycle worker to evaluate `Expiration` rules against the latest version in `.versions/` directories. Previously, `listExpiredObjectsByRules` only routed `.versions/` directories to `processVersionsDirectory` (for `NoncurrentVersionExpiration`), so the latest version was never evaluated. New functions:
- `latestVersionExpiredByRules()` — evaluates cached metadata from the `.versions` directory entry against `Expiration.Days`/`Date` rules
- `cleanupEmptyVersionsDirectories()` — removes `.versions` directories left empty after single-version object deletion

## Test plan

- [x] `TestShouldSkipTTLFastPathForVersionedBuckets` — versioning Enabled/Suspended skips TTL, empty versioning does not
- [x] `TestIntegration_VersionedBucket_ExpirationDays` — old versioned object expires, recent one doesn't, delete markers skipped
- [x] `TestIntegration_VersionedBucket_ExpirationDays_DeleteAndCleanup` — end-to-end: detect → delete version → cleanup empty `.versions/` dir
- [x] `TestIntegration_VersionedBucket_MultiVersion_ExpirationDays` — only latest version deleted, noncurrent preserved, `.versions/` dir kept
- [x] All existing lifecycle + s3api tests pass
- [x] New integration tests fail without the fix (`expected 1 expired, got 0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * S3 lifecycle expiration policies now fully support versioned buckets, with automatic evaluation of expiration rules for the latest version and cleanup of empty version directories.

* **Tests**
  * Added integration and unit tests validating S3 lifecycle expiration behavior for versioned buckets across various version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->