### PR TITLE
stabilize FUSE git reset recovery

### DIFF
--- a/test/fuse_integration/git_operations_test.go
+++ b/test/fuse_integration/git_operations_test.go
@@ -431,6 +431,17 @@ func resetToCommitWithRecovery(t *testing.T, bareRepo, localClone, mountClone, c
 			}
 			continue
 		}
+		// Verify git commands actually work in the directory — the kernel
+		// dcache can transiently show the dir then lose it after reset.
+		if _, err := tryGitCommand(mountClone, "rev-parse", "HEAD"); err != nil {
+			lastErr = fmt.Errorf("post-reset verification failed: %w", err)
+			if attempt < maxAttempts {
+				t.Logf("reset recovery attempt %d: %v — removing clone for re-create", attempt, lastErr)
+				os.RemoveAll(mountClone)
+				time.Sleep(2 * time.Second)
+			}
+			continue
+		}
 		return
 	}
 	require.NoError(t, lastErr, "git reset --hard %s failed after %d recovery attempts", commit, maxAttempts)


### PR DESCRIPTION
## What changed
Add a post-reset verification step in the FUSE git integration recovery helper.

After `git reset --hard`, the helper now runs `git rev-parse HEAD` inside the mount clone and treats a failure as a recovery condition, removing and re-creating the clone before retrying.

## Why this changed
The reset path was already checking that the clone directory reappeared, but that was not sufficient on the affected FUSE failure mode. The kernel dcache can briefly show the directory entry after reset and then lose it, so the helper could return even though subsequent git commands in that directory were about to fail.

## Impact
This makes `TestGitOperations` more resilient to the transient post-reset disappearance observed on the FUSE mount and keeps the recovery logic aligned with the actual symptom: git becoming unusable in the clone after reset.

## Root cause
Directory existence alone was an incomplete health check for the mount clone after `git reset --hard` on FUSE. A stale or transient directory entry could pass the old check while the clone was still broken.

## Validation
- `git diff --check`
- `cd test/fuse_integration && go test -run TestTryEnsureBareRepoPreservesCurrentBranch -count=1`
- `cd test/fuse_integration && go test -run TestGitOperations -count=1 -timeout 30m`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened recovery operation testing by adding post-recovery verification and enhanced retry logic to ensure operations complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->