### PR TITLE
revert temporary docker and trivy changes

### DIFF
--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   setup:
@@ -150,48 +149,9 @@ jobs:
           # Remove Go build cache
           sudo rm -rf /tmp/go-build*
 
-  trivy-scan:
-    runs-on: ubuntu-latest
-    needs: [setup, build]
-    strategy:
-      matrix:
-        variant: ${{ fromJSON(needs.setup.outputs.variants) }}
-    steps:
-      - name: Configure variant
-        id: config
-        run: |
-          if [ "${{ matrix.variant }}" == "large_disk" ]; then
-            echo "tag_suffix=_large_disk" >> $GITHUB_OUTPUT
-          else
-            echo "tag_suffix=" >> $GITHUB_OUTPUT
-          fi
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Run Trivy vulnerability scanner
-        # Pin to SHA — mutable tags were compromised (GHSA-69fq-xp46-6x23)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          # Scan amd64 only — OS packages are identical across architectures
-          # since they all use the same alpine base, so a single-arch scan
-          # provides sufficient coverage without multiplying CI time.
-          image-ref: ghcr.io/chrislusf/seaweedfs:${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}${{ steps.config.outputs.tag_suffix }}-amd64
-          format: sarif
-          output: trivy-results.sarif
-          severity: HIGH,CRITICAL
-          exit-code: '1'
-      - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: trivy-results.sarif
-
   create-manifest:
     runs-on: ubuntu-latest
-    needs: [setup, build, trivy-scan]
+    needs: [setup, build]
     if: github.event_name != 'pull_request'
     strategy:
       matrix:

--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -79,9 +79,5 @@ RUN mkdir -p /data/filerldb2 && \
 VOLUME /data
 WORKDIR /data
 
-# Run as non-root by default (satisfies security scanners).
-# Use `docker run --user root` if you need the entrypoint to fix
-# /data volume ownership before dropping privileges.
-USER seaweed
-
+# Entrypoint will handle permission fixes and user switching
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -37,9 +37,5 @@ RUN mkdir -p /data/filerldb2 && \
 VOLUME /data
 WORKDIR /data
 
-# Run as non-root by default (satisfies security scanners).
-# Use `docker run --user root` if you need the entrypoint to fix
-# /data volume ownership before dropping privileges.
-USER seaweed
-
+# Entrypoint will handle permission fixes and user switching
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## What changed
This PR temporarily reverts two recent changes:

- restore the published Docker images to the prior entrypoint-managed startup behavior by removing the default `USER seaweed` setting from the published Dockerfiles
- remove the Trivy scan job from the `container_latest` release workflow and restore manifest creation to depend only on `setup` and `build`

## Why
The non-root image default exposed a mismatch with the Helm chart deployment path, which overrides the image entrypoint and led to follow-on chart workarounds. This PR backs that change out for now so published images return to the previous behavior while the chart-side fix is addressed separately.

The Trivy release scan is also being temporarily reverted to unblock the current release workflow while that check is revisited.

## Impact
Published container images return to the previous startup model where the entrypoint manages permission fixes and user switching.

The `container_latest` workflow no longer runs the Trivy SARIF upload/fail-on-vulnerabilities path before publishing manifests.

## Root cause
The Docker change assumed the image entrypoint would remain responsible for permission setup, but the Helm StatefulSets invoke `/usr/bin/weed` directly with an overridden `command`, so that logic is bypassed in chart deployments.

## Validation
- `git diff --check`
- YAML parse of `.github/workflows/container_latest.yml`

Full container builds and end-to-end workflow execution were not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed container vulnerability scanning from CI/CD pipeline
  * Updated container startup process to delegate user permission configuration to the entrypoint script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->