### PR TITLE
[codex] reintroduce Trivy reporting and dry-run mode

### DIFF
--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -23,6 +23,11 @@ on:
           - all
           - standard
           - large_disk
+      publish:
+        description: 'Publish images and manifests'
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -33,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       variants: ${{ steps.set-variants.outputs.variants }}
+      publish: ${{ steps.set-publish.outputs.publish }}
     steps:
       - name: Select variants for this run
         id: set-variants
@@ -43,6 +49,14 @@ jobs:
             variants='["standard","large_disk"]'
           fi
           echo "variants=$variants" >> "$GITHUB_OUTPUT"
+      - name: Select publish mode
+        id: set-publish
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "publish=${{ github.event.inputs.publish }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     needs: [setup]
@@ -112,13 +126,13 @@ jobs:
           buildkitd-flags: "--debug"
           buildkitd-config: /tmp/buildkitd.toml
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: needs.setup.outputs.publish == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: needs.setup.outputs.publish == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -130,7 +144,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         with:
           context: ./docker
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}
           file: ./docker/Dockerfile.go_build
           platforms: linux/${{ matrix.platform }}
           # Push to GHCR only during build to avoid Docker Hub rate limits
@@ -166,12 +180,46 @@ jobs:
             echo "tag_suffix=" >> $GITHUB_OUTPUT
           fi
       - name: Login to GHCR
+        if: needs.setup.outputs.publish == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
-      - name: Trivy report
+      - name: Checkout for local scan build
+        if: needs.setup.outputs.publish != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_ref || github.ref }}
+      - name: Create BuildKit config for local scan build
+        if: needs.setup.outputs.publish != 'true'
+        run: |
+          cat > /tmp/buildkitd.toml <<EOF
+          [registry."docker.io"]
+            mirrors = ["https://mirror.gcr.io"]
+          EOF
+      - name: Set up Docker Buildx for local scan build
+        if: needs.setup.outputs.publish != 'true'
+        uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: "--debug"
+          buildkitd-config: /tmp/buildkitd.toml
+      - name: Build local scan image tarball
+        if: needs.setup.outputs.publish != 'true'
+        uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.go_build
+          platforms: linux/amd64
+          outputs: type=docker,dest=/tmp/seaweedfs${{ steps.config.outputs.tag_suffix }}-amd64.tar
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BRANCH=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_ref || github.sha }}
+            ${{ matrix.variant == 'large_disk' && 'TAGS=5BytesOffset' || '' }}
+      - name: Trivy report (published image)
+        if: needs.setup.outputs.publish == 'true'
         # Pin to SHA - mutable tags were compromised (GHSA-69fq-xp46-6x23)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
@@ -188,12 +236,26 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           exit-code: '0'
+      - name: Trivy report (local tarball)
+        if: needs.setup.outputs.publish != 'true'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          input: /tmp/seaweedfs${{ steps.config.outputs.tag_suffix }}-amd64.tar
+          scanners: vuln
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          limit-severities-for-sarif: true
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '0'
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-results.sarif
-      - name: Trivy gate
+      - name: Trivy gate (published image)
+        if: needs.setup.outputs.publish == 'true'
         # Gate only on fixable high/critical vulnerabilities. Non-fixable
         # findings are still visible in the SARIF upload above.
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -207,11 +269,23 @@ jobs:
           format: table
           exit-code: '1'
           skip-setup-trivy: true
+      - name: Trivy gate (local tarball)
+        if: needs.setup.outputs.publish != 'true'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          input: /tmp/seaweedfs${{ steps.config.outputs.tag_suffix }}-amd64.tar
+          scanners: vuln
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: table
+          exit-code: '1'
+          skip-setup-trivy: true
 
   create-manifest:
     runs-on: ubuntu-latest
     needs: [setup, build, trivy-scan]
-    if: github.event_name != 'pull_request'
+    if: needs.setup.outputs.publish == 'true' && github.event_name != 'pull_request'
     strategy:
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.variants) }}


### PR DESCRIPTION
## What changed
This PR reintroduces Trivy into the container release workflow, but with two changes to make it practical to use and easy to test:

- restores a dedicated `trivy-scan` job in `container_latest.yml`
- uploads SARIF results to GitHub Security without failing the workflow
- adds a second Trivy pass that fails only on `HIGH`/`CRITICAL` vulnerabilities with available fixes
- adds a manual `publish` boolean input for `workflow_dispatch`
- supports manual dry-run execution with `publish=false`, which builds and scans locally without pushing images or publishing manifests
- restores `create-manifest` to wait on the Trivy job before publishing manifests when publish mode is enabled

## Why
The previous all-or-nothing Trivy gate was too disruptive in practice, and the workflow also lacked a safe way to exercise the full release path without publishing images.

This version keeps security visibility while reducing noise:
- non-fixable findings still show up in SARIF for review
- the release workflow only blocks on fixable high-severity issues
- maintainers can manually run the workflow in dry-run mode to validate build and Trivy behavior without publishing images or manifests

## Impact
Container publishing regains automated Trivy coverage without returning to the earlier failure mode that blocked releases on unfixed findings.

Manual workflow runs can now be used as release rehearsals by setting `publish=false`.

## Validation
- `git diff --check -- .github/workflows/container_latest.yml`
- YAML parse of `.github/workflows/container_latest.yml`

I did not run the full GitHub Actions workflow locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated, variant-aware vulnerability scanning that reports findings to security monitoring systems and uploads standardized reports.
  * Scans run in all build modes and include variant-specific image/tarball tagging for traceability.

* **Chores**
  * Build pipeline can be configured to block publishing: when enabled, fixable HIGH/CRITICAL issues will fail the build.
  * Publishing now requires explicit enablement before image push and manifest creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->