### PR TITLE
docker: use alpine packages for Rust builder to fix linux/386 builds

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -16,15 +16,16 @@ RUN cd /go/src/github.com/seaweedfs/seaweedfs/weed \
   && export LDFLAGS="-X github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=$(git rev-parse --short HEAD)" \
   && CGO_ENABLED=0 go install -tags "$TAGS" -ldflags "-extldflags -static ${LDFLAGS}"
 
-# Rust volume server builder (amd64/arm64 only)
-FROM rust:1-alpine as rust_builder
+# Rust volume server builder. Alpine packages avoid depending on the
+# upstream rust:alpine manifest list, which no longer includes linux/386.
+FROM alpine:3.23 as rust_builder
 ARG TARGETARCH
-RUN apk add musl-dev protobuf-dev git
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/seaweed-volume /build/seaweed-volume
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/proto /build/proto
 WORKDIR /build/seaweed-volume
 ARG TAGS
 RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
+      apk add --no-cache musl-dev openssl-dev protobuf-dev git rust cargo; \
       if [ "$TAGS" = "5BytesOffset" ]; then \
         cargo build --release; \
       else \


### PR DESCRIPTION
## Summary
- Switch the Rust volume server builder stage from `rust:1-alpine` to `alpine:3.23` and install the Rust toolchain via `apk` packages
- The upstream `rust:alpine` manifest list no longer includes `linux/386`, breaking multi-platform container builds
- Moves package installation (`musl-dev`, `protobuf-dev`, `git`, `rust`, `cargo`) inside the architecture conditional so it only runs on `amd64`/`arm64`, and adds `openssl-dev` needed for the build

## Test plan
- [ ] Verify multi-platform build succeeds for `linux/amd64`, `linux/arm64`, and `linux/386`
- [ ] Confirm the Rust volume server binary is correctly built on amd64/arm64
- [ ] Confirm 386 builds skip the Rust stage as before without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure for improved dependency management and compatibility across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->