### PR TITLE
fix large_disk container rust build

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -21,9 +21,7 @@ RUN cd /go/src/github.com/seaweedfs/seaweedfs/weed \
 FROM alpine:3.23 as rust_builder
 ARG TARGETARCH
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/seaweed-volume /build/seaweed-volume
-COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/weed/pb /build/weed/pb
-COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/weed/static /build/weed/static
-COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/weed/util/version /build/weed/util/version
+COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/weed /build/weed
 WORKDIR /build/seaweed-volume
 ARG TAGS
 RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \


### PR DESCRIPTION
## Summary
- copy `weed/static` into the Rust image build context
- copy `weed/util/version` so `constants.go` remains available to `seaweed-volume`
- keep the existing multi-stage Docker build behavior otherwise unchanged

## Why
The `docker: build latest container` workflow was failing in the `build (amd64, large_disk)` job because the Rust `weed-volume` build now embeds files from `../weed/static/...` and reads `../weed/util/version/constants.go`. The `rust_builder` stage in `docker/Dockerfile.go_build` only copied `seaweed-volume/` and `weed/pb`, so `cargo build --release` failed with missing file errors.

## Impact
This restores the `large_disk` container build path for architectures that compile the Rust volume server in `docker/Dockerfile.go_build`.

## Validation
- `docker buildx build --progress=plain --target rust_builder --build-arg TAGS=5BytesOffset -f docker/Dockerfile.go_build .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to make additional files available during the Rust compilation stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->