### PR TITLE
Use Unix sockets for gRPC in weed server mode

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -333,29 +333,23 @@ func runServer(cmd *Command, args []string) bool {
 	// Register Unix socket paths for gRPC services running in this process
 	// so local inter-service communication uses Unix sockets instead of TCP.
 	// Resolve gRPC ports early (same calculation each service does internally).
-	if *isStartingMasterServer {
-		if *masterOptions.portGrpc == 0 {
-			*masterOptions.portGrpc = 10000 + *masterOptions.port
+	for _, svc := range []struct {
+		starting *bool
+		portGrpc *int
+		port     *int
+		name     string
+	}{
+		{isStartingMasterServer, masterOptions.portGrpc, masterOptions.port, "master"},
+		{isStartingVolumeServer, serverOptions.v.portGrpc, serverOptions.v.port, "volume"},
+		{isStartingFiler, filerOptions.portGrpc, filerOptions.port, "filer"},
+		{isStartingS3, s3Options.portGrpc, s3Options.port, "s3"},
+	} {
+		if *svc.starting {
+			if *svc.portGrpc == 0 {
+				*svc.portGrpc = 10000 + *svc.port
+			}
+			pb.RegisterLocalGrpcSocket(*svc.portGrpc, fmt.Sprintf("/tmp/seaweedfs-%s-grpc-%d.sock", svc.name, *svc.portGrpc))
 		}
-		pb.RegisterLocalGrpcSocket(*masterOptions.portGrpc, fmt.Sprintf("/tmp/seaweedfs-master-grpc-%d.sock", *masterOptions.portGrpc))
-	}
-	if *isStartingVolumeServer {
-		if *serverOptions.v.portGrpc == 0 {
-			*serverOptions.v.portGrpc = 10000 + *serverOptions.v.port
-		}
-		pb.RegisterLocalGrpcSocket(*serverOptions.v.portGrpc, fmt.Sprintf("/tmp/seaweedfs-volume-grpc-%d.sock", *serverOptions.v.portGrpc))
-	}
-	if *isStartingFiler {
-		if *filerOptions.portGrpc == 0 {
-			*filerOptions.portGrpc = 10000 + *filerOptions.port
-		}
-		pb.RegisterLocalGrpcSocket(*filerOptions.portGrpc, fmt.Sprintf("/tmp/seaweedfs-filer-grpc-%d.sock", *filerOptions.portGrpc))
-	}
-	if *isStartingS3 {
-		if *s3Options.portGrpc == 0 {
-			*s3Options.portGrpc = 10000 + *s3Options.port
-		}
-		pb.RegisterLocalGrpcSocket(*s3Options.portGrpc, fmt.Sprintf("/tmp/seaweedfs-s3-grpc-%d.sock", *s3Options.portGrpc))
 	}
 
 	serverWhiteList := util.StringSplit(*serverWhiteListOption, ",")


### PR DESCRIPTION
## Summary

- Extends the Unix socket gRPC optimization from `weed mini` (#8856) to `weed server`
- Registers Unix socket paths for each co-located service's gRPC port before startup, so master, volume, filer, and S3 communicate via Unix sockets instead of TCP loopback
- Only services actually started in this process get sockets registered (respects `-master`, `-volume`, `-filer`, `-s3` flags)
- gRPC ports are resolved early (same `port + 10000` calculation each service does internally) so socket paths are known before any service dials another

The gRPC server-side Unix socket listeners were already added in #8856 (master.go, filer.go, volume.go, s3.go) — this PR only adds the registration call in `server.go`.

## Test plan

- [x] `go build ./weed/...` succeeds
- [x] `go vet ./weed/command` clean
- [ ] Manual: `weed server -dir=/tmp/test-server` starts successfully
- [ ] Manual: `weed server -dir=/tmp/test-server -filer -s3` with S3 operations work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Unix-domain-socket endpoints for in-process gRPC communication between local components (master, volume, filer, S3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->