### PR TITLE
Fix stale admin lock metric when lock expires and is reacquired

### DIFF
--- a/weed/server/master_grpc_server_admin.go
+++ b/weed/server/master_grpc_server_admin.go
@@ -107,7 +107,7 @@ func (locks *AdminLocks) generateToken(lockName string, clientName string) (ts t
 	locks.Lock()
 	defer locks.Unlock()
 	if existing, found := locks.locks[lockName]; found && existing.lastClient != clientName {
-		stats.MasterAdminLock.WithLabelValues(existing.lastClient).Set(0)
+		stats.MasterAdminLock.DeleteLabelValues(existing.lastClient)
 	}
 	lock := &AdminLock{
 		accessSecret:   rand.Int64(),
@@ -121,7 +121,7 @@ func (locks *AdminLocks) generateToken(lockName string, clientName string) (ts t
 
 func (locks *AdminLocks) deleteLock(lockName string) {
 	locks.Lock()
-	stats.MasterAdminLock.WithLabelValues(locks.locks[lockName].lastClient).Set(0)
+	stats.MasterAdminLock.DeleteLabelValues(locks.locks[lockName].lastClient)
 	defer locks.Unlock()
 	delete(locks.locks, lockName)
 }


### PR DESCRIPTION
## Summary
- Fixes #8857
- When a lock expired without an explicit unlock and a different client acquired it, `generateToken` set the new client's metric to `1` but never cleared the old client's metric, causing multiple clients to appear as simultaneously holding the lock
- Clear the previous client's `SeaweedFS_master_admin_lock` gauge in `generateToken` when the client changes

## Test plan
- [ ] Acquire an admin lock with client A, let it expire, then acquire with client B — verify only client B shows metric value `1`
- [ ] Acquire and explicitly release a lock — verify metric is cleared (existing behavior, unchanged)
- [ ] Renew a lock with the same client — verify no metric disruption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics cleanup for admin lock management by properly removing stale metrics when locks are replaced or deleted, ensuring accurate monitoring and tracking of lock states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->