### PR TITLE
fix(shell): avoid marking skipped or unplaced volumes as fixed

### DIFF
--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -337,8 +337,9 @@ func (c *commandVolumeFixReplication) fixUnderReplicatedVolumes(commandEnv *Comm
 	}
 	for _, vid := range volumeIds {
 		for i := 0; i < retryCount+1; i++ {
-			if err = c.fixOneUnderReplicatedVolume(commandEnv, writer, applyChanges, volumeReplicas, vid, allLocations); err == nil {
-				if applyChanges {
+			var copied bool
+			if copied, err = c.fixOneUnderReplicatedVolume(commandEnv, writer, applyChanges, volumeReplicas, vid, allLocations); err == nil {
+				if applyChanges && copied {
 					fixedVolumes[strconv.FormatUint(uint64(vid), 10)] = len(volumeReplicas[vid])
 				}
 				break
@@ -350,7 +351,7 @@ func (c *commandVolumeFixReplication) fixUnderReplicatedVolumes(commandEnv *Comm
 	return fixedVolumes, nil
 }
 
-func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *CommandEnv, writer io.Writer, applyChanges bool, volumeReplicas map[uint32][]*VolumeReplica, vid uint32, allLocations []location) error {
+func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *CommandEnv, writer io.Writer, applyChanges bool, volumeReplicas map[uint32][]*VolumeReplica, vid uint32, allLocations []location) (bool, error) {
 	replicas := volumeReplicas[vid]
 	replica := pickOneReplicaToCopyFrom(replicas)
 	replicaPlacement, _ := super_block.NewReplicaPlacementFromByte(byte(replica.info.ReplicaPlacement))
@@ -370,7 +371,7 @@ func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *Co
 					var err error
 					matched, err = filepath.Match(*c.collectionPattern, replica.info.Collection)
 					if err != nil {
-						return fmt.Errorf("match pattern %s with collection %s: %v", *c.collectionPattern, replica.info.Collection, err)
+						return false, fmt.Errorf("match pattern %s with collection %s: %v", *c.collectionPattern, replica.info.Collection, err)
 					}
 				}
 				if !matched {
@@ -386,7 +387,7 @@ func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *Co
 			if !applyChanges {
 				// adjust volume count
 				addVolumeCount(dst.dataNode.DiskInfos[replica.info.DiskType], 1)
-				break
+				return true, nil
 			}
 
 			err := operation.WithVolumeServerClient(false, pb.NewServerAddressFromDataNode(dst.dataNode), commandEnv.option.GrpcDialOption, func(volumeServerClient volume_server_pb.VolumeServerClient) error {
@@ -415,19 +416,19 @@ func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *Co
 			})
 
 			if err != nil {
-				return err
+				return false, err
 			}
 
 			// adjust volume count
 			addVolumeCount(dst.dataNode.DiskInfos[replica.info.DiskType], 1)
-			break
+			return true, nil
 		}
 	}
 
 	if !foundNewLocation && !hasSkippedCollection {
 		fmt.Fprintf(writer, "failed to place volume %d replica as %s, existing:%+v\n", replica.info.Id, replicaPlacement, len(replicas))
 	}
-	return nil
+	return false, nil
 }
 
 func addVolumeCount(info *master_pb.DiskInfo, count int) {


### PR DESCRIPTION
## Summary

  This change fixes a logic bug in `volume.fix.replication`.

  Previously, a volume could be added to `fixedVolumes` even when no replica was actually created. This caused the command to wait for topology changes that would never happen, and eventually fail
  with:

  `replicas volume <id> mismatch in topology`

<img width="796" height="276" alt="image" src="https://github.com/user-attachments/assets/0e46e16c-6a1f-40f4-8574-e1da9fcd5497" />


  ## Root Cause

  `fixOneUnderReplicatedVolume()` used to return only `error`.

  For some no-op paths, it still returned `nil`, for example:

  - `collectionPattern` does not match
  - no eligible target location can be found (`failed to place`)

  The caller only checked `err == nil`, so these volumes were still treated as successfully fixed.

  ## Fix

  Change `fixOneUnderReplicatedVolume()` to return:

  `(copied bool, err error)`

  Behavior after this change:

  - `copied == true` only when replication was actually triggered and completed
  - `copied == false, err == nil` for skipped / no-op / failed-to-place paths
  - `fixedVolumes` is updated only when `copied == true`

  This prevents false success tracking and avoids incorrect topology wait / mismatch errors.

  ## Reproduction

  Test environment:

  - 3 masters
  - 2 volume servers
  - local `weed shell`
  - existing `solo` volumes with replication `010`

  Steps:

  1. Pick two volumes and remove one replica from each:
     - one matching the collection pattern, e.g. volume `180` with `collection:"solo"` and replication `010`
     - one non-matching volume, e.g. volume `175` with `collection:""` and replication `020`

     Example:

     ```bash
     weed shell -master=127.0.0.1:9333
     lock
     volume.delete -node=10.22.33.13:8082 -volumeId=180
     volume.delete -node=10.22.33.13:8082 -volumeId=175
     unlock

  2. Run:

     ```bash
     weed shell -master=127.0.0.1:9333
     lock
     volume.fix.replication -collectionPattern=solo -force -retry=1 -volumesPerStep=10
     unlock
     ```
  3. Before this fix, the command could:
      - print failed to place volume 180 ...
      - still treat it as fixed
      - then wait for topology updates and fail with:

     the number of locations for volume 180 has not increased yet, let's wait
     error: replicas volume 180 mismatch in topology
  4. After this fix:
      - failed to place ... volumes are not added to fixedVolumes
      - the command no longer enters false topology wait for skipped / unplaced volumes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy in tracking volume replication fixes and error handling during replica placement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->