### PR TITLE
Fix Admin UI master list showing gRPC port instead of HTTP port

### DIFF
--- a/weed/admin/dash/admin_server.go
+++ b/weed/admin/dash/admin_server.go
@@ -943,7 +943,7 @@ func (s *AdminServer) GetClusterMasters() (*ClusterMastersData, error) {
 			leaderCount++
 		}
 
-		masterMap[pb.ServerAddress(master.Address).ToHttpAddress()] = masterInfo
+		masterMap[masterInfo.Address] = masterInfo
 	}
 
 	// Then, get additional master information from Raft cluster


### PR DESCRIPTION
## Summary
- Fixes #8867 — follower master links in the Admin UI (`/clusters/masters`) showed gRPC ports instead of HTTP ports
- Raft stores server addresses as gRPC addresses (e.g., `host:19333`). The code was passing these through `ToHttpAddress()`, which can't extract the HTTP port from a plain gRPC address and returns it unchanged
- Use `GrpcAddressToServerAddress()` to properly convert gRPC addresses (port - 10000) back to HTTP addresses
- Also normalize the topology map keys to use HTTP addresses so the merge between topology and raft data works correctly

## Test plan
- [ ] Deploy a multi-master SeaweedFS cluster with Hashicorp Raft
- [ ] Navigate to Admin UI `/clusters/masters` page
- [ ] Verify all master links (leader and followers) show the correct HTTP port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cluster master address normalization so topology-derived and cluster-reported addresses use a consistent HTTP-form key. This ensures leader and suffrage updates from cluster reports are merged into the correct master entries, preventing mismatches and improving accuracy of master status in the admin dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->