### PR TITLE
Add manual trigger to Rust volume server release build workflow

### DIFF
--- a/.github/workflows/rust_binaries_release.yml
+++ b/.github/workflows/rust_binaries_release.yml
@@ -39,8 +39,16 @@ jobs:
       - name: Install cross-compilation tools
         if: matrix.cross
         run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo dpkg --add-architecture arm64
+          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu libssl-dev:arm64
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "OPENSSL_DIR=/usr" >> "$GITHUB_ENV"
+          echo "OPENSSL_INCLUDE_DIR=/usr/include" >> "$GITHUB_ENV"
+          echo "OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry and target
         uses: actions/cache@v5

--- a/seaweed-volume/Cargo.toml
+++ b/seaweed-volume/Cargo.toml
@@ -127,9 +127,6 @@ aws-sdk-s3 = { version = "1.125.0", default-features = false, features = ["sigv4
 aws-credential-types = "1"
 aws-types = "1"
 
-# Vendored OpenSSL for cross-compilation (transitive dep from AWS SDK)
-openssl = { version = "0.10", features = ["vendored"] }
-
 [dev-dependencies]
 tempfile = "3"
 


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` manual trigger support to the existing `rust_binaries_release.yml` workflow
- On tag push: uploads to GitHub release (existing behavior, unchanged)
- On manual trigger: uploads as downloadable workflow artifacts instead

## Test plan
- [ ] Trigger the workflow manually from the Actions tab and verify all 5 builds complete
- [ ] Verify tag-push releases still upload to GitHub releases as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to conditionally publish releases only on tag creation.
  * Added artifact storage for non-tag builds, enabling easier access to development binaries.
  * Enhanced cross-compilation support for ARM64 architecture builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->