### PR TITLE
fix(weed/worker/tasks/ec_balance): non-recursive reportProgress

### DIFF
--- a/weed/worker/tasks/ec_balance/ec_balance_task.go
+++ b/weed/worker/tasks/ec_balance/ec_balance_task.go
@@ -209,10 +209,11 @@ func (t *ECBalanceTask) GetProgress() float64 {
 	return t.progress
 }
 
-// reportProgress updates the stored progress and logs the stage
+// reportProgress updates the stored progress and reports it via the callback
 func (t *ECBalanceTask) reportProgress(progress float64, stage string) {
 	t.progress = progress
-	glog.Infof("EC balance: [%.2f] %s", progress, stage)
+	t.ReportProgressWithStage(progress, stage)
+	glog.Infof("EC balance volume %d: [%.2f] %s", t.volumeID, progress, stage)
 }
 
 // isDedupPhase checks if this is a dedup-phase task (source and target are the same node)


### PR DESCRIPTION
`ECBalanceTask.reportProgress()` is currently a recursive function that accepts progress percentage and `stage` as its arguments. Presently, it does nothing with `stage` and then calls itself into infinity.

This changes it to setting the progress, logging it, and exiting.

Mention of the non-existent callback is removed from the comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved EC balance progress reporting: progress is now recorded internally and emitted to logs with stage and percentage details for clearer monitoring and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->