### PR TITLE
STS: add GetCallerIdentity support

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -522,7 +522,7 @@ func (s3a *S3ApiServer) UnifiedPostHandler(w http.ResponseWriter, r *http.Reques
 
 	// 3. Dispatch
 	action := r.Form.Get("Action")
-	if strings.HasPrefix(action, "AssumeRole") {
+	if strings.HasPrefix(action, "AssumeRole") || action == "GetCallerIdentity" {
 		// STS
 		if s3a.stsHandlers == nil {
 			s3err.WriteErrorResponse(w, r, s3err.ErrServiceUnavailable)

--- a/weed/s3api/s3api_sts.go
+++ b/weed/s3api/s3api_sts.go
@@ -628,7 +628,7 @@ func (h *STSHandlers) handleGetCallerIdentity(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	identity, credential, _, _, sigErrCode := h.iam.verifyV4Signature(r, false)
+	identity, _, _, _, sigErrCode := h.iam.verifyV4Signature(r, false)
 	if sigErrCode != s3err.ErrNone {
 		glog.V(2).Infof("GetCallerIdentity SigV4 verification failed: %v", sigErrCode)
 		h.writeSTSErrorResponse(w, r, STSErrAccessDenied,
@@ -650,9 +650,6 @@ func (h *STSHandlers) handleGetCallerIdentity(w http.ResponseWriter, r *http.Req
 	}
 
 	userId := identity.Name
-	if credential != nil && credential.AccessKey != "" {
-		userId = credential.AccessKey
-	}
 
 	glog.V(2).Infof("GetCallerIdentity: identity=%s, arn=%s, account=%s", identity.Name, arn, accountID)
 

--- a/weed/s3api/s3api_sts_get_caller_identity_test.go
+++ b/weed/s3api/s3api_sts_get_caller_identity_test.go
@@ -13,7 +13,7 @@ func TestGetCallerIdentityResponse_XMLMarshal(t *testing.T) {
 	response := &GetCallerIdentityResponse{
 		Result: GetCallerIdentityResult{
 			Arn:     fmt.Sprintf("arn:aws:iam::%s:user/alice", defaultAccountID),
-			UserId:  "AKIAIOSFODNN7EXAMPLE",
+			UserId:  "alice",
 			Account: defaultAccountID,
 		},
 	}
@@ -26,7 +26,7 @@ func TestGetCallerIdentityResponse_XMLMarshal(t *testing.T) {
 	assert.Contains(t, xmlStr, "GetCallerIdentityResponse")
 	assert.Contains(t, xmlStr, "GetCallerIdentityResult")
 	assert.Contains(t, xmlStr, "<Arn>arn:aws:iam::000000000000:user/alice</Arn>")
-	assert.Contains(t, xmlStr, "<UserId>AKIAIOSFODNN7EXAMPLE</UserId>")
+	assert.Contains(t, xmlStr, "<UserId>alice</UserId>")
 	assert.Contains(t, xmlStr, "<Account>000000000000</Account>")
 	assert.Contains(t, xmlStr, "<RequestId>test-request-id</RequestId>")
 	assert.Contains(t, xmlStr, "https://sts.amazonaws.com/doc/2011-06-15/")


### PR DESCRIPTION
## Summary
- Implement the AWS STS `GetCallerIdentity` action, which returns the ARN, account ID, and user ID of the authenticated caller
- This is one of the most commonly used STS operations (e.g. `aws sts get-caller-identity`) for verifying credentials and determining the authenticated identity
- Follows the same patterns as existing STS actions (AssumeRole, AssumeRoleWithWebIdentity, AssumeRoleWithLDAPIdentity)

## Changes
- `weed/s3api/s3api_sts.go`: Add `handleGetCallerIdentity` handler, `GetCallerIdentityResponse`/`GetCallerIdentityResult` response types, and route the new action constant
- `weed/s3api/s3api_server.go`: Register explicit route for `?Action=GetCallerIdentity` and exclude it from the unified IAM matcher
- `weed/s3api/s3api_sts_get_caller_identity_test.go`: Tests for XML marshaling/unmarshaling of the response

## Test plan
- [x] Unit tests for XML response format (marshal and unmarshal)
- [x] Existing STS tests continue to pass
- [ ] Manual test: `aws sts get-caller-identity --endpoint-url http://localhost:8333` returns correct identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added STS `GetCallerIdentity` action support, allowing users to retrieve their AWS account ID, ARN, and user ID through signature-verified requests.

* **Tests**
  * Added test coverage for the `GetCallerIdentity` response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->