### PR TITLE
Prune unused memory_map fields

### DIFF
--- a/weed/storage/backend/memory_map/memory_map.go
+++ b/weed/storage/backend/memory_map/memory_map.go
@@ -6,19 +6,12 @@ import (
 )
 
 type MemoryBuffer struct {
-	aligned_length uint64
-	length         uint64
-	aligned_ptr    uintptr
-	ptr            uintptr
-	Buffer         []byte
+	Buffer []byte
 }
 
 type MemoryMap struct {
-	File                   *os.File
-	file_memory_map_handle uintptr
-	write_map_views        []MemoryBuffer
-	max_length             uint64
-	End_of_file            int64
+	File        *os.File
+	End_of_file int64
 }
 
 func ReadMemoryMapMaxSizeMb(memoryMapMaxSizeMbString string) (uint32, error) {


### PR DESCRIPTION
This prunes unused fields from `MemoryBuffer` and `MemoryMap` in the `memory_map` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal data structure definitions to reduce complexity and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->