### PR TITLE
fix(weed/filer/redis): dropped error

### DIFF
--- a/weed/filer/redis/universal_redis_store.go
+++ b/weed/filer/redis/universal_redis_store.go
@@ -173,14 +173,16 @@ func (store *UniversalRedisStore) ListDirectoryEntries(ctx context.Context, dirP
 		members = members[:limit]
 	}
 
+	var entry *filer.Entry
 	// fetch entry meta
 	for _, fileName := range members {
 		path := util.NewFullPath(string(dirPath), fileName)
-		entry, err := store.FindEntry(ctx, path)
+		entry, err = store.FindEntry(ctx, path)
 		lastFileName = fileName
 		if err != nil {
 			glog.V(0).InfofCtx(ctx, "list %s : %v", path, err)
 			if err == filer_pb.ErrNotFound {
+				err = nil
 				continue
 			}
 		} else {


### PR DESCRIPTION
This fixes a dropped `err` variable in `weed/filer/redis`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal directory listing logic to be more reliable and slightly more efficient when enumerating entries.

* **Bug Fixes**
  * Fixed an issue where directory listing could return an erroneous failure after a later-successful lookup; listings now correctly clear transient error state and report successful results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->