### PR TITLE
feat(admin): add profiling options for debugging high memory/CPU usage

### DIFF
--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -149,6 +149,16 @@ var cmdAdmin = &Command{
     - All static assets, API endpoints, and navigation links will use the prefix
     - Session cookies are scoped to the prefix path
 
+  Debugging and Profiling:
+    - Use -debug to start a pprof HTTP server for live profiling (localhost only)
+    - Set -debug.port to choose the pprof port (default 6060)
+    - Profiles are accessible at http://127.0.0.1:<debug.port>/debug/pprof/
+    - Use -cpuprofile and -memprofile to write profiles to files on shutdown
+    - WARNING: -debug exposes runtime internals; use only in trusted environments
+    - Examples:
+      weed admin -debug -debug.port=6060 -master="localhost:9333"
+      weed admin -cpuprofile=cpu.prof -memprofile=mem.prof -master="localhost:9333"
+
   Configuration File:
     - The security.toml file is read from ".", "$HOME/.seaweedfs/",
       "/usr/local/etc/seaweedfs/", or "/etc/seaweedfs/", in that order

--- a/weed/util/grace/pprof.go
+++ b/weed/util/grace/pprof.go
@@ -15,8 +15,8 @@ import (
 // The server runs in a goroutine and serves pprof endpoints at /debug/pprof/*.
 func StartDebugServer(debugPort int) {
 	go func() {
-		addr := fmt.Sprintf(":%d", debugPort)
-		glog.V(0).Infof("Starting debug server for pprof at http://localhost%s/debug/pprof/", addr)
+		addr := fmt.Sprintf("127.0.0.1:%d", debugPort)
+		glog.V(0).Infof("Starting debug server for pprof at http://%s/debug/pprof/", addr)
 		if err := http.ListenAndServe(addr, nil); err != nil && err != http.ErrServerClosed {
 			glog.Errorf("Failed to start debug server on %s: %v", addr, err)
 		}


### PR DESCRIPTION
## Summary
- Add `-debug` and `-debug.port` flags to start a pprof HTTP server for live profiling
- Add `-cpuprofile` and `-memprofile` flags for file-based profiling on shutdown
- Matches the profiling support already available in master, volume, filer, and other commands

Closes #8919

## Test plan
- [ ] Verify `weed admin -debug -debug.port=6060` starts pprof server accessible at `http://localhost:6060/debug/pprof/`
- [ ] Verify `weed admin -cpuprofile=cpu.prof -memprofile=mem.prof` writes profile files on shutdown
- [ ] Verify `go tool pprof http://localhost:6060/debug/pprof/heap` can collect heap profiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flags to enable a debug HTTP server at admin startup and to produce CPU/memory profiling output to specified files
* **Chores**
  * Debug HTTP server now binds to the loopback interface and startup logging reflects the explicit loopback address
<!-- end of auto-generated comment: release notes by coderabbit.ai -->