### PR TITLE
fix(admin): fix master leader link showing incorrect port in Admin UI

### DIFF
--- a/weed/server/master_grpc_server_raft.go
+++ b/weed/server/master_grpc_server_raft.go
@@ -41,7 +41,7 @@ func (ms *MasterServer) RaftListClusterServers(ctx context.Context, req *master_
 		// Add the current server itself (Peers() only returns other peers)
 		resp.ClusterServers = append(resp.ClusterServers, &master_pb.RaftListClusterServersResponse_ClusterServers{
 			Id:       currentServerName,
-			Address:  string(ms.option.Master),
+			Address:  ms.option.Master.ToGrpcAddress(),
 			Suffrage: "Voter",
 			IsLeader: currentServerName == leader,
 		})


### PR DESCRIPTION
## Summary

- Fixes the master leader link on Admin UI (`/clusters/masters`) showing port `-667` instead of the correct HTTP port (e.g., `9333`)
- Root cause: the old Raft implementation returned the HTTP address for the current server while all other code paths (HashicorpRaft, old Raft peers) return gRPC addresses. The Admin UI uniformly converts gRPC→HTTP by subtracting 10000, producing a negative port for the already-HTTP address.
- Fix: use `ToGrpcAddress()` so the current server's address is in gRPC format, consistent with all other entries.

Regression from 44d5cb8f (#8869).

Fixes #8921

## Test plan
- [x] `go build ./weed/server/` compiles
- [x] Existing Raft tests pass (`go test ./weed/server/ -run Raft`)
- [ ] Manual: verify Admin UI `/clusters/masters` shows correct HTTP port for leader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cluster server address formatting for gRPC communication compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->