### PR TITLE
fix(s3): apply PutObject multipart expansion to STS session policies

### DIFF
--- a/weed/iam/policy/aws_iam_compliance_test.go
+++ b/weed/iam/policy/aws_iam_compliance_test.go
@@ -180,6 +180,12 @@ func TestMatchesActionsMultipartExpansion(t *testing.T) {
 			requestedAction: "s3:CreateMultipartUpload",
 			expected:        true,
 		},
+		{
+			name:            "case-insensitive multipart action lookup",
+			actions:         []string{"s3:PutObject"},
+			requestedAction: "S3:CREATEMULTIPARTUPLOAD",
+			expected:        true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/weed/iam/policy/policy_engine.go
+++ b/weed/iam/policy/policy_engine.go
@@ -600,33 +600,31 @@ func (e *PolicyEngine) statementMatches(statement *Statement, evalCtx *Evaluatio
 	return true
 }
 
-// multipartActionSet contains S3 multipart upload actions that are implicitly
-// granted when s3:PutObject is allowed, since multipart upload is an
-// implementation detail of putting objects.
+// multipartActionSet contains lowercased S3 multipart upload actions that are
+// implicitly granted when s3:PutObject is allowed, since multipart upload is an
+// implementation detail of putting objects. Keys are lowercased for
+// case-insensitive lookup (AWS IAM actions are case-insensitive).
 var multipartActionSet = map[string]bool{
-	"s3:CreateMultipartUpload":      true,
-	"s3:UploadPart":                 true,
-	"s3:CompleteMultipartUpload":    true,
-	"s3:AbortMultipartUpload":       true,
-	"s3:ListMultipartUploadParts":   true,
-	"s3:ListBucketMultipartUploads": true,
+	"s3:createmultipartupload":      true,
+	"s3:uploadpart":                 true,
+	"s3:completemultipartupload":    true,
+	"s3:abortmultipartupload":       true,
+	"s3:listmultipartuploadparts":   true,
+	"s3:listbucketmultipartuploads": true,
 }
 
 // matchesActions checks if any action in the list matches the requested action.
 // It also implicitly grants multipart upload actions when s3:PutObject is allowed,
 // mirroring the behavior in the S3 API policy engine (see PR #8445).
 func (e *PolicyEngine) matchesActions(actions []string, requestedAction string, evalCtx *EvaluationContext) bool {
-	hasPutObjectPermission := false
+	isMultipart := multipartActionSet[strings.ToLower(requestedAction)]
 	for _, action := range actions {
 		if awsIAMMatch(action, requestedAction, evalCtx) {
 			return true
 		}
-		if !hasPutObjectPermission && awsIAMMatch(action, "s3:PutObject", evalCtx) {
-			hasPutObjectPermission = true
+		if isMultipart && awsIAMMatch(action, "s3:PutObject", evalCtx) {
+			return true
 		}
-	}
-	if hasPutObjectPermission && multipartActionSet[requestedAction] {
-		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

Fixes #8929.

- PR #8445 added logic to implicitly grant multipart upload actions when `s3:PutObject` is authorized, but only in the S3 API policy engine's `CompiledStatement.MatchesAction()` (`weed/s3api/policy_engine/types.go`)
- STS session policies are evaluated through a different code path: `IAMManager` → `PolicyEngine.EvaluatePolicyDocument()` → `matchesActions()` → `awsIAMMatch()` (`weed/iam/policy/policy_engine.go`), which did plain pattern matching without multipart expansion
- This adds the same multipart expansion logic to the IAM policy engine's `matchesActions()`, so STS-vended credentials with `s3:PutObject` in their session policy correctly allow `CreateMultipartUpload`, `UploadPart`, `CompleteMultipartUpload`, etc.

## Test plan

- [x] Added `TestMatchesActionsMultipartExpansion` covering all 6 multipart actions, negative cases, and wildcard patterns
- [x] All existing IAM policy and integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * S3 multipart upload authorization updated so policies granting s3:PutObject (or equivalent wildcards) also authorize related multipart operations (initiate, upload parts, complete, abort, and list multipart uploads).

* **Tests**
  * Added tests covering multipart action authorization, wildcard matching, and case-insensitive action lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->