### PR TITLE
fix(azuresink): delete freshly created blob on write failure

### DIFF
--- a/weed/replication/sink/azuresink/azure_sink.go
+++ b/weed/replication/sink/azuresink/azure_sink.go
@@ -147,6 +147,8 @@ func (g *AzureSink) CreateEntry(key string, entry *filer_pb.Entry, signatures []
 			if handleErr != nil {
 				return handleErr
 			}
+			// handleExistingBlob recreates the blob when needsWrite is true
+			freshlyCreated = needsWrite
 		} else {
 			return fmt.Errorf("azure create append blob %s/%s: %w", g.container, key, err)
 		}


### PR DESCRIPTION
## Summary

- In `CreateEntry`, `appendBlobClient.Create()` runs before content is written via `CopyFromChunkViews` or inline `entry.Content`. If either write path fails, an empty blob is left behind, silently replacing any previous valid data.
- Added a `cleanupOnError` helper that deletes the freshly created blob when a content write error occurs. This only triggers when the blob was created by the current call (not when `handleExistingBlob` determined the blob is already up-to-date).
- The cleanup logs a warning on both the original write failure and any cleanup failure, and tolerates `BlobNotFound` during cleanup (in case of concurrent deletion).

## Test plan

- [ ] Verify `go build ./weed/replication/sink/azuresink/` passes
- [ ] Simulate a `CopyFromChunkViews` failure and confirm the empty blob is deleted
- [ ] Confirm happy path (successful write) is unchanged
- [ ] Confirm that when `handleExistingBlob` returns `needsWrite=false`, no cleanup runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure replication reliability: the sink now detects newly created append blobs and will automatically remove any such blob if a subsequent write fails, avoiding orphaned or incomplete replicas and emitting a warning when cleanup occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->