### PR TITLE
fix: prevent stack overflow in ECBalanceTask.reportProgress

### DIFF
--- a/weed/worker/tasks/ec_balance/ec_balance_task.go
+++ b/weed/worker/tasks/ec_balance/ec_balance_task.go
@@ -3,6 +3,8 @@ package ec_balance
 import (
 	"context"
 	"fmt"
+	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -22,8 +24,8 @@ type ECBalanceTask struct {
 	volumeID       uint32
 	collection     string
 	grpcDialOption grpc.DialOption
-	progress       float64
-	reporting      bool // re-entry guard to prevent recursive reportProgress calls
+	progress       uint64 // atomic; stores float64 bits via math.Float64bits
+	reporting      int32  // atomic; re-entry guard to prevent recursive reportProgress calls
 }
 
 // NewECBalanceTask creates a new EC balance task instance
@@ -207,17 +209,16 @@ func (t *ECBalanceTask) EstimateTime(params *worker_pb.TaskParams) time.Duration
 
 // GetProgress returns current progress
 func (t *ECBalanceTask) GetProgress() float64 {
-	return t.progress
+	return math.Float64frombits(atomic.LoadUint64(&t.progress))
 }
 
 // reportProgress updates the stored progress and reports it via the callback
 func (t *ECBalanceTask) reportProgress(progress float64, stage string) {
-	if t.reporting {
+	if !atomic.CompareAndSwapInt32(&t.reporting, 0, 1) {
 		return
 	}
-	t.reporting = true
-	defer func() { t.reporting = false }()
-	t.progress = progress
+	defer atomic.StoreInt32(&t.reporting, 0)
+	atomic.StoreUint64(&t.progress, math.Float64bits(progress))
 	t.ReportProgressWithStage(progress, stage)
 	glog.Infof("EC balance volume %d: [%.2f] %s", t.volumeID, progress, stage)
 }


### PR DESCRIPTION
## Summary
- Fix stack overflow crash in `ECBalanceTask.reportProgress()` that kills the worker process
- Add re-entry guard (`reporting` bool) to prevent infinite recursion when `ReportProgressWithStage` invokes the `progressCallback` which re-enters `reportProgress`
- Crash was observed during EC shard rebalancing with ~22M recursive frames exhausting the 1GB goroutine stack limit

## Test plan
- [x] Existing `ec_balance` tests pass
- [ ] Verify EC shard rebalancing completes without worker crash
- [ ] Monitor goroutine stack usage during EC balance operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of EC balance progress reporting by preventing concurrent reporting conflicts and ensuring progress reads are consistent, avoiding incorrect or skipped progress updates during concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->