### PR TITLE
fix(stats): fix build on openbsd, solaris, and windows

### DIFF
--- a/weed/stats/disk_openbsd.go
+++ b/weed/stats/disk_openbsd.go
@@ -17,7 +17,9 @@ func fillInDiskStatus(disk *volume_server_pb.DiskStatus) {
 
 	disk.All = fs.F_blocks * uint64(fs.F_bsize)
 	disk.Free = fs.F_bfree * uint64(fs.F_bsize)
-	calculateDiskRemaining(disk)
+	disk.Used = disk.All - disk.Free
+	disk.PercentFree = float32((float64(disk.Free) / float64(disk.All)) * 100)
+	disk.PercentUsed = float32((float64(disk.Used) / float64(disk.All)) * 100)
 
 	return
 }

--- a/weed/stats/disk_solaris.go
+++ b/weed/stats/disk_solaris.go
@@ -17,7 +17,9 @@ func fillInDiskStatus(disk *volume_server_pb.DiskStatus) {
 
 	disk.All = stat.Blocks * uint64(stat.Bsize)
 	disk.Free = stat.Bfree * uint64(stat.Bsize)
-	calculateDiskRemaining(disk)
+	disk.Used = disk.All - disk.Free
+	disk.PercentFree = float32((float64(disk.Free) / float64(disk.All)) * 100)
+	disk.PercentUsed = float32((float64(disk.Used) / float64(disk.All)) * 100)
 
 	return
 }

--- a/weed/stats/disk_windows.go
+++ b/weed/stats/disk_windows.go
@@ -40,7 +40,9 @@ func fillInDiskStatus(disk *volume_server_pb.DiskStatus) {
 
 		return
 	}
-	calculateDiskRemaining(disk)
+	disk.Used = disk.All - disk.Free
+	disk.PercentFree = float32((float64(disk.Free) / float64(disk.All)) * 100)
+	disk.PercentUsed = float32((float64(disk.Used) / float64(disk.All)) * 100)
 
 	return
 }


### PR DESCRIPTION
## Summary
- `disk_openbsd.go`, `disk_solaris.go`, and `disk_windows.go` all call `calculateDiskRemaining()` which is never defined anywhere, causing build failures on those platforms
- Replaced with the same inline disk usage calculation used in `disk_supported.go`

## Test plan
- [ ] Verify `GOOS=openbsd go build ./weed/stats/` compiles
- [ ] Verify `GOOS=windows go build ./weed/stats/` compiles
- [ ] Verify `GOOS=solaris go build ./weed/stats/` compiles (requires solaris-compatible deps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined disk statistics calculations across OpenBSD, Solaris, and Windows platforms through internal logic reorganization, with no changes to reported values or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->