### PR TITLE
fix(weed/filer/redis2): fix dropped error

### DIFF
--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -208,6 +208,7 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 				err = nil
 				continue
 			}
+			break
 		} else {
 			if entry.TtlSec > 0 {
 				if entry.Attr.Crtime.Add(time.Duration(entry.TtlSec) * time.Second).Before(time.Now()) {


### PR DESCRIPTION
This fixes a dropped `err` variable that was being redeclared and lost in `weed/filer/redis2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where listing directory entries could return incorrect error states, improving the reliability of file listing operations in the storage system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->