### PR TITLE
chore(helm): document worker job categories and use 'all' as default

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1339,9 +1339,14 @@ worker:
   # Admin server to connect to
   adminServer: ""
 
-  # Worker job types - comma-separated list
-  # Available: vacuum, volume_balance, erasure_coding
-  jobType: "vacuum,volume_balance,erasure_coding"
+  # Worker job types - categories or comma-separated list of names/aliases
+  # Categories: all, default, heavy
+  #   default: vacuum, volume_balance, ec_balance, admin_script
+  #   heavy: erasure_coding, iceberg_maintenance
+  #   all: every registered job type
+  # Examples: "all", "default", "heavy", "default,iceberg" (default+iceberg), "vacuum,volume_balance"
+  # Refer: https://github.com/seaweedfs/seaweedfs/wiki/Worker
+  jobType: "all"
 
   # Maximum number of concurrent detection requests
   maxDetect: 1


### PR DESCRIPTION
## Summary
- Document the worker job category system (`all`, `default`, `heavy`) with all available job types in the Helm chart values
- Change the default `jobType` from an explicit list to `"all"` to match the CLI default
- Add usage examples and wiki reference link

Supersedes #9001

## Test plan
- [ ] Manual review of the Helm chart values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes Helm chart worker configuration. Default job type now defaults to the "all" category instead of a fixed list, with clarified documentation for supported categories and custom composition options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->