### PR TITLE
Update Helm Chart docs with instructions for deploying RocksDB variant

### DIFF
--- a/k8s/charts/seaweedfs/README.md
+++ b/k8s/charts/seaweedfs/README.md
@@ -49,6 +49,25 @@ CREATE TABLE IF NOT EXISTS `filemeta` (
 
 Alternative database can also be configured (e.g. leveldb, postgres) following the instructions at `filer.extraEnvironmentVars`.
 
+#### RocksDB variant
+
+The _large_disk_rocksdb image tag ships with RocksDB pre-configured as the filer backend.
+To use this image with the Helm chart, override the image and disable the chart's default WEED_LEVELDB2_ENABLED, which otherwise overrides the image's RocksDB configuration:
+
+```yaml
+# Update <VERSION> placeholder with desired seaweedfs version.
+master:
+  imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
+
+volume:
+  imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
+
+filer:
+  imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
+  extraEnvironmentVars:
+    WEED_LEVELDB2_ENABLED: "false"
+```
+
 ### Node Labels
 Kubernetes nodes can have labels which help to define which node(Host) will run which pod:
 

--- a/k8s/charts/seaweedfs/README.md
+++ b/k8s/charts/seaweedfs/README.md
@@ -51,11 +51,13 @@ Alternative database can also be configured (e.g. leveldb, postgres) following t
 
 #### RocksDB variant
 
-The _large_disk_rocksdb image tag ships with RocksDB pre-configured as the filer backend.
-To use this image with the Helm chart, override the image and disable the chart's default WEED_LEVELDB2_ENABLED, which otherwise overrides the image's RocksDB configuration:
+The `_large_disk_rocksdb` image tag ships with RocksDB pre-configured as the filer backend.
+To use this image with the Helm chart, override the image on all three components and disable
+the chart's default `WEED_LEVELDB2_ENABLED`, which would otherwise re-enable LevelDB2 and
+override the image's built-in RocksDB configuration:
 
 ```yaml
-# Update <VERSION> placeholder with desired seaweedfs version.
+# Replace <VERSION> with the desired seaweedfs version, e.g. 3.80_large_disk_rocksdb.
 master:
   imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
 
@@ -63,10 +65,18 @@ volume:
   imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
 
 filer:
+  enablePVC: true
   imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
   extraEnvironmentVars:
     WEED_LEVELDB2_ENABLED: "false"
 ```
+
+Notes:
+
+* `master` and `volume` use the same image tag so that all components share a consistent
+  SeaweedFS build; RocksDB itself is only used by the filer.
+* `filer.enablePVC: true` (or another form of persistent storage for the filer) is required
+  so that the RocksDB metadata store survives pod restarts — otherwise metadata will be lost.
 
 ### Node Labels
 Kubernetes nodes can have labels which help to define which node(Host) will run which pod:


### PR DESCRIPTION
# What problem are we solving?
A RocksDB image tag variant is provided, however I couldn't find any instructions on how to deploy this with the helm chart, which pre-bakes some default settings.


# How are we solving the problem?
Adds additional documentation which presents how to override the default image, as well as toggle a default for an environment variable currently set in the chart.

# How is the PR tested?
I've tested it locally in a k3d cluster, i'll admit though I am very new to seaweedfs and i'm very much open to feedback and discussion on this contribution. If existing docs exist elsewhere i'd be happy to be directed.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "RocksDB variant" section to the SeaweedFS Helm chart README with step-by-step guidance for running the RocksDB build as the filer backend: which images to use and override, disabling the chart's LevelDB2 setting, ensuring consistent images across components, and enabling persistent storage so RocksDB metadata survives pod restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->