### PR TITLE
fix(iam): preserve actions/resources in GetUserPolicy fallback

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"29ee915b-09e0-48f3-9dd6-bff6ad192910","pid":90116,"acquiredAt":1775755248591}
+{"sessionId":"d6574c47-eafc-4a94-9dce-f9ffea22b53c","pid":10111,"acquiredAt":1775248373916}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"d6574c47-eafc-4a94-9dce-f9ffea22b53c","pid":10111,"acquiredAt":1775248373916}
+{"sessionId":"29ee915b-09e0-48f3-9dd6-bff6ad192910","pid":90116,"acquiredAt":1775755248591}

--- a/weed/iamapi/iamapi_management_handlers.go
+++ b/weed/iamapi/iamapi_management_handlers.go
@@ -466,13 +466,12 @@ func (iama *IamApiServer) GetUserPolicy(s3cfg *iam_pb.S3ApiConfiguration, values
 
 			resource := "*"
 			if len(act) == 2 {
-				// If the path already refers to objects (contains '/'), use it as-is.
-				// Otherwise it's a bare bucket pattern; append "/*" to scope to objects.
-				if strings.Contains(act[1], "/") {
-					resource = fmt.Sprintf("arn:aws:s3:::%s", act[1])
-				} else {
-					resource = fmt.Sprintf("arn:aws:s3:::%s/*", act[1])
-				}
+				// Preserve the stored path verbatim so bucket-level and
+				// object-level resources remain distinguishable. GetActions
+				// stores the path exactly as parsed from the original ARN
+				// (e.g. "b-le*" for the bucket, "b-le*/*" for objects), and
+				// reconstruction should not rewrite one into the other.
+				resource = fmt.Sprintf("arn:aws:s3:::%s", act[1])
 			}
 			s3Action := fmt.Sprintf("s3:%s", MapToIdentitiesAction(act[0]))
 			// Dedupe actions per resource: the Read/Write/List internal verbs map to

--- a/weed/iamapi/iamapi_management_handlers.go
+++ b/weed/iamapi/iamapi_management_handlers.go
@@ -458,17 +458,34 @@ func (iama *IamApiServer) GetUserPolicy(s3cfg *iam_pb.S3ApiConfiguration, values
 
 		policyDocument := policy_engine.PolicyDocument{Version: policyDocumentVersion}
 		statements := make(map[string][]string)
+		seenAction := make(map[string]map[string]bool)
 		for _, action := range ident.Actions {
-			// parse "Read:EXAMPLE-BUCKET"
-			act := strings.Split(action, ":")
+			// parse "Read:EXAMPLE-BUCKET" or "Read:EXAMPLE-BUCKET/prefix/*"
+			// Use SplitN so the path component (which may contain ':') is preserved intact.
+			act := strings.SplitN(action, ":", 2)
 
 			resource := "*"
 			if len(act) == 2 {
-				resource = fmt.Sprintf("arn:aws:s3:::%s/*", act[1])
+				// If the path already refers to objects (contains '/'), use it as-is.
+				// Otherwise it's a bare bucket pattern; append "/*" to scope to objects.
+				if strings.Contains(act[1], "/") {
+					resource = fmt.Sprintf("arn:aws:s3:::%s", act[1])
+				} else {
+					resource = fmt.Sprintf("arn:aws:s3:::%s/*", act[1])
+				}
 			}
-			statements[resource] = append(statements[resource],
-				fmt.Sprintf("s3:%s", MapToIdentitiesAction(act[0])),
-			)
+			s3Action := fmt.Sprintf("s3:%s", MapToIdentitiesAction(act[0]))
+			// Dedupe actions per resource: the Read/Write/List internal verbs map to
+			// coarse wildcards (s3:Get*, s3:Put*, s3:List*), so multiple distinct
+			// original actions can collapse to the same reconstructed verb.
+			if seenAction[resource] == nil {
+				seenAction[resource] = make(map[string]bool)
+			}
+			if seenAction[resource][s3Action] {
+				continue
+			}
+			seenAction[resource][s3Action] = true
+			statements[resource] = append(statements[resource], s3Action)
 		}
 		for resource, actions := range statements {
 			isEqAction := false

--- a/weed/iamapi/iamapi_management_handlers_test.go
+++ b/weed/iamapi/iamapi_management_handlers_test.go
@@ -203,7 +203,8 @@ func TestPutGetUserPolicyIssue9008(t *testing.T) {
     }]
   }`
 
-	iama := &IamApiServer{s3ApiConfig: &mockIamS3ApiConfig{}}
+	mockCfg := &mockIamS3ApiConfig{}
+	iama := &IamApiServer{s3ApiConfig: mockCfg}
 	_, iamErr := iama.PutUserPolicy(s3cfg, url.Values{
 		"UserName":       []string{"steward"},
 		"PolicyName":     []string{"steward_policy"},
@@ -211,6 +212,8 @@ func TestPutGetUserPolicyIssue9008(t *testing.T) {
 	})
 	assert.Nil(t, iamErr)
 
+	// Part 1: verbatim round-trip. GetUserPolicy returns the exact document
+	// that was persisted, with Action and Resource lists intact.
 	resp, iamErr := iama.GetUserPolicy(s3cfg, url.Values{
 		"UserName":   []string{"steward"},
 		"PolicyName": []string{"steward_policy"},
@@ -224,13 +227,34 @@ func TestPutGetUserPolicyIssue9008(t *testing.T) {
 	assert.Equal(t, 1, len(got.Statement))
 	stmt := got.Statement[0]
 	assert.Equal(t, policy_engine.PolicyEffectAllow, stmt.Effect)
-
-	// Actions must match exactly what was submitted: no duplication, no
-	// collapsing to wildcards.
 	assert.ElementsMatch(t, []string{"s3:GetObject", "s3:PutObject", "s3:ListBucket"}, stmt.Action.Strings())
-
-	// Both resources must be preserved.
 	assert.ElementsMatch(t, []string{"arn:aws:s3:::b-le*", "arn:aws:s3:::b-le*/*"}, stmt.Resource.Strings())
+
+	// Part 2: fallback reconstruction. Clear the persisted inline policy so
+	// GetUserPolicy must rebuild the document from ident.Actions. The fallback
+	// is lossy (distinct S3 verbs collapse to wildcards like s3:Get*), but it
+	// must not duplicate actions nor conflate bucket-level and object-level
+	// resources.
+	mockCfg.policies = Policies{}
+
+	resp, iamErr = iama.GetUserPolicy(s3cfg, url.Values{
+		"UserName":   []string{"steward"},
+		"PolicyName": []string{"steward_policy"},
+	})
+	assert.Nil(t, iamErr)
+
+	var fallback policy_engine.PolicyDocument
+	assert.NoError(t, json.Unmarshal([]byte(resp.GetUserPolicyResult.PolicyDocument), &fallback))
+	assert.Equal(t, 1, len(fallback.Statement), "fallback should merge equal-action statements")
+	fstmt := fallback.Statement[0]
+
+	// Each coarse verb appears exactly once (no duplication from the
+	// Read/Write/List -> s3:Get*/s3:Put*/s3:List* expansion).
+	assert.ElementsMatch(t, []string{"s3:Get*", "s3:Put*", "s3:List*"}, fstmt.Action.Strings())
+
+	// Bucket-level and object-level resources stay distinct — the bare bucket
+	// pattern must not be rewritten to an object ARN.
+	assert.ElementsMatch(t, []string{"arn:aws:s3:::b-le*", "arn:aws:s3:::b-le*/*"}, fstmt.Resource.Strings())
 }
 
 func TestMultipleInlinePoliciesAggregateActions(t *testing.T) {

--- a/weed/iamapi/iamapi_management_handlers_test.go
+++ b/weed/iamapi/iamapi_management_handlers_test.go
@@ -186,6 +186,53 @@ func TestPutGetUserPolicyPreservesStatements(t *testing.T) {
 	assert.True(t, deleteObjectFound, "s3:DeleteObject action was lost")
 }
 
+// TestPutGetUserPolicyIssue9008 is a regression test for
+// https://github.com/seaweedfs/seaweedfs/issues/9008: put-user-policy followed
+// by get-user-policy must return the same policy document that was submitted,
+// with Action and Resource lists intact (no duplication, no collapsing).
+func TestPutGetUserPolicyIssue9008(t *testing.T) {
+	s3cfg := &iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{{Name: "steward"}},
+	}
+	policyJSON := `{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::b-le*", "arn:aws:s3:::b-le*/*"]
+    }]
+  }`
+
+	iama := &IamApiServer{s3ApiConfig: &mockIamS3ApiConfig{}}
+	_, iamErr := iama.PutUserPolicy(s3cfg, url.Values{
+		"UserName":       []string{"steward"},
+		"PolicyName":     []string{"steward_policy"},
+		"PolicyDocument": []string{policyJSON},
+	})
+	assert.Nil(t, iamErr)
+
+	resp, iamErr := iama.GetUserPolicy(s3cfg, url.Values{
+		"UserName":   []string{"steward"},
+		"PolicyName": []string{"steward_policy"},
+	})
+	assert.Nil(t, iamErr)
+
+	var got policy_engine.PolicyDocument
+	assert.NoError(t, json.Unmarshal([]byte(resp.GetUserPolicyResult.PolicyDocument), &got))
+
+	assert.Equal(t, "2012-10-17", got.Version)
+	assert.Equal(t, 1, len(got.Statement))
+	stmt := got.Statement[0]
+	assert.Equal(t, policy_engine.PolicyEffectAllow, stmt.Effect)
+
+	// Actions must match exactly what was submitted: no duplication, no
+	// collapsing to wildcards.
+	assert.ElementsMatch(t, []string{"s3:GetObject", "s3:PutObject", "s3:ListBucket"}, stmt.Action.Strings())
+
+	// Both resources must be preserved.
+	assert.ElementsMatch(t, []string{"arn:aws:s3:::b-le*", "arn:aws:s3:::b-le*/*"}, stmt.Resource.Strings())
+}
+
 func TestMultipleInlinePoliciesAggregateActions(t *testing.T) {
 	s3cfg := &iam_pb.S3ApiConfiguration{
 		Identities: []*iam_pb.Identity{{Name: "alice"}},


### PR DESCRIPTION
## Summary

Fixes #9008. When `GetUserPolicy` falls back to reconstructing a policy document from the aggregated `ident.Actions` (format `Verb:path`), the output was mangled:

- Paths that already contained `/` (e.g. `b-le*/*`) had another `/*` appended, producing nonsensical resources like `arn:aws:s3:::b-le*/*/*`.
- Distinct S3 actions that collapse to the same internal verb (e.g. `s3:GetObject` and `s3:GetBucketLocation` both map to `Read` → `s3:Get*`) were emitted multiple times in the same statement.
- `strings.Split(action, \":\")` shredded paths that contained `:`.

Changes in `weed/iamapi/iamapi_management_handlers.go`:
- Use `SplitN(action, \":\", 2)` so the path component is preserved intact.
- Only append `/*` to bare bucket patterns; paths already containing `/` are used as-is.
- Dedupe reconstructed actions per resource.

## Test plan

- [x] Added `TestPutGetUserPolicyIssue9008` — regression test using the exact reproducer from the issue (3 actions, 2 resources) and asserts the round-trip preserves them.
- [x] `go test ./weed/iamapi/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy retrieval so IAM actions preserve any path colons, S3 resource ARNs keep exact bucket/object forms (no unwanted /* rewriting), and actions are deduplicated per resource to avoid repeated statements.

* **Tests**
  * Added a regression test ensuring user inline policies round-trip intact and reconstructed documents maintain correct, non-duplicated actions and distinct bucket/object resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->