### PR TITLE
fix(filer/postgres): use pgx v5 API for PgBouncer simple protocol

### DIFF
--- a/weed/filer/postgres/pgx_conn.go
+++ b/weed/filer/postgres/pgx_conn.go
@@ -10,14 +10,14 @@ import (
 )
 
 // OpenPGXDB parses the given DSN into a pgx ConnConfig, applies PgBouncer
-// compatibility settings when requested, registers the config with the
-// pgx/v5 stdlib driver, opens a *sql.DB, and verifies it with Ping.
+// compatibility settings when requested, opens a *sql.DB via
+// stdlib.OpenDB, and verifies it with Ping.
 //
 // In pgx/v5 the prefer_simple_protocol DSN parameter was removed, so simple
 // protocol mode must be configured on the ConnConfig via
-// DefaultQueryExecMode. This helper centralizes that handling and, on any
-// failure after RegisterConnConfig, unregisters the config so we do not leak
-// entries in stdlib's global connection config map.
+// DefaultQueryExecMode. We use stdlib.OpenDB(config) rather than
+// RegisterConnConfig + sql.Open so we don't leak entries in stdlib's global
+// connection config map on either success or failure paths.
 //
 // adaptedSqlUrl is used only for error messages (the caller is expected to
 // have redacted any password).
@@ -36,20 +36,13 @@ func OpenPGXDB(sqlUrl, adaptedSqlUrl string, pgbouncerCompatible bool, maxIdle, 
 		connConfig.DescriptionCacheCapacity = 0
 	}
 
-	registeredConnStr := stdlib.RegisterConnConfig(connConfig)
-	db, dbErr := sql.Open("pgx", registeredConnStr)
-	if dbErr != nil {
-		stdlib.UnregisterConnConfig(registeredConnStr)
-		return nil, fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
-	}
-
+	db := stdlib.OpenDB(*connConfig)
 	db.SetMaxIdleConns(maxIdle)
 	db.SetMaxOpenConns(maxOpen)
 	db.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 
 	if err := db.Ping(); err != nil {
 		db.Close()
-		stdlib.UnregisterConnConfig(registeredConnStr)
 		return nil, fmt.Errorf("connect to %s error:%v", adaptedSqlUrl, err)
 	}
 

--- a/weed/filer/postgres/pgx_conn.go
+++ b/weed/filer/postgres/pgx_conn.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+// OpenPGXDB parses the given DSN into a pgx ConnConfig, applies PgBouncer
+// compatibility settings when requested, registers the config with the
+// pgx/v5 stdlib driver, opens a *sql.DB, and verifies it with Ping.
+//
+// In pgx/v5 the prefer_simple_protocol DSN parameter was removed, so simple
+// protocol mode must be configured on the ConnConfig via
+// DefaultQueryExecMode. This helper centralizes that handling and, on any
+// failure after RegisterConnConfig, unregisters the config so we do not leak
+// entries in stdlib's global connection config map.
+//
+// adaptedSqlUrl is used only for error messages (the caller is expected to
+// have redacted any password).
+func OpenPGXDB(sqlUrl, adaptedSqlUrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (*sql.DB, error) {
+	connConfig, parseErr := pgx.ParseConfig(sqlUrl)
+	if parseErr != nil {
+		return nil, fmt.Errorf("can not parse connection config for %s error:%v", adaptedSqlUrl, parseErr)
+	}
+
+	// PgBouncer compatibility: use the simple query protocol and disable
+	// statement caching. This avoids prepared statement issues with
+	// PgBouncer's transaction pooling mode.
+	if pgbouncerCompatible {
+		connConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+		connConfig.StatementCacheCapacity = 0
+		connConfig.DescriptionCacheCapacity = 0
+	}
+
+	registeredConnStr := stdlib.RegisterConnConfig(connConfig)
+	db, dbErr := sql.Open("pgx", registeredConnStr)
+	if dbErr != nil {
+		stdlib.UnregisterConnConfig(registeredConnStr)
+		return nil, fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
+	}
+
+	db.SetMaxIdleConns(maxIdle)
+	db.SetMaxOpenConns(maxOpen)
+	db.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
+
+	if err := db.Ping(); err != nil {
+		db.Close()
+		stdlib.UnregisterConnConfig(registeredConnStr)
+		return nil, fmt.Errorf("connect to %s error:%v", adaptedSqlUrl, err)
+	}
+
+	return db, nil
+}

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -13,7 +13,8 @@ import (
 	"strconv"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -68,12 +69,6 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 	// pgx-optimized connection string with better timeouts and connection handling
 	sqlUrl := "connect_timeout=30"
 
-	// PgBouncer compatibility: add prefer_simple_protocol=true when needed
-	// This avoids prepared statement issues with PgBouncer's transaction pooling mode
-	if pgbouncerCompatible {
-		sqlUrl += " prefer_simple_protocol=true"
-	}
-
 	if hostname != "" {
 		sqlUrl += " host=" + hostname
 	}
@@ -113,8 +108,27 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 		sqlUrl += " search_path=" + schema
 		adaptedSqlUrl += " search_path=" + schema
 	}
+	// Parse the DSN into a pgx config so we can configure driver-level
+	// options that are no longer accepted as DSN parameters in pgx/v5
+	// (notably prefer_simple_protocol, which was removed).
+	connConfig, parseErr := pgx.ParseConfig(sqlUrl)
+	if parseErr != nil {
+		return fmt.Errorf("can not parse connection config for %s error:%v", adaptedSqlUrl, parseErr)
+	}
+
+	// PgBouncer compatibility: use the simple query protocol and disable
+	// statement caching. This avoids prepared statement issues with
+	// PgBouncer's transaction pooling mode. In pgx/v5, prefer_simple_protocol
+	// is no longer a DSN parameter; it must be set on the config directly.
+	if pgbouncerCompatible {
+		connConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+		connConfig.StatementCacheCapacity = 0
+		connConfig.DescriptionCacheCapacity = 0
+	}
+
+	registeredConnStr := stdlib.RegisterConnConfig(connConfig)
 	var dbErr error
-	store.DB, dbErr = sql.Open("pgx", sqlUrl)
+	store.DB, dbErr = sql.Open("pgx", registeredConnStr)
 	if dbErr != nil {
 		if store.DB != nil {
 			store.DB.Close()

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -8,13 +8,8 @@
 package postgres
 
 import (
-	"database/sql"
-	"fmt"
 	"strconv"
-	"time"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -108,42 +103,11 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 		sqlUrl += " search_path=" + schema
 		adaptedSqlUrl += " search_path=" + schema
 	}
-	// Parse the DSN into a pgx config so we can configure driver-level
-	// options that are no longer accepted as DSN parameters in pgx/v5
-	// (notably prefer_simple_protocol, which was removed).
-	connConfig, parseErr := pgx.ParseConfig(sqlUrl)
-	if parseErr != nil {
-		return fmt.Errorf("can not parse connection config for %s error:%v", adaptedSqlUrl, parseErr)
+	db, openErr := OpenPGXDB(sqlUrl, adaptedSqlUrl, pgbouncerCompatible, maxIdle, maxOpen, maxLifetimeSeconds)
+	if openErr != nil {
+		return openErr
 	}
-
-	// PgBouncer compatibility: use the simple query protocol and disable
-	// statement caching. This avoids prepared statement issues with
-	// PgBouncer's transaction pooling mode. In pgx/v5, prefer_simple_protocol
-	// is no longer a DSN parameter; it must be set on the config directly.
-	if pgbouncerCompatible {
-		connConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
-		connConfig.StatementCacheCapacity = 0
-		connConfig.DescriptionCacheCapacity = 0
-	}
-
-	registeredConnStr := stdlib.RegisterConnConfig(connConfig)
-	var dbErr error
-	store.DB, dbErr = sql.Open("pgx", registeredConnStr)
-	if dbErr != nil {
-		if store.DB != nil {
-			store.DB.Close()
-		}
-		store.DB = nil
-		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
-	}
-
-	store.DB.SetMaxIdleConns(maxIdle)
-	store.DB.SetMaxOpenConns(maxOpen)
-	store.DB.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
-
-	if err = store.DB.Ping(); err != nil {
-		return fmt.Errorf("connect to %s error:%v", adaptedSqlUrl, err)
-	}
+	store.DB = db
 
 	return nil
 }

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -9,13 +9,9 @@ package postgres2
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strconv"
-	"time"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/filer/postgres"
@@ -113,42 +109,11 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		sqlUrl += " search_path=" + schema
 		adaptedSqlUrl += " search_path=" + schema
 	}
-	// Parse the DSN into a pgx config so we can configure driver-level
-	// options that are no longer accepted as DSN parameters in pgx/v5
-	// (notably prefer_simple_protocol, which was removed).
-	connConfig, parseErr := pgx.ParseConfig(sqlUrl)
-	if parseErr != nil {
-		return fmt.Errorf("can not parse connection config for %s error:%v", adaptedSqlUrl, parseErr)
+	db, openErr := postgres.OpenPGXDB(sqlUrl, adaptedSqlUrl, pgbouncerCompatible, maxIdle, maxOpen, maxLifetimeSeconds)
+	if openErr != nil {
+		return openErr
 	}
-
-	// PgBouncer compatibility: use the simple query protocol and disable
-	// statement caching. This avoids prepared statement issues with
-	// PgBouncer's transaction pooling mode. In pgx/v5, prefer_simple_protocol
-	// is no longer a DSN parameter; it must be set on the config directly.
-	if pgbouncerCompatible {
-		connConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
-		connConfig.StatementCacheCapacity = 0
-		connConfig.DescriptionCacheCapacity = 0
-	}
-
-	registeredConnStr := stdlib.RegisterConnConfig(connConfig)
-	var dbErr error
-	store.DB, dbErr = sql.Open("pgx", registeredConnStr)
-	if dbErr != nil {
-		if store.DB != nil {
-			store.DB.Close()
-		}
-		store.DB = nil
-		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
-	}
-
-	store.DB.SetMaxIdleConns(maxIdle)
-	store.DB.SetMaxOpenConns(maxOpen)
-	store.DB.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
-
-	if err = store.DB.Ping(); err != nil {
-		return fmt.Errorf("connect to %s error:%v", adaptedSqlUrl, err)
-	}
+	store.DB = db
 
 	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
 		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -14,7 +14,8 @@ import (
 	"strconv"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/filer/postgres"
@@ -73,12 +74,6 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 	// pgx-optimized connection string with better timeouts and connection handling
 	sqlUrl := "connect_timeout=30"
 
-	// PgBouncer compatibility: add prefer_simple_protocol=true when needed
-	// This avoids prepared statement issues with PgBouncer's transaction pooling mode
-	if pgbouncerCompatible {
-		sqlUrl += " prefer_simple_protocol=true"
-	}
-
 	if hostname != "" {
 		sqlUrl += " host=" + hostname
 	}
@@ -118,8 +113,27 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		sqlUrl += " search_path=" + schema
 		adaptedSqlUrl += " search_path=" + schema
 	}
+	// Parse the DSN into a pgx config so we can configure driver-level
+	// options that are no longer accepted as DSN parameters in pgx/v5
+	// (notably prefer_simple_protocol, which was removed).
+	connConfig, parseErr := pgx.ParseConfig(sqlUrl)
+	if parseErr != nil {
+		return fmt.Errorf("can not parse connection config for %s error:%v", adaptedSqlUrl, parseErr)
+	}
+
+	// PgBouncer compatibility: use the simple query protocol and disable
+	// statement caching. This avoids prepared statement issues with
+	// PgBouncer's transaction pooling mode. In pgx/v5, prefer_simple_protocol
+	// is no longer a DSN parameter; it must be set on the config directly.
+	if pgbouncerCompatible {
+		connConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+		connConfig.StatementCacheCapacity = 0
+		connConfig.DescriptionCacheCapacity = 0
+	}
+
+	registeredConnStr := stdlib.RegisterConnConfig(connConfig)
 	var dbErr error
-	store.DB, dbErr = sql.Open("pgx", sqlUrl)
+	store.DB, dbErr = sql.Open("pgx", registeredConnStr)
 	if dbErr != nil {
 		if store.DB != nil {
 			store.DB.Close()


### PR DESCRIPTION
## Summary
- Fixes the `FATAL: unsupported startup parameter: prefer_simple_protocol (SQLSTATE 08P01)` error when connecting the filer to PostgreSQL through PgBouncer with `pgbouncer_compatible = true`.
- In pgx/v5 the `prefer_simple_protocol` DSN parameter was removed, so appending it to the connection string caused it to be forwarded to the server as an unknown startup parameter and rejected.
- Both `weed/filer/postgres` and `weed/filer/postgres2` now parse the DSN via `pgx.ParseConfig`, and when `pgbouncer_compatible` is set they configure `DefaultQueryExecMode = QueryExecModeSimpleProtocol` and zero the statement/description caches on the `ConnConfig`, then register it with `stdlib.RegisterConnConfig` before `sql.Open`.

Fixes #9005

## Test plan
- [x] `go build ./weed/filer/postgres/... ./weed/filer/postgres2/...`
- [ ] Verify filer connects successfully through PgBouncer (transaction pooling) with `pgbouncer_compatible = true`
- [ ] Verify direct PostgreSQL connection still works with `pgbouncer_compatible = false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized PostgreSQL connection setup across components for consistency and maintainability.
  * Improved PgBouncer compatibility handling, standardized connection pooling and lifecycle configuration, and more robust error handling during DB initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->