### PR TITLE
Prune weed/worker/tasks

### DIFF
--- a/weed/worker/tasks/task.go
+++ b/weed/worker/tasks/task.go
@@ -1,27 +1,9 @@
 package tasks
 
 import (
-	"sync"
-	"time"
-
 	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
 	"github.com/seaweedfs/seaweedfs/weed/worker/types"
 )
-
-// BaseTask provides common functionality for all tasks
-type BaseTask struct {
-	taskType          types.TaskType
-	taskID            string
-	progress          float64
-	cancelled         bool
-	mutex             sync.RWMutex
-	startTime         time.Time
-	estimatedDuration time.Duration
-	logger            TaskLogger
-	loggerConfig      TaskLoggerConfig
-	progressCallback  func(float64, string) // Callback function for progress updates
-	currentStage      string                // Current stage description
-}
 
 // UnsupportedTaskTypeError represents an error for unsupported task types
 type UnsupportedTaskTypeError struct {

--- a/weed/worker/tasks/ui_base.go
+++ b/weed/worker/tasks/ui_base.go
@@ -75,12 +75,5 @@ func (ui *BaseUIProvider) ApplyTaskConfig(config types.TaskConfig) error {
 	return ui.applyTaskConfigFunc(config)
 }
 
-// CommonConfigGetter provides a common pattern for getting current configuration
-type CommonConfigGetter[T any] struct {
-	defaultConfig T
-	detectorFunc  func() T
-	schedulerFunc func() T
-}
-
 // RegisterUIFunc provides a common registration function signature
 type RegisterUIFunc[D, S any] func(uiRegistry *types.UIRegistry, detector D, scheduler S)


### PR DESCRIPTION
This removes two unused types from `weed/worker/tasks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal code structure by removing unused type definitions and imports to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->