### PR TITLE
fix(filer): update hard link ctime when nlink changes on unlink

### DIFF
--- a/test/pjdfstest/known_failures.txt
+++ b/test/pjdfstest/known_failures.txt
@@ -38,12 +38,9 @@ tests/unlink/02.t
 tests/unlink/03.t
 
 # ── Hard link nlink/ctime tracking (requires filer changes) ────────────
-# The filer does not update ctime on remaining hard link entries when one
-# link is removed, and nlink counts are not correctly maintained across
-# rename operations.
+# nlink counts are not correctly maintained across rename operations.
 tests/rename/23.t
 tests/rename/24.t
-tests/unlink/00.t
 
 # ── Parent directory mtime/ctime on deferred file create ───────────────
 # When file creation is deferred (not flushed to filer immediately),

--- a/weed/filer/filerstore_hardlink.go
+++ b/weed/filer/filerstore_hardlink.go
@@ -115,7 +115,7 @@ func (fsw *FilerStoreWrapper) DeleteHardLink(ctx context.Context, hardLinkId Har
 	}
 
 	// POSIX: update ctime when nlink changes (a hard link was removed).
-	entry.Attr.Ctime = time.Now()
+	entry.Attr.Ctime = time.Now().UTC()
 
 	newBlob, encodeErr := entry.EncodeAttributesAndChunks()
 	if encodeErr != nil {

--- a/weed/filer/filerstore_hardlink.go
+++ b/weed/filer/filerstore_hardlink.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -112,6 +113,9 @@ func (fsw *FilerStoreWrapper) DeleteHardLink(ctx context.Context, hardLinkId Har
 			key, entry.HardLinkCounter)
 		return fsw.KvDelete(ctx, key)
 	}
+
+	// POSIX: update ctime when nlink changes (a hard link was removed).
+	entry.Attr.Ctime = time.Now()
 
 	newBlob, encodeErr := entry.EncodeAttributesAndChunks()
 	if encodeErr != nil {


### PR DESCRIPTION
## Summary
- When a hard link is unlinked, POSIX requires that the remaining links' ctime is updated (the inode's nlink count changed). The filer's `DeleteHardLink()` decremented the counter in the KV store but did not update the ctime field.
- Set `ctime = time.Now()` on the KV entry before writing it back when the hard link counter is decremented but still > 0.
- Remove `tests/unlink/00.t` from `known_failures.txt` (all 112 subtests now pass).

## Test plan
- [x] `tests/unlink/00.t` — 112 subtests, all passing
- [x] Full pjdfstest suite — 205 files, 8492 tests, Result: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected change-time (ctime) updates for files with hard links so remaining links show proper ctime when one link is removed.

* **Tests**
  * Updated known-failures list to reflect improved hard-link behavior; one previously skipped test reinstated, while two rename-related tests remain skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->