### PR TITLE
fix(mount): report correct nlink for directories

### DIFF
--- a/weed/mount/weedfs_attr.go
+++ b/weed/mount/weedfs_attr.go
@@ -1,6 +1,7 @@
 package mount
 
 import (
+	"context"
 	"os"
 	"syscall"
 	"time"
@@ -16,15 +17,19 @@ func (wfs *WFS) GetAttr(cancel <-chan struct{}, input *fuse.GetAttrIn, out *fuse
 	glog.V(4).Infof("GetAttr %v", input.NodeId)
 	if input.NodeId == 1 {
 		wfs.setRootAttr(out)
+		wfs.applyDirNlink(&out.Attr, util.FullPath(wfs.option.FilerMountRootPath))
 		return fuse.OK
 	}
 
 	inode := input.NodeId
-	_, _, entry, status := wfs.maybeReadEntry(inode)
+	path, _, entry, status := wfs.maybeReadEntry(inode)
 	if status == fuse.OK {
 		out.AttrValid = 1
 		wfs.setAttrByPbEntry(&out.Attr, inode, entry, true)
 		wfs.applyInMemoryAtime(&out.Attr, inode)
+		if entry.IsDirectory {
+			wfs.applyDirNlink(&out.Attr, path)
+		}
 		return status
 	} else {
 		if fh, found := wfs.fhMap.FindFileHandle(inode); found {
@@ -176,7 +181,7 @@ func (wfs *WFS) setRootAttr(out *fuse.AttrOut) {
 	out.Ctime = now
 	out.Atime = now
 	out.Mode = toSyscallType(os.ModeDir) | uint32(wfs.option.MountMode)
-	out.Nlink = 1
+	out.Nlink = 2
 }
 
 func (wfs *WFS) setAttrByPbEntry(out *fuse.Attr, inode uint64, entry *filer_pb.Entry, calculateSize bool) {
@@ -208,7 +213,9 @@ func (wfs *WFS) setAttrByPbEntry(out *fuse.Attr, inode uint64, entry *filer_pb.E
 	out.Atimensec = uint32(entry.Attributes.MtimeNs)
 	// In-memory atime overlay is applied by the caller via applyInMemoryAtime.
 	out.Mode = toSyscallMode(os.FileMode(entry.Attributes.FileMode))
-	if entry.HardLinkCounter > 0 {
+	if entry.IsDirectory {
+		out.Nlink = 2
+	} else if entry.HardLinkCounter > 0 {
 		out.Nlink = uint32(entry.HardLinkCounter)
 	} else {
 		out.Nlink = 1
@@ -238,7 +245,9 @@ func (wfs *WFS) setAttrByFilerEntry(out *fuse.Attr, inode uint64, entry *filer.E
 		out.Ctimensec = uint32(entry.Attr.Mtime.Nanosecond())
 	}
 	out.Mode = toSyscallMode(entry.Attr.Mode)
-	if entry.HardLinkCounter > 0 {
+	if entry.IsDirectory() {
+		out.Nlink = 2
+	} else if entry.HardLinkCounter > 0 {
 		out.Nlink = uint32(entry.HardLinkCounter)
 	} else {
 		out.Nlink = 1
@@ -304,6 +313,22 @@ func (wfs *WFS) applyInMemoryAtime(out *fuse.Attr, inode uint64) {
 		out.Atimensec = uint32(t.Nanosecond())
 	}
 	wfs.atimeMu.Unlock()
+}
+
+// applyDirNlink sets nlink = 2 + number_of_subdirectories for a directory.
+// Only counts from the local metacache to avoid expensive filer queries.
+// When the cache has no entries (e.g. before readdir), keeps nlink=2.
+func (wfs *WFS) applyDirNlink(out *fuse.Attr, dirPath util.FullPath) {
+	var subdirCount uint32
+	wfs.metaCache.ListDirectoryEntries(context.Background(), dirPath, "", false, 100000, func(entry *filer.Entry) (bool, error) {
+		if entry.IsDirectory() {
+			subdirCount++
+		}
+		return true, nil
+	})
+	if subdirCount > 0 {
+		out.Nlink = 2 + subdirCount
+	}
 }
 
 func chmod(existing uint32, mode uint32) uint32 {

--- a/weed/mount/weedfs_dir_lookup.go
+++ b/weed/mount/weedfs_dir_lookup.go
@@ -44,6 +44,10 @@ func (wfs *WFS) Lookup(cancel <-chan struct{}, header *fuse.InHeader, name strin
 
 	wfs.outputFilerEntry(out, inode, localEntry)
 
+	if localEntry.IsDirectory() {
+		wfs.applyDirNlink(&out.Attr, fullFilePath)
+	}
+
 	return fuse.OK
 
 }


### PR DESCRIPTION
## Summary
- POSIX requires directory nlink = 2 (for `.` and `..`) + number of subdirectories. Previously SeaweedFS reported nlink=1 for all directories.
- Set nlink baseline to 2 for directories in `setAttrByPbEntry`, `setAttrByFilerEntry`, and `setRootAttr`.
- Add `applyDirNlink()` that counts subdirectories from the local metacache and sets `nlink = 2 + count`.
- Call from `GetAttr` and `Lookup` for directory entries.
- When the metacache has no entries (before readdir), nlink=2 is used as a safe default.

## Test plan
- [x] After readdir, directory nlink correctly reflects 2 + subdirectory count
- [x] Full pjdfstest suite: 206 files, only rename/24.t has 2 remaining subtests failing (nlink not updated before first readdir)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory hardlink counts now correctly reflect the actual number of subdirectories within each directory
  * Root directory hardlink attribute value corrected to match standard filesystem conventions
  * Improved directory attribute resolution to provide more accurate metadata for directory entries during lookup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->