### PR TITLE
test: switch to sanwan/pjdfstest fork for NAME_MAX-aware tests

### DIFF
--- a/test/pjdfstest/Dockerfile
+++ b/test/pjdfstest/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG PJDFSTEST_REPO=https://github.com/pjd/pjdfstest.git
-ARG PJDFSTEST_REF=03eb25706d8dbf3611c3f820b45b7a5e09a36c06
+ARG PJDFSTEST_REPO=https://github.com/sanwan/pjdfstest.git
+ARG PJDFSTEST_REF=d25636a227606f8960e5179741d8f4ad7030ef41
 
 RUN git clone "${PJDFSTEST_REPO}" /opt/pjdfstest && \
     cd /opt/pjdfstest && \

--- a/test/pjdfstest/known_failures.txt
+++ b/test/pjdfstest/known_failures.txt
@@ -6,37 +6,6 @@
 # A failure in any test NOT listed here will cause the CI job to fail,
 # catching regressions immediately.
 
-# ── Linux FUSE NAME_MAX=255 limitation ──────────────────────────────────
-# The Linux FUSE kernel module enforces NAME_MAX=255 at the VFS layer.
-# These tests create filenames >255 bytes which cannot be looked up via
-# normal syscalls (stat, chmod, etc.) after creation.
-tests/chmod/02.t
-tests/chmod/03.t
-tests/chown/02.t
-tests/chown/03.t
-tests/ftruncate/02.t
-tests/ftruncate/03.t
-tests/link/02.t
-tests/link/03.t
-tests/mkdir/02.t
-tests/mkdir/03.t
-tests/mkfifo/02.t
-tests/mkfifo/03.t
-tests/mknod/02.t
-tests/mknod/03.t
-tests/open/02.t
-tests/open/03.t
-tests/rename/01.t
-tests/rename/02.t
-tests/rmdir/02.t
-tests/rmdir/03.t
-tests/symlink/02.t
-tests/symlink/03.t
-tests/truncate/02.t
-tests/truncate/03.t
-tests/unlink/02.t
-tests/unlink/03.t
-
 # ── Directory nlink count before readdir ────────────────────────────────
 # Directory nlink = 2 + subdirectory count is only accurate after the
 # directory children have been cached (readdir). Before that, nlink=2.
@@ -51,4 +20,3 @@ tests/rename/21.t
 # Making DeleteHardLink errors non-fatal prevents the entry from blocking
 # rmdir in most cases, but the test still has 1 subtest that fails.
 tests/unlink/14.t
-

--- a/test/pjdfstest/run.sh
+++ b/test/pjdfstest/run.sh
@@ -26,8 +26,8 @@ FILER_ADDR="127.0.0.1:${FILER_PORT}"
 
 # Pin to an immutable upstream commit so CI is reproducible. Override via env
 # if you want to test against a different ref or fork.
-PJDFSTEST_REPO="${PJDFSTEST_REPO:-https://github.com/pjd/pjdfstest.git}"
-PJDFSTEST_REF="${PJDFSTEST_REF:-03eb25706d8dbf3611c3f820b45b7a5e09a36c06}"
+PJDFSTEST_REPO="${PJDFSTEST_REPO:-https://github.com/sanwan/pjdfstest.git}"
+PJDFSTEST_REF="${PJDFSTEST_REF:-d25636a227606f8960e5179741d8f4ad7030ef41}"
 PJDFSTEST_TESTS="${PJDFSTEST_TESTS:-tests/}"
 
 mini_pid=""

--- a/weed/mount/weedfs_stats.go
+++ b/weed/mount/weedfs_stats.go
@@ -109,7 +109,7 @@ func (wfs *WFS) StatFs(cancel <-chan struct{}, in *fuse.InHeader, out *fuse.Stat
 	out.Ffree = math.MaxInt64 - actualFileCount
 
 	// Report the maximum length of a name and the minimum fragment size
-	out.NameLen = 1024
+	out.NameLen = 255
 	out.Frsize = uint32(blockSize)
 
 	return fuse.OK


### PR DESCRIPTION
## Summary
- Switch from upstream `pjd/pjdfstest` to `sanwan/pjdfstest` fork (same fork used by JuiceFS).
- The sanwan fork uses `pathconf(_PC_NAME_MAX)` to dynamically determine the filesystem's NAME_MAX limit, instead of hardcoding ~768-byte filenames that exceed the Linux FUSE kernel NAME_MAX=255.
- Remove all 26 NAME_MAX-related entries from `known_failures.txt`, reducing the skip list from 31 to 5 entries.

## Test plan
- [ ] pjdfstest CI job passes with the sanwan fork
- [ ] Long filename tests (*/02.t, */03.t) now pass correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use a different test source and pinned reference by default.
  * Removed an outdated known-failures block so additional tests now run in CI.

* **Bug Fixes**
  * Adjusted the reported filesystem filename-length limit to 255 characters, affecting name-length reporting and related checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->