### PR TITLE
fix(mount): gate directory nlink counting behind -posix.dirNLink option

### DIFF
--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -55,6 +55,9 @@ type MountOptions struct {
 	// Distributed lock for cross-mount write coordination
 	distributedLock *bool
 
+	// POSIX compliance options
+	posixDirNlink *bool
+
 	// FUSE performance options
 	writebackCache *bool
 	asyncDio       *bool
@@ -130,6 +133,9 @@ func init() {
 
 	// Distributed lock for cross-mount write coordination
 	mountOptions.distributedLock = cmdMount.Flag.Bool("dlm", false, "enable distributed lock for cross-mount write coordination (only one mount can write a file at a time)")
+
+	// POSIX compliance options
+	mountOptions.posixDirNlink = cmdMount.Flag.Bool("posix.dirNLink", false, "report POSIX-compliant directory nlink (2 + subdirectory count); costs one directory listing per stat")
 
 	// FUSE performance options
 	mountOptions.writebackCache = cmdMount.Flag.Bool("writebackCache", false, "enable FUSE writeback cache for improved write performance (at risk of data loss on crash)")

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -354,6 +354,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		DirIdleEvictSec:   *option.dirIdleEvictSec,
 		EnableDistributedLock: option.distributedLock != nil && *option.distributedLock,
 		WritebackCache:       option.writebackCache != nil && *option.writebackCache,
+		PosixDirNlink:        option.posixDirNlink != nil && *option.posixDirNlink,
 	})
 
 	// create mount root

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -93,6 +93,12 @@ type Option struct {
 	// When true, Flush() returns immediately and data upload + metadata flush happen in background.
 	WritebackCache bool
 
+	// PosixDirNlink enables POSIX-compliant directory nlink counting
+	// (nlink = 2 + number_of_subdirectories). This requires listing
+	// cached directory entries on every stat, which has a performance cost.
+	// When false (default), directories report nlink=2.
+	PosixDirNlink bool
+
 	uniqueCacheDirForRead  string
 	uniqueCacheDirForWrite string
 }

--- a/weed/mount/weedfs_attr.go
+++ b/weed/mount/weedfs_attr.go
@@ -17,7 +17,9 @@ func (wfs *WFS) GetAttr(cancel <-chan struct{}, input *fuse.GetAttrIn, out *fuse
 	glog.V(4).Infof("GetAttr %v", input.NodeId)
 	if input.NodeId == 1 {
 		wfs.setRootAttr(out)
-		wfs.applyDirNlink(&out.Attr, util.FullPath(wfs.option.FilerMountRootPath))
+		if wfs.option.PosixDirNlink {
+			wfs.applyDirNlink(&out.Attr, util.FullPath(wfs.option.FilerMountRootPath))
+		}
 		return fuse.OK
 	}
 
@@ -27,7 +29,7 @@ func (wfs *WFS) GetAttr(cancel <-chan struct{}, input *fuse.GetAttrIn, out *fuse
 		out.AttrValid = 1
 		wfs.setAttrByPbEntry(&out.Attr, inode, entry, true)
 		wfs.applyInMemoryAtime(&out.Attr, inode)
-		if entry.IsDirectory {
+		if entry.IsDirectory && wfs.option.PosixDirNlink {
 			wfs.applyDirNlink(&out.Attr, path)
 		}
 		return status

--- a/weed/mount/weedfs_dir_lookup.go
+++ b/weed/mount/weedfs_dir_lookup.go
@@ -44,7 +44,7 @@ func (wfs *WFS) Lookup(cancel <-chan struct{}, header *fuse.InHeader, name strin
 
 	wfs.outputFilerEntry(out, inode, localEntry)
 
-	if localEntry.IsDirectory() {
+	if localEntry.IsDirectory() && wfs.option.PosixDirNlink {
 		wfs.applyDirNlink(&out.Attr, fullFilePath)
 	}
 


### PR DESCRIPTION
## Summary
- Gate the directory nlink counting (2 + subdirectory count from #9023) behind a new `-posix.dirNLink` flag (default: off).
- When disabled (default), directories report nlink=2 (POSIX baseline, no performance cost).
- When enabled, directories report nlink=2 + cached subdirectory count (requires listing cached entries on stat).
- Uses `posix.` prefix to allow future POSIX compliance options under the same namespace.

## Test plan
- [x] Compiles cleanly
- [ ] Without flag: directories report nlink=2
- [ ] With `-posix.dirNLink`: directories report nlink=2+subdirs after readdir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `-posix.dirNLink` mount option to control directory hardlink count reporting. When enabled, directories report nlink as 2 + number of subdirectories; when disabled, defaults to nlink = 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->