### PR TITLE
fix(mount): skip metadata flush for unlinked-while-open files

### DIFF
--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -144,6 +144,13 @@ func (wfs *WFS) doFlush(fh *FileHandle, uid, gid uint32, allowAsync bool) fuse.S
 		return fuse.OK
 	}
 
+	// Skip metadata flush if the file was unlinked while open.
+	// The filer entry is already gone; flushing would recreate it.
+	if fh.isDeleted {
+		glog.V(3).Infof("doFlush %s fh %d: file was unlinked, skipping metadata flush", fileFullPath, fh.fh)
+		return fuse.OK
+	}
+
 	if isOverQuota {
 		return fuse.Status(syscall.ENOSPC)
 	}


### PR DESCRIPTION
## Summary
- When a file is unlinked while still open (open-unlink-close pattern), the synchronous `doFlush` path recreates the entry on the filer during close, causing the parent directory to appear non-empty.
- Add an `fh.isDeleted` check in the synchronous flush path (`doFlush`), matching the existing check in the async flush path (`completeAsyncFlush`).
- This partially addresses pjdfstest `unlink/14.t` test 7 (rmdir ENOTEMPTY after open-unlink-close).

## Test plan
- [ ] pjdfstest `unlink/14.t`
- [ ] Full pjdfstest suite (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could cause deleted files to be unexpectedly recreated when unlinked while still open, ensuring proper cleanup during concurrent file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->