### PR TITLE
test: remove unlink/14.t from pjdfstest known failures

### DIFF
--- a/test/pjdfstest/known_failures.txt
+++ b/test/pjdfstest/known_failures.txt
@@ -16,7 +16,3 @@ tests/rename/24.t
 # causes cascading test failures within the test file.
 tests/rename/21.t
 
-# ── rmdir after hard link unlink ───────────────────────────────────────
-# Making DeleteHardLink errors non-fatal prevents the entry from blocking
-# rmdir in most cases, but the test still has 1 subtest that fails.
-tests/unlink/14.t


### PR DESCRIPTION
## Summary
- Remove `tests/unlink/14.t` from `known_failures.txt`. The `isDeleted` check in `doFlush` (merged in #9027) correctly skips metadata flush for unlinked-while-open files, preventing the entry from being recreated on close.
- Full pjdfstest suite: 235 files, 8803 tests, Result: PASS.

## Test plan
- [x] `tests/unlink/14.t` — 7 subtests, all passing
- [x] Full pjdfstest suite — all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation in CI/CD processes to improve code quality and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->