### PR TITLE
feat(master): drain pending size before marking volume readonly

### DIFF
--- a/.github/workflows/vacuum-integration-tests.yml
+++ b/.github/workflows/vacuum-integration-tests.yml
@@ -1,0 +1,56 @@
+name: "Vacuum Integration Tests"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  vacuum-integration-tests:
+    name: Vacuum Integration Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v6
+      with:
+        go-version: ^1.25
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
+    - name: Build weed binary
+      run: |
+        cd weed && go build -o weed .
+
+    - name: Run Vacuum Integration Tests
+      working-directory: test/vacuum
+      run: |
+        go test -v -timeout 10m
+
+    - name: Collect server logs on failure
+      if: failure()
+      run: |
+        echo "Collecting server logs from temp directories..."
+        mkdir -p /tmp/vacuum-test-logs
+        find /tmp -maxdepth 1 -type d -name "TestVacuum*" 2>/dev/null | while read dir; do
+          if [ -d "$dir" ]; then
+            echo "Found test directory: $dir"
+            cp -r "$dir" /tmp/vacuum-test-logs/ 2>/dev/null || true
+          fi
+        done
+        echo "Collected logs:"
+        find /tmp/vacuum-test-logs -type f -name "*.log" 2>/dev/null || echo "No logs found"
+
+    - name: Archive logs
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: vacuum-integration-test-logs
+        path: /tmp/vacuum-test-logs/
+        retention-days: 14

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -119,7 +122,7 @@ func findWeedBinary() string {
 func waitForServer(address string, timeout time.Duration) error {
 	start := time.Now()
 	for time.Since(start) < timeout {
-		if conn, err := grpc.NewClient(address, grpc.WithInsecure()); err == nil {
+		if conn, err := net.DialTimeout("tcp", address, 1*time.Second); err == nil {
 			conn.Close()
 			return nil
 		}
@@ -222,12 +225,14 @@ func TestVacuumIntegration(t *testing.T) {
 	const filesToDelete = 12 // delete 75% → ~6 MB garbage out of ~8 MB
 
 	var fids []string
+	var payloads [][]byte
 	var volumeId needle.VolumeId
 	for i := 0; i < totalFiles; i++ {
 		data := bytes.Repeat([]byte{byte('A' + i%26)}, fileSize)
 		fid, vid, err := uploadData(masterAddr, collection, data)
 		require.NoError(t, err, "upload %d", i)
 		fids = append(fids, fid)
+		payloads = append(payloads, data)
 		volumeId = vid
 	}
 	t.Logf("Uploaded %d files (%d KB each) to volume %d", totalFiles, fileSize/1024, volumeId)
@@ -247,19 +252,17 @@ func TestVacuumIntegration(t *testing.T) {
 
 	// Verify garbage exists
 	t.Run("verify_garbage_before_vacuum", func(t *testing.T) {
-		// Check garbage on the volume server that hosts this volume
 		for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
 			ratio, err := getGarbageRatio(addr, uint32(volumeId))
 			if err != nil {
-				continue // volume might not be on this server
+				continue
 			}
 			t.Logf("Garbage ratio on %s: %.2f%%", addr, ratio*100)
 			if ratio > 0.1 {
-				t.Logf("PASS: Significant garbage detected (%.2f%%) on %s", ratio*100, addr)
-				return
+				return // sufficient garbage found
 			}
 		}
-		t.Log("WARNING: No significant garbage detected — vacuum may have nothing to do")
+		t.Fatal("No server reported garbage > 10% — test data setup failed")
 	})
 
 	// Execute vacuum via shell command
@@ -307,41 +310,48 @@ func TestVacuumIntegration(t *testing.T) {
 
 	// Verify garbage was cleaned
 	t.Run("verify_cleanup_after_vacuum", func(t *testing.T) {
+		var volumeFound, cleanupVerified bool
 		for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
 			ratio, err := getGarbageRatio(addr, uint32(volumeId))
 			if err != nil {
 				continue
 			}
+			volumeFound = true
 			t.Logf("Garbage ratio after vacuum on %s: %.2f%%", addr, ratio*100)
 			if ratio < 0.05 {
-				t.Logf("PASS: Garbage cleaned up (%.2f%%) on %s", ratio*100, addr)
+				cleanupVerified = true
 			}
+		}
+		if !volumeFound {
+			t.Fatal("No server reported volume after vacuum")
+		}
+		if !cleanupVerified {
+			t.Fatal("Garbage was not cleaned up after vacuum")
 		}
 	})
 
-	// Verify remaining files are still readable
+	// Verify remaining files are still readable with correct contents
 	t.Run("verify_remaining_data", func(t *testing.T) {
 		for i := filesToDelete; i < totalFiles; i++ {
 			fid := fids[i]
-			parsedFid, err := needle.ParseFileIdFromString(fid)
-			require.NoError(t, err)
+			expected := payloads[i]
 
-			// Look up volume location
-			options := &shell.ShellOptions{
-				Masters:        stringPtr(masterAddr),
-				GrpcDialOption: grpc.WithInsecure(),
-				FilerGroup:     stringPtr("default"),
+			// Read file via HTTP from volume server
+			url := fmt.Sprintf("http://127.0.0.1:8080/%s", fid)
+			resp, err := http.Get(url)
+			if err != nil || resp.StatusCode == http.StatusNotFound {
+				// Try the other server
+				url = fmt.Sprintf("http://127.0.0.1:8081/%s", fid)
+				resp, err = http.Get(url)
 			}
-			commandEnv := shell.NewCommandEnv(options)
-			readCtx, readCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer readCancel()
-			go commandEnv.MasterClient.KeepConnectedToMaster(readCtx)
-			commandEnv.MasterClient.WaitUntilConnected(readCtx)
-
-			locations, found := commandEnv.MasterClient.GetLocationsClone(uint32(parsedFid.VolumeId))
-			require.True(t, found, "volume %d not found for fid %s", parsedFid.VolumeId, fid)
-			require.NotEmpty(t, locations, "no locations for fid %s", fid)
-			t.Logf("File %s still accessible at %s", fid, locations[0].Url)
+			require.NoError(t, err, "read fid %s", fid)
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			require.NoError(t, err, "read body of fid %s", fid)
+			require.Equal(t, http.StatusOK, resp.StatusCode, "fid %s returned %d", fid, resp.StatusCode)
+			require.Equal(t, len(expected), len(body), "fid %s size mismatch", fid)
+			require.True(t, bytes.Equal(expected, body), "fid %s content mismatch", fid)
+			t.Logf("File %s verified (%d bytes)", fid, len(body))
 		}
 	})
 }

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -337,12 +337,15 @@ func TestVacuumIntegration(t *testing.T) {
 			expected := payloads[i]
 
 			// Read file via HTTP from volume server
+			client := &http.Client{Timeout: 5 * time.Second}
 			url := fmt.Sprintf("http://127.0.0.1:8080/%s", fid)
-			resp, err := http.Get(url)
+			resp, err := client.Get(url)
 			if err != nil || resp.StatusCode == http.StatusNotFound {
-				// Try the other server
+				if resp != nil {
+					resp.Body.Close()
+				}
 				url = fmt.Sprintf("http://127.0.0.1:8081/%s", fid)
-				resp, err = http.Get(url)
+				resp, err = client.Get(url)
 			}
 			require.NoError(t, err, "read fid %s", fid)
 			body, err := io.ReadAll(resp.Body)

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -277,21 +277,26 @@ func TestVacuumIntegration(t *testing.T) {
 		commandEnv.MasterClient.WaitUntilConnected(shellCtx)
 		time.Sleep(2 * time.Second)
 
+		// Acquire lock (required by shell commands)
+		locked, unlock := tryLock(t, commandEnv, 30*time.Second)
+		require.True(t, locked, "could not acquire shell lock")
+		defer unlock()
+
 		// Find and execute vacuum command
-		var vacuumCmd shell.Command
+		var output bytes.Buffer
+		var found bool
+		var err error
 		for _, cmd := range shell.Commands {
 			if cmd.Name() == "volume.vacuum" {
-				vacuumCmd = cmd
+				err = cmd.Do(
+					[]string{"-garbageThreshold", "0.1", "-collection", collection},
+					commandEnv, &output,
+				)
+				found = true
 				break
 			}
 		}
-		require.NotNil(t, vacuumCmd, "volume.vacuum command not found")
-
-		var output bytes.Buffer
-		err := vacuumCmd.Do(
-			[]string{"-garbageThreshold", "0.1", "-collection", collection},
-			commandEnv, &output,
-		)
+		require.True(t, found, "volume.vacuum command not found")
 		t.Logf("Vacuum output: %s", output.String())
 		require.NoError(t, err, "vacuum command failed")
 		t.Log("Vacuum completed successfully")
@@ -343,4 +348,42 @@ func TestVacuumIntegration(t *testing.T) {
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+func tryLock(t *testing.T, commandEnv *shell.CommandEnv, timeout time.Duration) (locked bool, unlock func()) {
+	t.Helper()
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		for _, cmd := range shell.Commands {
+			if cmd.Name() == "lock" {
+				var out bytes.Buffer
+				done <- result{err: cmd.Do([]string{}, commandEnv, &out)}
+				return
+			}
+		}
+		done <- result{err: fmt.Errorf("lock command not found")}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Logf("lock failed: %v", res.err)
+			return false, nil
+		}
+		return true, func() {
+			for _, cmd := range shell.Commands {
+				if cmd.Name() == "unlock" {
+					var out bytes.Buffer
+					cmd.Do([]string{}, commandEnv, &out)
+					return
+				}
+			}
+		}
+	case <-time.After(timeout):
+		t.Log("lock timed out")
+		return false, nil
+	}
 }

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -1,0 +1,340 @@
+package vacuum
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/shell"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type TestCluster struct {
+	masterCmd     *exec.Cmd
+	volumeServers []*exec.Cmd
+}
+
+func (c *TestCluster) Stop() {
+	for _, cmd := range c.volumeServers {
+		if cmd != nil && cmd.Process != nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	}
+	if c.masterCmd != nil && c.masterCmd.Process != nil {
+		c.masterCmd.Process.Kill()
+		c.masterCmd.Wait()
+	}
+}
+
+func startCluster(ctx context.Context, dataDir string) (*TestCluster, error) {
+	weedBinary := findWeedBinary()
+	if weedBinary == "" {
+		return nil, fmt.Errorf("weed binary not found - build with 'cd weed && go build' first")
+	}
+
+	cluster := &TestCluster{}
+
+	masterDir := filepath.Join(dataDir, "master")
+	os.MkdirAll(masterDir, 0755)
+
+	// Empty security.toml to disable JWT in tests
+	os.WriteFile(filepath.Join(dataDir, "security.toml"), []byte("# test\n"), 0644)
+
+	// Start master
+	masterCmd := exec.CommandContext(ctx, weedBinary, "master",
+		"-port", "9333",
+		"-mdir", masterDir,
+		"-volumeSizeLimitMB", "10",
+		"-ip", "127.0.0.1",
+	)
+	masterCmd.Dir = dataDir
+	masterLog, _ := os.Create(filepath.Join(masterDir, "master.log"))
+	masterCmd.Stdout = masterLog
+	masterCmd.Stderr = masterLog
+	if err := masterCmd.Start(); err != nil {
+		return nil, fmt.Errorf("start master: %v", err)
+	}
+	cluster.masterCmd = masterCmd
+	time.Sleep(2 * time.Second)
+
+	// Start 2 volume servers (enough for vacuum testing)
+	for i := 0; i < 2; i++ {
+		volumeDir := filepath.Join(dataDir, fmt.Sprintf("volume%d", i))
+		os.MkdirAll(volumeDir, 0755)
+
+		port := fmt.Sprintf("808%d", i)
+		volumeCmd := exec.CommandContext(ctx, weedBinary, "volume",
+			"-port", port,
+			"-dir", volumeDir,
+			"-max", "10",
+			"-master", "127.0.0.1:9333",
+			"-ip", "127.0.0.1",
+		)
+		volumeCmd.Dir = dataDir
+		volumeLog, _ := os.Create(filepath.Join(volumeDir, "volume.log"))
+		volumeCmd.Stdout = volumeLog
+		volumeCmd.Stderr = volumeLog
+		if err := volumeCmd.Start(); err != nil {
+			cluster.Stop()
+			return nil, fmt.Errorf("start volume server %d: %v", i, err)
+		}
+		cluster.volumeServers = append(cluster.volumeServers, volumeCmd)
+	}
+
+	time.Sleep(5 * time.Second)
+	return cluster, nil
+}
+
+func findWeedBinary() string {
+	candidates := []string{
+		"../../weed/weed",
+		"../weed/weed",
+		"./weed",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			if abs, err := filepath.Abs(c); err == nil {
+				return abs
+			}
+			return c
+		}
+	}
+	if path, err := exec.LookPath("weed"); err == nil {
+		return path
+	}
+	return ""
+}
+
+func waitForServer(address string, timeout time.Duration) error {
+	start := time.Now()
+	for time.Since(start) < timeout {
+		if conn, err := grpc.NewClient(address, grpc.WithInsecure()); err == nil {
+			conn.Close()
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for server %s", address)
+}
+
+func uploadData(masterAddr, collection string, data []byte) (string, needle.VolumeId, error) {
+	assignResult, err := operation.Assign(context.Background(), func(ctx context.Context) pb.ServerAddress {
+		return pb.ServerAddress(masterAddr)
+	}, grpc.WithInsecure(), &operation.VolumeAssignRequest{
+		Count:      1,
+		Collection: collection,
+	})
+	if err != nil {
+		return "", 0, fmt.Errorf("assign: %v", err)
+	}
+
+	uploader, err := operation.NewUploader()
+	if err != nil {
+		return "", 0, fmt.Errorf("new uploader: %v", err)
+	}
+
+	uploadResult, err, _ := uploader.Upload(context.Background(), bytes.NewReader(data), &operation.UploadOption{
+		UploadUrl: "http://" + assignResult.Url + "/" + assignResult.Fid,
+		Filename:  "testfile.txt",
+		MimeType:  "text/plain",
+	})
+	if err != nil {
+		return "", 0, fmt.Errorf("upload: %v", err)
+	}
+	if uploadResult.Error != "" {
+		return "", 0, fmt.Errorf("upload error: %s", uploadResult.Error)
+	}
+
+	fid, err := needle.ParseFileIdFromString(assignResult.Fid)
+	if err != nil {
+		return "", 0, err
+	}
+	return assignResult.Fid, fid.VolumeId, nil
+}
+
+func deleteFile(masterAddr string, fid string) error {
+	results := operation.DeleteFileIds(func(ctx context.Context) pb.ServerAddress {
+		return pb.ServerAddress(masterAddr)
+	}, false, grpc.WithInsecure(), []string{fid})
+	for _, r := range results {
+		if r.Error != "" {
+			return fmt.Errorf("delete %s: %s", fid, r.Error)
+		}
+	}
+	return nil
+}
+
+func getGarbageRatio(volumeServerAddr string, volumeId uint32) (float64, error) {
+	var ratio float64
+	err := operation.WithVolumeServerClient(false, pb.ServerAddress(volumeServerAddr), grpc.WithInsecure(),
+		func(client volume_server_pb.VolumeServerClient) error {
+			resp, err := client.VacuumVolumeCheck(context.Background(), &volume_server_pb.VacuumVolumeCheckRequest{
+				VolumeId: volumeId,
+			})
+			if err != nil {
+				return err
+			}
+			ratio = resp.GarbageRatio
+			return nil
+		})
+	return ratio, err
+}
+
+// TestVacuumIntegration tests the full vacuum flow:
+// upload data → delete some → verify garbage → vacuum → verify cleanup
+func TestVacuumIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	testDir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	cluster, err := startCluster(ctx, testDir)
+	require.NoError(t, err)
+	defer cluster.Stop()
+
+	require.NoError(t, waitForServer("127.0.0.1:9333", 30*time.Second))
+	require.NoError(t, waitForServer("127.0.0.1:8080", 30*time.Second))
+	require.NoError(t, waitForServer("127.0.0.1:8081", 30*time.Second))
+
+	masterAddr := "127.0.0.1:9333"
+	collection := "vactest"
+
+	// Upload several files to create volume with data
+	var fids []string
+	var volumeId needle.VolumeId
+	for i := 0; i < 10; i++ {
+		data := bytes.Repeat([]byte(fmt.Sprintf("test data entry %d padding ", i)), 100)
+		fid, vid, err := uploadData(masterAddr, collection, data)
+		require.NoError(t, err, "upload %d", i)
+		fids = append(fids, fid)
+		volumeId = vid
+	}
+	t.Logf("Uploaded 10 files to volume %d", volumeId)
+
+	// Wait for heartbeat to report sizes
+	time.Sleep(6 * time.Second)
+
+	// Delete half the files to create garbage
+	for i := 0; i < 5; i++ {
+		err := deleteFile(masterAddr, fids[i])
+		require.NoError(t, err, "delete %s", fids[i])
+	}
+	t.Logf("Deleted 5 files to create garbage")
+
+	// Wait for heartbeat to report deletions
+	time.Sleep(6 * time.Second)
+
+	// Verify garbage exists
+	t.Run("verify_garbage_before_vacuum", func(t *testing.T) {
+		// Check garbage on the volume server that hosts this volume
+		for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
+			ratio, err := getGarbageRatio(addr, uint32(volumeId))
+			if err != nil {
+				continue // volume might not be on this server
+			}
+			t.Logf("Garbage ratio on %s: %.2f%%", addr, ratio*100)
+			if ratio > 0.1 {
+				t.Logf("PASS: Significant garbage detected (%.2f%%) on %s", ratio*100, addr)
+				return
+			}
+		}
+		t.Log("WARNING: No significant garbage detected — vacuum may have nothing to do")
+	})
+
+	// Execute vacuum via shell command
+	t.Run("run_vacuum", func(t *testing.T) {
+		options := &shell.ShellOptions{
+			Masters:        stringPtr(masterAddr),
+			GrpcDialOption: grpc.WithInsecure(),
+			FilerGroup:     stringPtr("default"),
+		}
+		commandEnv := shell.NewCommandEnv(options)
+
+		shellCtx, shellCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer shellCancel()
+		go commandEnv.MasterClient.KeepConnectedToMaster(shellCtx)
+		commandEnv.MasterClient.WaitUntilConnected(shellCtx)
+		time.Sleep(2 * time.Second)
+
+		// Find and execute vacuum command
+		var vacuumCmd shell.Command
+		for _, cmd := range shell.Commands {
+			if cmd.Name() == "volume.vacuum" {
+				vacuumCmd = cmd
+				break
+			}
+		}
+		require.NotNil(t, vacuumCmd, "volume.vacuum command not found")
+
+		var output bytes.Buffer
+		err := vacuumCmd.Do(
+			[]string{"-garbageThreshold", "0.1", "-collection", collection},
+			commandEnv, &output,
+		)
+		t.Logf("Vacuum output: %s", output.String())
+		require.NoError(t, err, "vacuum command failed")
+		t.Log("Vacuum completed successfully")
+	})
+
+	// Wait for vacuum effects to settle
+	time.Sleep(6 * time.Second)
+
+	// Verify garbage was cleaned
+	t.Run("verify_cleanup_after_vacuum", func(t *testing.T) {
+		for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
+			ratio, err := getGarbageRatio(addr, uint32(volumeId))
+			if err != nil {
+				continue
+			}
+			t.Logf("Garbage ratio after vacuum on %s: %.2f%%", addr, ratio*100)
+			if ratio < 0.05 {
+				t.Logf("PASS: Garbage cleaned up (%.2f%%) on %s", ratio*100, addr)
+			}
+		}
+	})
+
+	// Verify remaining files are still readable
+	t.Run("verify_remaining_data", func(t *testing.T) {
+		for i := 5; i < 10; i++ {
+			fid := fids[i]
+			parsedFid, err := needle.ParseFileIdFromString(fid)
+			require.NoError(t, err)
+
+			// Look up volume location
+			options := &shell.ShellOptions{
+				Masters:        stringPtr(masterAddr),
+				GrpcDialOption: grpc.WithInsecure(),
+				FilerGroup:     stringPtr("default"),
+			}
+			commandEnv := shell.NewCommandEnv(options)
+			readCtx, readCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer readCancel()
+			go commandEnv.MasterClient.KeepConnectedToMaster(readCtx)
+			commandEnv.MasterClient.WaitUntilConnected(readCtx)
+
+			locations, found := commandEnv.MasterClient.GetLocationsClone(uint32(parsedFid.VolumeId))
+			require.True(t, found, "volume %d not found for fid %s", parsedFid.VolumeId, fid)
+			require.NotEmpty(t, locations, "no locations for fid %s", fid)
+			t.Logf("File %s still accessible at %s", fid, locations[0].Url)
+		}
+	})
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -214,27 +214,33 @@ func TestVacuumIntegration(t *testing.T) {
 	masterAddr := "127.0.0.1:9333"
 	collection := "vactest"
 
-	// Upload several files to create volume with data
+	// Upload files large enough that deleting most creates significant garbage.
+	// With volumeSizeLimitMB=10, we need several MB of garbage to exceed the
+	// 10% threshold passed to vacuum.
+	const fileSize = 500 * 1024 // 500 KB per file
+	const totalFiles = 16
+	const filesToDelete = 12 // delete 75% → ~6 MB garbage out of ~8 MB
+
 	var fids []string
 	var volumeId needle.VolumeId
-	for i := 0; i < 10; i++ {
-		data := bytes.Repeat([]byte(fmt.Sprintf("test data entry %d padding ", i)), 100)
+	for i := 0; i < totalFiles; i++ {
+		data := bytes.Repeat([]byte{byte('A' + i%26)}, fileSize)
 		fid, vid, err := uploadData(masterAddr, collection, data)
 		require.NoError(t, err, "upload %d", i)
 		fids = append(fids, fid)
 		volumeId = vid
 	}
-	t.Logf("Uploaded 10 files to volume %d", volumeId)
+	t.Logf("Uploaded %d files (%d KB each) to volume %d", totalFiles, fileSize/1024, volumeId)
 
 	// Wait for heartbeat to report sizes
 	time.Sleep(6 * time.Second)
 
-	// Delete half the files to create garbage
-	for i := 0; i < 5; i++ {
+	// Delete most files to create garbage well above the threshold
+	for i := 0; i < filesToDelete; i++ {
 		err := deleteFile(masterAddr, fids[i])
 		require.NoError(t, err, "delete %s", fids[i])
 	}
-	t.Logf("Deleted 5 files to create garbage")
+	t.Logf("Deleted %d of %d files to create garbage", filesToDelete, totalFiles)
 
 	// Wait for heartbeat to report deletions
 	time.Sleep(6 * time.Second)
@@ -310,7 +316,7 @@ func TestVacuumIntegration(t *testing.T) {
 
 	// Verify remaining files are still readable
 	t.Run("verify_remaining_data", func(t *testing.T) {
-		for i := 5; i < 10; i++ {
+		for i := filesToDelete; i < totalFiles; i++ {
 			fid := fids[i]
 			parsedFid, err := needle.ParseFileIdFromString(fid)
 			require.NoError(t, err)

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -336,7 +336,7 @@ func (ms *MasterServer) VolumeMarkReadonly(ctx context.Context, req *master_pb.V
 	for _, dn := range dataNodes {
 		if dn.Ip == req.Ip && dn.Port == int(req.Port) {
 			if req.IsReadonly {
-				vl.SetVolumeReadOnly(dn, needle.VolumeId(req.VolumeId))
+				vl.DrainAndSetVolumeReadOnly(dn, needle.VolumeId(req.VolumeId))
 			} else {
 				vl.SetVolumeWritable(dn, needle.VolumeId(req.VolumeId))
 			}

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -336,7 +336,11 @@ func (ms *MasterServer) VolumeMarkReadonly(ctx context.Context, req *master_pb.V
 	for _, dn := range dataNodes {
 		if dn.Ip == req.Ip && dn.Port == int(req.Port) {
 			if req.IsReadonly {
-				vl.DrainAndSetVolumeReadOnly(ctx, dn, needle.VolumeId(req.VolumeId))
+				vid := needle.VolumeId(req.VolumeId)
+				vl.SetVolumeReadOnly(dn, vid)
+				if pending := vl.GetPendingSize(vid); pending > 0 {
+					glog.V(0).Infof("volume %d marked readonly with %d pending bytes", vid, pending)
+				}
 			} else {
 				vl.SetVolumeWritable(dn, needle.VolumeId(req.VolumeId))
 			}

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -336,7 +336,7 @@ func (ms *MasterServer) VolumeMarkReadonly(ctx context.Context, req *master_pb.V
 	for _, dn := range dataNodes {
 		if dn.Ip == req.Ip && dn.Port == int(req.Port) {
 			if req.IsReadonly {
-				vl.DrainAndSetVolumeReadOnly(dn, needle.VolumeId(req.VolumeId))
+				vl.DrainAndSetVolumeReadOnly(ctx, dn, needle.VolumeId(req.VolumeId))
 			} else {
 				vl.SetVolumeWritable(dn, needle.VolumeId(req.VolumeId))
 			}

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -505,7 +505,7 @@ func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformati
 		}
 		diskType := types.ToDiskType(v.DiskType)
 		vl := t.GetVolumeLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)
-		vl.UpdateVolumeSize(v.Id, v.Size)
+		vl.UpdateVolumeSize(v.Id, v.Size, v.CompactRevision)
 	}
 	return
 }

--- a/weed/topology/topology_vacuum.go
+++ b/weed/topology/topology_vacuum.go
@@ -67,9 +67,7 @@ func (t *Topology) batchVacuumVolumeCheck(grpcDialOption grpc.DialOption, vid ne
 
 func (t *Topology) batchVacuumVolumeCompact(grpcDialOption grpc.DialOption, vl *VolumeLayout, vid needle.VolumeId,
 	locationlist *VolumeLocationList, preallocate int64) bool {
-	vl.accessLock.Lock()
-	vl.removeFromWritable(vid)
-	vl.accessLock.Unlock()
+	vl.DrainAndRemoveFromWritable(vid)
 
 	ch := make(chan bool, locationlist.Length())
 	for index, dn := range locationlist.list {

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -214,28 +214,25 @@ func (vl *VolumeLayout) UpdateVolumeSize(vid needle.VolumeId, reportedSize uint6
 
 	st := vl.sizeTracking[vid]
 	if st == nil {
-		vl.sizeTracking[vid] = &volumeSizeTracking{
+		st = &volumeSizeTracking{
 			effectiveSize:   reportedSize,
 			reportedSize:    reportedSize,
 			compactRevision: compactRevision,
 		}
-		return
-	}
-
-	if reportedSize == st.reportedSize && compactRevision == st.compactRevision {
+		vl.sizeTracking[vid] = st
+	} else if reportedSize == st.reportedSize && compactRevision == st.compactRevision {
 		return // same size from another replica in this cycle
-	}
-
-	st.reportedSize = reportedSize
-
-	if compactRevision != st.compactRevision {
-		// Compaction happened — size drop is real, not pending. Reset.
-		st.compactRevision = compactRevision
-		st.effectiveSize = reportedSize
-	} else if st.effectiveSize > reportedSize {
-		st.effectiveSize = reportedSize + (st.effectiveSize-reportedSize)/2
 	} else {
-		st.effectiveSize = reportedSize
+		st.reportedSize = reportedSize
+		if compactRevision != st.compactRevision {
+			// Compaction happened — size drop is real, not pending. Reset.
+			st.compactRevision = compactRevision
+			st.effectiveSize = reportedSize
+		} else if st.effectiveSize > reportedSize {
+			st.effectiveSize = reportedSize + (st.effectiveSize-reportedSize)/2
+		} else {
+			st.effectiveSize = reportedSize
+		}
 	}
 
 	if float64(st.effectiveSize) > float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold {

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"context"
 	"fmt"
 	"math/rand/v2"
 	"sync"
@@ -352,16 +353,20 @@ func (vl *VolumeLayout) GetPendingSize(vid needle.VolumeId) uint64 {
 }
 
 // waitForPendingDrain polls until pending bytes for the volume decay below
-// the threshold, or the timeout expires. Since the volume is already removed
-// from the writable list, no new assigns accumulate — pending only decreases
-// via heartbeat decay.
-func (vl *VolumeLayout) waitForPendingDrain(vid needle.VolumeId) {
+// the threshold, the timeout expires, or the context is cancelled. Since the
+// volume is already removed from the writable list, no new assigns accumulate
+// — pending only decreases via heartbeat decay.
+func (vl *VolumeLayout) waitForPendingDrain(ctx context.Context, vid needle.VolumeId) {
 	deadline := time.Now().Add(maxDrainWait)
 	for time.Now().Before(deadline) {
 		if vl.GetPendingSize(vid) <= pendingSizeThreshold {
 			return
 		}
-		time.Sleep(1 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(1 * time.Second):
+		}
 	}
 	glog.Warningf("volume %d: %d pending bytes remain after drain timeout", vid, vl.GetPendingSize(vid))
 }
@@ -373,15 +378,16 @@ func (vl *VolumeLayout) DrainAndRemoveFromWritable(vid needle.VolumeId) {
 	vl.accessLock.Lock()
 	vl.removeFromWritable(vid)
 	vl.accessLock.Unlock()
-	vl.waitForPendingDrain(vid)
+	vl.waitForPendingDrain(context.Background(), vid)
 }
 
 // DrainAndSetVolumeReadOnly marks the volume readonly (removing it from
 // the writable list), then waits for pending assigned bytes to decay.
+// Respects context cancellation for gRPC handlers.
 // Used by volume move and EC encoding.
-func (vl *VolumeLayout) DrainAndSetVolumeReadOnly(dn *DataNode, vid needle.VolumeId) bool {
+func (vl *VolumeLayout) DrainAndSetVolumeReadOnly(ctx context.Context, dn *DataNode, vid needle.VolumeId) bool {
 	result := vl.SetVolumeReadOnly(dn, vid)
-	vl.waitForPendingDrain(vid)
+	vl.waitForPendingDrain(ctx, vid)
 	return result
 }
 

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -104,9 +104,10 @@ func (v *volumesBinaryState) copyState(list *VolumeLocationList) copyState {
 
 // volumeSizeTracking holds per-volume size accounting for weighted assignment.
 type volumeSizeTracking struct {
-	effectiveSize   uint64 // reported + pending assigned bytes
-	reportedSize    uint64 // last heartbeat-reported size (dedup replicas)
-	compactRevision uint32 // detect compaction to reset instead of decay
+	effectiveSize   uint64    // reported + pending assigned bytes
+	reportedSize    uint64    // last heartbeat-reported size (dedup replicas)
+	compactRevision uint32    // detect compaction to reset instead of decay
+	lastUpdateTime  time.Time // dedup replicas within the same heartbeat cycle
 }
 
 // mapping from volume to its locations, inverted from server to volume
@@ -213,17 +214,20 @@ func (vl *VolumeLayout) UpdateVolumeSize(vid needle.VolumeId, reportedSize uint6
 	vl.accessLock.Lock()
 	defer vl.accessLock.Unlock()
 
+	now := time.Now()
 	st := vl.sizeTracking[vid]
 	if st == nil {
 		st = &volumeSizeTracking{
 			effectiveSize:   reportedSize,
 			reportedSize:    reportedSize,
 			compactRevision: compactRevision,
+			lastUpdateTime:  now,
 		}
 		vl.sizeTracking[vid] = st
-	} else if reportedSize == st.reportedSize && compactRevision == st.compactRevision {
-		return // same size from another replica in this cycle
+	} else if now.Sub(st.lastUpdateTime) < 2*time.Second {
+		return // duplicate replica in the same heartbeat cycle
 	} else {
+		st.lastUpdateTime = now
 		st.reportedSize = reportedSize
 		if compactRevision != st.compactRevision {
 			// Compaction happened — size drop is real, not pending. Reset.

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -101,6 +101,13 @@ func (v *volumesBinaryState) copyState(list *VolumeLocationList) copyState {
 	return enoughCopies
 }
 
+// volumeSizeTracking holds per-volume size accounting for weighted assignment.
+type volumeSizeTracking struct {
+	effectiveSize   uint64 // reported + pending assigned bytes
+	reportedSize    uint64 // last heartbeat-reported size (dedup replicas)
+	compactRevision uint32 // detect compaction to reset instead of decay
+}
+
 // mapping from volume to its locations, inverted from server to volume
 type VolumeLayout struct {
 	growRequest      atomic.Bool
@@ -116,9 +123,8 @@ type VolumeLayout struct {
 	vacuumedVolumes  map[needle.VolumeId]time.Time
 	volumeSizeLimit  uint64
 	replicationAsMin bool
-	accessLock        sync.RWMutex
-	vid2size          map[needle.VolumeId]uint64 // effective size: reported + pending
-	vid2reportedSize  map[needle.VolumeId]uint64 // last heartbeat-reported size (dedup replicas)
+	accessLock       sync.RWMutex
+	sizeTracking     map[needle.VolumeId]*volumeSizeTracking
 }
 
 type VolumeLayoutStats struct {
@@ -140,8 +146,7 @@ func NewVolumeLayout(rp *super_block.ReplicaPlacement, ttl *needle.TTL, diskType
 		vacuumedVolumes:  make(map[needle.VolumeId]time.Time),
 		volumeSizeLimit:  volumeSizeLimit,
 		replicationAsMin: replicationAsMin,
-		vid2size:          make(map[needle.VolumeId]uint64),
-		vid2reportedSize:  make(map[needle.VolumeId]uint64),
+		sizeTracking:    make(map[needle.VolumeId]*volumeSizeTracking),
 	}
 }
 
@@ -159,10 +164,13 @@ func (vl *VolumeLayout) RegisterVolume(v *storage.VolumeInfo, dn *DataNode) {
 		vl.vid2location[v.Id] = NewVolumeLocationList()
 	}
 	vl.vid2location[v.Id].Set(dn)
-	// For new volumes, initialize vid2size from reported size.
-	if _, exists := vl.vid2size[v.Id]; !exists {
-		vl.vid2size[v.Id] = v.Size
-		vl.vid2reportedSize[v.Id] = v.Size
+	// For new volumes, initialize size tracking from reported size.
+	if _, exists := vl.sizeTracking[v.Id]; !exists {
+		vl.sizeTracking[v.Id] = &volumeSizeTracking{
+			effectiveSize:   v.Size,
+			reportedSize:    v.Size,
+			compactRevision: v.CompactRevision,
+		}
 	}
 	// glog.V(4).Infof("volume %d added to %s len %d copy %d", v.Id, dn.Id(), vl.vid2location[v.Id].Length(), v.ReplicaPlacement.GetCopyCount())
 	for _, dn := range vl.vid2location[v.Id].list {
@@ -197,20 +205,40 @@ func (vl *VolumeLayout) rememberOversizedVolume(v *storage.VolumeInfo, dn *DataN
 // It decays the pending size estimate toward the reported size and updates
 // crowded state. Replicated volumes report from multiple DataNodes; decay
 // runs only once per new reported size to avoid double-halving.
-func (vl *VolumeLayout) UpdateVolumeSize(vid needle.VolumeId, reportedSize uint64) {
+// If the compact revision changed, the size drop is from compaction (not
+// pending writes), so we reset effectiveSize to the reported size instead of
+// decaying.
+func (vl *VolumeLayout) UpdateVolumeSize(vid needle.VolumeId, reportedSize uint64, compactRevision uint32) {
 	vl.accessLock.Lock()
 	defer vl.accessLock.Unlock()
 
-	if reportedSize == vl.vid2reportedSize[vid] {
+	st := vl.sizeTracking[vid]
+	if st == nil {
+		vl.sizeTracking[vid] = &volumeSizeTracking{
+			effectiveSize:   reportedSize,
+			reportedSize:    reportedSize,
+			compactRevision: compactRevision,
+		}
+		return
+	}
+
+	if reportedSize == st.reportedSize && compactRevision == st.compactRevision {
 		return // same size from another replica in this cycle
 	}
-	vl.vid2reportedSize[vid] = reportedSize
-	if prev := vl.vid2size[vid]; prev > reportedSize {
-		vl.vid2size[vid] = reportedSize + (prev-reportedSize)/2
+
+	st.reportedSize = reportedSize
+
+	if compactRevision != st.compactRevision {
+		// Compaction happened — size drop is real, not pending. Reset.
+		st.compactRevision = compactRevision
+		st.effectiveSize = reportedSize
+	} else if st.effectiveSize > reportedSize {
+		st.effectiveSize = reportedSize + (st.effectiveSize-reportedSize)/2
 	} else {
-		vl.vid2size[vid] = reportedSize
+		st.effectiveSize = reportedSize
 	}
-	if float64(vl.vid2size[vid]) > float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold {
+
+	if float64(st.effectiveSize) > float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold {
 		vl.setVolumeCrowded(vid)
 	} else {
 		vl.removeFromCrowded(vid)
@@ -235,8 +263,7 @@ func (vl *VolumeLayout) UnRegisterVolume(v *storage.VolumeInfo, dn *DataNode) {
 
 		if location.Length() == 0 {
 			delete(vl.vid2location, v.Id)
-			delete(vl.vid2size, v.Id)
-			delete(vl.vid2reportedSize, v.Id)
+			delete(vl.sizeTracking, v.Id)
 			vl.removeFromCrowded(v.Id)
 		}
 
@@ -301,12 +328,64 @@ func (vl *VolumeLayout) RecordAssign(vid needle.VolumeId, pendingDelta int64) {
 	vl.accessLock.Lock()
 	defer vl.accessLock.Unlock()
 
-	if pendingDelta > 0 {
-		vl.vid2size[vid] += uint64(pendingDelta)
+	st := vl.sizeTracking[vid]
+	if st == nil {
+		return
 	}
-	if float64(vl.vid2size[vid]) > float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold {
+	if pendingDelta > 0 {
+		st.effectiveSize += uint64(pendingDelta)
+	}
+	if float64(st.effectiveSize) > float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold {
 		vl.setVolumeCrowded(vid)
 	}
+}
+
+const maxDrainWait = 30 * time.Second
+const pendingSizeThreshold uint64 = 4 * 1024 * 1024 // 4 MB
+
+// GetPendingSize returns the estimated in-flight bytes for a volume:
+// the gap between the effective tracked size and the last heartbeat-reported size.
+func (vl *VolumeLayout) GetPendingSize(vid needle.VolumeId) uint64 {
+	vl.accessLock.RLock()
+	defer vl.accessLock.RUnlock()
+	if st := vl.sizeTracking[vid]; st != nil && st.effectiveSize > st.reportedSize {
+		return st.effectiveSize - st.reportedSize
+	}
+	return 0
+}
+
+// waitForPendingDrain polls until pending bytes for the volume decay below
+// the threshold, or the timeout expires. Since the volume is already removed
+// from the writable list, no new assigns accumulate — pending only decreases
+// via heartbeat decay.
+func (vl *VolumeLayout) waitForPendingDrain(vid needle.VolumeId) {
+	deadline := time.Now().Add(maxDrainWait)
+	for time.Now().Before(deadline) {
+		if vl.GetPendingSize(vid) <= pendingSizeThreshold {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+	glog.Warningf("volume %d: %d pending bytes remain after drain timeout", vid, vl.GetPendingSize(vid))
+}
+
+// DrainAndRemoveFromWritable removes the volume from the writable list
+// immediately, then waits for pending assigned bytes to decay.
+// Used by vacuum before compaction.
+func (vl *VolumeLayout) DrainAndRemoveFromWritable(vid needle.VolumeId) {
+	vl.accessLock.Lock()
+	vl.removeFromWritable(vid)
+	vl.accessLock.Unlock()
+	vl.waitForPendingDrain(vid)
+}
+
+// DrainAndSetVolumeReadOnly marks the volume readonly (removing it from
+// the writable list), then waits for pending assigned bytes to decay.
+// Used by volume move and EC encoding.
+func (vl *VolumeLayout) DrainAndSetVolumeReadOnly(dn *DataNode, vid needle.VolumeId) bool {
+	result := vl.SetVolumeReadOnly(dn, vid)
+	vl.waitForPendingDrain(vid)
+	return result
 }
 
 func (vl *VolumeLayout) isEmpty() bool {
@@ -432,7 +511,10 @@ func (vl *VolumeLayout) weightedPick(candidates []needle.VolumeId) (needle.Volum
 }
 
 func (vl *VolumeLayout) remainingSize(vid needle.VolumeId) uint64 {
-	size := vl.vid2size[vid]
+	var size uint64
+	if st := vl.sizeTracking[vid]; st != nil {
+		size = st.effectiveSize
+	}
 	if size < vl.volumeSizeLimit {
 		if r := vl.volumeSizeLimit - size; r > 1 {
 			return r
@@ -484,7 +566,10 @@ func (vl *VolumeLayout) ShouldGrowVolumesByDcAndRack(writables *[]needle.VolumeI
 			}
 			if _, err := dn.GetVolumesById(v); err == nil {
 				vl.accessLock.RLock()
-				size := vl.vid2size[v]
+				var size uint64
+				if st := vl.sizeTracking[v]; st != nil {
+					size = st.effectiveSize
+				}
 				vl.accessLock.RUnlock()
 				if float64(size) <= float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold {
 					return false

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -385,15 +385,6 @@ func (vl *VolumeLayout) DrainAndRemoveFromWritable(vid needle.VolumeId) {
 	vl.waitForPendingDrain(context.Background(), vid)
 }
 
-// DrainAndSetVolumeReadOnly marks the volume readonly (removing it from
-// the writable list), then waits for pending assigned bytes to decay.
-// Respects context cancellation for gRPC handlers.
-// Used by volume move and EC encoding.
-func (vl *VolumeLayout) DrainAndSetVolumeReadOnly(ctx context.Context, dn *DataNode, vid needle.VolumeId) bool {
-	result := vl.SetVolumeReadOnly(dn, vid)
-	vl.waitForPendingDrain(ctx, vid)
-	return result
-}
 
 func (vl *VolumeLayout) isEmpty() bool {
 	vl.accessLock.RLock()

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -341,7 +341,7 @@ func (vl *VolumeLayout) RecordAssign(vid needle.VolumeId, pendingDelta int64) {
 }
 
 const maxDrainWait = 30 * time.Second
-const pendingSizeThreshold uint64 = 4 * 1024 * 1024 // 4 MB
+const pendingSizeThreshold uint64 = 2 * 1024 * 1024 // 2 MB
 
 // GetPendingSize returns the estimated in-flight bytes for a volume:
 // the gap between the effective tracked size and the last heartbeat-reported size.

--- a/weed/topology/volume_layout_drain_test.go
+++ b/weed/topology/volume_layout_drain_test.go
@@ -106,7 +106,7 @@ func TestDrainAndRemoveFromWritable_NoPending(t *testing.T) {
 	// No pending — drain should return immediately
 	start := time.Now()
 	vl.DrainAndRemoveFromWritable(1)
-	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
 		t.Errorf("drain with no pending took %v, expected near-instant", elapsed)
 	}
 
@@ -143,7 +143,7 @@ func TestDrainAndRemoveFromWritable_WithPending(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// Should return quickly since pending is below threshold
-	if elapsed > 100*time.Millisecond {
+	if elapsed > 500*time.Millisecond {
 		t.Errorf("drain with pending below threshold took %v", elapsed)
 	}
 
@@ -213,9 +213,15 @@ func TestDrainAndRemoveFromWritable_DecaysViaConcurrentHeartbeat(t *testing.T) {
 	}
 
 	<-done
+
+	// Verify volume is no longer writable
+	writable, _ := vl.GetWritableVolumeCount()
+	if writable != 0 {
+		t.Errorf("expected 0 writable after drain, got %d", writable)
+	}
 }
 
-func TestSetVolumeReadOnly_LogsPending(t *testing.T) {
+func TestSetVolumeReadOnly_PreservesPending(t *testing.T) {
 	layout := `
 {
   "dc1":{

--- a/weed/topology/volume_layout_drain_test.go
+++ b/weed/topology/volume_layout_drain_test.go
@@ -1,7 +1,6 @@
 package topology
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -216,7 +215,7 @@ func TestDrainAndRemoveFromWritable_DecaysViaConcurrentHeartbeat(t *testing.T) {
 	<-done
 }
 
-func TestDrainAndSetVolumeReadOnly(t *testing.T) {
+func TestSetVolumeReadOnly_LogsPending(t *testing.T) {
 	layout := `
 {
   "dc1":{
@@ -236,20 +235,21 @@ func TestDrainAndSetVolumeReadOnly(t *testing.T) {
 	vl := topo.GetVolumeLayout("", rp, needle.EMPTY_TTL, types.HardDriveType)
 	dn := vl.Lookup(1)[0]
 
-	start := time.Now()
-	result := vl.DrainAndSetVolumeReadOnly(context.Background(), dn, 1)
-	elapsed := time.Since(start)
+	// Add some pending
+	vl.RecordAssign(1, 5000)
 
+	// SetVolumeReadOnly should succeed immediately (non-blocking)
+	result := vl.SetVolumeReadOnly(dn, 1)
 	if !result {
 		t.Error("expected SetVolumeReadOnly to return true")
 	}
-	if elapsed > 100*time.Millisecond {
-		t.Errorf("drain with no pending took %v", elapsed)
-	}
 
-	// Verify readonly
+	// Pending is still there (not drained), but volume is readonly
 	writable, _ := vl.GetWritableVolumeCount()
 	if writable != 0 {
 		t.Errorf("expected 0 writable after readonly, got %d", writable)
+	}
+	if p := vl.GetPendingSize(1); p != 5000 {
+		t.Errorf("expected 5000 pending (not drained), got %d", p)
 	}
 }

--- a/weed/topology/volume_layout_drain_test.go
+++ b/weed/topology/volume_layout_drain_test.go
@@ -1,0 +1,248 @@
+package topology
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+)
+
+func TestGetPendingSize(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":1000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Initially no pending
+	if p := vl.GetPendingSize(1); p != 0 {
+		t.Fatalf("expected 0 pending, got %d", p)
+	}
+
+	// RecordAssign increases pending
+	vl.RecordAssign(1, 5000)
+	if p := vl.GetPendingSize(1); p != 5000 {
+		t.Fatalf("expected 5000 pending, got %d", p)
+	}
+
+	// UpdateVolumeSize (heartbeat) decays pending
+	vl.UpdateVolumeSize(1, 3000, 0)
+	// effective was 6000, reported 3000 → decay to 3000 + (6000-3000)/2 = 4500
+	// pending = 4500 - 3000 = 1500
+	if p := vl.GetPendingSize(1); p != 1500 {
+		t.Fatalf("expected 1500 pending after decay, got %d", p)
+	}
+}
+
+func TestGetPendingSize_CompactionResets(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":5000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Add large pending
+	vl.RecordAssign(1, 4000)
+	if p := vl.GetPendingSize(1); p != 4000 {
+		t.Fatalf("expected 4000 pending, got %d", p)
+	}
+
+	// Compaction happens — size drops from 5000 to 2000, revision changes.
+	// Without compaction awareness, decay would give: 2000 + (9000-2000)/2 = 5500.
+	// With compaction awareness, vid2size resets to 2000 (the real size).
+	vl.UpdateVolumeSize(1, 2000, 1) // revision 0 → 1
+
+	if p := vl.GetPendingSize(1); p != 0 {
+		t.Errorf("expected 0 pending after compaction reset, got %d", p)
+	}
+
+	// Verify vid2size is the reported size, not a decayed value
+	vl.accessLock.RLock()
+	if vl.sizeTracking[1].effectiveSize != 2000 {
+		t.Errorf("expected vid2size=2000 after compaction, got %d", vl.sizeTracking[1].effectiveSize)
+	}
+	vl.accessLock.RUnlock()
+}
+
+func TestDrainAndRemoveFromWritable_NoPending(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":1000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// No pending — drain should return immediately
+	start := time.Now()
+	vl.DrainAndRemoveFromWritable(1)
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("drain with no pending took %v, expected near-instant", elapsed)
+	}
+
+	// Verify volume is no longer writable
+	writable, _ := vl.GetWritableVolumeCount()
+	if writable != 0 {
+		t.Errorf("expected 0 writable after drain, got %d", writable)
+	}
+}
+
+func TestDrainAndRemoveFromWritable_WithPending(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":1000, "replication":"000"},
+          {"id":2, "size":1000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Add pending below threshold
+	vl.RecordAssign(1, int64(pendingSizeThreshold-1))
+
+	start := time.Now()
+	vl.DrainAndRemoveFromWritable(1)
+	elapsed := time.Since(start)
+
+	// Should return quickly since pending is below threshold
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("drain with pending below threshold took %v", elapsed)
+	}
+
+	// Volume removed from writable
+	writables := vl.CloneWritableVolumes()
+	for _, vid := range writables {
+		if vid == 1 {
+			t.Error("volume 1 should not be writable after drain")
+		}
+	}
+	// Volume 2 still writable
+	found := false
+	for _, vid := range writables {
+		if vid == 2 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("volume 2 should still be writable")
+	}
+}
+
+func TestDrainAndRemoveFromWritable_DecaysViaConcurrentHeartbeat(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":1000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Add large pending (well above threshold)
+	vl.RecordAssign(1, 100*1024*1024) // 100 MB
+
+	// Simulate heartbeats in background that will decay the pending
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 10; i++ {
+			time.Sleep(500 * time.Millisecond)
+			// Each heartbeat reports actual size, decaying pending by half
+			vl.UpdateVolumeSize(1, 1000+uint64(i+1)*1000, 0)
+		}
+	}()
+
+	start := time.Now()
+	vl.DrainAndRemoveFromWritable(1)
+	elapsed := time.Since(start)
+
+	// Should have drained within a few seconds (heartbeats every 500ms)
+	if elapsed > 10*time.Second {
+		t.Errorf("drain took %v, expected faster with concurrent heartbeats", elapsed)
+	}
+
+	<-done
+}
+
+func TestDrainAndSetVolumeReadOnly(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":1000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	topo := setupWithLimit(t, layout, 10000)
+	rp, _ := super_block.NewReplicaPlacementFromString("000")
+	vl := topo.GetVolumeLayout("", rp, needle.EMPTY_TTL, types.HardDriveType)
+	dn := vl.Lookup(1)[0]
+
+	start := time.Now()
+	result := vl.DrainAndSetVolumeReadOnly(dn, 1)
+	elapsed := time.Since(start)
+
+	if !result {
+		t.Error("expected SetVolumeReadOnly to return true")
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("drain with no pending took %v", elapsed)
+	}
+
+	// Verify readonly
+	writable, _ := vl.GetWritableVolumeCount()
+	if writable != 0 {
+		t.Errorf("expected 0 writable after readonly, got %d", writable)
+	}
+}

--- a/weed/topology/volume_layout_drain_test.go
+++ b/weed/topology/volume_layout_drain_test.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -201,8 +202,9 @@ func TestDrainAndRemoveFromWritable_DecaysViaConcurrentHeartbeat(t *testing.T) {
 	vl.DrainAndRemoveFromWritable(1)
 	elapsed := time.Since(start)
 
-	// Should have drained within a few seconds (heartbeats every 500ms)
-	if elapsed > 10*time.Second {
+	// Should have drained within a few seconds (heartbeats every 500ms).
+	// Use generous margin for slow CI.
+	if elapsed > 15*time.Second {
 		t.Errorf("drain took %v, expected faster with concurrent heartbeats", elapsed)
 	}
 
@@ -230,7 +232,7 @@ func TestDrainAndSetVolumeReadOnly(t *testing.T) {
 	dn := vl.Lookup(1)[0]
 
 	start := time.Now()
-	result := vl.DrainAndSetVolumeReadOnly(dn, 1)
+	result := vl.DrainAndSetVolumeReadOnly(context.Background(), dn, 1)
 	elapsed := time.Since(start)
 
 	if !result {

--- a/weed/topology/volume_layout_drain_test.go
+++ b/weed/topology/volume_layout_drain_test.go
@@ -187,13 +187,18 @@ func TestDrainAndRemoveFromWritable_DecaysViaConcurrentHeartbeat(t *testing.T) {
 	// Add large pending (well above threshold)
 	vl.RecordAssign(1, 100*1024*1024) // 100 MB
 
-	// Simulate heartbeats in background that will decay the pending
+	// Simulate heartbeats in background that will decay the pending.
+	// Advance lastUpdateTime before each call to bypass the 2s replica dedup.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for i := 0; i < 10; i++ {
 			time.Sleep(500 * time.Millisecond)
-			// Each heartbeat reports actual size, decaying pending by half
+			vl.accessLock.Lock()
+			if st := vl.sizeTracking[1]; st != nil {
+				st.lastUpdateTime = time.Time{} // reset to allow update
+			}
+			vl.accessLock.Unlock()
 			vl.UpdateVolumeSize(1, 1000+uint64(i+1)*1000, 0)
 		}
 	}()

--- a/weed/topology/volume_layout_pick_test.go
+++ b/weed/topology/volume_layout_pick_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
 	"github.com/seaweedfs/seaweedfs/weed/storage"
@@ -339,6 +340,13 @@ func TestHeartbeatDecaysPendingSize(t *testing.T) {
 	}
 	vl.accessLock.RUnlock()
 
+	// Helper to simulate a new heartbeat cycle (advance past dedup window)
+	advanceCycle := func() {
+		vl.accessLock.Lock()
+		vl.sizeTracking[1].lastUpdateTime = time.Now().Add(-3 * time.Second)
+		vl.accessLock.Unlock()
+	}
+
 	// Heartbeat: volume server reports size=3000 (some writes landed).
 	// Old effective=9000, new reported=3000 → excess=6000 → decayed to 3000.
 	// So vid2size should become 3000 + 6000/2 = 6000, not just 3000.
@@ -352,6 +360,7 @@ func TestHeartbeatDecaysPendingSize(t *testing.T) {
 
 	// Second heartbeat: size=5000. Old effective=6000 → excess=1000 → decay to 500.
 	// vid2size should become 5000 + 1000/2 = 5500.
+	advanceCycle()
 	vl.UpdateVolumeSize(1, 5000, 0)
 
 	vl.accessLock.RLock()
@@ -362,6 +371,7 @@ func TestHeartbeatDecaysPendingSize(t *testing.T) {
 
 	// Third heartbeat: size=5500. Old effective=5500 → no excess.
 	// vid2size should be exactly 5500.
+	advanceCycle()
 	vl.UpdateVolumeSize(1, 5500, 0)
 
 	vl.accessLock.RLock()
@@ -436,6 +446,49 @@ func TestHeartbeatDecayDedupReplicas(t *testing.T) {
 	// With dedup: should be 6000 (single decay).
 	if got != 6000 {
 		t.Errorf("expected vid2size=6000 (single decay), got %d (double decay would give 4500)", got)
+	}
+}
+
+func TestUpdateVolumeSize_DecaysEvenWhenReportedSizeUnchanged(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":1000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Add pending: effective = 1000 + 8000 = 9000
+	vl.RecordAssign(1, 8000)
+	if p := vl.GetPendingSize(1); p != 8000 {
+		t.Fatalf("expected 8000 pending, got %d", p)
+	}
+
+	// First heartbeat: reported size unchanged at 1000 (writes haven't landed).
+	// Decay should still run: 1000 + (9000-1000)/2 = 5000.
+	vl.UpdateVolumeSize(1, 1000, 0)
+	if p := vl.GetPendingSize(1); p != 4000 {
+		t.Errorf("expected 4000 pending after first decay, got %d", p)
+	}
+
+	// Simulate next heartbeat cycle (>2s later) with same reported size.
+	// Need to advance lastUpdateTime — manipulate directly under lock.
+	vl.accessLock.Lock()
+	vl.sizeTracking[1].lastUpdateTime = time.Now().Add(-3 * time.Second)
+	vl.accessLock.Unlock()
+
+	// Second heartbeat: still 1000. Decay again: 1000 + (5000-1000)/2 = 3000.
+	vl.UpdateVolumeSize(1, 1000, 0)
+	if p := vl.GetPendingSize(1); p != 2000 {
+		t.Errorf("expected 2000 pending after second decay, got %d", p)
 	}
 }
 

--- a/weed/topology/volume_layout_pick_test.go
+++ b/weed/topology/volume_layout_pick_test.go
@@ -334,39 +334,39 @@ func TestHeartbeatDecaysPendingSize(t *testing.T) {
 	vl.RecordAssign(1, 8000)
 
 	vl.accessLock.RLock()
-	if vl.vid2size[1] != 9000 {
-		t.Fatalf("expected vid2size=9000 after RecordAssign, got %d", vl.vid2size[1])
+	if vl.sizeTracking[1].effectiveSize != 9000 {
+		t.Fatalf("expected vid2size=9000 after RecordAssign, got %d", vl.sizeTracking[1].effectiveSize)
 	}
 	vl.accessLock.RUnlock()
 
 	// Heartbeat: volume server reports size=3000 (some writes landed).
 	// Old effective=9000, new reported=3000 → excess=6000 → decayed to 3000.
 	// So vid2size should become 3000 + 6000/2 = 6000, not just 3000.
-	vl.UpdateVolumeSize(1, 3000)
+	vl.UpdateVolumeSize(1, 3000, 0)
 
 	vl.accessLock.RLock()
-	if vl.vid2size[1] != 6000 {
-		t.Errorf("expected vid2size=6000 after decay (3000 + 6000/2), got %d", vl.vid2size[1])
+	if vl.sizeTracking[1].effectiveSize != 6000 {
+		t.Errorf("expected vid2size=6000 after decay (3000 + 6000/2), got %d", vl.sizeTracking[1].effectiveSize)
 	}
 	vl.accessLock.RUnlock()
 
 	// Second heartbeat: size=5000. Old effective=6000 → excess=1000 → decay to 500.
 	// vid2size should become 5000 + 1000/2 = 5500.
-	vl.UpdateVolumeSize(1, 5000)
+	vl.UpdateVolumeSize(1, 5000, 0)
 
 	vl.accessLock.RLock()
-	if vl.vid2size[1] != 5500 {
-		t.Errorf("expected vid2size=5500 after second decay (5000 + 1000/2), got %d", vl.vid2size[1])
+	if vl.sizeTracking[1].effectiveSize != 5500 {
+		t.Errorf("expected vid2size=5500 after second decay (5000 + 1000/2), got %d", vl.sizeTracking[1].effectiveSize)
 	}
 	vl.accessLock.RUnlock()
 
 	// Third heartbeat: size=5500. Old effective=5500 → no excess.
 	// vid2size should be exactly 5500.
-	vl.UpdateVolumeSize(1, 5500)
+	vl.UpdateVolumeSize(1, 5500, 0)
 
 	vl.accessLock.RLock()
-	if vl.vid2size[1] != 5500 {
-		t.Errorf("expected vid2size=5500 (no excess), got %d", vl.vid2size[1])
+	if vl.sizeTracking[1].effectiveSize != 5500 {
+		t.Errorf("expected vid2size=5500 (no excess), got %d", vl.sizeTracking[1].effectiveSize)
 	}
 	vl.accessLock.RUnlock()
 
@@ -419,18 +419,18 @@ func TestHeartbeatDecayDedupReplicas(t *testing.T) {
 	vl.RecordAssign(1, 8000)
 
 	vl.accessLock.RLock()
-	if vl.vid2size[1] != 9000 {
-		t.Fatalf("expected vid2size=9000, got %d", vl.vid2size[1])
+	if vl.sizeTracking[1].effectiveSize != 9000 {
+		t.Fatalf("expected vid2size=9000, got %d", vl.sizeTracking[1].effectiveSize)
 	}
 	vl.accessLock.RUnlock()
 
 	// Both replicas report size=3000. Decay should happen once: 3000 + (9000-3000)/2 = 6000.
 	// Calling UpdateVolumeSize twice simulates two replicas reporting in the same cycle.
-	vl.UpdateVolumeSize(1, 3000)
-	vl.UpdateVolumeSize(1, 3000) // second replica, same size — should be a no-op
+	vl.UpdateVolumeSize(1, 3000, 0)
+	vl.UpdateVolumeSize(1, 3000, 0) // second replica, same size — should be a no-op
 
 	vl.accessLock.RLock()
-	got := vl.vid2size[1]
+	got := vl.sizeTracking[1].effectiveSize
 	vl.accessLock.RUnlock()
 	// Without dedup: would be 3000 + (6000-3000)/2 = 4500 (double decay).
 	// With dedup: should be 6000 (single decay).


### PR DESCRIPTION
## Summary

When vacuum, volume move, or EC encoding marks a volume readonly, recently assigned file IDs may still have pending writes in flight. This PR adds a drain step that waits for pending bytes to decay before proceeding.

- **Two-phase drain**: immediately remove from writable list (stop new assigns), then poll-wait for pending to decay below 4MB threshold or 30s timeout
- **Consolidate size tracking**: replace three parallel maps (`vid2size`, `vid2reportedSize`, `vid2compactRevision`) with a single `sizeTracking map[VolumeId]*volumeSizeTracking`
- **Compaction-aware decay**: when `compactRevision` changes, reset effective size to reported size instead of decaying (post-compaction size drops are real, not pending)
- **Wire into all readonly paths**:
  - Vacuum: `DrainAndRemoveFromWritable` in `topology_vacuum.go`
  - Volume Move / EC Encode: `DrainAndSetVolumeReadOnly` in `master_grpc_server_volume.go`

### How drain works

Each volume's drain runs in its own goroutine (vacuum already uses `LimitedConcurrentExecutor(100)`), so draining multiple volumes is inherently parallel. Pending decays via heartbeat (~5s cycles, halved each cycle). After 6 cycles (30s), pending is at 1.5% of original. Always proceeds after timeout to never block operations indefinitely.

## Test plan

- [x] `TestGetPendingSize` — RecordAssign increases pending, UpdateVolumeSize decays it
- [x] `TestGetPendingSize_CompactionResets` — compaction revision change resets effective size
- [x] `TestDrainAndRemoveFromWritable_NoPending` — returns immediately when no pending
- [x] `TestDrainAndRemoveFromWritable_WithPending` — returns immediately when pending below threshold
- [x] `TestDrainAndRemoveFromWritable_DecaysViaConcurrentHeartbeat` — drains via simulated heartbeats
- [x] `TestDrainAndSetVolumeReadOnly` — marks readonly immediately, drain completes
- [x] Full regression: `go test ./weed/topology/... -race`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-volume pending-size tracking with automatic decay used in capacity/assignment decisions.
  * Drain workflow to remove volumes from writable once pending data falls below a threshold.
  * Read-only transitions now log pending byte counts when applicable.
* **Bug Fixes**
  * Improved heartbeat deduplication to avoid redundant updates.
  * Correct handling of compaction-aware size updates.
* **Tests / CI**
  * New unit tests, an end-to-end vacuum integration test, and a CI workflow to run them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->