### PR TITLE
fix(filer): prevent data corruption during graceful shutdown

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -31,6 +31,7 @@ import (
 	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
 	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 	"github.com/seaweedfs/seaweedfs/weed/util/version"
 )
 
@@ -434,6 +435,12 @@ func (fo *FilerOptions) startFiler() {
 	go grpcS.Serve(grpcL)
 	pb.ServeGrpcOnLocalSocket(grpcS, grpcPort)
 
+	// Register graceful shutdown for gRPC server to wait for active RPCs
+	grace.OnInterrupt(func() {
+		glog.V(0).Infof("Gracefully stopping gRPC server")
+		grpcS.GracefulStop()
+	})
+
 	if runtime.GOOS != "windows" {
 		localSocket := *fo.localSocket
 		if localSocket == "" {
@@ -497,6 +504,22 @@ func (fo *FilerOptions) startFiler() {
 			}()
 		}
 		httpS := newHttpServer(defaultMux, tlsConfig)
+
+		// Register HTTP server shutdown hook
+		grace.OnInterrupt(func() {
+			glog.V(0).Infof("Gracefully stopping HTTPS server")
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+			defer cancel()
+			if err := httpS.Shutdown(shutdownCtx); err != nil {
+				glog.Warningf("HTTPS server shutdown: %v", err)
+			}
+		})
+
+		// Register filer shutdown hook (database closes last)
+		grace.OnInterrupt(func() {
+			fs.Shutdown()
+		})
+
 		if MiniClusterCtx != nil {
 			ctx := MiniClusterCtx
 			go func() {
@@ -517,6 +540,22 @@ func (fo *FilerOptions) startFiler() {
 			}()
 		}
 		httpS := newHttpServer(defaultMux, nil)
+
+		// Register HTTP server shutdown hook
+		grace.OnInterrupt(func() {
+			glog.V(0).Infof("Gracefully stopping HTTP server")
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+			defer cancel()
+			if err := httpS.Shutdown(shutdownCtx); err != nil {
+				glog.Warningf("HTTP server shutdown: %v", err)
+			}
+		})
+
+		// Register filer shutdown hook (database closes last)
+		grace.OnInterrupt(func() {
+			fs.Shutdown()
+		})
+
 		if MiniClusterCtx != nil {
 			ctx := MiniClusterCtx
 			go func() {

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/viper"
@@ -382,6 +383,15 @@ func (fo *FilerOptions) startFiler() {
 		glog.Fatalf("Filer startup error: %v", nfs_err)
 	}
 
+	// Ensure fs.Shutdown() runs exactly once, whether triggered by a signal hook
+	// or by the main goroutine after Serve() returns (e.g., MiniCluster tests).
+	var shutdownOnce sync.Once
+	shutdownFiler := func() {
+		shutdownOnce.Do(func() {
+			fs.Shutdown()
+		})
+	}
+
 	if *fo.publicPort != 0 {
 		publicListeningAddress := util.JoinHostPort(*fo.bindIp, *fo.publicPort)
 		glog.V(0).Infoln("Start Seaweed filer server", version.Version(), "public at", publicListeningAddress)
@@ -452,6 +462,7 @@ func (fo *FilerOptions) startFiler() {
 		}
 	})
 
+	var socketServer *http.Server
 	if runtime.GOOS != "windows" {
 		localSocket := *fo.localSocket
 		if localSocket == "" {
@@ -460,14 +471,12 @@ func (fo *FilerOptions) startFiler() {
 		if err := os.Remove(localSocket); err != nil && !os.IsNotExist(err) {
 			glog.Fatalf("Failed to remove %s, error: %s", localSocket, err.Error())
 		}
-		go func() {
-			// start on local unix socket
-			filerSocketListener, err := net.Listen("unix", localSocket)
-			if err != nil {
-				glog.Fatalf("Failed to listen on %s: %v", localSocket, err)
-			}
-			newHttpServer(defaultMux, nil).Serve(filerSocketListener)
-		}()
+		filerSocketListener, err := net.Listen("unix", localSocket)
+		if err != nil {
+			glog.Fatalf("Failed to listen on %s: %v", localSocket, err)
+		}
+		socketServer = newHttpServer(defaultMux, nil)
+		go socketServer.Serve(filerSocketListener)
 	}
 
 	if viper.GetString("https.filer.key") != "" {
@@ -507,24 +516,33 @@ func (fo *FilerOptions) startFiler() {
 
 		security.FixTlsConfig(util.GetViper(), tlsConfig)
 
+		var localTLSServer *http.Server
 		if filerLocalListener != nil {
+			localTLSServer = newHttpServer(defaultMux, tlsConfig)
 			go func() {
-				if err := newHttpServer(defaultMux, tlsConfig).ServeTLS(filerLocalListener, "", ""); err != nil {
+				if err := localTLSServer.ServeTLS(filerLocalListener, "", ""); err != nil {
 					glog.Errorf("Filer Fail to serve: %v", err)
 				}
 			}()
 		}
 		httpS := newHttpServer(defaultMux, tlsConfig)
 
-		// Register HTTP server shutdown hook
+		// Register shutdown hooks: stop all HTTP servers, then close filer database
 		grace.OnInterrupt(func() {
-			glog.V(0).Infof("Gracefully stopping HTTPS server")
+			glog.V(0).Infof("Gracefully stopping all HTTP servers")
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
+			if socketServer != nil {
+				socketServer.Shutdown(shutdownCtx)
+			}
+			if localTLSServer != nil {
+				localTLSServer.Shutdown(shutdownCtx)
+			}
 			if err := httpS.Shutdown(shutdownCtx); err != nil {
 				glog.Warningf("HTTPS server shutdown: %v", err)
 			}
 		})
+		grace.OnInterrupt(shutdownFiler)
 
 		if MiniClusterCtx != nil {
 			ctx := MiniClusterCtx
@@ -538,26 +556,35 @@ func (fo *FilerOptions) startFiler() {
 			glog.Fatalf("Filer Fail to serve: %v", err)
 		}
 		// Close database after servers have stopped to prevent data corruption
-		fs.Shutdown()
+		shutdownFiler()
 	} else {
+		var localHTTPServer *http.Server
 		if filerLocalListener != nil {
+			localHTTPServer = newHttpServer(defaultMux, nil)
 			go func() {
-				if err := newHttpServer(defaultMux, nil).Serve(filerLocalListener); err != nil {
+				if err := localHTTPServer.Serve(filerLocalListener); err != nil {
 					glog.Errorf("Filer Fail to serve: %v", err)
 				}
 			}()
 		}
 		httpS := newHttpServer(defaultMux, nil)
 
-		// Register HTTP server shutdown hook
+		// Register shutdown hooks: stop all HTTP servers, then close filer database
 		grace.OnInterrupt(func() {
-			glog.V(0).Infof("Gracefully stopping HTTP server")
+			glog.V(0).Infof("Gracefully stopping all HTTP servers")
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
+			if socketServer != nil {
+				socketServer.Shutdown(shutdownCtx)
+			}
+			if localHTTPServer != nil {
+				localHTTPServer.Shutdown(shutdownCtx)
+			}
 			if err := httpS.Shutdown(shutdownCtx); err != nil {
 				glog.Warningf("HTTP server shutdown: %v", err)
 			}
 		})
+		grace.OnInterrupt(shutdownFiler)
 
 		if MiniClusterCtx != nil {
 			ctx := MiniClusterCtx
@@ -571,6 +598,6 @@ func (fo *FilerOptions) startFiler() {
 			glog.Fatalf("Filer Fail to serve: %v", err)
 		}
 		// Close database after servers have stopped to prevent data corruption
-		fs.Shutdown()
+		shutdownFiler()
 	}
 }

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -438,7 +438,18 @@ func (fo *FilerOptions) startFiler() {
 	// Register graceful shutdown for gRPC server to wait for active RPCs
 	grace.OnInterrupt(func() {
 		glog.V(0).Infof("Gracefully stopping gRPC server")
-		grpcS.GracefulStop()
+		stopped := make(chan struct{})
+		go func() {
+			grpcS.GracefulStop()
+			close(stopped)
+		}()
+		select {
+		case <-stopped:
+			glog.V(0).Infof("gRPC server stopped gracefully")
+		case <-time.After(10 * time.Second):
+			glog.V(0).Infof("gRPC server graceful stop timed out, forcing stop")
+			grpcS.Stop()
+		}
 	})
 
 	if runtime.GOOS != "windows" {
@@ -508,16 +519,11 @@ func (fo *FilerOptions) startFiler() {
 		// Register HTTP server shutdown hook
 		grace.OnInterrupt(func() {
 			glog.V(0).Infof("Gracefully stopping HTTPS server")
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			if err := httpS.Shutdown(shutdownCtx); err != nil {
 				glog.Warningf("HTTPS server shutdown: %v", err)
 			}
-		})
-
-		// Register filer shutdown hook (database closes last)
-		grace.OnInterrupt(func() {
-			fs.Shutdown()
 		})
 
 		if MiniClusterCtx != nil {
@@ -531,6 +537,8 @@ func (fo *FilerOptions) startFiler() {
 		if err := httpS.ServeTLS(filerListener, "", ""); err != nil && err != http.ErrServerClosed {
 			glog.Fatalf("Filer Fail to serve: %v", err)
 		}
+		// Close database after servers have stopped to prevent data corruption
+		fs.Shutdown()
 	} else {
 		if filerLocalListener != nil {
 			go func() {
@@ -544,16 +552,11 @@ func (fo *FilerOptions) startFiler() {
 		// Register HTTP server shutdown hook
 		grace.OnInterrupt(func() {
 			glog.V(0).Infof("Gracefully stopping HTTP server")
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			if err := httpS.Shutdown(shutdownCtx); err != nil {
 				glog.Warningf("HTTP server shutdown: %v", err)
 			}
-		})
-
-		// Register filer shutdown hook (database closes last)
-		grace.OnInterrupt(func() {
-			fs.Shutdown()
 		})
 
 		if MiniClusterCtx != nil {
@@ -567,5 +570,7 @@ func (fo *FilerOptions) startFiler() {
 		if err := httpS.Serve(filerListener); err != nil && err != http.ErrServerClosed {
 			glog.Fatalf("Filer Fail to serve: %v", err)
 		}
+		// Close database after servers have stopped to prevent data corruption
+		fs.Shutdown()
 	}
 }

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -258,9 +258,6 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	fs.filer.LoadRemoteStorageConfAndMapping()
 
 	grace.OnReload(fs.Reload)
-	grace.OnInterrupt(func() {
-		fs.Shutdown()
-	})
 
 	fs.SetupDlmReplication()
 	fs.filer.Dlm.LockRing.SetTakeSnapshotCallback(fs.OnDlmChangeSnapshot)
@@ -301,19 +298,7 @@ func (fs *FilerServer) checkWithMaster() {
 // Shutdown gracefully shuts down the filer server by waiting for in-flight uploads to complete.
 // This prevents data corruption when the process receives SIGTERM during active uploads.
 func (fs *FilerServer) Shutdown() {
-	glog.V(0).Infof("Filer shutdown initiated, waiting for in-flight uploads to complete")
-
-	// Wait for all in-flight uploads to complete
-	for {
-		remaining := atomic.LoadInt64(&fs.inFlightUploads)
-		if remaining == 0 {
-			break
-		}
-		glog.V(0).Infof("Waiting for %d in-flight upload(s) to complete", remaining)
-		time.Sleep(1 * time.Second)
-	}
-
-	glog.V(0).Infof("All uploads complete, proceeding with filer shutdown")
+	glog.V(0).Infof("Shutting down filer")
 	fs.filer.Shutdown()
 }
 

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -259,7 +259,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 
 	grace.OnReload(fs.Reload)
 	grace.OnInterrupt(func() {
-		fs.filer.Shutdown()
+		fs.Shutdown()
 	})
 
 	fs.SetupDlmReplication()
@@ -296,6 +296,25 @@ func (fs *FilerServer) checkWithMaster() {
 			}
 		}
 	}
+}
+
+// Shutdown gracefully shuts down the filer server by waiting for in-flight uploads to complete.
+// This prevents data corruption when the process receives SIGTERM during active uploads.
+func (fs *FilerServer) Shutdown() {
+	glog.V(0).Infof("Filer shutdown initiated, waiting for in-flight uploads to complete")
+
+	// Wait for all in-flight uploads to complete
+	for {
+		remaining := atomic.LoadInt64(&fs.inFlightUploads)
+		if remaining == 0 {
+			break
+		}
+		glog.V(0).Infof("Waiting for %d in-flight upload(s) to complete", remaining)
+		time.Sleep(1 * time.Second)
+	}
+
+	glog.V(0).Infof("All uploads complete, proceeding with filer shutdown")
+	fs.filer.Shutdown()
 }
 
 func (fs *FilerServer) Reload() {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/8908  
                                                                        
  During Kubernetes pod restarts (SIGTERM), the filer database closes immediately while HTTP/gRPC requests are
  still processing. This causes in-flight writes to fail mid-operation, resulting in data corruption.              
                                                                                                                 
  Scenario: Pushing multiple Docker Registry images in parallel → pod restart (e.g., certwatchdog) → some images
  corrupted with SHA mismatch errors.

  Root cause: Database shutdown hook was registered before server shutdown hooks, causing the database to close
  while servers were still accepting new requests.

  # How are we solving the problem?

  Fixed the shutdown hook execution order:
  1. Stop gRPC/HTTP servers first (reject new requests, wait for active ones)
  2. Close database last (after all operations complete)

  Changes:
  - weed/command/filer.go (+39 lines): Added graceful shutdown hooks for gRPC (GracefulStop()) and HTTP servers
  (Shutdown() with 25s timeout)
  - weed/server/filer_server.go (-16 lines): Removed early database shutdown hook registration, moved to execute
  after servers stop


# How is the PR tested?

Built and verified locally. Full testing requires Kubernetes environment with pod restarts under load (Docker Registry scenario). The fix follows Go best practices for graceful shutdown using standard GracefulStop() andShutdown() methods.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown with coordinated, timeout-bound termination of HTTP and gRPC services and ensured storage cleanup after servers stop.
  * Safer interrupt handling to avoid double shutdowns and to fall back to forced stop after timeouts.

* **New Features**
  * Added an explicit server Shutdown action to allow controlled programmatic shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->