### PR TITLE
fix(admin): allow control chars in file paths when browsing filer

### DIFF
--- a/weed/admin/handlers/file_browser_handlers.go
+++ b/weed/admin/handlers/file_browser_handlers.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -398,7 +399,7 @@ func (h *FileBrowserHandlers) uploadFileToFiler(filePath string, fileHeader *mul
 
 	// Create the upload URL - the httpClient will normalize to the correct scheme (http/https)
 	// based on the https.client configuration in security.toml
-	uploadURL := fmt.Sprintf("%s%s", filerHttpAddress, cleanFilePath)
+	uploadURL := filerFileURL(filerHttpAddress, cleanFilePath)
 
 	// Normalize the URL scheme based on TLS configuration
 	uploadURL, err = h.httpClient.NormalizeHttpScheme(uploadURL)
@@ -503,12 +504,14 @@ func (h *FileBrowserHandlers) validateAndCleanFilePath(filePath string) (string,
 		return "", fmt.Errorf("path traversal not allowed")
 	}
 
-	// Additional validation: ensure path doesn't contain dangerous characters
-	if strings.ContainsAny(cleanPath, "\x00\r\n") {
-		return "", fmt.Errorf("path contains invalid characters")
-	}
-
 	return cleanPath, nil
+}
+
+// filerFileURL joins the filer HTTP address with a validated file path, URL-escaping
+// the path so that control characters and other bytes that are legal in S3 object keys
+// cannot inject into the HTTP request target.
+func filerFileURL(filerHttpAddress, cleanFilePath string) string {
+	return filerHttpAddress + (&url.URL{Path: cleanFilePath}).EscapedPath()
 }
 
 // fetchFileContent fetches file content from the filer and returns the content or an error.
@@ -529,7 +532,7 @@ func (h *FileBrowserHandlers) fetchFileContent(filePath string, timeout time.Dur
 	}
 
 	// Create the file URL with proper scheme based on TLS configuration
-	fileURL := fmt.Sprintf("%s%s", filerHttpAddress, cleanFilePath)
+	fileURL := filerFileURL(filerHttpAddress, cleanFilePath)
 	fileURL, err = h.httpClient.NormalizeHttpScheme(fileURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to construct file URL: %w", err)
@@ -597,7 +600,7 @@ func (h *FileBrowserHandlers) DownloadFile(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Create the download URL with proper scheme based on TLS configuration
-	downloadURL := fmt.Sprintf("%s%s", filerHttpAddress, cleanFilePath)
+	downloadURL := filerFileURL(filerHttpAddress, cleanFilePath)
 	downloadURL, err = h.httpClient.NormalizeHttpScheme(downloadURL)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "Failed to construct download URL: "+err.Error())
@@ -1043,7 +1046,7 @@ func (h *FileBrowserHandlers) isLikelyTextFile(filePath string, maxCheckSize int
 	}
 
 	// Create the file URL with proper scheme based on TLS configuration
-	fileURL := fmt.Sprintf("%s%s", filerHttpAddress, cleanFilePath)
+	fileURL := filerFileURL(filerHttpAddress, cleanFilePath)
 	fileURL, err = h.httpClient.NormalizeHttpScheme(fileURL)
 	if err != nil {
 		glog.Errorf("Failed to normalize URL scheme: %v", err)

--- a/weed/admin/handlers/file_browser_handlers_test.go
+++ b/weed/admin/handlers/file_browser_handlers_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAndCleanFilePath_AllowsControlChars(t *testing.T) {
+	h := &FileBrowserHandlers{}
+
+	// S3 object keys may legally contain any UTF-8 bytes, including control
+	// characters like \n, \r, and \x00. The admin UI must be able to browse
+	// and manage such entries rather than refusing them.
+	cases := []string{
+		"/buckets/profilebuilder/3testGB.zip\n ",
+		"/foo\rbar",
+		"/foo\x00bar",
+		"/normal/path.txt",
+	}
+	for _, in := range cases {
+		got, err := h.validateAndCleanFilePath(in)
+		if err != nil {
+			t.Errorf("validateAndCleanFilePath(%q) unexpected error: %v", in, err)
+			continue
+		}
+		if !strings.HasPrefix(got, "/") {
+			t.Errorf("validateAndCleanFilePath(%q) = %q, want leading /", in, got)
+		}
+	}
+}
+
+func TestValidateAndCleanFilePath_RejectsEmpty(t *testing.T) {
+	h := &FileBrowserHandlers{}
+	if _, err := h.validateAndCleanFilePath(""); err == nil {
+		t.Errorf("expected empty path rejection")
+	}
+}
+
+func TestFilerFileURL_EscapesControlChars(t *testing.T) {
+	got := filerFileURL("http://127.0.0.1:8888", "/buckets/profilebuilder/3testGB.zip\n ")
+	want := "http://127.0.0.1:8888/buckets/profilebuilder/3testGB.zip%0A%20"
+	if got != want {
+		t.Errorf("filerFileURL = %q, want %q", got, want)
+	}
+	// A path with no special characters should round-trip unchanged.
+	if got := filerFileURL("http://h:1", "/a/b.txt"); got != "http://h:1/a/b.txt" {
+		t.Errorf("filerFileURL unchanged path = %q", got)
+	}
+}

--- a/weed/admin/handlers/file_browser_handlers_test.go
+++ b/weed/admin/handlers/file_browser_handlers_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -10,21 +9,28 @@ func TestValidateAndCleanFilePath_AllowsControlChars(t *testing.T) {
 
 	// S3 object keys may legally contain any UTF-8 bytes, including control
 	// characters like \n, \r, and \x00. The admin UI must be able to browse
-	// and manage such entries rather than refusing them.
-	cases := []string{
-		"/buckets/profilebuilder/3testGB.zip\n ",
-		"/foo\rbar",
-		"/foo\x00bar",
-		"/normal/path.txt",
+	// and manage such entries rather than silently stripping or rejecting them.
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/buckets/profilebuilder/3testGB.zip\n ", "/buckets/profilebuilder/3testGB.zip\n "},
+		{"/foo\rbar", "/foo\rbar"},
+		{"/foo\x00bar", "/foo\x00bar"},
+		{"/normal/path.txt", "/normal/path.txt"},
+		// Missing leading slash should be added back.
+		{"relative/path.txt", "/relative/path.txt"},
+		// Duplicate slashes should be collapsed by path.Clean.
+		{"/a//b", "/a/b"},
 	}
-	for _, in := range cases {
-		got, err := h.validateAndCleanFilePath(in)
+	for _, tc := range cases {
+		got, err := h.validateAndCleanFilePath(tc.in)
 		if err != nil {
-			t.Errorf("validateAndCleanFilePath(%q) unexpected error: %v", in, err)
+			t.Errorf("validateAndCleanFilePath(%q) unexpected error: %v", tc.in, err)
 			continue
 		}
-		if !strings.HasPrefix(got, "/") {
-			t.Errorf("validateAndCleanFilePath(%q) = %q, want leading /", in, got)
+		if got != tc.want {
+			t.Errorf("validateAndCleanFilePath(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }
@@ -37,13 +43,20 @@ func TestValidateAndCleanFilePath_RejectsEmpty(t *testing.T) {
 }
 
 func TestFilerFileURL_EscapesControlChars(t *testing.T) {
-	got := filerFileURL("http://127.0.0.1:8888", "/buckets/profilebuilder/3testGB.zip\n ")
-	want := "http://127.0.0.1:8888/buckets/profilebuilder/3testGB.zip%0A%20"
-	if got != want {
-		t.Errorf("filerFileURL = %q, want %q", got, want)
+	cases := []struct {
+		addr string
+		path string
+		want string
+	}{
+		{"http://127.0.0.1:8888", "/buckets/profilebuilder/3testGB.zip\n ", "http://127.0.0.1:8888/buckets/profilebuilder/3testGB.zip%0A%20"},
+		{"http://127.0.0.1:8888", "/buckets/profilebuilder/file\rname", "http://127.0.0.1:8888/buckets/profilebuilder/file%0Dname"},
+		{"http://127.0.0.1:8888", "/buckets/profilebuilder/file\x00name", "http://127.0.0.1:8888/buckets/profilebuilder/file%00name"},
+		// Plain path round-trips unchanged.
+		{"http://h:1", "/a/b.txt", "http://h:1/a/b.txt"},
 	}
-	// A path with no special characters should round-trip unchanged.
-	if got := filerFileURL("http://h:1", "/a/b.txt"); got != "http://h:1/a/b.txt" {
-		t.Errorf("filerFileURL unchanged path = %q", got)
+	for _, tc := range cases {
+		if got := filerFileURL(tc.addr, tc.path); got != tc.want {
+			t.Errorf("filerFileURL(%q, %q) = %q, want %q", tc.addr, tc.path, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- The admin UI's `validateAndCleanFilePath` rejected any path containing `\x00`, `\r`, or `\n` with "path contains invalid characters". These bytes are legal in S3 object keys, so an object created via the S3 API whose key happens to end in e.g. `\n ` (a surprisingly easy thing to do when a client appends stray whitespace to the URL path) existed on the filer but was completely unreachable from the admin UI — browse, download, and upload all failed.
- Remove the control-character rejection. Instead, URL-escape the path when constructing filer request URLs so those bytes can't inject into the HTTP request target. Path traversal protection via `path.Clean` + `..` check is unchanged.
- Add unit tests for `validateAndCleanFilePath` (control chars accepted, empty rejected) and for the new `filerFileURL` helper (escapes `\n`/space to `%0A%20`, leaves plain paths unchanged).

## Repro of the underlying user report
Discussion: seaweedfs/seaweedfs#8481

1. S3 `PutObject` with a key containing a trailing `\n ` (e.g. `aws s3api put-object --key $'foo.zip\n '`). Central filer stores the entry literally.
2. `filer.sync` faithfully replicates the entry name to the edge filer.
3. Edge admin UI tries to browse the bucket → rejects the entry with "Invalid file path: path contains invalid characters".

After this change, the admin UI can list, download, and manage objects whose keys contain control characters, consistent with what the S3 API already accepts.

## Test plan
- [x] `go test ./weed/admin/handlers/...`
- [ ] Manually browse a bucket in the admin UI containing an object with `\n` in its key and confirm listing + download work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file browser with improved handling of special characters in file names and paths, providing more reliable file upload, download, and content retrieval operations.

* **Tests**
  * Added unit tests for file path validation and processing to ensure consistent and reliable behavior across various file name formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->