### PR TITLE
correctly namespace all `define` calls

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -82,7 +82,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "admin.image" . }}
+          image: {{ template "seaweedfs.admin.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           {{- $adminAuthEnabled := or .Values.admin.secret.existingSecret .Values.admin.secret.adminPassword }}
           {{- $urlPrefix := .Values.admin.urlPrefix }}
@@ -242,7 +242,7 @@ spec:
           securityContext: {{- omit .Values.admin.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.admin.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.admin.sidecars "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.admin.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         {{- if eq .Values.admin.data.type "hostPath" }}
@@ -303,7 +303,7 @@ spec:
       nodeSelector:
         {{ tpl .Values.admin.nodeSelector . | indent 8 | trim }}
       {{- end }}
-  {{- $pvc_exists := include "admin.pvc_exists" . -}}
+  {{- $pvc_exists := include "seaweedfs.admin.pvc_exists" . -}}
   {{- if $pvc_exists }}
   volumeClaimTemplates:
     {{- if eq .Values.admin.data.type "persistentVolumeClaim" }}

--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -77,7 +77,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "master.image" . }}
+          image: {{ template "seaweedfs.master.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             {{- /* Determine default cluster alias and the corresponding env var keys to avoid conflicts */}}
@@ -418,7 +418,7 @@ spec:
             {{- omit .Values.allInOne.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.allInOne.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.allInOne.sidecars "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.allInOne.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         - name: data

--- a/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -164,7 +164,7 @@ spec:
           securityContext: {{- omit .Values.cosi.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.cosi.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.cosi.sidecars "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.cosi.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         - name: socket

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "filer.image" . }}
+          image: {{ template "seaweedfs.filer.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             - name: POD_IP
@@ -317,7 +317,7 @@ spec:
           securityContext: {{- omit .Values.filer.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
         {{- if .Values.filer.sidecars }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.filer.sidecars "context" $) | nindent 8 }}
+        {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.filer.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if eq .Values.filer.logs.type "hostPath" }}
@@ -413,7 +413,7 @@ spec:
       storageClassName: {{ .Values.filer.storageClass }}
       {{- end }}
   {{- end }}
-  {{- $pvc_exists := include "filer.pvc_exists" . -}}
+  {{- $pvc_exists := include "seaweedfs.filer.pvc_exists" . -}}
   {{- if $pvc_exists }}
   volumeClaimTemplates:
     {{- if eq .Values.filer.data.type "persistentVolumeClaim" }}

--- a/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -80,7 +80,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "master.image" . }}
+          image: {{ template "seaweedfs.master.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             - name: POD_IP
@@ -251,7 +251,7 @@ spec:
           securityContext: {{- omit .Values.master.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
         {{- if .Values.master.sidecars }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
+        {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if eq .Values.master.logs.type "hostPath" }}
@@ -312,7 +312,7 @@ spec:
       nodeSelector:
         {{ tpl .Values.master.nodeSelector . | indent 8 | trim }}
       {{- end }}
-  {{- $pvc_exists := include "master.pvc_exists" . -}}
+  {{- $pvc_exists := include "seaweedfs.master.pvc_exists" . -}}
   {{- if $pvc_exists }}
   volumeClaimTemplates:
     {{- if eq .Values.master.data.type "persistentVolumeClaim"}}

--- a/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "s3.image" . }}
+          image: {{ template "seaweedfs.s3.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             - name: POD_IP
@@ -226,7 +226,7 @@ spec:
           securityContext: {{- omit .Values.s3.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.s3.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.s3.sidecars "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.s3.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         {{- if .Values.s3.enableAuth }}

--- a/k8s/charts/seaweedfs/templates/s3/s3-secret.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-secret.yaml
@@ -15,15 +15,15 @@
 {{- $access_key_admin := $adminCreds.accessKey -}}
 {{- $secret_key_admin := $adminCreds.secretKey -}}
 {{- if not (and $access_key_admin $secret_key_admin) -}}
-  {{- $access_key_admin = include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
-  {{- $secret_key_admin = include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+  {{- $access_key_admin = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+  {{- $secret_key_admin = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
 {{- end -}}
 {{- $readCreds := $creds.read | default dict -}}
 {{- $access_key_read := $readCreds.accessKey -}}
 {{- $secret_key_read := $readCreds.secretKey -}}
 {{- if not (and $access_key_read $secret_key_read) -}}
-  {{- $access_key_read = include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
-  {{- $secret_key_read = include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+  {{- $access_key_read = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+  {{- $secret_key_read = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
 {{- end -}}
 apiVersion: v1
 kind: Secret

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "sftp.image" . }}
+          image: {{ template "seaweedfs.sftp.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             - name: POD_IP
@@ -233,7 +233,7 @@ spec:
           securityContext: {{- omit .Values.sftp.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.sftp.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.sftp.sidecars "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.sftp.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         {{- if .Values.sftp.enableAuth }}

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-secret.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-secret.yaml
@@ -1,8 +1,8 @@
 {{- if or .Values.sftp.enabled .Values.allInOne.enabled }}
 {{- $secretName := printf "%s-sftp-secret" (include "seaweedfs.fullname" .) }}
-{{- $admin_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_password" 20) -}}
-{{- $read_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "readonly_password" 20) -}}
-{{- $public_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "public_user_password" 20) -}}
+{{- $admin_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_password" "length" 20) -}}
+{{- $read_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "readonly_password" "length" 20) -}}
+{{- $public_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "public_user_password" "length" 20) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-secret.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-secret.yaml
@@ -1,8 +1,8 @@
 {{- if or .Values.sftp.enabled .Values.allInOne.enabled }}
 {{- $secretName := printf "%s-sftp-secret" (include "seaweedfs.fullname" .) }}
-{{- $admin_pwd := include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_password" 20) -}}
-{{- $read_user_pwd := include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "readonly_password" 20) -}}
-{{- $public_user_pwd := include "getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "public_user_password" 20) -}}
+{{- $admin_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_password" 20) -}}
+{{- $read_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "readonly_password" 20) -}}
+{{- $public_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "public_user_password" 20) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -72,77 +72,77 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/* Return the proper filer image */}}
-{{- define "filer.image" -}}
+{{- define "seaweedfs.filer.image" -}}
 {{- if .Values.filer.imageOverride -}}
 {{- $imageOverride := .Values.filer.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Return the proper master image */}}
-{{- define "master.image" -}}
+{{- define "seaweedfs.master.image" -}}
 {{- if .Values.master.imageOverride -}}
 {{- $imageOverride := .Values.master.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Return the proper s3 image */}}
-{{- define "s3.image" -}}
+{{- define "seaweedfs.s3.image" -}}
 {{- if .Values.s3.imageOverride -}}
 {{- $imageOverride := .Values.s3.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Return the proper sftp image */}}
-{{- define "sftp.image" -}}
+{{- define "seaweedfs.sftp.image" -}}
 {{- if .Values.sftp.imageOverride -}}
 {{- $imageOverride := .Values.sftp.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Return the proper admin image */}}
-{{- define "admin.image" -}}
+{{- define "seaweedfs.admin.image" -}}
 {{- if .Values.admin.imageOverride -}}
 {{- $imageOverride := .Values.admin.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Return the proper worker image */}}
-{{- define "worker.image" -}}
+{{- define "seaweedfs.worker.image" -}}
 {{- if .Values.worker.imageOverride -}}
 {{- $imageOverride := .Values.worker.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Return the proper volume image */}}
-{{- define "volume.image" -}}
+{{- define "seaweedfs.volume.image" -}}
 {{- if .Values.volume.imageOverride -}}
 {{- $imageOverride := .Values.volume.imageOverride -}}
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
-{{- include "common.image" . }}
+{{- include "seaweedfs.image" . }}
 {{- end -}}
 {{- end -}}
 
 {{/* Computes the container image name for all components (if they are not overridden) */}}
-{{- define "common.image" -}}
+{{- define "seaweedfs.image" -}}
 {{- $registryName := default .Values.image.registry .Values.global.imageRegistry | toString -}}
 {{- $repositoryName := default .Values.image.repository .Values.global.seaweedfs.image.repository | toString -}}
 {{- $name := .Values.global.seaweedfs.image.name | toString -}}
@@ -160,7 +160,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/* check if any Volume PVC exists */}}
-{{- define "volume.pvc_exists" -}}
+{{- define "seaweedfs.volume.pvc_exists" -}}
 {{- if or (or (eq .Values.volume.data.type "persistentVolumeClaim") (and (eq .Values.volume.idx.type "persistentVolumeClaim") .Values.volume.dir_idx )) (eq .Values.volume.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
@@ -169,7 +169,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/* check if any Filer PVC exists */}}
-{{- define "filer.pvc_exists" -}}
+{{- define "seaweedfs.filer.pvc_exists" -}}
 {{- if or (eq .Values.filer.data.type "persistentVolumeClaim") (eq .Values.filer.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
@@ -178,7 +178,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/* check if any Master PVC exists */}}
-{{- define "master.pvc_exists" -}}
+{{- define "seaweedfs.master.pvc_exists" -}}
 {{- if or (eq .Values.master.data.type "persistentVolumeClaim") (eq .Values.master.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
@@ -187,7 +187,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/* check if any Admin PVC exists */}}
-{{- define "admin.pvc_exists" -}}
+{{- define "seaweedfs.admin.pvc_exists" -}}
 {{- if or (eq .Values.admin.data.type "persistentVolumeClaim") (eq .Values.admin.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
@@ -196,7 +196,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 
 {{/* check if any InitContainers exist for Volumes */}}
-{{- define "volume.initContainers_exists" -}}
+{{- define "seaweedfs.volume.initContainers_exists" -}}
 {{- if or (not (empty .Values.volume.idx )) (not (empty .Values.volume.initContainers )) -}}
 {{- printf "true" -}}
 {{- else -}}
@@ -225,10 +225,10 @@ imagePullSecrets:
 {{/*
 Renders a value that contains template perhaps with scope if the scope is present.
 Usage:
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+{{ include "seaweedfs.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "seaweedfs.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
 */}}
-{{- define "common.tplvalues.render" -}}
+{{- define "seaweedfs.tplvalues.render" -}}
 {{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
 {{- if contains "{{" (toJson .value) }}
   {{- if .scope }}
@@ -245,9 +245,9 @@ Usage:
 Converts a Kubernetes quantity like "256Mi" or "2G" to a float64 in base units,
 handling both binary (Ki, Mi, Gi) and decimal (m, k, M) suffixes; numeric inputs
 Usage:
-{{ include "common.resource-quantity" "10Gi" }}
+{{ include "seaweedfs.resource-quantity" "10Gi" }}
 */}}
-{{- define "common.resource-quantity" -}}
+{{- define "seaweedfs.resource-quantity" -}}
     {{- $value := . -}}
     {{- $unit := 1.0 -}}
     {{- if typeIs "string" . -}}
@@ -267,7 +267,7 @@ Usage:
 getOrGeneratePassword will check if a password exists in a secret and return it,
 or generate a new random password if it doesn't exist.
 */}}
-{{- define "getOrGeneratePassword" -}}
+{{- define "seaweedfs.getOrGeneratePassword" -}}
 {{- $params := . -}}
 {{- $namespace := $params.namespace -}}
 {{- $secretName := $params.secretName -}}

--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -68,7 +68,7 @@ spec:
       {{- include "seaweedfs.imagePullSecrets" $ | nindent 6 }}
       containers:
       - name: post-install-job
-        image: {{ template "master.image" . }}
+        image: {{ template "seaweedfs.master.image" . }}
         imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
         env:
           - name: WEED_CLUSTER_DEFAULT

--- a/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -35,8 +35,8 @@
 {{-             $pvcName := printf "%s-%s-%s-%d" $dir.name $seaweedfsName $volumeName $e }}
 {{-             $currentPVC := (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $pvcName) }}
 {{-             if and $currentPVC }}
-{{-             $oldSize := include "common.resource-quantity" $currentPVC.spec.resources.requests.storage }}
-{{-             $newSize := include "common.resource-quantity" $desiredSize }}
+{{-             $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
+{{-             $newSize := include "seaweedfs.resource-quantity" $desiredSize }}
 {{-               if gt $newSize $oldSize }}
 {{-               $commands = append $commands (printf "kubectl patch pvc %s-%s-%s-%d -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"%s\"}}}}'" $dir.name $seaweedfsName $volumeName $e $desiredSize) }}
 {{-               end }}

--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -71,12 +71,12 @@ spec:
       {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ $volume.serviceAccountName | default (include "seaweedfs.serviceAccountName" $) | quote }} # for deleting statefulset pods after migration
-      {{- $initContainers_exists := include "volume.initContainers_exists" $ -}}
+      {{- $initContainers_exists := include "seaweedfs.volume.initContainers_exists" $ -}}
       {{- if $initContainers_exists }}
       initContainers:
         {{- if $volume.idx }}
         - name: seaweedfs-vol-move-idx
-          image: {{ template "volume.image" $ }}
+          image: {{ template "seaweedfs.volume.image" $ }}
           imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
           command: [ '/bin/sh', '-c' ]
           args: [ '{{range $dir :=  $volume.dataDirs }}if ls /{{$dir.name}}/*.idx  >/dev/null 2>&1; then mv /{{$dir.name}}/*.idx /idx/ ; fi; {{end}}' ]
@@ -104,7 +104,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "volume.image" $ }}
+          image: {{ template "seaweedfs.volume.image" $ }}
           imagePullPolicy: {{ default "IfNotPresent" $.Values.global.seaweedfs.imagePullPolicy }}
           env:
             - name: POD_NAME
@@ -274,7 +274,7 @@ spec:
           securityContext: {{- omit $volume.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if $volume.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.sidecars) "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.sidecars) "context" $) | nindent 8 }}
       {{- end }}
       volumes:
 

--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -77,7 +77,7 @@ spec:
       {{- end }}
       containers:
         - name: seaweedfs
-          image: {{ template "worker.image" . }}
+          image: {{ template "seaweedfs.worker.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             - name: POD_IP
@@ -219,7 +219,7 @@ spec:
           securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.worker.sidecars }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | nindent 8 }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         {{- if eq .Values.worker.data.type "hostPath" }}


### PR DESCRIPTION
# What problem are we solving?
Fixes #8905


# How are we solving the problem?
By namespacing all `define`s. For example: `admin.image` -> `seaweedfs.admin.image`.

AFAIK people started using the `common` namepace when copy-pasting code from bitnami helm charts. But bitnami uses `common` because they actually have a subchart that is called `common`. If your chart is called `seaweedfs`, you need to namespace your `define`s under `seaweedfs.*`. Not namespacing at all is plain wrong.

# How is the PR tested?
* `helm template`
* `helm diff` against my umbrella chart that was previously failing due to #8905.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Helm chart helper templates with improved namespace organization to enhance maintainability and clarity across SeaweedFS deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->