### PR TITLE
s3api: prune bucket-scoped IAM actions on DeleteBucket

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1807,39 +1807,62 @@ func (iam *IdentityAccessManagement) syncRuntimePoliciesToIAMManager(ctx context
 // bucket (e.g. "Read:bucket", "Write:bucket/prefix") from the persisted S3 IAM
 // configuration. Wildcarded resources and global actions are preserved because
 // they may cover other buckets. Static (read-only) identities are not touched.
-// Returns true if the configuration was changed and saved.
+//
+// Updates are applied per-identity via the credential store's UpdateUser path,
+// which rewrites only the affected user record. This avoids a full-config
+// read-modify-write cycle that could clobber unrelated concurrent IAM edits.
+// Returns true if any identity was updated.
 func (iam *IdentityAccessManagement) PruneBucketFromConfiguration(ctx context.Context, bucket string) (bool, error) {
 	if iam == nil || iam.credentialManager == nil || bucket == "" {
 		return false, nil
 	}
-	config, err := iam.credentialManager.LoadConfiguration(ctx)
+	usernames, err := iam.credentialManager.ListUsers(ctx)
 	if err != nil {
 		return false, err
 	}
 	changed := false
-	for _, ident := range config.Identities {
+	var firstErr error
+	for _, username := range usernames {
+		if iam.IsStaticIdentity(username) {
+			continue
+		}
+		ident, err := iam.credentialManager.GetUser(ctx, username)
+		if err != nil {
+			if errors.Is(err, credential.ErrUserNotFound) {
+				continue
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
 		if ident == nil || ident.IsStatic {
 			continue
 		}
 		kept := ident.Actions[:0]
+		pruned := false
 		for _, a := range ident.Actions {
 			if actionScopedToBucket(a, bucket) {
-				changed = true
+				pruned = true
 				continue
 			}
 			kept = append(kept, a)
 		}
+		if !pruned {
+			continue
+		}
 		ident.Actions = kept
+		if err := iam.credentialManager.UpdateUser(ctx, username, ident); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		changed = true
 	}
-	if !changed {
-		return false, nil
-	}
-	if err := iam.credentialManager.SaveConfiguration(ctx, config); err != nil {
-		return false, err
-	}
-	// In-memory identities will be refreshed via the filer metadata subscription
-	// (see onIamConfigChange), which fans the update out to every S3 server.
-	return true, nil
+	// In-memory identities refresh via the filer metadata subscription
+	// (onIamConfigChange), which fans the update out to every S3 server.
+	return changed, firstErr
 }
 
 // actionScopedToBucket reports whether a configured action string like

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1803,6 +1803,60 @@ func (iam *IdentityAccessManagement) syncRuntimePoliciesToIAMManager(ctx context
 	return manager.SyncRuntimePolicies(ctx, policies)
 }
 
+// PruneBucketFromConfiguration removes any identity actions scoped to the given
+// bucket (e.g. "Read:bucket", "Write:bucket/prefix") from the persisted S3 IAM
+// configuration. Wildcarded resources and global actions are preserved because
+// they may cover other buckets. Static (read-only) identities are not touched.
+// Returns true if the configuration was changed and saved.
+func (iam *IdentityAccessManagement) PruneBucketFromConfiguration(ctx context.Context, bucket string) (bool, error) {
+	if iam == nil || iam.credentialManager == nil || bucket == "" {
+		return false, nil
+	}
+	config, err := iam.credentialManager.LoadConfiguration(ctx)
+	if err != nil {
+		return false, err
+	}
+	changed := false
+	for _, ident := range config.Identities {
+		if ident == nil || ident.IsStatic {
+			continue
+		}
+		kept := ident.Actions[:0]
+		for _, a := range ident.Actions {
+			if actionScopedToBucket(a, bucket) {
+				changed = true
+				continue
+			}
+			kept = append(kept, a)
+		}
+		ident.Actions = kept
+	}
+	if !changed {
+		return false, nil
+	}
+	if err := iam.credentialManager.SaveConfiguration(ctx, config); err != nil {
+		return false, err
+	}
+	// In-memory identities will be refreshed via the filer metadata subscription
+	// (see onIamConfigChange), which fans the update out to every S3 server.
+	return true, nil
+}
+
+// actionScopedToBucket reports whether a configured action string like
+// "Read:bucket" or "Write:bucket/prefix" is scoped exclusively to the given
+// bucket. Wildcard resources are never considered scoped to a single bucket.
+func actionScopedToBucket(action, bucket string) bool {
+	idx := strings.Index(action, ":")
+	if idx < 0 {
+		return false
+	}
+	resource := action[idx+1:]
+	if strings.ContainsAny(resource, "*?") {
+		return false
+	}
+	return resource == bucket || strings.HasPrefix(resource, bucket+"/")
+}
+
 // LoadS3ApiConfigurationFromCredentialManager loads configuration using the credential manager
 func (iam *IdentityAccessManagement) LoadS3ApiConfigurationFromCredentialManager() error {
 	glog.V(1).Infof("Loading S3 API configuration from credential manager")

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -405,6 +405,15 @@ func (s3a *S3ApiServer) DeleteBucketHandler(w http.ResponseWriter, r *http.Reque
 	s3a.invalidateBucketConfigCache(bucket)
 	stats_collect.DeleteBucketMetrics(bucket)
 
+	// Prune identity actions that were scoped to this bucket via s3.configure.
+	// Logged but not fatal: the bucket is already gone, and leftover entries
+	// are harmless until the bucket (or another with the same name) reappears.
+	if s3a.iam != nil {
+		if _, err := s3a.iam.PruneBucketFromConfiguration(r.Context(), bucket); err != nil {
+			glog.Errorf("DeleteBucketHandler: failed to prune IAM actions for bucket %s: %v", bucket, err)
+		}
+	}
+
 	s3err.WriteEmptyResponse(w, r, http.StatusNoContent)
 }
 

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -406,12 +406,14 @@ func (s3a *S3ApiServer) DeleteBucketHandler(w http.ResponseWriter, r *http.Reque
 	stats_collect.DeleteBucketMetrics(bucket)
 
 	// Prune identity actions that were scoped to this bucket via s3.configure.
-	// Logged but not fatal: the bucket is already gone, and leftover entries
-	// are harmless until the bucket (or another with the same name) reappears.
+	// Use a bounded background context so the cleanup survives client disconnect;
+	// the bucket is already gone and this is best-effort bookkeeping.
 	if s3a.iam != nil {
-		if _, err := s3a.iam.PruneBucketFromConfiguration(r.Context(), bucket); err != nil {
+		pruneCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if _, err := s3a.iam.PruneBucketFromConfiguration(pruneCtx, bucket); err != nil {
 			glog.Errorf("DeleteBucketHandler: failed to prune IAM actions for bucket %s: %v", bucket, err)
 		}
+		cancel()
 	}
 
 	s3err.WriteEmptyResponse(w, r, http.StatusNoContent)


### PR DESCRIPTION
## Summary
- After `DeleteBucket`, strip any identity actions configured via `s3.configure` that were scoped to the deleted bucket (`Read:bucket`, `Write:bucket/prefix`, …) so stale auth metadata no longer lingers.
- Save via the credential manager and let the existing filer metadata subscription (`onIamConfigChange`) fan the in-memory reload out to every S3 server — no extra reload call needed.
- Wildcarded resources (e.g. `Admin:*`, `Read:buck*`) and static identities are intentionally left alone, since they may cover other buckets.

Fixes #5310

## Test plan
- [ ] `go build ./weed/s3api/...`
- [ ] Manual: `s3.configure` an identity with `Read:foo` and `Write:foo/prefix`, `DeleteBucket foo`, confirm those actions disappear from the persisted IAM config and from the in-memory runtime on all S3 servers.
- [ ] Manual: verify an identity with `Admin:*` and `Read:other-bucket` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bucket deletion to automatically clean up associated access management configurations. This ensures that access permissions scoped exclusively to a deleted bucket are properly removed from user credentials, preventing orphaned permissions from remaining in the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->