### PR TITLE
fix(weed/worker/tasks): log dropped errors

### DIFF
--- a/weed/worker/tasks/task_logger.go
+++ b/weed/worker/tasks/task_logger.go
@@ -199,7 +199,10 @@ func (l *FileTaskLogger) LogProgress(progress float64, message string) {
 	}
 
 	l.writeLogEntry(entry)
-	l.saveMetadata() // Update metadata with new progress
+	// Update metadata with new progress
+	if err := l.saveMetadata(); err != nil {
+		glog.Warningf("Failed to save initial task metadata: %v", err)
+	}
 }
 
 // LogStatus logs task status change
@@ -216,7 +219,10 @@ func (l *FileTaskLogger) LogStatus(status string, message string) {
 	}
 
 	l.writeLogEntry(entry)
-	l.saveMetadata() // Update metadata with new status
+	// Update metadata with new status
+	if err := l.saveMetadata(); err != nil {
+		glog.Warningf("Failed to update metadata with new status: %v", err)
+	}
 }
 
 // LogWithFields logs a message with structured fields
@@ -263,7 +269,9 @@ func (l *FileTaskLogger) Close() error {
 	}
 
 	// Save final metadata
-	l.saveMetadata()
+	if err := l.saveMetadata(); err != nil {
+		glog.Warningf("Failed to save final task metadata: %v", err)
+	}
 
 	// Close log file
 	if l.logFile != nil {


### PR DESCRIPTION
This captures and logs three `err` variables in `weed/worker/tasks` that were being silently discarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for metadata persistence. The system now emits warnings when metadata operations fail instead of silently ignoring errors, while ensuring core logging operations continue uninterrupted. This enhances system reliability and resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->