### PR TITLE
docker: upgrade libcrypto3/libssl3 to clear Trivy HIGH (CVE-2026-28390)

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -56,7 +56,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh 
 # To disable: docker run -e GODEBUG=fips140=off ...
 
 # Install dependencies and create non-root user
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache zlib libcrypto3 libssl3 && \
     apk add --no-cache fuse curl su-exec libgcc && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed

--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -56,8 +56,8 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh 
 # To disable: docker run -e GODEBUG=fips140=off ...
 
 # Install dependencies and create non-root user
-RUN apk upgrade --no-cache zlib libcrypto3 libssl3 && \
-    apk add --no-cache fuse curl su-exec libgcc && \
+RUN apk upgrade --no-cache zlib && \
+    apk add --no-cache fuse curl su-exec libgcc libcrypto3 libssl3 && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed
 


### PR DESCRIPTION
## Summary
- Trivy gate on `ghcr.io/seaweedfs/seaweedfs:latest-amd64` is failing with 2 HIGH CVEs against `libcrypto3`/`libssl3` 3.5.5-r0 on the alpine 3.23.3 base (CVE-2026-28390, OpenSSL NULL-deref DoS in CMS; fixed in 3.5.6-r0).
- Add `libcrypto3 libssl3` to the existing `apk upgrade --no-cache` in `docker/Dockerfile.go_build` so rebuilt images pull the patched openssl without waiting for a new alpine base tag.

## Test plan
- [ ] CI `container_latest` workflow builds the image and the Trivy gate passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build-time cryptographic and compression dependencies, including adding FIPS-capable cryptography runtime packages to the final build stage to ensure compatible runtime crypto and zlib upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->