### PR TITLE
test(vacuum): fix flaky TestVacuumIntegration across multiple volumes

### DIFF
--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -262,12 +262,18 @@ func TestVacuumIntegration(t *testing.T) {
 	// Wait for heartbeat to report deletions
 	time.Sleep(6 * time.Second)
 
-	// Verify garbage exists on at least one of the volumes we deleted from.
+	// Verify garbage exists on every volume we deleted from.
 	// Retry briefly in case heartbeats / deletions have not fully settled.
+	// We require all dirty volumes to report garbage > threshold so that
+	// the subsequent vacuum + cleanup check has a well-defined expectation
+	// for every volume, not just the first one that happens to be ready.
 	t.Run("verify_garbage_before_vacuum", func(t *testing.T) {
-		deadline := time.Now().Add(15 * time.Second)
+		deadline := time.Now().Add(20 * time.Second)
+		var lastMissing needle.VolumeId
 		for {
+			ready := true
 			for _, vid := range dirtyVolumes {
+				volumeReady := false
 				for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
 					ratio, err := getGarbageRatio(addr, uint32(vid))
 					if err != nil {
@@ -275,16 +281,25 @@ func TestVacuumIntegration(t *testing.T) {
 					}
 					t.Logf("Garbage ratio for volume %d on %s: %.2f%%", vid, addr, ratio*100)
 					if ratio > 0.1 {
-						return // sufficient garbage found
+						volumeReady = true
+						break
 					}
 				}
+				if !volumeReady {
+					ready = false
+					lastMissing = vid
+					break
+				}
+			}
+			if ready {
+				return
 			}
 			if time.Now().After(deadline) {
 				break
 			}
 			time.Sleep(1 * time.Second)
 		}
-		t.Fatal("No volume reported garbage > 10% — test data setup failed")
+		t.Fatalf("volume %d did not report garbage > 10%% — test data setup failed", lastMissing)
 	})
 
 	// Execute vacuum via shell command
@@ -327,31 +342,49 @@ func TestVacuumIntegration(t *testing.T) {
 		t.Log("Vacuum completed successfully")
 	})
 
-	// Wait for vacuum effects to settle
-	time.Sleep(6 * time.Second)
-
 	// Verify garbage was cleaned on every volume we deleted from.
+	// Vacuum + heartbeat reporting is asynchronous, so retry until each
+	// volume reports a cleaned ratio or the deadline expires.
 	t.Run("verify_cleanup_after_vacuum", func(t *testing.T) {
+		deadline := time.Now().Add(30 * time.Second)
+		remaining := map[needle.VolumeId]struct{}{}
 		for _, vid := range dirtyVolumes {
-			var volumeFound, cleanupVerified bool
-			for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
-				ratio, err := getGarbageRatio(addr, uint32(vid))
-				if err != nil {
-					continue
-				}
-				volumeFound = true
-				t.Logf("Garbage ratio for volume %d after vacuum on %s: %.2f%%", vid, addr, ratio*100)
-				if ratio < 0.05 {
-					cleanupVerified = true
-				}
-			}
-			if !volumeFound {
-				t.Fatalf("No server reported volume %d after vacuum", vid)
-			}
-			if !cleanupVerified {
-				t.Fatalf("Garbage on volume %d was not cleaned up after vacuum", vid)
-			}
+			remaining[vid] = struct{}{}
 		}
+		var lastErr string
+		for {
+			for vid := range remaining {
+				var volumeFound, cleanupVerified bool
+				for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
+					ratio, err := getGarbageRatio(addr, uint32(vid))
+					if err != nil {
+						continue
+					}
+					volumeFound = true
+					t.Logf("Garbage ratio for volume %d after vacuum on %s: %.2f%%", vid, addr, ratio*100)
+					if ratio < 0.05 {
+						cleanupVerified = true
+						break
+					}
+				}
+				switch {
+				case !volumeFound:
+					lastErr = fmt.Sprintf("no server reported volume %d after vacuum", vid)
+				case !cleanupVerified:
+					lastErr = fmt.Sprintf("garbage on volume %d was not cleaned up after vacuum", vid)
+				default:
+					delete(remaining, vid)
+				}
+			}
+			if len(remaining) == 0 {
+				return
+			}
+			if time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(1 * time.Second)
+		}
+		t.Fatal(lastErr)
 	})
 
 	// Verify remaining files are still readable with correct contents

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -246,6 +248,8 @@ func TestVacuumIntegration(t *testing.T) {
 	for v := range dirtyVolumesSet {
 		dirtyVolumes = append(dirtyVolumes, v)
 	}
+	// Sort for deterministic log output and stable iteration order across runs.
+	sort.Slice(dirtyVolumes, func(i, j int) bool { return dirtyVolumes[i] < dirtyVolumes[j] })
 	t.Logf("Uploaded %d files (%d KB each) across volumes %v; will delete from volumes %v",
 		totalFiles, fileSize/1024, fileVolumes, dirtyVolumes)
 
@@ -351,7 +355,7 @@ func TestVacuumIntegration(t *testing.T) {
 		for _, vid := range dirtyVolumes {
 			remaining[vid] = struct{}{}
 		}
-		var lastErr string
+		failureReasons := map[needle.VolumeId]string{}
 		for {
 			for vid := range remaining {
 				var volumeFound, cleanupVerified bool
@@ -369,11 +373,12 @@ func TestVacuumIntegration(t *testing.T) {
 				}
 				switch {
 				case !volumeFound:
-					lastErr = fmt.Sprintf("no server reported volume %d after vacuum", vid)
+					failureReasons[vid] = fmt.Sprintf("no server reported volume %d after vacuum", vid)
 				case !cleanupVerified:
-					lastErr = fmt.Sprintf("garbage on volume %d was not cleaned up after vacuum", vid)
+					failureReasons[vid] = fmt.Sprintf("garbage on volume %d was not cleaned up after vacuum", vid)
 				default:
 					delete(remaining, vid)
+					delete(failureReasons, vid)
 				}
 			}
 			if len(remaining) == 0 {
@@ -384,7 +389,17 @@ func TestVacuumIntegration(t *testing.T) {
 			}
 			time.Sleep(1 * time.Second)
 		}
-		t.Fatal(lastErr)
+		stillFailing := make([]needle.VolumeId, 0, len(remaining))
+		for vid := range remaining {
+			stillFailing = append(stillFailing, vid)
+		}
+		sort.Slice(stillFailing, func(i, j int) bool { return stillFailing[i] < stillFailing[j] })
+		msgs := make([]string, 0, len(stillFailing))
+		for _, vid := range stillFailing {
+			msgs = append(msgs, failureReasons[vid])
+		}
+		t.Fatalf("cleanup verification failed for %d volume(s): %s",
+			len(stillFailing), strings.Join(msgs, "; "))
 	})
 
 	// Verify remaining files are still readable with correct contents

--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -226,16 +226,28 @@ func TestVacuumIntegration(t *testing.T) {
 
 	var fids []string
 	var payloads [][]byte
-	var volumeId needle.VolumeId
+	var fileVolumes []needle.VolumeId
 	for i := 0; i < totalFiles; i++ {
 		data := bytes.Repeat([]byte{byte('A' + i%26)}, fileSize)
 		fid, vid, err := uploadData(masterAddr, collection, data)
 		require.NoError(t, err, "upload %d", i)
 		fids = append(fids, fid)
 		payloads = append(payloads, data)
-		volumeId = vid
+		fileVolumes = append(fileVolumes, vid)
 	}
-	t.Logf("Uploaded %d files (%d KB each) to volume %d", totalFiles, fileSize/1024, volumeId)
+	// Collect the set of volumes that will contain garbage after the deletes below.
+	// The master may spread uploads across multiple volumes, so we cannot assume
+	// a single volume id holds all the garbage.
+	dirtyVolumesSet := map[needle.VolumeId]struct{}{}
+	for i := 0; i < filesToDelete; i++ {
+		dirtyVolumesSet[fileVolumes[i]] = struct{}{}
+	}
+	var dirtyVolumes []needle.VolumeId
+	for v := range dirtyVolumesSet {
+		dirtyVolumes = append(dirtyVolumes, v)
+	}
+	t.Logf("Uploaded %d files (%d KB each) across volumes %v; will delete from volumes %v",
+		totalFiles, fileSize/1024, fileVolumes, dirtyVolumes)
 
 	// Wait for heartbeat to report sizes
 	time.Sleep(6 * time.Second)
@@ -250,19 +262,29 @@ func TestVacuumIntegration(t *testing.T) {
 	// Wait for heartbeat to report deletions
 	time.Sleep(6 * time.Second)
 
-	// Verify garbage exists
+	// Verify garbage exists on at least one of the volumes we deleted from.
+	// Retry briefly in case heartbeats / deletions have not fully settled.
 	t.Run("verify_garbage_before_vacuum", func(t *testing.T) {
-		for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
-			ratio, err := getGarbageRatio(addr, uint32(volumeId))
-			if err != nil {
-				continue
+		deadline := time.Now().Add(15 * time.Second)
+		for {
+			for _, vid := range dirtyVolumes {
+				for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
+					ratio, err := getGarbageRatio(addr, uint32(vid))
+					if err != nil {
+						continue
+					}
+					t.Logf("Garbage ratio for volume %d on %s: %.2f%%", vid, addr, ratio*100)
+					if ratio > 0.1 {
+						return // sufficient garbage found
+					}
+				}
 			}
-			t.Logf("Garbage ratio on %s: %.2f%%", addr, ratio*100)
-			if ratio > 0.1 {
-				return // sufficient garbage found
+			if time.Now().After(deadline) {
+				break
 			}
+			time.Sleep(1 * time.Second)
 		}
-		t.Fatal("No server reported garbage > 10% — test data setup failed")
+		t.Fatal("No volume reported garbage > 10% — test data setup failed")
 	})
 
 	// Execute vacuum via shell command
@@ -308,25 +330,27 @@ func TestVacuumIntegration(t *testing.T) {
 	// Wait for vacuum effects to settle
 	time.Sleep(6 * time.Second)
 
-	// Verify garbage was cleaned
+	// Verify garbage was cleaned on every volume we deleted from.
 	t.Run("verify_cleanup_after_vacuum", func(t *testing.T) {
-		var volumeFound, cleanupVerified bool
-		for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
-			ratio, err := getGarbageRatio(addr, uint32(volumeId))
-			if err != nil {
-				continue
+		for _, vid := range dirtyVolumes {
+			var volumeFound, cleanupVerified bool
+			for _, addr := range []string{"127.0.0.1:8080", "127.0.0.1:8081"} {
+				ratio, err := getGarbageRatio(addr, uint32(vid))
+				if err != nil {
+					continue
+				}
+				volumeFound = true
+				t.Logf("Garbage ratio for volume %d after vacuum on %s: %.2f%%", vid, addr, ratio*100)
+				if ratio < 0.05 {
+					cleanupVerified = true
+				}
 			}
-			volumeFound = true
-			t.Logf("Garbage ratio after vacuum on %s: %.2f%%", addr, ratio*100)
-			if ratio < 0.05 {
-				cleanupVerified = true
+			if !volumeFound {
+				t.Fatalf("No server reported volume %d after vacuum", vid)
 			}
-		}
-		if !volumeFound {
-			t.Fatal("No server reported volume after vacuum")
-		}
-		if !cleanupVerified {
-			t.Fatal("Garbage was not cleaned up after vacuum")
+			if !cleanupVerified {
+				t.Fatalf("Garbage on volume %d was not cleaned up after vacuum", vid)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Summary
- `TestVacuumIntegration` tracked only the *last* uploaded file's volume id. With `-volumeSizeLimitMB 10` and 16×500KB files, the master can spread uploads across volumes, so the tracked id could point to a volume with no deletes and thus 0% garbage — causing `verify_garbage_before_vacuum` to fail even though vacuum actually ran correctly on the other volume. Observed flake: https://github.com/seaweedfs/seaweedfs/actions/runs/24373555757/job/71182127729
- Track the set of volumes where deletes actually occurred (`dirtyVolumes`) and verify garbage/cleanup against all of them on both volume servers.
- Add a short retry loop on the pre-vacuum garbage check to absorb heartbeat jitter.

## Test plan
- [ ] `cd weed && go build` then `go test -v ./test/vacuum/...`
- [ ] Vacuum Integration Tests CI job green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced garbage-collection integration tests to verify cleanup across all storage volumes affected by uploads/deletes.
  * Switched to de-duplicated per-volume tracking so assertions check each impacted volume’s garbage ratio instead of a single sample.
  * Improved robustness with timeout-based polling and clearer, volume-specific failure messages for pre- and post-cleanup verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->