### PR TITLE
fix(mount): stop double-applying umask in Mkdir

### DIFF
--- a/test/pjdfstest/known_failures.txt
+++ b/test/pjdfstest/known_failures.txt
@@ -6,8 +6,3 @@
 # A failure in any test NOT listed here will cause the CI job to fail,
 # catching regressions immediately.
 
-# ── Directory rename permission edge case ──────────────────────────────
-# Cross-directory rename of a subdirectory with restricted permissions
-# causes cascading test failures within the test file.
-tests/rename/21.t
-

--- a/weed/mount/weedfs_dir_mkrm.go
+++ b/weed/mount/weedfs_dir_mkrm.go
@@ -38,7 +38,7 @@ func (wfs *WFS) Mkdir(cancel <-chan struct{}, in *fuse.MkdirIn, name string, out
 			Mtime:    now,
 			Crtime:   now,
 			Ctime:    now,
-			FileMode: uint32(os.ModeDir) | in.Mode&^uint32(wfs.option.Umask),
+			FileMode: uint32(os.ModeDir) | in.Mode,
 			Uid:      in.Uid,
 			Gid:      in.Gid,
 		},


### PR DESCRIPTION
## Summary

- `Mkdir` was masking `in.Mode` with `wfs.option.Umask` on top of the kernel's VFS umask pass, so a caller with `umask=0` asking for `mkdir(0777)` got `0755` (`0777 & ~022`, the mount's default).
- `Create` and `Symlink` don't apply this second pass — `Mkdir` was the odd one out. The resulting dirs ended up with fewer write bits than the caller actually asked for, which broke cross-user rename permission checks: the kernel's `may_delete` rejects with `EACCES` when the parent lacks `o+w` even though the caller explicitly requested it.
- Drop the extra umask so `Mkdir` trusts `in.Mode` exactly like `Create`. The `-umask` CLI flag still applies to the internal cache dirs the mount creates for itself via `os.MkdirAll` (`weed/mount/weedfs.go:545-547`); only the user-facing `Mkdir` path changes.
- Unblocks `tests/rename/21.t` in pjdfstest and removes it from `known_failures.txt`, which is now empty.

## Root cause trace

pjdfstest's `tests/rename/21.t` walks:

1. `mkdir n2 0777; mkdir n3 0777` as root.
2. As UID 65534, try several renames through `n2`/`n3`, expecting the kernel to allow them because `n2`/`n3` are world-writable.

Repro in the docker harness showed `ls -la` reporting `n2` and `n3` as **`0755`**, not `0777`. pjdfstest sets `umask(0)` before every call, so the kernel VFS forwarded `in.Mode=0777` to FUSE unchanged — then `weed/mount/weedfs_dir_mkrm.go:41` chopped `022` off it via `in.Mode &^ uint32(wfs.option.Umask)`. UID 65534 then couldn't pass `may_delete` on the `0755` parents and the test's rename calls returned `EACCES` (test 5 cascaded to `ENOENT` because test 4's rename never happened; tests 12–14 cascaded the same way for the file-rename branch).

## Test plan

- [x] `go build ./...`
- [x] `go test ./weed/mount/...`
- [x] `tests/rename/21.t` in docker: 16/16 pass (was 4 failing)
- [x] Full pjdfstest suite in docker with an empty `known_failures.txt`: **236 files, 8819 tests, all PASS**, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory creation now properly applies requested file mode permissions without modification.

* **Tests**
  * Re-enabled a test that was previously marked as a known failure and skipped by continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->