### PR TITLE
fix(mount): serialize hard-link mutations on HardLinkId

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -123,6 +123,7 @@ type WFS struct {
 	fuseServer           *fuse.Server
 	IsOverQuota          bool
 	fhLockTable          *util.LockTable[FileHandleId]
+	hardLinkLockTable    *util.LockTable[string]
 	posixLocks           *PosixLockTable
 	rdmaClient           *RDMAMountClient
 	FilerConf            *filer.FilerConf
@@ -213,6 +214,7 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 		filerClient:       filerClient, // nil for proxy mode, initialized for direct access
 		pendingAsyncFlush: make(map[uint64]chan struct{}),
 		fhLockTable:       util.NewLockTable[FileHandleId](),
+		hardLinkLockTable: util.NewLockTable[string](),
 		posixLocks:        NewPosixLockTable(),
 		refreshingDirs:    make(map[util.FullPath]struct{}),
 		atimeMap:          make(map[uint64]time.Time, 8192),

--- a/weed/mount/weedfs_file_copy_range_test.go
+++ b/weed/mount/weedfs_file_copy_range_test.go
@@ -314,9 +314,10 @@ func newCopyRangeTestWFS() *WFS {
 			VolumeServerAccess: "filerProxy",
 			FilerAddresses:     []pb.ServerAddress{"127.0.0.1:8888"},
 		},
-		inodeToPath: NewInodeToPath(util.FullPath("/"), 0),
-		fhMap:       NewFileHandleToInode(),
-		fhLockTable: util.NewLockTable[FileHandleId](),
+		inodeToPath:       NewInodeToPath(util.FullPath("/"), 0),
+		fhMap:             NewFileHandleToInode(),
+		fhLockTable:       util.NewLockTable[FileHandleId](),
+		hardLinkLockTable: util.NewLockTable[string](),
 	}
 	wfs.copyBufferPool.New = func() any {
 		return make([]byte, 1024)

--- a/weed/mount/weedfs_file_mkrm.go
+++ b/weed/mount/weedfs_file_mkrm.go
@@ -188,6 +188,23 @@ func (wfs *WFS) Unlink(cancel <-chan struct{}, header *fuse.InHeader, name strin
 		return fuse.EPERM
 	}
 
+	// For hard-linked files, serialize all concurrent mutations on the
+	// same HardLinkId so the filer-side blob decrement and the mount-side
+	// sibling cache sync are observed atomically by other unlinkers.
+	// Without this, two concurrent unlinks on different links of the same
+	// file both read the same pre-decrement counter and both stamp their
+	// siblings to counter-1, leaving the cache one higher than the blob.
+	// Re-load the entry under the lock so we see any sibling update a
+	// prior holder just applied.
+	if entry != nil && len(entry.HardLinkId) > 0 {
+		hlKey := string(entry.HardLinkId)
+		lock := wfs.hardLinkLockTable.AcquireLock("unlink", hlKey, util.ExclusiveLock)
+		defer wfs.hardLinkLockTable.ReleaseLock(hlKey, lock)
+		if fresh, freshCode := wfs.maybeLoadEntry(entryFullPath); freshCode == fuse.OK && fresh != nil {
+			entry = fresh
+		}
+	}
+
 	// POSIX: enforce sticky bit on the parent directory.
 	if dirEntry, dirCode := wfs.maybeLoadEntry(dirFullPath); dirCode == fuse.OK && dirEntry != nil && dirEntry.Attributes != nil {
 		targetUid := uint32(0)

--- a/weed/mount/weedfs_file_mkrm.go
+++ b/weed/mount/weedfs_file_mkrm.go
@@ -200,9 +200,19 @@ func (wfs *WFS) Unlink(cancel <-chan struct{}, header *fuse.InHeader, name strin
 		hlKey := string(entry.HardLinkId)
 		lock := wfs.hardLinkLockTable.AcquireLock("unlink", hlKey, util.ExclusiveLock)
 		defer wfs.hardLinkLockTable.ReleaseLock(hlKey, lock)
-		if fresh, freshCode := wfs.maybeLoadEntry(entryFullPath); freshCode == fuse.OK && fresh != nil {
-			entry = fresh
+		// If another thread unlinked the entry while we waited for the
+		// lock, the file is already gone — return OK like the initial
+		// maybeLoadEntry path above. Do not fall back to the stale
+		// pre-lock snapshot: proceeding with its HardLinkCounter would
+		// reintroduce the stale-base update the lock is meant to prevent.
+		fresh, freshCode := wfs.maybeLoadEntry(entryFullPath)
+		if freshCode == fuse.ENOENT {
+			return fuse.OK
 		}
+		if freshCode != fuse.OK {
+			return freshCode
+		}
+		entry = fresh
 	}
 
 	// POSIX: enforce sticky bit on the parent directory.

--- a/weed/mount/weedfs_file_mkrm_test.go
+++ b/weed/mount/weedfs_file_mkrm_test.go
@@ -114,7 +114,8 @@ func newCreateTestWFS(t *testing.T) (*WFS, *createEntryTestServer) {
 		signature:   1,
 		inodeToPath: NewInodeToPath(root, 0),
 		fhMap:       NewFileHandleToInode(),
-		fhLockTable: util.NewLockTable[FileHandleId](),
+		fhLockTable:       util.NewLockTable[FileHandleId](),
+		hardLinkLockTable: util.NewLockTable[string](),
 	}
 	wfs.metaCache = meta_cache.NewMetaCache(
 		filepath.Join(t.TempDir(), "meta"),

--- a/weed/mount/weedfs_link.go
+++ b/weed/mount/weedfs_link.go
@@ -55,6 +55,19 @@ func (wfs *WFS) Link(cancel <-chan struct{}, in *fuse.LinkIn, name string, out *
 		return fuse.EPERM
 	}
 
+	// If the source is already a hard link, serialize on its HardLinkId
+	// so concurrent Link/Unlink operations on different siblings cannot
+	// both compute a new counter from a stale base. Re-load the entry
+	// under the lock to pick up any prior holder's sibling update.
+	if len(oldEntry.HardLinkId) > 0 {
+		hlKey := string(oldEntry.HardLinkId)
+		lock := wfs.hardLinkLockTable.AcquireLock("link", hlKey, util.ExclusiveLock)
+		defer wfs.hardLinkLockTable.ReleaseLock(hlKey, lock)
+		if fresh, freshStatus := wfs.maybeLoadEntry(oldEntryPath); freshStatus == fuse.OK && fresh != nil {
+			oldEntry = fresh
+		}
+	}
+
 	// update old file to hardlink mode
 	origHardLinkId := oldEntry.HardLinkId
 	origHardLinkCounter := oldEntry.HardLinkCounter

--- a/weed/mount/weedfs_link.go
+++ b/weed/mount/weedfs_link.go
@@ -63,9 +63,14 @@ func (wfs *WFS) Link(cancel <-chan struct{}, in *fuse.LinkIn, name string, out *
 		hlKey := string(oldEntry.HardLinkId)
 		lock := wfs.hardLinkLockTable.AcquireLock("link", hlKey, util.ExclusiveLock)
 		defer wfs.hardLinkLockTable.ReleaseLock(hlKey, lock)
-		if fresh, freshStatus := wfs.maybeLoadEntry(oldEntryPath); freshStatus == fuse.OK && fresh != nil {
-			oldEntry = fresh
+		// Do not fall back to the pre-lock snapshot: if the source was
+		// deleted while we waited, we must abort instead of deriving
+		// the next counter from a stale entry.
+		fresh, freshStatus := wfs.maybeLoadEntry(oldEntryPath)
+		if freshStatus != fuse.OK {
+			return freshStatus
 		}
+		oldEntry = fresh
 	}
 
 	// update old file to hardlink mode

--- a/weed/mount/weedfs_link.go
+++ b/weed/mount/weedfs_link.go
@@ -63,9 +63,20 @@ func (wfs *WFS) Link(cancel <-chan struct{}, in *fuse.LinkIn, name string, out *
 		hlKey := string(oldEntry.HardLinkId)
 		lock := wfs.hardLinkLockTable.AcquireLock("link", hlKey, util.ExclusiveLock)
 		defer wfs.hardLinkLockTable.ReleaseLock(hlKey, lock)
-		// Do not fall back to the pre-lock snapshot: if the source was
-		// deleted while we waited, we must abort instead of deriving
-		// the next counter from a stale entry.
+		// Under the lock, re-resolve the source alias from the inode.
+		// A concurrent Unlink that held this same lock may have removed
+		// the specific alias we picked pre-lock even though other
+		// sibling hard links for the same inode are still around;
+		// GetPath(Oldnodeid) returns whichever alias is still active.
+		refreshedPath, refreshedStatus := wfs.inodeToPath.GetPath(in.Oldnodeid)
+		if refreshedStatus != fuse.OK {
+			return refreshedStatus
+		}
+		oldEntryPath = refreshedPath
+		oldParentPath, _ = oldEntryPath.DirAndName()
+		// Do not fall back to the pre-lock snapshot: if every alias
+		// was deleted while we waited, abort instead of deriving the
+		// next counter from a stale entry.
 		fresh, freshStatus := wfs.maybeLoadEntry(oldEntryPath)
 		if freshStatus != fuse.OK {
 			return freshStatus


### PR DESCRIPTION
## Summary

- Fixes a data race flagged in the review of #9062: concurrent `Unlink`s on different links of the same file could leave the mount metacache with a stale `HardLinkCounter` one higher than the filer's authoritative shared blob.
- Adds a new `hardLinkLockTable *util.LockTable[string]` on `WFS` keyed by `HardLinkId`. `Unlink` and `Link` acquire this lock when the target is already a hard link, held across the filer mutation and the `syncHardLinkSiblings` call.
- Re-loads the source entry under the lock so the second waiter sees the updated sibling counter its predecessor just wrote before computing its own `counter ± 1` delta.
- Leaves the first-link race (empty `HardLinkId` on the source) alone — that's a separate pre-existing issue.

## Race being fixed

With three links `n0,n1,n2` at counter 3:

1. Thread A: `unlink n0` loads `entry.counter = 3`.
2. Thread B: `unlink n2` loads `entry.counter = 3` before A's sync lands.
3. A: filer delete (blob `3 → 2`), `syncHardLinkSiblings` stamps `n1,n2` to 2. ✓
4. B: filer delete (blob `2 → 1`), computes `decremented = 3 - 1 = 2` from its stale base, stamps `n1` to 2. ✗

True blob counter is 1, but the mount metacache holds 2. Any subsequent `lstat` that hits the metacache (and the kernel attr cache, which is also invalidated from the stale value) reports the wrong `nlink`.

The fix makes A's `load → delete → sync` block B until A completes; B's re-load under the lock sees `counter = 2` (what A wrote to the sibling), computes `decremented = 1`, and stamps correctly.

## Test plan

- [x] `go build ./weed/mount/...`
- [x] `go test ./weed/mount/...`
- [x] Full pjdfstest suite in docker: **235 files, 8803 tests, all PASS**, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization for hard-link operations: link and unlink now serialize concurrent changes and operate on a refreshed entry view to prevent races and stale-view deletions.

* **Tests**
  * Updated tests and test setup to initialize the new synchronization constructs and validate consistent hard-link behavior under concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->