### PR TITLE
perf(s3): add optional shared in-memory chunk cache for GET

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -150,6 +150,7 @@ func init() {
 	filerS3Options.portIceberg = cmdFiler.Flag.Int("s3.port.iceberg", 8181, "Iceberg REST Catalog server listen port (0 to disable)")
 	filerS3Options.externalUrl = cmdFiler.Flag.String("s3.externalUrl", "", "the external URL clients use to connect (e.g. https://api.example.com:9000). Used for S3 signature verification behind a reverse proxy. Falls back to S3_EXTERNAL_URL env var.")
 	filerS3Options.defaultFileMode = cmdFiler.Flag.String("s3.defaultFileMode", "", "default file mode for S3 uploaded objects, e.g. 0660, 0644, 0666")
+	filerS3Options.cacheSizeMB = cmdFiler.Flag.Int64("s3.cacheCapacityMB", 0, "in-memory chunk cache capacity in MB for S3 GETs shared across requests (0 disables)")
 
 	// start webdav on filer
 	filerStartWebDav = cmdFiler.Flag.Bool("webdav", false, "whether to start webdav gateway")

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -251,6 +251,7 @@ func initMiniS3Flags() {
 	miniS3Options.allowDeleteBucketNotEmpty = miniS3AllowDeleteBucketNotEmpty
 	miniS3Options.externalUrl = cmdMini.Flag.String("s3.externalUrl", "", "the external URL clients use to connect (e.g. https://api.example.com:9000). Used for S3 signature verification behind a reverse proxy. Falls back to S3_EXTERNAL_URL env var.")
 	miniS3Options.defaultFileMode = cmdMini.Flag.String("s3.defaultFileMode", "", "default file mode for S3 uploaded objects, e.g. 0660, 0644, 0666")
+	miniS3Options.cacheSizeMB = cmdMini.Flag.Int64("s3.cacheCapacityMB", 0, "in-memory chunk cache capacity in MB for S3 GETs shared across requests (0 disables)")
 	// In mini mode, S3 uses the shared debug server started at line 681, not its own separate debug server
 	miniS3Options.debug = new(bool) // explicitly false
 	miniS3Options.debugPort = cmdMini.Flag.Int("s3.debug.port", 6060, "http port for debugging (unused in mini mode)")

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -73,6 +73,7 @@ type S3Options struct {
 	cipher                    *bool
 	externalUrl               *string
 	defaultFileMode           *string
+	cacheSizeMB               *int64
 }
 
 func init() {
@@ -109,6 +110,7 @@ func init() {
 	s3StandaloneOptions.cipher = cmdS3.Flag.Bool("encryptVolumeData", false, "encrypt data on volume servers")
 	s3StandaloneOptions.externalUrl = cmdS3.Flag.String("externalUrl", "", "the external URL clients use to connect (e.g. https://api.example.com:9000). Used for S3 signature verification behind a reverse proxy. Falls back to S3_EXTERNAL_URL env var.")
 	s3StandaloneOptions.defaultFileMode = cmdS3.Flag.String("defaultFileMode", "", "default file mode for S3 uploaded objects, e.g. 0660, 0644, 0666")
+	s3StandaloneOptions.cacheSizeMB = cmdS3.Flag.Int64("cacheCapacityMB", 0, "in-memory chunk cache capacity in MB for S3 GETs shared across requests (0 disables)")
 }
 
 var cmdS3 = &Command{
@@ -343,6 +345,7 @@ func (s3opt *S3Options) startS3Server() bool {
 		GrpcPort:                  *s3opt.portGrpc,
 		ExternalUrl:               s3opt.resolveExternalUrl(),
 		DefaultFileMode:           defaultFileMode,
+		CacheSizeMB:               *s3opt.cacheSizeMB,
 	})
 	if s3ApiServer_err != nil {
 		glog.Fatalf("S3 API Server startup error: %v", s3ApiServer_err)

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -181,6 +181,7 @@ func init() {
 	s3Options.cipher = cmdServer.Flag.Bool("s3.encryptVolumeData", false, "encrypt data on volume servers for S3 uploads")
 	s3Options.externalUrl = cmdServer.Flag.String("s3.externalUrl", "", "the external URL clients use to connect (e.g. https://api.example.com:9000). Used for S3 signature verification behind a reverse proxy. Falls back to S3_EXTERNAL_URL env var.")
 	s3Options.defaultFileMode = cmdServer.Flag.String("s3.defaultFileMode", "", "default file mode for S3 uploaded objects, e.g. 0660, 0644, 0666")
+	s3Options.cacheSizeMB = cmdServer.Flag.Int64("s3.cacheCapacityMB", 0, "in-memory chunk cache capacity in MB for S3 GETs shared across requests (0 disables)")
 
 	sftpOptions.port = cmdServer.Flag.Int("sftp.port", 2022, "SFTP server listen port")
 	sftpOptions.sshPrivateKey = cmdServer.Flag.String("sftp.sshPrivateKey", "", "path to the SSH private key file for host authentication")

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -62,7 +62,15 @@ type S3ApiServerOption struct {
 	GrpcPort                  int
 	ExternalUrl               string // external URL clients use, for signature verification behind a reverse proxy
 	DefaultFileMode           uint32 // default file permission mode for S3 uploads (e.g. 0660, 0644)
+	CacheSizeMB               int64  // in-memory chunk cache capacity in MB for the shared ReaderCache; 0 disables
 }
+
+// s3ChunkCacheChunkSizeMB is the assumed chunk size (in MiB) used to convert
+// CacheSizeMB into the entry count the in-memory cache accepts. This matches
+// the default -filer.maxMB for all filer/webdav/mini flag sites. It is NOT a
+// hard limit — larger chunks still get cached, this just means the byte budget
+// is approximate when upload-side chunking is configured larger.
+const s3ChunkCacheChunkSizeMB = 4
 
 type S3ApiServer struct {
 	s3_pb.UnimplementedSeaweedS3IamCacheServer
@@ -185,12 +193,22 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 		}
 	}()
 
-	// Shared ReaderCache for the S3 GET streaming path. The chunk cache is
-	// nil for now — all TieredChunkCache receiver methods are nil-safe. A
-	// follow-up adds an in-memory chunk cache on top. Keeping this shared
+	// Shared ReaderCache for the S3 GET streaming path. Keeping this shared
 	// (rather than per-request) avoids the per-request Close(), which would
 	// otherwise wait for background chunk downloads that run on
 	// context.Background() even after the client disconnects.
+	//
+	// The underlying ChunkCache is controlled by option.CacheSizeMB below:
+	//   - CacheSizeMB == 0: a nil *chunk_cache.TieredChunkCache is used (its
+	//     receiver methods are nil-safe). Completed chunks are not deposited
+	//     into a cross-request cache — concurrent readers still share in-flight
+	//     downloads through the ReaderCache's downloaders map, but repeat reads
+	//     refetch from volume servers.
+	//   - CacheSizeMB > 0: a chunk_cache.ChunkCacheInMemory is created and
+	//     wrapped in the ReaderCache, so repeat and concurrent reads hit
+	//     memory. maxEntries is approximated from the byte budget and the
+	//     assumed chunk size (s3ChunkCacheChunkSizeMB), clamped to a small
+	//     floor so tiny caches still function.
 	//
 	// Downloader slots: each slot holds one in-flight / recently-completed
 	// chunk buffer (~4 MiB by default), so this caps both peak memory for
@@ -199,7 +217,30 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 	// because it typically has a handful of clients; S3 serves many
 	// concurrent readers, so we pick a more generous default here.
 	const s3ReaderCacheDownloaderLimit = 256
-	readerCache := filer.NewReaderCache(s3ReaderCacheDownloaderLimit, (*chunk_cache.TieredChunkCache)(nil), filerClient.GetLookupFileIdFunction())
+
+	// Negative CacheSizeMB is a misconfiguration; fail fast rather than
+	// silently behaving like 0.
+	if option.CacheSizeMB < 0 {
+		return nil, fmt.Errorf("invalid -s3.cacheCapacityMB %d: must be >= 0", option.CacheSizeMB)
+	}
+	var chunkCache chunk_cache.ChunkCache
+	if option.CacheSizeMB > 0 {
+		// ccache sizes entries by count; convert the configured byte budget
+		// via the assumed chunk size. Clamp to a floor so tiny caches still
+		// function.
+		maxEntries := option.CacheSizeMB / s3ChunkCacheChunkSizeMB
+		if maxEntries < 8 {
+			maxEntries = 8
+		}
+		chunkCache = chunk_cache.NewChunkCacheInMemory(maxEntries)
+		// Log the effective capacity after the floor clamp, not the configured
+		// value — a user passing `-s3.cacheCapacityMB=1` actually gets 8 entries
+		// ≈ 32 MiB because of the floor.
+		glog.V(0).Infof("s3 chunk cache enabled: in-memory, ~%dMB (%d chunks of ~%dMB)", maxEntries*s3ChunkCacheChunkSizeMB, maxEntries, s3ChunkCacheChunkSizeMB)
+	} else {
+		chunkCache = (*chunk_cache.TieredChunkCache)(nil)
+	}
+	readerCache := filer.NewReaderCache(s3ReaderCacheDownloaderLimit, chunkCache, filerClient.GetLookupFileIdFunction())
 
 	s3ApiServer = &S3ApiServer{
 		option:                option,


### PR DESCRIPTION
## Summary

Builds on #9068 to add an optional server-wide chunk cache for the S3 GET path. When enabled, concurrent and repeat GETs of the same object share a single prefetch + in-memory cache layer instead of each request re-fetching every chunk from volume servers.

> **Base branch:** \`s3-get-chunkreadat\` (PR #9068). Please merge #9068 first; this PR rebases onto master afterward.

## What changes

- New \`-s3.cacheCapacityMB\` flag (default **0**, disabled). Registered at all four S3 flag sites (\`s3.go\`, \`server.go\`, \`filer.go\`, \`mini.go\`) per the comment on \`command.S3Options\`.
- When \`> 0\`, \`NewS3ApiServer\` constructs a \`chunk_cache.ChunkCacheInMemory\` and wraps it in a shared \`filer.ReaderCache\`. Every GET reuses these instead of building a per-request cache.
- When \`0\`, falls through to the per-request \`ReaderCache\` path introduced in #9068 — **no behavior change**.

## Measurements

\`weed mini\` + 1 GiB random object over loopback, single-stream \`curl\` on a presigned URL (MB/s):

| build                       | cold | warm 2 | warm 3 | warm 4 |
|-----------------------------|-----:|-------:|-------:|-------:|
| master (io.Pipe)            | 2117 |   2216 |     —  |     —  |
| #9068 (per-request cache)   | 2902 |   3805 |   3730 |     —  |
| **this PR, cache=4096 MB**  | **2791** | **5080** | **5011** | **5178** |

- ~70% **warm** speedup vs #9068 — warm reads hit memory and bypass volume servers entirely.
- ~4% **cold** regression vs #9068 — from the extra memcpy inside \`ChunkCacheInMemory.SetChunk\` (ccache requires an owned copy of the data).
- On real deployments where volume servers are across a network (not loopback) the warm win will be dramatically larger than the cold cost.

## Design notes

- **In-memory only.** A disk-backed \`TieredChunkCache\` was tried first, matching what the WebDAV server uses. It regressed cold-read throughput ~12x on loopback (2900 → 180 MB/s) because the chunk fetchers block on local disk I/O that is *slower* than the TCP volume-server fetch it is supposed to accelerate. Keeping this PR memory-only avoids that trap and keeps the feature opt-in. A disk tier can be revisited as a follow-up if real workloads demand it.
- **No \`reader.Close()\` on the shared path.** \`ChunkReadAt.Close()\` calls \`readerCache.destroy()\` which tears down the shared \`downloaders\` map — calling it would blow away other concurrent requests. Eviction is handled by the \`ReaderCache\` \`limit\` instead. The per-request fallback path still calls \`Close()\`.
- Sizing: \`maxEntries = cacheCapacityMB / 4\` assumes the default 4 MB chunk size. Clamped to a floor of 8 so tiny caches still work.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./weed/s3api/... ./weed/filer/...\`
- [x] \`weed mini -s3.cacheCapacityMB=0\` — baseline, same throughput as #9068
- [x] \`weed mini -s3.cacheCapacityMB=4096\` — warm GETs ~5 GB/s (numbers above)
- [ ] Multi-reader concurrency soak (multiple curls in parallel on the same key)
- [ ] Real LAN deployment to confirm warm win scales with volume-server distance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added s3.cacheCapacityMB setting to enable an optional shared in-memory cache for S3 GETs (MB); default 0 disables caching.
  * Cache capacity is translated into allocated entries with an enforced minimum when enabled.

* **Bug Fixes**
  * Startup now fails fast for invalid (negative) cache size values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->