### PR TITLE
build(docker): upgrade all Alpine packages in final image

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -56,7 +56,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh 
 # To disable: docker run -e GODEBUG=fips140=off ...
 
 # Install dependencies and create non-root user
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache fuse curl su-exec libgcc libcrypto3 libssl3 && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -7,7 +7,7 @@ COPY ./filer.toml /etc/seaweedfs/filer.toml
 COPY ./entrypoint.sh /entrypoint.sh
 
 # Install dependencies and create non-root user
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache fuse curl su-exec && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed

--- a/docker/Dockerfile.rocksdb_large
+++ b/docker/Dockerfile.rocksdb_large
@@ -34,7 +34,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/filer_rocksdb.
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh /entrypoint.sh
 
 # Install dependencies and create non-root user
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache fuse snappy gflags curl su-exec && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed

--- a/docker/Dockerfile.rocksdb_large_local
+++ b/docker/Dockerfile.rocksdb_large_local
@@ -17,7 +17,7 @@ COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/filer_rocksdb.
 COPY --from=builder /go/src/github.com/seaweedfs/seaweedfs/docker/entrypoint.sh /entrypoint.sh
 
 # Install dependencies and create non-root user
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache fuse snappy gflags curl tmux su-exec && \
     addgroup -g 1000 seaweed && \
     adduser -D -u 1000 -G seaweed seaweed


### PR DESCRIPTION
## Summary
- Trivy gate failed on the published image with CVE-2026-28390 in `libcrypto3`/`libssl3` (Alpine 3.23, fixed in 3.5.6-r0). See https://github.com/seaweedfs/seaweedfs/actions/runs/24386836462/job/71231757428.
- The final stage of the Docker images previously ran `apk upgrade --no-cache zlib`, which only patched zlib. Broaden to `apk upgrade --no-cache` so every Alpine security fix (openssl included) is applied at build time.
- Applied to `Dockerfile.go_build`, `Dockerfile.rocksdb_large`, `Dockerfile.rocksdb_large_local`, and `Dockerfile.local`.

## Test plan
- [ ] CI container build succeeds
- [ ] Trivy gate passes on the rebuilt `large_disk` image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configurations to upgrade all available packages during the build process, improving overall dependency freshness across build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->