### PR TITLE
fix(s3): allow anonymous ListBuckets with prefix-scoped List action

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1413,8 +1413,14 @@ func (iam *IdentityAccessManagement) authRequestWithAuthType(r *http.Request, ac
 	// through buckets and checking permissions for each. Skip the global check here.
 	policyAllows := false
 
-	if action == s3_constants.ACTION_LIST && bucket == "" && identity.Name != s3_constants.AccountAnonymousId {
-		// ListBuckets operation for authenticated users - authorization handled per-bucket in the handler
+	if action == s3_constants.ACTION_LIST && bucket == "" &&
+		(identity.Name != s3_constants.AccountAnonymousId || anonymousHasListAction(identity)) {
+		// ListBuckets operation - authorization handled per-bucket in the handler.
+		// For authenticated users this is always deferred to the handler. For the
+		// anonymous identity we only defer when it actually carries a List action
+		// (e.g. "List:prefix-*"); otherwise fall through to the global check so
+		// an anonymous caller with no permissions is rejected outright rather
+		// than receiving an empty ListAllMyBuckets result.
 	} else {
 		// First check bucket policy if one exists
 		// Bucket policies can grant or deny access to specific users/principals
@@ -1587,6 +1593,24 @@ func (identity *Identity) CanDo(action Action, bucket string, objectKey string) 
 	}
 	//log error
 	glog.V(3).Infof("identity %s is not allowed to perform action %s on %s", identity.Name, action, bucket+"/"+objectKey)
+	return false
+}
+
+// anonymousHasListAction reports whether the anonymous identity carries any
+// List-scoped legacy action (e.g. "List", "List:*", "List:prefix-*"). Used to
+// decide whether an unauthenticated ListBuckets request should be deferred to
+// the per-bucket check in the handler or denied at the global auth layer.
+func anonymousHasListAction(identity *Identity) bool {
+	if identity == nil {
+		return false
+	}
+	listPrefix := string(s3_constants.ACTION_LIST)
+	for _, a := range identity.Actions {
+		act := string(a)
+		if act == listPrefix || strings.HasPrefix(act, listPrefix+":") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1414,7 +1414,7 @@ func (iam *IdentityAccessManagement) authRequestWithAuthType(r *http.Request, ac
 	policyAllows := false
 
 	if action == s3_constants.ACTION_LIST && bucket == "" &&
-		(identity.Name != s3_constants.AccountAnonymousId || anonymousHasListAction(identity)) {
+		(identity.Name != s3_constants.AccountAnonymousId || identity.hasListAction()) {
 		// ListBuckets operation - authorization handled per-bucket in the handler.
 		// For authenticated users this is always deferred to the handler. For the
 		// anonymous identity we only defer when it actually carries a List action
@@ -1596,18 +1596,23 @@ func (identity *Identity) CanDo(action Action, bucket string, objectKey string) 
 	return false
 }
 
-// anonymousHasListAction reports whether the anonymous identity carries any
-// List-scoped legacy action (e.g. "List", "List:*", "List:prefix-*"). Used to
-// decide whether an unauthenticated ListBuckets request should be deferred to
-// the per-bucket check in the handler or denied at the global auth layer.
-func anonymousHasListAction(identity *Identity) bool {
+// hasListAction reports whether the identity carries any List-scoped legacy
+// action (e.g. "List", "List:*", "List:prefix-*") or has administrative
+// privileges. Used to decide whether a ListBuckets request from an anonymous
+// identity should be deferred to the per-bucket check in the handler or
+// denied at the global auth layer.
+func (identity *Identity) hasListAction() bool {
 	if identity == nil {
 		return false
 	}
+	if identity.isAdmin() {
+		return true
+	}
 	listPrefix := string(s3_constants.ACTION_LIST)
+	listPrefixWithColon := listPrefix + ":"
 	for _, a := range identity.Actions {
 		act := string(a)
-		if act == listPrefix || strings.HasPrefix(act, listPrefix+":") {
+		if act == listPrefix || strings.HasPrefix(act, listPrefixWithColon) {
 			return true
 		}
 	}

--- a/weed/s3api/auto_signature_v4_test.go
+++ b/weed/s3api/auto_signature_v4_test.go
@@ -132,6 +132,33 @@ func TestCheckaAnonymousRequestAuthType(t *testing.T) {
 
 }
 
+// TestAnonymousListBucketsWithPrefixAction verifies that an anonymous identity
+// holding a prefix-scoped List action (e.g. "List:prefix-*") is not denied at
+// the global auth layer when issuing ListBuckets. The per-bucket permission
+// check happens inside ListBucketsHandler, so the global auth step must let
+// the request through.
+//
+// Regression test for https://github.com/seaweedfs/seaweedfs/issues/9072
+func TestAnonymousListBucketsWithPrefixAction(t *testing.T) {
+	iam := &IdentityAccessManagement{
+		hashes:       make(map[string]*sync.Pool),
+		hashCounters: make(map[string]*int32),
+	}
+	_ = iam.loadS3ApiConfiguration(&iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{
+			{
+				Name:    s3_constants.AccountAnonymousId,
+				Actions: []string{"Read:prefix-*", "List:prefix-*"},
+			},
+		},
+	})
+
+	req := mustNewRequest(http.MethodGet, "http://127.0.0.1:9000/", 0, nil, t)
+	if _, s3Error := iam.authRequest(req, s3_constants.ACTION_LIST); s3Error != s3err.ErrNone {
+		t.Errorf("anonymous ListBuckets with prefix-scoped List action: want ErrNone, got %d", s3Error)
+	}
+}
+
 func TestCheckAdminRequestAuthType(t *testing.T) {
 	iam := &IdentityAccessManagement{
 		hashes:       make(map[string]*sync.Pool),


### PR DESCRIPTION
## Summary
- Fixes #9072 — anonymous identities with a prefix-scoped `List:prefix-*` action were getting `AccessDenied` on `GET /` because the auth middleware ran `CanDo` with an empty bucket, which never matches a scoped action.
- Defer ListBuckets authorization to `ListBucketsHandler` for the anonymous identity when it actually carries any `List` action, mirroring the existing behavior for authenticated users. Anonymous identities with no `List` action are still rejected at the global auth layer, preserving the secure-by-default posture introduced in #8348.
- Added a regression unit test (`TestAnonymousListBucketsWithPrefixAction`) asserting that `authRequest` no longer denies anonymous `ListBuckets` when the anonymous identity has `List:prefix-*`.

## Test plan
- [x] `go build ./weed/s3api/...`
- [x] `go test ./weed/s3api/ -count=1` (all pass, including the new regression test and the existing `TestReproIssue7912` security cases which still reject truly permission-less anonymous requests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization for anonymous bucket listing: prefix-scoped List permissions are correctly recognized and anonymous requests without appropriate List permission are properly blocked at the global check.

* **Tests**
  * Added test coverage validating anonymous ListBuckets behavior when prefix-scoped List permissions are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->