### PR TITLE
fix(helm): skip s3 ServiceMonitor when only filer.s3 is enabled

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3/s3-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-servicemonitor.yaml
@@ -1,10 +1,8 @@
 {{- include "seaweedfs.compat" . -}}
 {{- /*
-  Only the standalone S3 gateway (s3.enabled) exposes a "metrics" port on the
-  seaweedfs-s3 Service. When only the embedded filer S3 gateway is enabled
-  (filer.s3.enabled), the filer process itself exposes the metrics and is
-  already scraped by the filer ServiceMonitor, so creating an s3 ServiceMonitor
-  here would match 0 targets (issue #9080).
+  The seaweedfs-s3 Service only gains a "metrics" port when the standalone S3
+  gateway is enabled. With only the embedded filer S3 gateway, metrics live on
+  the filer process and are already scraped by the filer ServiceMonitor.
 */ -}}
 {{- if and .Values.s3.enabled .Values.s3.metricsPort .Values.global.seaweedfs.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1

--- a/k8s/charts/seaweedfs/templates/s3/s3-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-servicemonitor.yaml
@@ -1,7 +1,12 @@
 {{- include "seaweedfs.compat" . -}}
-{{- if or .Values.s3.enabled .Values.filer.s3.enabled }}
-{{- if .Values.s3.metricsPort }}
-{{- if .Values.global.seaweedfs.monitoring.enabled }}
+{{- /*
+  Only the standalone S3 gateway (s3.enabled) exposes a "metrics" port on the
+  seaweedfs-s3 Service. When only the embedded filer S3 gateway is enabled
+  (filer.s3.enabled), the filer process itself exposes the metrics and is
+  already scraped by the filer ServiceMonitor, so creating an s3 ServiceMonitor
+  here would match 0 targets (issue #9080).
+*/ -}}
+{{- if and .Values.s3.enabled .Values.s3.metricsPort .Values.global.seaweedfs.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -30,6 +35,4 @@ spec:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: s3
-{{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- Fixes #9080. When `filer.s3.enabled=true` and `s3.enabled=false`, the chart still emitted a `seaweedfs-s3` ServiceMonitor that matched 0 targets, because the `seaweedfs-s3` Service in that mode only exposes the `swfs-s3` (8333) port and no `metrics` port.
- Guard the `seaweedfs-s3` ServiceMonitor on `.Values.s3.enabled` (the only mode in which the s3 Service gains a `metrics` port). The embedded filer S3 gateway's metrics are already scraped by the filer ServiceMonitor since they live on the filer process's metrics port.

## Test plan
- [x] `helm lint k8s/charts/seaweedfs`
- [x] `helm template ... --set global.seaweedfs.monitoring.enabled=true --set filer.s3.enabled=true --set s3.enabled=false` — no `seaweedfs-s3` ServiceMonitor is rendered; filer/master/volume ServiceMonitors still render.
- [x] `helm template ... --set global.seaweedfs.monitoring.enabled=true --set s3.enabled=true` — `seaweedfs-s3` ServiceMonitor still renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 metrics monitoring to activate only when standalone S3 is enabled, a metrics port is configured, and global SeaweedFS monitoring is explicitly enabled. Prevents ServiceMonitor creation for embedded filer S3 setups and avoids mismatched or incorrect monitoring in mixed deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->