### PR TITLE
chore(weed/mq/kafka/schema): remove unused functions

### DIFF
--- a/weed/mq/kafka/schema/avro_decoder.go
+++ b/weed/mq/kafka/schema/avro_decoder.go
@@ -431,12 +431,6 @@ func convertAvroSimpleType(avroType string) (*schema_pb.Type, error) {
 	}
 }
 
-// convertAvroComplexType converts complex Avro types to SeaweedMQ types
-func convertAvroComplexType(avroType map[string]interface{}) (*schema_pb.Type, error) {
-	fieldType, _, err := convertAvroComplexTypeWithRepeated(avroType)
-	return fieldType, err
-}
-
 // convertAvroComplexTypeWithRepeated converts complex Avro types to SeaweedMQ types and returns if it's repeated
 func convertAvroComplexTypeWithRepeated(avroType map[string]interface{}) (*schema_pb.Type, bool, error) {
 	typeStr, ok := avroType["type"].(string)

--- a/weed/mq/kafka/schema/manager.go
+++ b/weed/mq/kafka/schema/manager.go
@@ -641,11 +641,6 @@ func recordValueToMapWithAvroContext(recordValue *schema_pb.RecordValue, preserv
 	return result
 }
 
-// schemaValueToGoValue converts a schema Value back to a Go value
-func schemaValueToGoValue(value *schema_pb.Value) interface{} {
-	return schemaValueToGoValueWithAvroContext(value, false)
-}
-
 // schemaValueToGoValueWithAvroContext converts a schema Value back to a Go value
 // with optional Avro union format preservation
 func schemaValueToGoValueWithAvroContext(value *schema_pb.Value, preserveAvroUnions bool) interface{} {


### PR DESCRIPTION
This prunes two unused functions from `weed/mq/kafka/schema`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal helper functions to streamline codebase maintenance. No user-facing changes or impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->