### PR TITLE
fix(master): do not re-enter warmup when a fresh cluster grows its first volume

### DIFF
--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -145,12 +145,16 @@ type Node interface {
 }
 
 type NodeImpl struct {
-	diskUsages   *DiskUsages
-	id           NodeId
-	parent       Node
+	diskUsages *DiskUsages
+	id         NodeId
+	parent     Node
 	sync.RWMutex // lock children
-	children     map[NodeId]Node
-	maxVolumeId  needle.VolumeId
+	children    map[NodeId]Node
+	// maxVolumeId uses atomic ops so UpAdjustMaxVolumeId (called from the
+	// volume server heartbeat path) and GetMaxVolumeId (called from the
+	// master's assign / warmup checks) can run concurrently without a
+	// data race on NodeImpl.
+	maxVolumeId atomic.Uint32
 
 	//for rack, data center, topology
 	nodeType string
@@ -391,16 +395,23 @@ func (n *NodeImpl) UpAdjustDiskUsageDelta(diskType types.DiskType, diskUsage *Di
 		n.parent.UpAdjustDiskUsageDelta(diskType, diskUsage)
 	}
 }
-func (n *NodeImpl) UpAdjustMaxVolumeId(vid needle.VolumeId) { //can be negative
-	if n.maxVolumeId < vid {
-		n.maxVolumeId = vid
-		if n.parent != nil {
-			n.parent.UpAdjustMaxVolumeId(vid)
+func (n *NodeImpl) UpAdjustMaxVolumeId(vid needle.VolumeId) {
+	target := uint32(vid)
+	for {
+		current := n.maxVolumeId.Load()
+		if current >= target {
+			return
 		}
+		if n.maxVolumeId.CompareAndSwap(current, target) {
+			break
+		}
+	}
+	if n.parent != nil {
+		n.parent.UpAdjustMaxVolumeId(vid)
 	}
 }
 func (n *NodeImpl) GetMaxVolumeId() needle.VolumeId {
-	return n.maxVolumeId
+	return needle.VolumeId(n.maxVolumeId.Load())
 }
 
 func (n *NodeImpl) LinkChildNode(node Node) {

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -156,11 +156,10 @@ func (t *Topology) IsWarmingUp() bool {
 	lastChange := t.lastLeaderChangeTime
 	hadVolumes := t.hadVolumesAtLeaderChange
 	t.lastLeaderChangeTimeLock.RUnlock()
-	if !hadVolumes {
+	if !hadVolumes || lastChange.IsZero() {
 		return false
 	}
-	warmupDuration := time.Duration(t.pulse*WarmupPulseMultiplier) * time.Second
-	return !lastChange.IsZero() && time.Since(lastChange) < warmupDuration
+	return time.Since(lastChange) < t.WarmupDuration()
 }
 
 // WarmupDuration returns the configured warmup duration based on pulse interval.

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -71,6 +71,7 @@ type Topology struct {
 	topologyIdLock sync.RWMutex
 
 	lastLeaderChangeTime     time.Time
+	hadVolumesAtLeaderChange bool
 	lastLeaderChangeTimeLock sync.RWMutex
 }
 
@@ -121,10 +122,17 @@ func (t *Topology) IsChildLocked() (bool, error) {
 }
 
 // SetLastLeaderChangeTime records the time of the most recent leader transition.
+// It also snapshots whether the topology already had known volumes at that
+// moment. IsWarmingUp uses the snapshot instead of the live MaxVolumeId so a
+// fresh cluster that happens to grow its first volume inside the warmup window
+// does not retroactively flip into "warming up" state — there is no prior
+// topology to wait for on a bootstrap.
 func (t *Topology) SetLastLeaderChangeTime(ts time.Time) {
+	hadVolumes := t.GetMaxVolumeId() > 0
 	t.lastLeaderChangeTimeLock.Lock()
 	defer t.lastLeaderChangeTimeLock.Unlock()
 	t.lastLeaderChangeTime = ts
+	t.hadVolumesAtLeaderChange = hadVolumes
 }
 
 // GetLastLeaderChangeTime returns the time of the most recent leader transition.
@@ -137,14 +145,21 @@ func (t *Topology) GetLastLeaderChangeTime() time.Time {
 // IsWarmingUp returns true if the master recently became leader and may not yet
 // have a complete topology. After a leader change or restart, volume servers need
 // up to WarmupPulseMultiplier heartbeat intervals to reconnect and report their volumes.
-// Returns false on a fresh cluster start (MaxVolumeId == 0) since there are no
-// existing volumes to wait for.
+// Returns false on a fresh cluster start — i.e. when no volumes existed at the
+// time of the leader change — since there is no prior topology state to wait for.
+// Checking the *live* MaxVolumeId here would make a bootstrapping cluster flip
+// into warming-up the moment its first volume is grown, which manifested as a
+// 15-second window of spurious Unavailable errors on AssignVolume for workloads
+// that start writing immediately (see #8777).
 func (t *Topology) IsWarmingUp() bool {
-	if t.GetMaxVolumeId() == 0 {
+	t.lastLeaderChangeTimeLock.RLock()
+	lastChange := t.lastLeaderChangeTime
+	hadVolumes := t.hadVolumesAtLeaderChange
+	t.lastLeaderChangeTimeLock.RUnlock()
+	if !hadVolumes {
 		return false
 	}
 	warmupDuration := time.Duration(t.pulse*WarmupPulseMultiplier) * time.Second
-	lastChange := t.GetLastLeaderChangeTime()
 	return !lastChange.IsZero() && time.Since(lastChange) < warmupDuration
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #9091 on issue #8777. After the writable-chunk cap deadlock fix, a second issue surfaced on the same fio reproducer: thousands of mount-side `filerGrpcAddress assign volume: ... rpc error: code = Canceled desc = grpc: the client connection is closing` errors during the file-close flush storm, and an EIO return from fio's final `close()`.

**Root cause**: `Topology.IsWarmingUp` reads the *live* `GetMaxVolumeId`. On a fresh cluster the master seeds `lastLeaderChangeTime = time.Now()` at startup (`master_server.go:239`), and the `MaxVolumeId==0` guard is supposed to short-circuit IsWarmingUp for bootstraps. That guard breaks the moment the first volume is grown inside the warmup window: `MaxVolumeId` flips from 0 to 1, `lastLeaderChangeTime` is still within `3*pulse` (15 s default), and IsWarmingUp retroactively returns true for several seconds. Every AssignVolume in that window returns `codes.Unavailable`, which trips `shouldInvalidateConnection` on the filer and tears down its cached master connection. The teardown surfaces as `client connection is closing` on every concurrent in-flight call that hit the same cached conn — and the filer forwards that message verbatim via `AssignVolumeResponse.Error`, so the mount log fills with scary errors for what should be a clean run.

**Fix**: snapshot `hadVolumesAtLeaderChange` inside `SetLastLeaderChangeTime` and read the snapshot in `IsWarmingUp` instead of the live `MaxVolumeId`. A fresh cluster snapshots "no volumes at leader change" → IsWarmingUp stays false through the entire warmup window. A real leader transition on a populated cluster still snapshots "has volumes" → IsWarmingUp behaves exactly as before until `3*pulse` passes.

## Test plan

Verified with the same containerized reproducer used for #9091: 4 jobs × 250 nrfiles × 40 MiB × 4k randwrite direct.

- [x] Baseline (master): fio `rc=1` (EIO on close), 2809 mount error lines matching `filerGrpcAddress assign volume ... client connection is closing`, 788 filer lines matching `warming up`, 331 `Removing cached gRPC connection to ...19333 due to error: master is warming up`
- [x] Patched: fio `rc=0` in 1.9 s at 79.2 MiB/s, 0 mount errors, 0 filer `warming up` lines, 0 cached-master-conn invalidations
- [x] `go test ./weed/topology/...` passes

Related: #9091 (writable-chunk cap deadlock). This PR is orthogonal — stacking both fixes gives a clean fio run on the reporter's config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate cluster warm-up detection after leadership changes by recording whether data existed at the moment of transition, improving system readiness reporting.
* **Stability**
  * Improved internal handling of volume identifiers to reduce races and ensure more reliable state updates under concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->