### PR TITLE
feat(mount): proactive flush of idle writable chunks

### DIFF
--- a/weed/mount/dirty_pages_chunked.go
+++ b/weed/mount/dirty_pages_chunked.go
@@ -92,6 +92,10 @@ func (pages *ChunkedDirtyPages) EvictOneWritableChunk() bool {
 	return pages.uploadPipeline.EvictOneWritableChunk()
 }
 
+func (pages *ChunkedDirtyPages) ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int) bool {
+	return pages.uploadPipeline.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, frontierLag)
+}
+
 func (pages *ChunkedDirtyPages) LockForRead(startOffset, stopOffset int64) {
 	pages.uploadPipeline.LockForRead(startOffset, stopOffset)
 }

--- a/weed/mount/dirty_pages_chunked.go
+++ b/weed/mount/dirty_pages_chunked.go
@@ -92,8 +92,8 @@ func (pages *ChunkedDirtyPages) EvictOneWritableChunk() bool {
 	return pages.uploadPipeline.EvictOneWritableChunk()
 }
 
-func (pages *ChunkedDirtyPages) ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int) bool {
-	return pages.uploadPipeline.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, frontierLag)
+func (pages *ChunkedDirtyPages) ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int, isSequential bool) bool {
+	return pages.uploadPipeline.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, frontierLag, isSequential)
 }
 
 func (pages *ChunkedDirtyPages) LockForRead(startOffset, stopOffset int64) {

--- a/weed/mount/page_writer.go
+++ b/weed/mount/page_writer.go
@@ -85,6 +85,10 @@ func (pw *PageWriter) EvictOneWritableChunk() bool {
 	return pw.randomWriter.EvictOneWritableChunk()
 }
 
+func (pw *PageWriter) ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int) bool {
+	return pw.randomWriter.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, frontierLag)
+}
+
 func max(x, y int64) int64 {
 	if x > y {
 		return x

--- a/weed/mount/page_writer.go
+++ b/weed/mount/page_writer.go
@@ -85,8 +85,8 @@ func (pw *PageWriter) EvictOneWritableChunk() bool {
 	return pw.randomWriter.EvictOneWritableChunk()
 }
 
-func (pw *PageWriter) ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int) bool {
-	return pw.randomWriter.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, frontierLag)
+func (pw *PageWriter) ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int, isSequential bool) bool {
+	return pw.randomWriter.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, frontierLag, isSequential)
 }
 
 func max(x, y int64) int64 {

--- a/weed/mount/page_writer/activity_score.go
+++ b/weed/mount/page_writer/activity_score.go
@@ -1,10 +1,13 @@
 package page_writer
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 type ActivityScore struct {
-	lastActiveTsNs         int64
-	decayedActivenessScore int64
+	lastActiveTsNs         int64 // atomic
+	decayedActivenessScore int64 // atomic
 }
 
 func NewActivityScore() *ActivityScore {
@@ -13,27 +16,37 @@ func NewActivityScore() *ActivityScore {
 
 func (as *ActivityScore) MarkRead() {
 	now := time.Now().UnixNano()
-	deltaTime := (now - as.lastActiveTsNs) >> 30 // about number of seconds
-	as.lastActiveTsNs = now
-
-	as.decayedActivenessScore = as.decayedActivenessScore>>deltaTime + 256
-	if as.decayedActivenessScore < 0 {
-		as.decayedActivenessScore = 0
+	last := atomic.SwapInt64(&as.lastActiveTsNs, now)
+	deltaTime := (now - last) >> 30 // about number of seconds
+	for {
+		old := atomic.LoadInt64(&as.decayedActivenessScore)
+		score := old>>deltaTime + 256
+		if score < 0 {
+			score = 0
+		}
+		if atomic.CompareAndSwapInt64(&as.decayedActivenessScore, old, score) {
+			break
+		}
 	}
 }
 
 func (as *ActivityScore) MarkWrite() {
 	now := time.Now().UnixNano()
-	deltaTime := (now - as.lastActiveTsNs) >> 30 // about number of seconds
-	as.lastActiveTsNs = now
-
-	as.decayedActivenessScore = as.decayedActivenessScore>>deltaTime + 1024
-	if as.decayedActivenessScore < 0 {
-		as.decayedActivenessScore = 0
+	last := atomic.SwapInt64(&as.lastActiveTsNs, now)
+	deltaTime := (now - last) >> 30 // about number of seconds
+	for {
+		old := atomic.LoadInt64(&as.decayedActivenessScore)
+		score := old>>deltaTime + 1024
+		if score < 0 {
+			score = 0
+		}
+		if atomic.CompareAndSwapInt64(&as.decayedActivenessScore, old, score) {
+			break
+		}
 	}
 }
 
 func (as *ActivityScore) ActivityScore() int64 {
-	deltaTime := (time.Now().UnixNano() - as.lastActiveTsNs) >> 30 // about number of seconds
-	return as.decayedActivenessScore >> deltaTime
+	deltaTime := (time.Now().UnixNano() - atomic.LoadInt64(&as.lastActiveTsNs)) >> 30
+	return atomic.LoadInt64(&as.decayedActivenessScore) >> deltaTime
 }

--- a/weed/mount/page_writer/activity_score.go
+++ b/weed/mount/page_writer/activity_score.go
@@ -11,7 +11,7 @@ func NewActivityScore() *ActivityScore {
 	return &ActivityScore{}
 }
 
-func (as ActivityScore) MarkRead() {
+func (as *ActivityScore) MarkRead() {
 	now := time.Now().UnixNano()
 	deltaTime := (now - as.lastActiveTsNs) >> 30 // about number of seconds
 	as.lastActiveTsNs = now
@@ -22,7 +22,7 @@ func (as ActivityScore) MarkRead() {
 	}
 }
 
-func (as ActivityScore) MarkWrite() {
+func (as *ActivityScore) MarkWrite() {
 	now := time.Now().UnixNano()
 	deltaTime := (now - as.lastActiveTsNs) >> 30 // about number of seconds
 	as.lastActiveTsNs = now
@@ -33,7 +33,7 @@ func (as ActivityScore) MarkWrite() {
 	}
 }
 
-func (as ActivityScore) ActivityScore() int64 {
+func (as *ActivityScore) ActivityScore() int64 {
 	deltaTime := (time.Now().UnixNano() - as.lastActiveTsNs) >> 30 // about number of seconds
 	return as.decayedActivenessScore >> deltaTime
 }

--- a/weed/mount/page_writer/dirty_pages.go
+++ b/weed/mount/page_writer/dirty_pages.go
@@ -8,7 +8,7 @@ type DirtyPages interface {
 	LockForRead(startOffset, stopOffset int64)
 	UnlockForRead(startOffset, stopOffset int64)
 	EvictOneWritableChunk() bool
-	ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int) bool
+	ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int, isSequential bool) bool
 }
 
 func max(x, y int64) int64 {

--- a/weed/mount/page_writer/dirty_pages.go
+++ b/weed/mount/page_writer/dirty_pages.go
@@ -8,6 +8,7 @@ type DirtyPages interface {
 	LockForRead(startOffset, stopOffset int64)
 	UnlockForRead(startOffset, stopOffset int64)
 	EvictOneWritableChunk() bool
+	ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio int64, frontierLag int) bool
 }
 
 func max(x, y int64) int64 {

--- a/weed/mount/page_writer/page_chunk.go
+++ b/weed/mount/page_writer/page_chunk.go
@@ -13,5 +13,6 @@ type PageChunk interface {
 	IsComplete() bool
 	ActivityScore() int64
 	WrittenSize() int64
+	LastWriteTsNs() int64
 	SaveContent(saveFn SaveToStorageFunc)
 }

--- a/weed/mount/page_writer/page_chunk_mem.go
+++ b/weed/mount/page_writer/page_chunk_mem.go
@@ -3,6 +3,7 @@ package page_writer
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
@@ -21,6 +22,7 @@ type MemChunk struct {
 	chunkSize       int64
 	logicChunkIndex LogicChunkIndex
 	activityScore   *ActivityScore
+	lastWriteTsNs   atomic.Int64
 }
 
 func NewMemChunk(logicChunkIndex LogicChunkIndex, chunkSize int64) *MemChunk {
@@ -50,6 +52,7 @@ func (mc *MemChunk) WriteDataAt(src []byte, offset int64, tsNs int64) (n int) {
 	n = copy(mc.buf[innerOffset:], src)
 	mc.usage.MarkWritten(innerOffset, innerOffset+int64(n), tsNs)
 	mc.activityScore.MarkWrite()
+	mc.lastWriteTsNs.Store(time.Now().UnixNano())
 
 	return
 }
@@ -88,6 +91,10 @@ func (mc *MemChunk) WrittenSize() int64 {
 	defer mc.RUnlock()
 
 	return mc.usage.WrittenSize()
+}
+
+func (mc *MemChunk) LastWriteTsNs() int64 {
+	return mc.lastWriteTsNs.Load()
 }
 
 func (mc *MemChunk) SaveContent(saveFn SaveToStorageFunc) {

--- a/weed/mount/page_writer/page_chunk_mem.go
+++ b/weed/mount/page_writer/page_chunk_mem.go
@@ -3,7 +3,6 @@ package page_writer
 import (
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
@@ -52,7 +51,7 @@ func (mc *MemChunk) WriteDataAt(src []byte, offset int64, tsNs int64) (n int) {
 	n = copy(mc.buf[innerOffset:], src)
 	mc.usage.MarkWritten(innerOffset, innerOffset+int64(n), tsNs)
 	mc.activityScore.MarkWrite()
-	mc.lastWriteTsNs.Store(time.Now().UnixNano())
+	mc.lastWriteTsNs.Store(tsNs)
 
 	return
 }

--- a/weed/mount/page_writer/page_chunk_swapfile.go
+++ b/weed/mount/page_writer/page_chunk_swapfile.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -32,6 +34,7 @@ type SwapFileChunk struct {
 	logicChunkIndex  LogicChunkIndex
 	actualChunkIndex ActualChunkIndex
 	activityScore    *ActivityScore
+	lastWriteTsNs    atomic.Int64
 	//memChunk         *MemChunk
 }
 
@@ -124,6 +127,7 @@ func (sc *SwapFileChunk) WriteDataAt(src []byte, offset int64, tsNs int64) (n in
 	}
 	//sc.memChunk.WriteDataAt(src, offset, tsNs)
 	sc.activityScore.MarkWrite()
+	sc.lastWriteTsNs.Store(time.Now().UnixNano())
 
 	return
 }
@@ -177,6 +181,10 @@ func (sc *SwapFileChunk) WrittenSize() int64 {
 	sc.RLock()
 	defer sc.RUnlock()
 	return sc.usage.WrittenSize()
+}
+
+func (sc *SwapFileChunk) LastWriteTsNs() int64 {
+	return sc.lastWriteTsNs.Load()
 }
 
 func (sc *SwapFileChunk) SaveContent(saveFn SaveToStorageFunc) {

--- a/weed/mount/page_writer/page_chunk_swapfile.go
+++ b/weed/mount/page_writer/page_chunk_swapfile.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -127,7 +126,7 @@ func (sc *SwapFileChunk) WriteDataAt(src []byte, offset int64, tsNs int64) (n in
 	}
 	//sc.memChunk.WriteDataAt(src, offset, tsNs)
 	sc.activityScore.MarkWrite()
-	sc.lastWriteTsNs.Store(time.Now().UnixNano())
+	sc.lastWriteTsNs.Store(tsNs)
 
 	return
 }

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -88,9 +88,15 @@ func (up *UploadPipeline) SaveDataAt(p []byte, off int64, isSequential bool, tsN
 
 	logicChunkIndex := LogicChunkIndex(off / up.ChunkSize)
 
-	// track write frontier for proactive flushing
-	if int64(logicChunkIndex) > atomic.LoadInt64(&up.lastWriteChunkIndex) {
-		atomic.StoreInt64(&up.lastWriteChunkIndex, int64(logicChunkIndex))
+	// track write frontier for proactive flushing (CAS to avoid regression)
+	for {
+		old := atomic.LoadInt64(&up.lastWriteChunkIndex)
+		if int64(logicChunkIndex) <= old {
+			break
+		}
+		if atomic.CompareAndSwapInt64(&up.lastWriteChunkIndex, old, int64(logicChunkIndex)) {
+			break
+		}
 	}
 
 	pageChunk, found := up.writableChunks[logicChunkIndex]
@@ -195,10 +201,6 @@ func (up *UploadPipeline) MaybeReadDataAt(p []byte, off int64, tsNs int64) (maxS
 	maxStop = max(maxStop, writableMaxStop)
 
 	return
-}
-
-func (up *UploadPipeline) UploaderCount() int32 {
-	return atomic.LoadInt32(&up.uploaderCount)
 }
 
 func (up *UploadPipeline) FlushAll() {

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -302,7 +302,7 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 // that partially-written chunks drain continuously instead of piling up
 // until fsync.
 func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, maxHoldNs int64, fillRatio int64, frontierLag int, isSequential bool) bool {
-	if atomic.LoadInt32(&up.uploaderCount) >= up.concurrentWriterMax/2 {
+	if up.concurrentWriterMax <= 0 || atomic.LoadInt32(&up.uploaderCount)*2 >= up.concurrentWriterMax {
 		return false
 	}
 

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -28,7 +28,6 @@ type UploadPipeline struct {
 	readerCountCond     *sync.Cond
 	accountant          *WriteBufferAccountant
 	lastWriteChunkIndex int64 // atomic: highest LogicChunkIndex written
-	isSequential        int32 // atomic bool: 1 if sequential, 0 if random
 }
 
 type SealedChunk struct {
@@ -89,14 +88,9 @@ func (up *UploadPipeline) SaveDataAt(p []byte, off int64, isSequential bool, tsN
 
 	logicChunkIndex := LogicChunkIndex(off / up.ChunkSize)
 
-	// track write frontier and pattern for proactive flushing
+	// track write frontier for proactive flushing
 	if int64(logicChunkIndex) > atomic.LoadInt64(&up.lastWriteChunkIndex) {
 		atomic.StoreInt64(&up.lastWriteChunkIndex, int64(logicChunkIndex))
-	}
-	if isSequential {
-		atomic.StoreInt32(&up.isSequential, 1)
-	} else {
-		atomic.StoreInt32(&up.isSequential, 0)
 	}
 
 	pageChunk, found := up.writableChunks[logicChunkIndex]
@@ -307,7 +301,7 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 // chunk was sealed. The caller (ChunkFlusher) invokes this periodically so
 // that partially-written chunks drain continuously instead of piling up
 // until fsync.
-func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, maxHoldNs int64, fillRatio int64, frontierLag int) bool {
+func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, maxHoldNs int64, fillRatio int64, frontierLag int, isSequential bool) bool {
 	if atomic.LoadInt32(&up.uploaderCount) >= up.concurrentWriterMax/2 {
 		return false
 	}
@@ -320,7 +314,7 @@ func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, max
 	}
 
 	frontier := atomic.LoadInt64(&up.lastWriteChunkIndex)
-	isSeq := atomic.LoadInt32(&up.isSequential) != 0
+	isSeq := isSequential
 
 	var bestIdx LogicChunkIndex = -1
 	var bestBytes int64 = -1

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -12,20 +12,23 @@ import (
 type LogicChunkIndex int
 
 type UploadPipeline struct {
-	uploaderCount      int32
-	uploaderCountCond  *sync.Cond
-	filepath           util.FullPath
-	ChunkSize          int64
-	uploaders          *util.LimitedConcurrentExecutor
-	saveToStorageFn    SaveToStorageFunc
-	writableChunkLimit int
-	swapFile           *SwapFile
-	chunksLock         sync.Mutex
-	writableChunks     map[LogicChunkIndex]PageChunk
-	sealedChunks       map[LogicChunkIndex]*SealedChunk
-	activeReadChunks   map[LogicChunkIndex]int
-	readerCountCond    *sync.Cond
-	accountant         *WriteBufferAccountant
+	uploaderCount       int32
+	uploaderCountCond   *sync.Cond
+	filepath            util.FullPath
+	ChunkSize           int64
+	uploaders           *util.LimitedConcurrentExecutor
+	saveToStorageFn     SaveToStorageFunc
+	writableChunkLimit  int
+	concurrentWriterMax int32
+	swapFile            *SwapFile
+	chunksLock          sync.Mutex
+	writableChunks      map[LogicChunkIndex]PageChunk
+	sealedChunks        map[LogicChunkIndex]*SealedChunk
+	activeReadChunks    map[LogicChunkIndex]int
+	readerCountCond     *sync.Cond
+	accountant          *WriteBufferAccountant
+	lastWriteChunkIndex int64 // atomic: highest LogicChunkIndex written
+	isSequential        int32 // atomic bool: 1 if sequential, 0 if random
 }
 
 type SealedChunk struct {
@@ -63,16 +66,17 @@ func (sc *SealedChunk) FreeReference(messageOnFree string) {
 // any synchronization.
 func NewUploadPipeline(writers *util.LimitedConcurrentExecutor, chunkSize int64, saveToStorageFn SaveToStorageFunc, bufferChunkLimit int, swapFileDir string, accountant *WriteBufferAccountant) *UploadPipeline {
 	t := &UploadPipeline{
-		ChunkSize:          chunkSize,
-		writableChunks:     make(map[LogicChunkIndex]PageChunk),
-		sealedChunks:       make(map[LogicChunkIndex]*SealedChunk),
-		uploaders:          writers,
-		uploaderCountCond:  sync.NewCond(&sync.Mutex{}),
-		saveToStorageFn:    saveToStorageFn,
-		activeReadChunks:   make(map[LogicChunkIndex]int),
-		writableChunkLimit: bufferChunkLimit,
-		swapFile:           NewSwapFile(swapFileDir, chunkSize),
-		accountant:         accountant,
+		ChunkSize:           chunkSize,
+		writableChunks:      make(map[LogicChunkIndex]PageChunk),
+		sealedChunks:        make(map[LogicChunkIndex]*SealedChunk),
+		uploaders:           writers,
+		uploaderCountCond:   sync.NewCond(&sync.Mutex{}),
+		saveToStorageFn:     saveToStorageFn,
+		activeReadChunks:    make(map[LogicChunkIndex]int),
+		writableChunkLimit:  bufferChunkLimit,
+		concurrentWriterMax: int32(bufferChunkLimit),
+		swapFile:            NewSwapFile(swapFileDir, chunkSize),
+		accountant:          accountant,
 	}
 	t.readerCountCond = sync.NewCond(&t.chunksLock)
 	return t
@@ -84,6 +88,16 @@ func (up *UploadPipeline) SaveDataAt(p []byte, off int64, isSequential bool, tsN
 	defer up.chunksLock.Unlock()
 
 	logicChunkIndex := LogicChunkIndex(off / up.ChunkSize)
+
+	// track write frontier and pattern for proactive flushing
+	if int64(logicChunkIndex) > atomic.LoadInt64(&up.lastWriteChunkIndex) {
+		atomic.StoreInt64(&up.lastWriteChunkIndex, int64(logicChunkIndex))
+	}
+	if isSequential {
+		atomic.StoreInt32(&up.isSequential, 1)
+	} else {
+		atomic.StoreInt32(&up.isSequential, 0)
+	}
 
 	pageChunk, found := up.writableChunks[logicChunkIndex]
 	if !found {
@@ -189,6 +203,10 @@ func (up *UploadPipeline) MaybeReadDataAt(p []byte, off int64, tsNs int64) (maxS
 	return
 }
 
+func (up *UploadPipeline) UploaderCount() int32 {
+	return atomic.LoadInt32(&up.uploaderCount)
+}
+
 func (up *UploadPipeline) FlushAll() {
 	up.flushChunks()
 	up.waitForCurrentWritersToComplete()
@@ -281,6 +299,59 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 		return false
 	}
 	up.moveToSealed(up.writableChunks[bestIndex], bestIndex)
+	return true
+}
+
+// ProactiveFlush seals at most one idle writable chunk that is unlikely to
+// receive further writes, submitting it for async upload. Returns true if a
+// chunk was sealed. The caller (ChunkFlusher) invokes this periodically so
+// that partially-written chunks drain continuously instead of piling up
+// until fsync.
+func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, maxHoldNs int64, fillRatio int64, frontierLag int) bool {
+	if atomic.LoadInt32(&up.uploaderCount) >= up.concurrentWriterMax/2 {
+		return false
+	}
+
+	up.chunksLock.Lock()
+	defer up.chunksLock.Unlock()
+
+	if len(up.writableChunks) == 0 {
+		return false
+	}
+
+	frontier := atomic.LoadInt64(&up.lastWriteChunkIndex)
+	isSeq := atomic.LoadInt32(&up.isSequential) != 0
+
+	var bestIdx LogicChunkIndex = -1
+	var bestBytes int64 = -1
+
+	for lci, chunk := range up.writableChunks {
+		lastWrite := chunk.LastWriteTsNs()
+		if lastWrite == 0 {
+			continue
+		}
+		age := nowNs - lastWrite
+		if age < idleThresholdNs {
+			continue
+		}
+		written := chunk.WrittenSize()
+		nearlyFull := written >= fillRatio
+		behindFrontier := isSeq && int64(lci) <= frontier-int64(frontierLag)
+		stale := age >= maxHoldNs
+
+		if !nearlyFull && !behindFrontier && !stale {
+			continue
+		}
+		if written > bestBytes {
+			bestIdx = lci
+			bestBytes = written
+		}
+	}
+	if bestIdx < 0 {
+		return false
+	}
+	glog.V(3).Infof("%s proactive flush chunk %d (%d bytes written)", up.filepath, bestIdx, bestBytes)
+	up.moveToSealed(up.writableChunks[bestIdx], bestIdx)
 	return true
 }
 

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -376,6 +376,7 @@ func (wfs *WFS) StartBackgroundTasks() error {
 	go wfs.loopCheckQuota()
 	go wfs.loopFlushDirtyMetadata()
 	go wfs.loopEvictIdleDirCache()
+	go wfs.loopProactiveFlush()
 
 	if wfs.option.WritebackCache {
 		wfs.fileIdPool = NewFileIdPool(wfs)

--- a/weed/mount/weedfs_chunk_flusher.go
+++ b/weed/mount/weedfs_chunk_flusher.go
@@ -1,0 +1,47 @@
+package mount
+
+import (
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+)
+
+const (
+	proactiveFlushInterval  = 200 * time.Millisecond
+	proactiveIdleThreshold  = 500 * time.Millisecond
+	proactiveMaxHoldTime    = 5 * time.Second
+	proactiveFillRatioNumer = 9
+	proactiveFillRatioDenom = 10
+	proactiveFrontierLag    = 2
+)
+
+func (wfs *WFS) loopProactiveFlush() {
+	ticker := time.NewTicker(proactiveFlushInterval)
+	defer ticker.Stop()
+
+	glog.V(0).Infof("proactive chunk flusher started (idle=%v maxHold=%v)", proactiveIdleThreshold, proactiveMaxHoldTime)
+
+	for range ticker.C {
+		wfs.proactiveFlushOnce()
+	}
+}
+
+func (wfs *WFS) proactiveFlushOnce() {
+	nowNs := time.Now().UnixNano()
+	idleNs := proactiveIdleThreshold.Nanoseconds()
+	maxHoldNs := proactiveMaxHoldTime.Nanoseconds()
+	fillRatio := wfs.option.ChunkSizeLimit * proactiveFillRatioNumer / proactiveFillRatioDenom
+
+	var handles []*FileHandle
+	wfs.fhMap.RLock()
+	for _, fh := range wfs.fhMap.inode2fh {
+		if fh != nil && fh.dirtyPages != nil {
+			handles = append(handles, fh)
+		}
+	}
+	wfs.fhMap.RUnlock()
+
+	for _, fh := range handles {
+		fh.dirtyPages.ProactiveFlush(nowNs, idleNs, maxHoldNs, fillRatio, proactiveFrontierLag)
+	}
+}

--- a/weed/mount/weedfs_chunk_flusher.go
+++ b/weed/mount/weedfs_chunk_flusher.go
@@ -42,6 +42,7 @@ func (wfs *WFS) proactiveFlushOnce() {
 	wfs.fhMap.RUnlock()
 
 	for _, fh := range handles {
-		fh.dirtyPages.ProactiveFlush(nowNs, idleNs, maxHoldNs, fillRatio, proactiveFrontierLag)
+		isSeq := fh.dirtyPages.writerPattern.IsSequentialMode()
+		fh.dirtyPages.ProactiveFlush(nowNs, idleNs, maxHoldNs, fillRatio, proactiveFrontierLag, isSeq)
 	}
 }


### PR DESCRIPTION
## Summary

- Add a background `ChunkFlusher` goroutine (200ms scan interval) that proactively seals and uploads writable chunks that are idle and unlikely to receive further writes
- A chunk is flushed when idle >= 500ms AND one of: nearly full (>= 90%), behind the sequential write frontier by 2+ chunks, or stale for 5+ seconds
- Only flushes when the upload pipeline has spare capacity (< half of concurrent writer slots)
- Fix `ActivityScore` value-receiver bug where `MarkRead`/`MarkWrite` silently discarded mutations
- Add `LastWriteTsNs()` to `PageChunk` interface for per-chunk write timestamp tracking
- Add write frontier and sequential-mode tracking to `UploadPipeline`

This prevents partial chunks from accumulating until fsync/close, which benefits bursty or small-file workloads where chunks may never reach `IsComplete()`.

## Test plan

- [x] All existing `page_writer` tests pass (`go test ./weed/mount/page_writer/...`)
- [x] Full `go build ./...` succeeds
- [x] Data integrity verified: write 10 MiB random file via FUSE mount, read back, MD5 matches
- [x] Proactive flusher confirmed running via mount log: `proactive chunk flusher started`
- [ ] FIO benchmark suite with writeback cache to measure improvement on bursty workloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background proactive chunk-flushing: periodic loop that seals/uploads idle, long-held, or nearly-full chunks using configurable thresholds; writers and chunks now expose proactive-flush capability and track last-write timestamps to make smarter decisions.

* **Refactor**
  * Improved concurrent activity scoring to use atomic updates, reducing races and making activity metrics thread-safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->