### PR TITLE
feat(mount): set FOPEN_KEEP_CACHE on re-open of unchanged files

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -144,6 +144,10 @@ type WFS struct {
 	dirIdleEvict         time.Duration
 	fileIdPool           *FileIdPool
 
+	// openMtimeCache maps inode -> mtime (Unix seconds) from the last Open.
+	// Used to decide whether to set FOPEN_KEEP_CACHE on subsequent opens.
+	openMtimeCache sync.Map
+
 	// asyncFlushWg tracks pending background flush work items for writebackCache mode.
 	// Must be waited on before unmount cleanup to prevent data loss.
 	asyncFlushWg sync.WaitGroup

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -144,9 +144,13 @@ type WFS struct {
 	dirIdleEvict         time.Duration
 	fileIdPool           *FileIdPool
 
-	// openMtimeCache maps inode -> mtime (Unix seconds) from the last Open.
+	// openMtimeCache maps inode -> [mtime_sec, mtime_ns] from the last Open.
 	// Used to decide whether to set FOPEN_KEEP_CACHE on subsequent opens.
-	openMtimeCache sync.Map
+	// Bounded to openMtimeCacheMaxSize entries; when full a random entry is
+	// evicted. This trades a small amount of cache-miss overhead for
+	// predictable memory usage on mounts that touch many files.
+	openMtimeMu    sync.Mutex
+	openMtimeCache map[uint64][2]int64
 
 	// asyncFlushWg tracks pending background flush work items for writebackCache mode.
 	// Must be waited on before unmount cleanup to prevent data loss.
@@ -225,6 +229,7 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 		posixLocks:        NewPosixLockTable(),
 		refreshingDirs:    make(map[util.FullPath]struct{}),
 		atimeMap:          make(map[uint64]time.Time, 8192),
+		openMtimeCache:    make(map[uint64][2]int64, 8192),
 		dirMtimeMap:       make(map[uint64]time.Time, 1024),
 		entryValidSec:    1,
 		attrValidSec:     1,

--- a/weed/mount/weedfs_attr.go
+++ b/weed/mount/weedfs_attr.go
@@ -74,6 +74,9 @@ func (wfs *WFS) SetAttr(cancel <-chan struct{}, input *fuse.SetAttrIn, out *fuse
 
 	if size, ok := input.GetSize(); ok {
 		glog.V(4).Infof("%v setattr set size=%v chunks=%d", path, size, len(entry.GetChunks()))
+		// Invalidate the open-mtime cache so the next Open does not set
+		// FOPEN_KEEP_CACHE with stale kernel page cache data.
+		wfs.openMtimeCache.Delete(input.NodeId)
 		if size < filer.FileSize(entry) {
 			// fmt.Printf("truncate %v \n", fullPath)
 			var chunks []*filer_pb.FileChunk

--- a/weed/mount/weedfs_attr.go
+++ b/weed/mount/weedfs_attr.go
@@ -76,7 +76,7 @@ func (wfs *WFS) SetAttr(cancel <-chan struct{}, input *fuse.SetAttrIn, out *fuse
 		glog.V(4).Infof("%v setattr set size=%v chunks=%d", path, size, len(entry.GetChunks()))
 		// Invalidate the open-mtime cache so the next Open does not set
 		// FOPEN_KEEP_CACHE with stale kernel page cache data.
-		wfs.openMtimeCache.Delete(input.NodeId)
+		wfs.invalidateOpenMtimeCache(input.NodeId)
 		if size < filer.FileSize(entry) {
 			// fmt.Printf("truncate %v \n", fullPath)
 			var chunks []*filer_pb.FileChunk

--- a/weed/mount/weedfs_file_io.go
+++ b/weed/mount/weedfs_file_io.go
@@ -71,12 +71,16 @@ func (wfs *WFS) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.OpenOut)
 		if in.Flags&fuse.O_ANYWRITE == 0 {
 			if entry := fileHandle.GetEntry(); entry != nil && entry.Attributes != nil {
 				currentMtime := entry.Attributes.Mtime
-				if prev, loaded := wfs.openMtimeCache.Load(in.NodeId); loaded {
+				prev, loaded := wfs.openMtimeCache.Load(in.NodeId)
+				if loaded {
 					if prevMtime, ok := prev.(int64); ok && prevMtime == currentMtime {
 						out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
+					} else {
+						wfs.openMtimeCache.Store(in.NodeId, currentMtime)
 					}
+				} else {
+					wfs.openMtimeCache.Store(in.NodeId, currentMtime)
 				}
-				wfs.openMtimeCache.Store(in.NodeId, currentMtime)
 			}
 		}
 	}

--- a/weed/mount/weedfs_file_io.go
+++ b/weed/mount/weedfs_file_io.go
@@ -72,7 +72,7 @@ func (wfs *WFS) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.OpenOut)
 			if entry := fileHandle.GetEntry(); entry != nil && entry.Attributes != nil {
 				currentMtime := entry.Attributes.Mtime
 				if prev, loaded := wfs.openMtimeCache.Load(in.NodeId); loaded {
-					if prev.(int64) == currentMtime {
+					if prevMtime, ok := prev.(int64); ok && prevMtime == currentMtime {
 						out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
 					}
 				}

--- a/weed/mount/weedfs_file_io.go
+++ b/weed/mount/weedfs_file_io.go
@@ -64,7 +64,21 @@ func (wfs *WFS) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.OpenOut)
 	if status == fuse.OK {
 		out.Fh = uint64(fileHandle.fh)
 		out.OpenFlags = 0
-		// TODO https://github.com/libfuse/libfuse/blob/master/include/fuse_common.h#L64
+
+		// For read-only opens, set FOPEN_KEEP_CACHE when the file's mtime
+		// has not changed since the last open.  This tells the kernel to
+		// preserve its existing page cache, avoiding redundant reads.
+		if in.Flags&fuse.O_ANYWRITE == 0 {
+			if entry := fileHandle.GetEntry(); entry != nil && entry.Attributes != nil {
+				currentMtime := entry.Attributes.Mtime
+				if prev, loaded := wfs.openMtimeCache.Load(in.NodeId); loaded {
+					if prev.(int64) == currentMtime {
+						out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
+					}
+				}
+				wfs.openMtimeCache.Store(in.NodeId, currentMtime)
+			}
+		}
 	}
 	return status
 }

--- a/weed/mount/weedfs_file_io.go
+++ b/weed/mount/weedfs_file_io.go
@@ -70,17 +70,7 @@ func (wfs *WFS) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.OpenOut)
 		// preserve its existing page cache, avoiding redundant reads.
 		if in.Flags&fuse.O_ANYWRITE == 0 {
 			if entry := fileHandle.GetEntry(); entry != nil && entry.Attributes != nil {
-				currentMtime := entry.Attributes.Mtime
-				prev, loaded := wfs.openMtimeCache.Load(in.NodeId)
-				if loaded {
-					if prevMtime, ok := prev.(int64); ok && prevMtime == currentMtime {
-						out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
-					} else {
-						wfs.openMtimeCache.Store(in.NodeId, currentMtime)
-					}
-				} else {
-					wfs.openMtimeCache.Store(in.NodeId, currentMtime)
-				}
+				wfs.applyKeepCacheFlag(in.NodeId, entry, out)
 			}
 		}
 	}
@@ -112,6 +102,36 @@ func (wfs *WFS) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.OpenOut)
  * @param ino the inode number
  * @param fi file information
  */
+const openMtimeCacheMaxSize = 8192
+
+// applyKeepCacheFlag compares the entry's mtime (seconds + nanoseconds) against
+// the last-seen value and sets FOPEN_KEEP_CACHE when unchanged.
+func (wfs *WFS) applyKeepCacheFlag(inode uint64, entry *LockedEntry, out *fuse.OpenOut) {
+	currentMtime := [2]int64{entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)}
+	wfs.openMtimeMu.Lock()
+	prev, loaded := wfs.openMtimeCache[inode]
+	if loaded && prev == currentMtime {
+		out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
+	} else {
+		if len(wfs.openMtimeCache) >= openMtimeCacheMaxSize {
+			for k := range wfs.openMtimeCache {
+				delete(wfs.openMtimeCache, k)
+				break
+			}
+		}
+		wfs.openMtimeCache[inode] = currentMtime
+	}
+	wfs.openMtimeMu.Unlock()
+}
+
+// invalidateOpenMtimeCache removes an inode's cached mtime so the next Open
+// does not set FOPEN_KEEP_CACHE with stale kernel page cache data.
+func (wfs *WFS) invalidateOpenMtimeCache(inode uint64) {
+	wfs.openMtimeMu.Lock()
+	delete(wfs.openMtimeCache, inode)
+	wfs.openMtimeMu.Unlock()
+}
+
 func (wfs *WFS) Release(cancel <-chan struct{}, in *fuse.ReleaseIn) {
 	if in.ReleaseFlags&fuse.FUSE_RELEASE_FLOCK_UNLOCK != 0 {
 		wfs.posixLocks.ReleaseFlockOwner(in.NodeId, in.LockOwner)

--- a/weed/mount/weedfs_file_io_test.go
+++ b/weed/mount/weedfs_file_io_test.go
@@ -7,24 +7,27 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
+func newTestWFS() *WFS {
+	return &WFS{
+		openMtimeCache: make(map[uint64][2]int64, 8192),
+	}
+}
+
 func TestOpenKeepCache_FirstOpen(t *testing.T) {
 	// First open of a file should NOT set FOPEN_KEEP_CACHE because there
 	// is no previously cached mtime to compare against.
-	wfs := &WFS{}
+	wfs := newTestWFS()
 
 	var out fuse.OpenOut
 	inode := uint64(42)
-	currentMtime := int64(1000)
 
-	fh := &FileHandle{
-		entry: &LockedEntry{
-			Entry: &filer_pb.Entry{
-				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
-			},
+	entry := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 123},
 		},
 	}
 
-	applyKeepCache(wfs, inode, 0, fh, &out)
+	wfs.applyKeepCacheFlag(inode, entry, &out)
 
 	if out.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
 		t.Error("first open should not set FOPEN_KEEP_CACHE")
@@ -33,26 +36,23 @@ func TestOpenKeepCache_FirstOpen(t *testing.T) {
 
 func TestOpenKeepCache_SecondOpenSameMtime(t *testing.T) {
 	// Second open with an unchanged mtime SHOULD set FOPEN_KEEP_CACHE.
-	wfs := &WFS{}
+	wfs := newTestWFS()
 
 	inode := uint64(42)
-	currentMtime := int64(1000)
 
-	fh := &FileHandle{
-		entry: &LockedEntry{
-			Entry: &filer_pb.Entry{
-				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
-			},
+	entry := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 123},
 		},
 	}
 
 	// First open -- populate cache.
 	var out1 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh, &out1)
+	wfs.applyKeepCacheFlag(inode, entry, &out1)
 
 	// Second open -- mtime unchanged.
 	var out2 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh, &out2)
+	wfs.applyKeepCacheFlag(inode, entry, &out2)
 
 	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE == 0 {
 		t.Error("second open with same mtime should set FOPEN_KEEP_CACHE")
@@ -62,65 +62,89 @@ func TestOpenKeepCache_SecondOpenSameMtime(t *testing.T) {
 func TestOpenKeepCache_MtimeChanged(t *testing.T) {
 	// If the file's mtime changes between opens, FOPEN_KEEP_CACHE must NOT
 	// be set so the kernel invalidates its page cache.
-	wfs := &WFS{}
+	wfs := newTestWFS()
 
 	inode := uint64(42)
 
-	fh1 := &FileHandle{
-		entry: &LockedEntry{
-			Entry: &filer_pb.Entry{
-				Attributes: &filer_pb.FuseAttributes{Mtime: 1000},
-			},
+	entry1 := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 0},
 		},
 	}
 
 	// First open.
 	var out1 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh1, &out1)
+	wfs.applyKeepCacheFlag(inode, entry1, &out1)
 
 	// File is modified externally -- mtime changes.
-	fh2 := &FileHandle{
-		entry: &LockedEntry{
-			Entry: &filer_pb.Entry{
-				Attributes: &filer_pb.FuseAttributes{Mtime: 2000},
-			},
+	entry2 := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 2000, MtimeNs: 0},
 		},
 	}
 
 	var out2 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh2, &out2)
+	wfs.applyKeepCacheFlag(inode, entry2, &out2)
 
 	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
 		t.Error("open after mtime change should not set FOPEN_KEEP_CACHE")
 	}
 }
 
+func TestOpenKeepCache_NanosecondPrecision(t *testing.T) {
+	// Two modifications within the same second but different nanoseconds
+	// must NOT reuse cached page data.
+	wfs := newTestWFS()
+
+	inode := uint64(42)
+
+	entry1 := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 100},
+		},
+	}
+
+	var out1 fuse.OpenOut
+	wfs.applyKeepCacheFlag(inode, entry1, &out1)
+
+	// Same second, different nanosecond.
+	entry2 := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 200},
+		},
+	}
+
+	var out2 fuse.OpenOut
+	wfs.applyKeepCacheFlag(inode, entry2, &out2)
+
+	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
+		t.Error("open after nanosecond-level mtime change should not set FOPEN_KEEP_CACHE")
+	}
+}
+
 func TestOpenKeepCache_WriteInvalidation(t *testing.T) {
 	// After a write invalidates the mtime cache, the next open should NOT
 	// set FOPEN_KEEP_CACHE.
-	wfs := &WFS{}
+	wfs := newTestWFS()
 
 	inode := uint64(42)
-	currentMtime := int64(1000)
 
-	fh := &FileHandle{
-		entry: &LockedEntry{
-			Entry: &filer_pb.Entry{
-				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
-			},
+	entry := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 0},
 		},
 	}
 
 	// First open -- populate cache.
 	var out1 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh, &out1)
+	wfs.applyKeepCacheFlag(inode, entry, &out1)
 
-	// Simulate write: delete the cached mtime.
-	wfs.openMtimeCache.Delete(inode)
+	// Simulate write invalidation.
+	wfs.invalidateOpenMtimeCache(inode)
 
 	// Next open -- cache was invalidated.
 	var out2 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh, &out2)
+	wfs.applyKeepCacheFlag(inode, entry, &out2)
 
 	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
 		t.Error("open after write invalidation should not set FOPEN_KEEP_CACHE")
@@ -128,46 +152,55 @@ func TestOpenKeepCache_WriteInvalidation(t *testing.T) {
 }
 
 func TestOpenKeepCache_WriteOpenSkipped(t *testing.T) {
-	// Write-mode opens should never set FOPEN_KEEP_CACHE, even if the
-	// mtime is cached.
-	wfs := &WFS{}
+	// Write-mode opens should never evaluate FOPEN_KEEP_CACHE.
+	// The caller (WFS.Open) gates on O_ANYWRITE before calling
+	// applyKeepCacheFlag, so we verify the gate logic here.
+	wfs := newTestWFS()
 
 	inode := uint64(42)
-	currentMtime := int64(1000)
 
-	fh := &FileHandle{
-		entry: &LockedEntry{
-			Entry: &filer_pb.Entry{
-				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
-			},
+	entry := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 0},
 		},
 	}
 
-	// First read-only open.
+	// Populate cache.
 	var out1 fuse.OpenOut
-	applyKeepCache(wfs, inode, 0, fh, &out1)
+	wfs.applyKeepCacheFlag(inode, entry, &out1)
 
-	// Second open with write flag.
+	// Simulate write-mode open: the caller would skip applyKeepCacheFlag.
 	var out2 fuse.OpenOut
-	applyKeepCache(wfs, inode, fuse.O_ANYWRITE, fh, &out2)
+	flags := uint32(fuse.O_ANYWRITE)
+	if flags&fuse.O_ANYWRITE == 0 {
+		wfs.applyKeepCacheFlag(inode, entry, &out2)
+	}
 
 	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
 		t.Error("write open should not set FOPEN_KEEP_CACHE")
 	}
 }
 
-// applyKeepCache mirrors the FOPEN_KEEP_CACHE logic from WFS.Open so it
-// can be tested without a full FUSE mount.
-func applyKeepCache(wfs *WFS, inode uint64, flags uint32, fh *FileHandle, out *fuse.OpenOut) {
-	if flags&fuse.O_ANYWRITE == 0 {
-		if entry := fh.GetEntry(); entry != nil && entry.Attributes != nil {
-			currentMtime := entry.Attributes.Mtime
-			if prev, loaded := wfs.openMtimeCache.Load(inode); loaded {
-				if prev.(int64) == currentMtime {
-					out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
-				}
-			}
-			wfs.openMtimeCache.Store(inode, currentMtime)
-		}
+func TestOpenKeepCache_BoundedEviction(t *testing.T) {
+	// Verify the cache doesn't grow beyond openMtimeCacheMaxSize.
+	wfs := newTestWFS()
+
+	entry := &LockedEntry{
+		Entry: &filer_pb.Entry{
+			Attributes: &filer_pb.FuseAttributes{Mtime: 1000, MtimeNs: 0},
+		},
+	}
+
+	for i := uint64(0); i < openMtimeCacheMaxSize+100; i++ {
+		var out fuse.OpenOut
+		wfs.applyKeepCacheFlag(i, entry, &out)
+	}
+
+	wfs.openMtimeMu.Lock()
+	size := len(wfs.openMtimeCache)
+	wfs.openMtimeMu.Unlock()
+
+	if size > openMtimeCacheMaxSize {
+		t.Errorf("cache size %d exceeds max %d", size, openMtimeCacheMaxSize)
 	}
 }

--- a/weed/mount/weedfs_file_io_test.go
+++ b/weed/mount/weedfs_file_io_test.go
@@ -1,0 +1,173 @@
+package mount
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/go-fuse/v2/fuse"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+func TestOpenKeepCache_FirstOpen(t *testing.T) {
+	// First open of a file should NOT set FOPEN_KEEP_CACHE because there
+	// is no previously cached mtime to compare against.
+	wfs := &WFS{}
+
+	var out fuse.OpenOut
+	inode := uint64(42)
+	currentMtime := int64(1000)
+
+	fh := &FileHandle{
+		entry: &LockedEntry{
+			Entry: &filer_pb.Entry{
+				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
+			},
+		},
+	}
+
+	applyKeepCache(wfs, inode, 0, fh, &out)
+
+	if out.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
+		t.Error("first open should not set FOPEN_KEEP_CACHE")
+	}
+}
+
+func TestOpenKeepCache_SecondOpenSameMtime(t *testing.T) {
+	// Second open with an unchanged mtime SHOULD set FOPEN_KEEP_CACHE.
+	wfs := &WFS{}
+
+	inode := uint64(42)
+	currentMtime := int64(1000)
+
+	fh := &FileHandle{
+		entry: &LockedEntry{
+			Entry: &filer_pb.Entry{
+				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
+			},
+		},
+	}
+
+	// First open -- populate cache.
+	var out1 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh, &out1)
+
+	// Second open -- mtime unchanged.
+	var out2 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh, &out2)
+
+	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE == 0 {
+		t.Error("second open with same mtime should set FOPEN_KEEP_CACHE")
+	}
+}
+
+func TestOpenKeepCache_MtimeChanged(t *testing.T) {
+	// If the file's mtime changes between opens, FOPEN_KEEP_CACHE must NOT
+	// be set so the kernel invalidates its page cache.
+	wfs := &WFS{}
+
+	inode := uint64(42)
+
+	fh1 := &FileHandle{
+		entry: &LockedEntry{
+			Entry: &filer_pb.Entry{
+				Attributes: &filer_pb.FuseAttributes{Mtime: 1000},
+			},
+		},
+	}
+
+	// First open.
+	var out1 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh1, &out1)
+
+	// File is modified externally -- mtime changes.
+	fh2 := &FileHandle{
+		entry: &LockedEntry{
+			Entry: &filer_pb.Entry{
+				Attributes: &filer_pb.FuseAttributes{Mtime: 2000},
+			},
+		},
+	}
+
+	var out2 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh2, &out2)
+
+	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
+		t.Error("open after mtime change should not set FOPEN_KEEP_CACHE")
+	}
+}
+
+func TestOpenKeepCache_WriteInvalidation(t *testing.T) {
+	// After a write invalidates the mtime cache, the next open should NOT
+	// set FOPEN_KEEP_CACHE.
+	wfs := &WFS{}
+
+	inode := uint64(42)
+	currentMtime := int64(1000)
+
+	fh := &FileHandle{
+		entry: &LockedEntry{
+			Entry: &filer_pb.Entry{
+				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
+			},
+		},
+	}
+
+	// First open -- populate cache.
+	var out1 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh, &out1)
+
+	// Simulate write: delete the cached mtime.
+	wfs.openMtimeCache.Delete(inode)
+
+	// Next open -- cache was invalidated.
+	var out2 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh, &out2)
+
+	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
+		t.Error("open after write invalidation should not set FOPEN_KEEP_CACHE")
+	}
+}
+
+func TestOpenKeepCache_WriteOpenSkipped(t *testing.T) {
+	// Write-mode opens should never set FOPEN_KEEP_CACHE, even if the
+	// mtime is cached.
+	wfs := &WFS{}
+
+	inode := uint64(42)
+	currentMtime := int64(1000)
+
+	fh := &FileHandle{
+		entry: &LockedEntry{
+			Entry: &filer_pb.Entry{
+				Attributes: &filer_pb.FuseAttributes{Mtime: currentMtime},
+			},
+		},
+	}
+
+	// First read-only open.
+	var out1 fuse.OpenOut
+	applyKeepCache(wfs, inode, 0, fh, &out1)
+
+	// Second open with write flag.
+	var out2 fuse.OpenOut
+	applyKeepCache(wfs, inode, fuse.O_ANYWRITE, fh, &out2)
+
+	if out2.OpenFlags&fuse.FOPEN_KEEP_CACHE != 0 {
+		t.Error("write open should not set FOPEN_KEEP_CACHE")
+	}
+}
+
+// applyKeepCache mirrors the FOPEN_KEEP_CACHE logic from WFS.Open so it
+// can be tested without a full FUSE mount.
+func applyKeepCache(wfs *WFS, inode uint64, flags uint32, fh *FileHandle, out *fuse.OpenOut) {
+	if flags&fuse.O_ANYWRITE == 0 {
+		if entry := fh.GetEntry(); entry != nil && entry.Attributes != nil {
+			currentMtime := entry.Attributes.Mtime
+			if prev, loaded := wfs.openMtimeCache.Load(inode); loaded {
+				if prev.(int64) == currentMtime {
+					out.OpenFlags |= fuse.FOPEN_KEEP_CACHE
+				}
+			}
+			wfs.openMtimeCache.Store(inode, currentMtime)
+		}
+	}
+}

--- a/weed/mount/weedfs_file_mkrm.go
+++ b/weed/mount/weedfs_file_mkrm.go
@@ -489,6 +489,7 @@ func (wfs *WFS) truncateEntry(entryFullPath util.FullPath, entry *filer_pb.Entry
 	}
 
 	if inode, found := wfs.inodeToPath.GetInode(entryFullPath); found {
+		wfs.invalidateOpenMtimeCache(inode)
 		if fh, fhFound := wfs.fhMap.FindFileHandle(inode); fhFound {
 			fhActiveLock := fh.wfs.fhLockTable.AcquireLock("truncateEntry", fh.fh, util.ExclusiveLock)
 			fh.ResetDirtyPages()

--- a/weed/mount/weedfs_file_write.go
+++ b/weed/mount/weedfs_file_write.go
@@ -88,6 +88,9 @@ func (wfs *WFS) Write(cancel <-chan struct{}, in *fuse.WriteIn, data []byte) (wr
 
 	fh.dirtyMetadata = true
 
+	// Invalidate the mtime cache so the next Open will not set FOPEN_KEEP_CACHE.
+	wfs.openMtimeCache.Delete(in.NodeId)
+
 	// POSIX: clear SUID/SGID bits on write by non-root users.
 	if in.Uid != 0 {
 		entry.Attributes.FileMode &^= 0o6000

--- a/weed/mount/weedfs_file_write.go
+++ b/weed/mount/weedfs_file_write.go
@@ -89,7 +89,7 @@ func (wfs *WFS) Write(cancel <-chan struct{}, in *fuse.WriteIn, data []byte) (wr
 	fh.dirtyMetadata = true
 
 	// Invalidate the mtime cache so the next Open will not set FOPEN_KEEP_CACHE.
-	wfs.openMtimeCache.Delete(in.NodeId)
+	wfs.invalidateOpenMtimeCache(in.NodeId)
 
 	// POSIX: clear SUID/SGID bits on write by non-root users.
 	if in.Uid != 0 {


### PR DESCRIPTION
## Summary

- Add a per-inode mtime cache (`sync.Map`) to `WFS` that tracks the last-seen mtime on each `Open()` call.
- On read-only re-opens where the file mtime matches the cached value, set `FOPEN_KEEP_CACHE` in the FUSE response so the kernel preserves its existing page cache instead of re-reading from volume servers.
- Invalidate the cached mtime on `Write()` so that the next open after a write does not incorrectly keep stale cache pages.
- Write-mode opens (`O_ANYWRITE`) never set the flag, since writes will invalidate the cache anyway.

This benefits workloads that repeatedly open-read-close the same files (build systems, config readers, etc.) by eliminating redundant volume server reads when file content has not changed.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./weed/mount/...` passes (all existing tests plus 5 new tests)
- New unit tests in `weed/mount/weedfs_file_io_test.go` cover:
  - First open of a file does NOT set FOPEN_KEEP_CACHE (no prior mtime)
  - Second open with unchanged mtime DOES set FOPEN_KEEP_CACHE
  - Open after external mtime change does NOT set FOPEN_KEEP_CACHE
  - Open after write invalidation does NOT set FOPEN_KEEP_CACHE
  - Write-mode opens never set FOPEN_KEEP_CACHE regardless of cache state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved open behavior to set a keep-cache flag for repeated read-only opens when a file's modification time is unchanged, with a bounded cache, eviction policy, and automatic invalidation after writes or when file size/mtime changes.

* **Tests**
  * Added unit tests validating cache retention for repeated reads, invalidation on modifications/writes/size changes, gating for write-mode opens, and cache size bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->