### PR TITLE
perf(cache): drop OS page cache after disk cache reads

### DIFF
--- a/weed/storage/backend/disk_file.go
+++ b/weed/storage/backend/disk_file.go
@@ -115,6 +115,13 @@ func (df *DiskFile) Name() string {
 	return df.fullFilePath
 }
 
+func (df *DiskFile) Fd() uintptr {
+	if df.File == nil {
+		return ^uintptr(0)
+	}
+	return df.File.Fd()
+}
+
 func (df *DiskFile) Sync() error {
 	if df.File == nil {
 		return os.ErrClosed

--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -114,10 +114,17 @@ func (v *ChunkCacheVolume) Reset() (*ChunkCacheVolume, error) {
 	return LoadOrCreateChunkCacheVolume(v.fileName, v.sizeLimit)
 }
 
+// minFadviseSize is the minimum read size (in bytes) before we call fadvise
+// DONTNEED. For small reads the syscall overhead outweighs the benefit, and
+// the kernel's page cache may serve the data again sooner than we think.
+const minFadviseSize = 1 << 20 // 1 MiB
+
 // dropReadCache advises the kernel to drop page cache for the byte range
 // just read. This is best-effort; failures are logged at V(4).
+// Only applied for reads >= minFadviseSize to avoid syscall overhead on
+// small needle reads where the kernel page cache is more beneficial.
 func (v *ChunkCacheVolume) dropReadCache(offset int64, length int64) {
-	if length <= 0 {
+	if length < minFadviseSize {
 		return
 	}
 	type fdProvider interface {

--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -117,11 +117,17 @@ func (v *ChunkCacheVolume) Reset() (*ChunkCacheVolume, error) {
 // dropReadCache advises the kernel to drop page cache for the byte range
 // just read. This is best-effort; failures are logged at V(4).
 func (v *ChunkCacheVolume) dropReadCache(offset int64, length int64) {
+	if length <= 0 {
+		return
+	}
 	type fdProvider interface {
 		Fd() uintptr
 	}
 	if fp, ok := v.DataBackend.(fdProvider); ok {
 		fd := int(fp.Fd())
+		if fd < 0 {
+			return
+		}
 		if err := util.DropOSPageCache(fd, offset, length); err != nil {
 			glog.V(4).Infof("fadvise DONTNEED %s offset %d len %d: %v", v.fileName, offset, length, err)
 		}

--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -114,6 +114,20 @@ func (v *ChunkCacheVolume) Reset() (*ChunkCacheVolume, error) {
 	return LoadOrCreateChunkCacheVolume(v.fileName, v.sizeLimit)
 }
 
+// dropReadCache advises the kernel to drop page cache for the byte range
+// just read. This is best-effort; failures are logged at V(4).
+func (v *ChunkCacheVolume) dropReadCache(offset int64, length int64) {
+	type fdProvider interface {
+		Fd() uintptr
+	}
+	if fp, ok := v.DataBackend.(fdProvider); ok {
+		fd := int(fp.Fd())
+		if err := util.DropOSPageCache(fd, offset, length); err != nil {
+			glog.V(4).Infof("fadvise DONTNEED %s offset %d len %d: %v", v.fileName, offset, length, err)
+		}
+	}
+}
+
 func (v *ChunkCacheVolume) GetNeedle(key types.NeedleId) ([]byte, error) {
 
 	nv, ok := v.nm.Get(key)
@@ -121,10 +135,11 @@ func (v *ChunkCacheVolume) GetNeedle(key types.NeedleId) ([]byte, error) {
 		return nil, storage.ErrorNotFound
 	}
 	data := make([]byte, nv.Size)
-	if readSize, readErr := v.DataBackend.ReadAt(data, nv.Offset.ToActualOffset()); readErr != nil {
+	readOffset := nv.Offset.ToActualOffset()
+	if readSize, readErr := v.DataBackend.ReadAt(data, readOffset); readErr != nil {
 		if readSize != int(nv.Size) {
 			return nil, fmt.Errorf("read %s.dat [%d,%d): %v",
-				v.fileName, nv.Offset.ToActualOffset(), nv.Offset.ToActualOffset()+int64(nv.Size), readErr)
+				v.fileName, readOffset, readOffset+int64(nv.Size), readErr)
 		}
 	} else {
 		if readSize != int(nv.Size) {
@@ -132,6 +147,7 @@ func (v *ChunkCacheVolume) GetNeedle(key types.NeedleId) ([]byte, error) {
 		}
 	}
 
+	v.dropReadCache(readOffset, int64(nv.Size))
 	return data, nil
 }
 
@@ -146,12 +162,13 @@ func (v *ChunkCacheVolume) getNeedleSlice(key types.NeedleId, offset, length uin
 		return nil, ErrorOutOfBounds
 	}
 	data := make([]byte, wanted)
+	readOffset := nv.Offset.ToActualOffset() + int64(offset)
 	var readSize int
 	var readErr error
-	if readSize, readErr = v.DataBackend.ReadAt(data, nv.Offset.ToActualOffset()+int64(offset)); readErr != nil {
+	if readSize, readErr = v.DataBackend.ReadAt(data, readOffset); readErr != nil {
 		if readSize != wanted {
 			return nil, fmt.Errorf("read %s.dat [%d,%d): %v",
-				v.fileName, nv.Offset.ToActualOffset()+int64(offset), int(nv.Offset.ToActualOffset())+int(offset)+wanted, readErr)
+				v.fileName, readOffset, int64(readOffset)+int64(wanted), readErr)
 		}
 	} else {
 		if readSize != wanted {
@@ -160,6 +177,9 @@ func (v *ChunkCacheVolume) getNeedleSlice(key types.NeedleId, offset, length uin
 	}
 	if readErr != nil && readSize == wanted {
 		readErr = nil
+	}
+	if readSize > 0 {
+		v.dropReadCache(readOffset, int64(readSize))
 	}
 	return data, readErr
 }
@@ -174,10 +194,11 @@ func (v *ChunkCacheVolume) readNeedleSliceAt(data []byte, key types.NeedleId, of
 		// should never happen, but better than panicking
 		return 0, ErrorOutOfBounds
 	}
-	if n, err = v.DataBackend.ReadAt(data, nv.Offset.ToActualOffset()+int64(offset)); err != nil {
+	readOffset := nv.Offset.ToActualOffset() + int64(offset)
+	if n, err = v.DataBackend.ReadAt(data, readOffset); err != nil {
 		if n != wanted {
 			return n, fmt.Errorf("read %s.dat [%d,%d): %v",
-				v.fileName, nv.Offset.ToActualOffset()+int64(offset), int(nv.Offset.ToActualOffset())+int(offset)+wanted, err)
+				v.fileName, readOffset, int64(readOffset)+int64(wanted), err)
 		}
 	} else {
 		if n != wanted {
@@ -186,6 +207,9 @@ func (v *ChunkCacheVolume) readNeedleSliceAt(data []byte, key types.NeedleId, of
 	}
 	if err != nil && n == wanted {
 		err = nil
+	}
+	if n > 0 {
+		v.dropReadCache(readOffset, int64(n))
 	}
 	return n, err
 }

--- a/weed/util/fadvise_linux.go
+++ b/weed/util/fadvise_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package util
+
+import "golang.org/x/sys/unix"
+
+// DropOSPageCache advises the kernel that the given byte range is no longer
+// needed in the page cache. This is useful after reading from a user-space
+// cache (e.g., on-disk chunk cache) to prevent the kernel from double-caching
+// the same data.
+func DropOSPageCache(fd int, offset int64, length int64) error {
+	return unix.Fadvise(fd, offset, length, unix.FADV_DONTNEED)
+}

--- a/weed/util/fadvise_linux_test.go
+++ b/weed/util/fadvise_linux_test.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDropOSPageCache(t *testing.T) {
+	f, err := os.CreateTemp("", "fadvise_test")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	data := make([]byte, 4096)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	// Read the data back to populate page cache
+	buf := make([]byte, 4096)
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		t.Fatalf("failed to read test data: %v", err)
+	}
+
+	// Call DropOSPageCache and verify no error
+	fd := int(f.Fd())
+	if err := DropOSPageCache(fd, 0, int64(len(data))); err != nil {
+		t.Errorf("DropOSPageCache returned error: %v", err)
+	}
+}

--- a/weed/util/fadvise_other.go
+++ b/weed/util/fadvise_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package util
+
+// DropOSPageCache is a no-op on non-Linux platforms.
+func DropOSPageCache(fd int, offset int64, length int64) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- After reading chunk data from the on-disk cache, call `posix_fadvise(FADV_DONTNEED)` on the read byte range so the kernel drops those pages from its page cache
- Prevents double-caching: data already lives in SeaweedFS's user-space disk cache, so keeping a second copy in the kernel page cache wastes RAM
- The fadvise call is best-effort (failures logged at V(4), never propagated) and is a no-op on non-Linux platforms

## Test plan

- [ ] `go build ./...` passes (verified locally on macOS -- non-linux no-op compiles cleanly)
- [ ] `go test ./weed/util/chunk_cache/...` passes (existing `TestOnDisk` exercises all three read paths: `GetNeedle`, `getNeedleSlice`, `readNeedleSliceAt`)
- [ ] `go test ./weed/storage/backend/...` passes (confirms `DiskFile.Fd()` addition is safe)
- [ ] Linux-only unit test in `weed/util/fadvise_linux_test.go` verifies `DropOSPageCache` returns no error on a real fd
- [ ] On a Linux mount with a large disk cache, verify via `/proc/meminfo` or `vmtouch` that cached page counts drop after reads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OS page-cache eviction on Linux to reduce kernel cache pressure after reads.
  * Storage backends now expose a file handle identifier to enable best-effort cache drops when available.
  * Non-Linux platforms provide a safe no-op implementation.

* **Tests**
  * Added test coverage validating the page-cache eviction behavior on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->