### PR TITLE
ci(pjdfstest): cache docker layers via GHA to avoid apt mirror flakes

### DIFF
--- a/.github/workflows/pjdfstest.yml
+++ b/.github/workflows/pjdfstest.yml
@@ -39,8 +39,13 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Start local Docker registry
+      run: docker run -d --restart=always -p 5000:5000 --name registry registry:2
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
+      with:
+        driver-opts: network=host
 
     - name: Build weed race binary
       run: |
@@ -52,19 +57,31 @@ jobs:
       with:
         context: docker
         file: docker/Dockerfile.e2e
-        tags: chrislusf/seaweedfs:e2e
-        load: true
+        tags: localhost:5000/chrislusf/seaweedfs:e2e
+        push: true
         cache-from: type=gha,scope=pjdfstest-e2e
         cache-to: type=gha,mode=max,scope=pjdfstest-e2e
+
+    - name: Tag e2e image for docker compose
+      run: |
+        docker pull localhost:5000/chrislusf/seaweedfs:e2e
+        docker tag localhost:5000/chrislusf/seaweedfs:e2e chrislusf/seaweedfs:e2e
 
     - name: Build pjdfstest image
       uses: docker/build-push-action@v6
       with:
         context: test/pjdfstest
-        tags: chrislusf/seaweedfs:pjdfstest
-        load: true
+        build-contexts: |
+          chrislusf/seaweedfs:e2e=docker-image://localhost:5000/chrislusf/seaweedfs:e2e
+        tags: localhost:5000/chrislusf/seaweedfs:pjdfstest
+        push: true
         cache-from: type=gha,scope=pjdfstest-harness
         cache-to: type=gha,mode=max,scope=pjdfstest-harness
+
+    - name: Tag pjdfstest image for docker compose
+      run: |
+        docker pull localhost:5000/chrislusf/seaweedfs:pjdfstest
+        docker tag localhost:5000/chrislusf/seaweedfs:pjdfstest chrislusf/seaweedfs:pjdfstest
 
     - name: Start SeaweedFS cluster
       run: |

--- a/.github/workflows/pjdfstest.yml
+++ b/.github/workflows/pjdfstest.yml
@@ -39,18 +39,32 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    - name: Build SeaweedFS e2e image
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Build weed race binary
       run: |
         cd docker
-        make build_e2e || {
-          echo "Retrying without buildx cache..."
-          make binary_race
-          docker build --no-cache -t chrislusf/seaweedfs:e2e -f Dockerfile.e2e .
-        }
+        make binary_race
+
+    - name: Build SeaweedFS e2e image
+      uses: docker/build-push-action@v6
+      with:
+        context: docker
+        file: docker/Dockerfile.e2e
+        tags: chrislusf/seaweedfs:e2e
+        load: true
+        cache-from: type=gha,scope=pjdfstest-e2e
+        cache-to: type=gha,mode=max,scope=pjdfstest-e2e
 
     - name: Build pjdfstest image
-      run: |
-        docker build -t chrislusf/seaweedfs:pjdfstest test/pjdfstest/
+      uses: docker/build-push-action@v6
+      with:
+        context: test/pjdfstest
+        tags: chrislusf/seaweedfs:pjdfstest
+        load: true
+        cache-from: type=gha,scope=pjdfstest-harness
+        cache-to: type=gha,mode=max,scope=pjdfstest-harness
 
     - name: Start SeaweedFS cluster
       run: |

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -7,8 +7,8 @@ LABEL author="Chris Lu"
 # Production images (Dockerfile.go_build) use proper user isolation with su-exec.
 # For testing purposes, running as root avoids permission complexities and dependency
 # on Alpine-specific tools like su-exec (not available in Ubuntu repos).
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
     --no-install-recommends \
     --no-install-suggests \
     curl \

--- a/test/pjdfstest/Dockerfile
+++ b/test/pjdfstest/Dockerfile
@@ -1,7 +1,7 @@
 FROM chrislusf/seaweedfs:e2e
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
     --no-install-recommends \
     --no-install-suggests \
     autoconf \


### PR DESCRIPTION
## Summary
- Replace local buildx cache + manual fallback in `pjdfstest.yml` with `docker/setup-buildx-action` and `docker/build-push-action` using `type=gha` cache backend; the apt install layer is reused across runs so Ubuntu mirrors are only hit when `Dockerfile.e2e` or `test/pjdfstest/Dockerfile` changes.
- Add `Acquire::Retries=5` and `Acquire::http::Timeout=30` to the `apt-get` invocations so first-run cache-miss builds survive transient mirror sync errors (e.g. `File has unexpected size ... Mirror sync in progress?`).
- Drop the `|| { fallback }` retry block; no longer needed now that buildx has a working cache driver via `setup-buildx-action`.

Context: recent failures like https://github.com/seaweedfs/seaweedfs/actions/runs/24523780739/job/71688376231 where the first `make build_e2e` failed (buildx cache driver mismatch) and the fallback also failed (Ubuntu mirror returned a mid-sync `Packages.gz` with the wrong size).

## Test plan
- [ ] `pjdfstest` workflow passes on this PR (first run will still hit mirrors once to warm the GHA cache)
- [ ] A second push to the branch shows a cache hit on the `Build SeaweedFS e2e image` and `Build pjdfstest image` steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI Docker builds to use a local registry and Buildx with caching, pushing/pulling and re-tagging images for more reliable artifact handling.
  * Improved package install robustness in images by adding retry and timeout behavior, reducing transient build failures, flaky CI runs, and speeding rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->