### PR TITLE
fix(mount): avoid self-notify deadlock in Link and CopyFileRange handlers

### DIFF
--- a/weed/mount/weedfs_file_copy_range.go
+++ b/weed/mount/weedfs_file_copy_range.go
@@ -251,7 +251,11 @@ func (wfs *WFS) applyServerSideWholeFileCopyResult(fhIn, fhOut *FileHandle, dstP
 	}
 	fhOut.dirtyMetadata = false
 	wfs.updateServerSideWholeFileCopyMetaCache(dstPath, entry)
-	wfs.invalidateCopyDestinationCache(fhOut.inode, dstPath)
+	// Note: we intentionally skip fuseServer.InodeNotify/EntryNotify here.
+	// This runs inside the CopyFileRange request handler; those notifies
+	// would write onto the same /dev/fuse fd the kernel is still waiting
+	// on for this request's reply, deadlocking the mount. The kernel will
+	// re-read attrs once its attr-cache TTL expires.
 }
 
 func (wfs *WFS) updateServerSideWholeFileCopyMetaCache(dstPath util.FullPath, entry *filer_pb.Entry) {
@@ -501,16 +505,3 @@ func (wfs *WFS) filerCopyJWT() security.EncodedJwt {
 	return security.GenJwtForFilerServer(wfs.option.FilerSigningKey, wfs.option.FilerSigningExpiresAfterSec)
 }
 
-func (wfs *WFS) invalidateCopyDestinationCache(inode uint64, fullPath util.FullPath) {
-	if wfs.fuseServer != nil {
-		if status := wfs.fuseServer.InodeNotify(inode, 0, -1); status != fuse.OK {
-			glog.V(4).Infof("CopyFileRange invalidate inode %d: %v", inode, status)
-		}
-		dir, name := fullPath.DirAndName()
-		if parentInode, found := wfs.inodeToPath.GetInode(util.FullPath(dir)); found {
-			if status := wfs.fuseServer.EntryNotify(parentInode, name); status != fuse.OK {
-				glog.V(4).Infof("CopyFileRange invalidate entry %s: %v", fullPath, status)
-			}
-		}
-	}
-}

--- a/weed/mount/weedfs_link.go
+++ b/weed/mount/weedfs_link.go
@@ -231,9 +231,9 @@ func (wfs *WFS) syncHardLinkSiblings(inode uint64, authoritativeEntry *filer_pb.
 			glog.V(4).Infof("syncHardLinkSiblings update %s: %v", p, err)
 		}
 	}
-	if wfs.fuseServer != nil {
-		if status := wfs.fuseServer.InodeNotify(inode, 0, -1); status != fuse.OK {
-			glog.V(4).Infof("syncHardLinkSiblings invalidate inode %d: %v", inode, status)
-		}
-	}
+	// Note: we deliberately do NOT call fuseServer.InodeNotify here. That
+	// call would be made from the FUSE Link request handler goroutine, and
+	// writes onto the same /dev/fuse fd that the kernel is still waiting to
+	// read the Link reply from — causing a self-notify deadlock. The kernel
+	// will re-stat siblings once its attr-cache TTL expires.
 }


### PR DESCRIPTION
## Summary

- The `Link` handler's `syncHardLinkSiblings` (`weed/mount/weedfs_link.go:235`) and the `CopyFileRange` server-side-copy path's `invalidateCopyDestinationCache` (`weed/mount/weedfs_file_copy_range.go:504`) called `fuseServer.InodeNotify` / `EntryNotify` synchronously from inside a FUSE request handler. Notifications and replies share the same `/dev/fuse` fd, so the `syscall.Write` can block indefinitely when the kernel has not yet drained its queue — the mount then deadlocks.
- A goroutine dump from a stuck mount captured the `Link` handler blocked in `syscall.Write` inside `InodeNotify`, with every other goroutine idle (worker pools, gRPC keepalives, FUSE read loop waiting on the same fd).
- This patch drops those two synchronous notify calls. The local meta cache is still updated inline so subsequent filesystem ops see fresh state; the kernel's attr/dentry caches refresh once their TTL expires.

Note: this trades the eager kernel-cache invalidation for correctness. If the pjdfstest `link/00.t` regression that motivated the original `InodeNotify` re-appears because the kernel serves a stale `nlink` until attr TTL, we can re-introduce the notify asynchronously (`go wfs.fuseServer.InodeNotify(...)`) in a follow-up instead of reverting this fix.

## Test plan

- [x] `go vet ./weed/mount/...`
- [x] `go test ./weed/mount/...`
- [ ] Manual: reproduce the original stuck-mount scenario (hard-link + stat loop) and confirm the mount no longer deadlocks
- [ ] Re-run pjdfstest `link/` suite to confirm no regression in `nlink` visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified file copy and link operation handling by leveraging kernel cache revalidation instead of explicit cache invalidation notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->