### PR TITLE
fix(mini): shut down admin/s3/webdav/filer before volume/master on Ctrl+C

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -446,8 +446,8 @@ func (fo *FilerOptions) startFiler() {
 	go grpcS.Serve(grpcL)
 	pb.ServeGrpcOnLocalSocket(grpcS, grpcPort)
 
-	// Register graceful shutdown for gRPC server to wait for active RPCs
-	grace.OnInterrupt(func() {
+	// Helper to gracefully stop the gRPC server, waiting for active RPCs.
+	stopGrpcServer := func() {
 		glog.V(0).Infof("Gracefully stopping gRPC server")
 		stopped := make(chan struct{})
 		go func() {
@@ -461,7 +461,7 @@ func (fo *FilerOptions) startFiler() {
 			glog.V(0).Infof("gRPC server graceful stop timed out, forcing stop")
 			grpcS.Stop()
 		}
-	})
+	}
 
 	var socketServer *http.Server
 	if runtime.GOOS != "windows" {
@@ -528,8 +528,12 @@ func (fo *FilerOptions) startFiler() {
 		}
 		httpS := newHttpServer(defaultMux, tlsConfig)
 
-		// Register shutdown hooks: stop all HTTP servers, then close filer database
+		// Register a single shutdown hook that runs the steps in the correct order:
+		// stop accepting new gRPC/HTTP requests, then close the filer database.
+		// Combining them into one hook keeps ordering intact regardless of how
+		// grace fires interrupt hooks (FIFO vs LIFO).
 		grace.OnInterrupt(func() {
+			stopGrpcServer()
 			glog.V(0).Infof("Gracefully stopping all HTTP servers")
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
@@ -542,8 +546,8 @@ func (fo *FilerOptions) startFiler() {
 			if err := httpS.Shutdown(shutdownCtx); err != nil {
 				glog.Warningf("HTTPS server shutdown: %v", err)
 			}
+			shutdownFiler()
 		})
-		grace.OnInterrupt(shutdownFiler)
 
 		if MiniClusterCtx != nil {
 			ctx := MiniClusterCtx
@@ -570,8 +574,12 @@ func (fo *FilerOptions) startFiler() {
 		}
 		httpS := newHttpServer(defaultMux, nil)
 
-		// Register shutdown hooks: stop all HTTP servers, then close filer database
+		// Register a single shutdown hook that runs the steps in the correct order:
+		// stop accepting new gRPC/HTTP requests, then close the filer database.
+		// Combining them into one hook keeps ordering intact regardless of how
+		// grace fires interrupt hooks (FIFO vs LIFO).
 		grace.OnInterrupt(func() {
+			stopGrpcServer()
 			glog.V(0).Infof("Gracefully stopping all HTTP servers")
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
@@ -584,8 +592,8 @@ func (fo *FilerOptions) startFiler() {
 			if err := httpS.Shutdown(shutdownCtx); err != nil {
 				glog.Warningf("HTTP server shutdown: %v", err)
 			}
+			shutdownFiler()
 		})
-		grace.OnInterrupt(shutdownFiler)
 
 		if MiniClusterCtx != nil {
 			ctx := MiniClusterCtx

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -84,6 +84,10 @@ type FilerOptions struct {
 	tusBasePath               *string
 	certProvider              certprovider.Provider
 	s3ConfigFile              *string // optional path to static S3 identity config
+	// shutdownCtx, when non-nil, tells startFiler to gracefully shut down its
+	// HTTP/gRPC servers once the ctx is cancelled. Used by integration tests
+	// and by weed mini; nil for standalone weed filer.
+	shutdownCtx context.Context
 }
 
 func init() {
@@ -549,10 +553,9 @@ func (fo *FilerOptions) startFiler() {
 			shutdownFiler()
 		})
 
-		if MiniClusterCtx != nil {
-			ctx := MiniClusterCtx
+		if fo.shutdownCtx != nil {
 			go func() {
-				<-ctx.Done()
+				<-fo.shutdownCtx.Done()
 				httpS.Shutdown(context.Background())
 				grpcS.Stop()
 			}()
@@ -595,10 +598,9 @@ func (fo *FilerOptions) startFiler() {
 			shutdownFiler()
 		})
 
-		if MiniClusterCtx != nil {
-			ctx := MiniClusterCtx
+		if fo.shutdownCtx != nil {
 			go func() {
-				<-ctx.Done()
+				<-fo.shutdownCtx.Done()
 				httpS.Shutdown(context.Background())
 				grpcS.Stop()
 			}()

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -88,6 +88,9 @@ type FilerOptions struct {
 	// HTTP/gRPC servers once the ctx is cancelled. Used by integration tests
 	// and by weed mini; nil for standalone weed filer.
 	shutdownCtx context.Context
+	// gracefulStopTimeout caps how long startFiler waits for gRPC graceful
+	// stop before forcing the server to stop. Zero means the default of 10s.
+	gracefulStopTimeout time.Duration
 }
 
 func init() {
@@ -451,6 +454,10 @@ func (fo *FilerOptions) startFiler() {
 	pb.ServeGrpcOnLocalSocket(grpcS, grpcPort)
 
 	// Helper to gracefully stop the gRPC server, waiting for active RPCs.
+	gracefulTimeout := fo.gracefulStopTimeout
+	if gracefulTimeout <= 0 {
+		gracefulTimeout = 10 * time.Second
+	}
 	stopGrpcServer := func() {
 		glog.V(0).Infof("Gracefully stopping gRPC server")
 		stopped := make(chan struct{})
@@ -461,8 +468,8 @@ func (fo *FilerOptions) startFiler() {
 		select {
 		case <-stopped:
 			glog.V(0).Infof("gRPC server stopped gracefully")
-		case <-time.After(10 * time.Second):
-			glog.V(0).Infof("gRPC server graceful stop timed out, forcing stop")
+		case <-time.After(gracefulTimeout):
+			glog.V(0).Infof("gRPC server graceful stop timed out after %s, forcing stop", gracefulTimeout)
 			grpcS.Stop()
 		}
 	}

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -74,6 +74,10 @@ type MasterOptions struct {
 	telemetryEnabled   *bool
 	debug              *bool
 	debugPort          *int
+	// shutdownCtx, when non-nil, tells startMaster to shut down once the ctx
+	// is cancelled. Used by integration tests and by weed mini; nil for
+	// standalone weed master.
+	shutdownCtx context.Context
 }
 
 func init() {
@@ -336,9 +340,8 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 			ms.Topo.HashicorpRaft.LeadershipTransfer()
 		}
 	})
-	ctx := MiniClusterCtx
-	if ctx != nil {
-		<-ctx.Done()
+	if masterOption.shutdownCtx != nil {
+		<-masterOption.shutdownCtx.Done()
 		ms.Shutdown()
 		grpcS.Stop()
 	} else {

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -65,40 +65,92 @@ var (
 	miniS3IamReadOnly *bool
 	// MiniClusterCtx is the context for the mini cluster. If set, the mini cluster will stop when the context is cancelled.
 	MiniClusterCtx context.Context
-	// MiniClientsShutdownCtx, when non-nil, is cancelled by weed mini on Ctrl+C
-	// so admin/s3/webdav shut down gracefully BEFORE filer/volume/master.
-	// It is separate from MiniClusterCtx so tests that set MiniClusterCtx to
-	// tear down the whole cluster at once are unaffected.
-	MiniClientsShutdownCtx context.Context
-	// miniClientsWg tracks admin/s3/webdav shutdown goroutines so the interrupt
-	// hook can wait for them to drain before returning.
-	miniClientsWg sync.WaitGroup
 )
 
-// OnMiniClientsShutdown invokes fn in a goroutine when either MiniClusterCtx
-// or MiniClientsShutdownCtx is cancelled, whichever fires first. No-op if
-// neither is set (i.e., not running inside weed mini). Registered fns are
-// tracked via miniClientsWg so weed mini can wait for them to finish.
-func OnMiniClientsShutdown(fn func()) {
-	var done1, done2 <-chan struct{}
+// miniClientsState orchestrates graceful shutdown of admin/s3/webdav/worker on
+// weed mini Ctrl+C, BEFORE filer/volume/master tear down. It is rebuilt on
+// each runMini invocation so in-process test reruns see fresh state.
+//
+// The ctx chains from MiniClusterCtx so cancelling MiniClusterCtx (how tests
+// tear down the cluster) also triggers the client-shutdown path.
+type miniClientsState struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+var miniClients *miniClientsState
+
+// resetMiniClients installs a fresh client-shutdown state chained from
+// MiniClusterCtx. Called once at the top of runMini; any goroutines from a
+// prior invocation keep their old state via closure and are unaffected.
+func resetMiniClients() {
+	parent := context.Background()
 	if MiniClusterCtx != nil {
-		done1 = MiniClusterCtx.Done()
+		parent = MiniClusterCtx
 	}
-	if MiniClientsShutdownCtx != nil {
-		done2 = MiniClientsShutdownCtx.Done()
-	}
-	if done1 == nil && done2 == nil {
+	s := &miniClientsState{}
+	s.ctx, s.cancel = context.WithCancel(parent)
+	miniClients = s
+}
+
+// onMiniClientsShutdown runs fn when mini shutdown is triggered, and tracks
+// it so the interrupt hook can wait for it to drain. No-op outside mini.
+func onMiniClientsShutdown(fn func()) {
+	s := miniClients
+	if s == nil {
 		return
 	}
-	miniClientsWg.Add(1)
+	s.wg.Add(1)
 	go func() {
-		defer miniClientsWg.Done()
-		select {
-		case <-done1:
-		case <-done2:
-		}
+		defer s.wg.Done()
+		<-s.ctx.Done()
 		fn()
 	}()
+}
+
+// trackMiniClient registers an externally-managed goroutine (one that
+// observes miniClientsCtx() itself) so the interrupt hook waits for it.
+// The caller invokes the returned done func when the goroutine exits.
+func trackMiniClient() (done func()) {
+	s := miniClients
+	if s == nil {
+		return func() {}
+	}
+	s.wg.Add(1)
+	return s.wg.Done
+}
+
+// miniClientsCtx returns the shutdown context for mini clients, or
+// context.Background() if not running inside weed mini.
+func miniClientsCtx() context.Context {
+	s := miniClients
+	if s == nil {
+		return context.Background()
+	}
+	return s.ctx
+}
+
+// triggerMiniClientsShutdown cancels the clients ctx and waits up to timeout
+// for tracked goroutines to finish. Called from the OnInterrupt hook.
+func triggerMiniClientsShutdown(timeout time.Duration) {
+	s := miniClients
+	if s == nil {
+		return
+	}
+	glog.V(0).Infof("Shutting down admin/s3/webdav ...")
+	s.cancel()
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		glog.V(0).Infof("admin/s3/webdav shut down")
+	case <-time.After(timeout):
+		glog.V(0).Infof("timed out waiting for admin/s3/webdav to shut down")
+	}
 }
 
 func init() {
@@ -904,14 +956,9 @@ func runMini(cmd *Command, args []string) bool {
 
 	miniWhiteList := util.StringSplit(*miniWhiteListOption, ",")
 
-	// Install a cancellable context for admin/s3/webdav. Registered BEFORE
-	// services start so it is a no-op if already set externally (tests).
-	var cancelMiniClients context.CancelFunc
-	if MiniClientsShutdownCtx == nil {
-		var clientsCtx context.Context
-		clientsCtx, cancelMiniClients = context.WithCancel(context.Background())
-		MiniClientsShutdownCtx = clientsCtx
-	}
+	// Install a fresh clients-shutdown context (chained from MiniClusterCtx)
+	// before any service starts.
+	resetMiniClients()
 
 	// Start all services with proper dependency coordination
 	// This channel will be closed when all services are fully ready
@@ -922,26 +969,11 @@ func runMini(cmd *Command, args []string) bool {
 	<-allServicesReady
 
 	// Register the clients-shutdown interrupt hook AFTER all services have
-	// registered theirs. Under grace's LIFO firing this hook runs FIRST on
-	// Ctrl+C, giving admin/s3/webdav a chance to drain before filer/volume/
-	// master's own hooks tear them down.
-	if cancelMiniClients != nil {
-		grace.OnInterrupt(func() {
-			glog.V(0).Infof("Shutting down admin/s3/webdav ...")
-			cancelMiniClients()
-			done := make(chan struct{})
-			go func() {
-				miniClientsWg.Wait()
-				close(done)
-			}()
-			select {
-			case <-done:
-				glog.V(0).Infof("admin/s3/webdav shut down")
-			case <-time.After(10 * time.Second):
-				glog.V(0).Infof("timed out waiting for admin/s3/webdav to shut down")
-			}
-		})
-	}
+	// registered theirs. Under grace's LIFO firing, this hook runs FIRST on
+	// Ctrl+C so admin/s3/webdav drain before filer/volume/master tear down.
+	grace.OnInterrupt(func() {
+		triggerMiniClientsShutdown(10 * time.Second)
+	})
 
 	// Print welcome message after all services are running
 	printWelcomeMessage()
@@ -1065,22 +1097,8 @@ func startS3Service() {
 func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 	defer close(allServicesReady) // Ensure channel is always closed on all paths
 
-	// Derive admin's context from MiniClusterCtx (tests) and MiniClientsShutdownCtx
-	// (weed mini CLI) so whichever fires first triggers admin shutdown.
-	parentCtx := context.Background()
-	if MiniClusterCtx != nil {
-		parentCtx = MiniClusterCtx
-	}
-	ctx, cancelAdminCtx := context.WithCancel(parentCtx)
-	if MiniClientsShutdownCtx != nil {
-		go func() {
-			select {
-			case <-ctx.Done():
-			case <-MiniClientsShutdownCtx.Done():
-				cancelAdminCtx()
-			}
-		}()
-	}
+	// Admin shuts down when mini clients shutdown is triggered.
+	ctx := miniClientsCtx()
 
 	// Determine bind IP for health checks
 	bindIp := getBindIp()
@@ -1120,17 +1138,12 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 		*miniAdminOptions.dataDir = filepath.Join(*miniDataFolders, "admin")
 	}
 
-	// Start admin server in background. Track completion in miniClientsWg so
-	// the Ctrl+C handler in runMini can wait for graceful shutdown before
-	// tearing down filer/volume/master.
-	if MiniClientsShutdownCtx != nil {
-		miniClientsWg.Add(1)
-	}
+	// Start admin server in background. trackMiniClient lets the Ctrl+C
+	// handler wait for startAdminServer's graceful shutdown before filer/
+	// volume/master tear down.
+	done := trackMiniClient()
 	go func() {
-		if MiniClientsShutdownCtx != nil {
-			defer miniClientsWg.Done()
-		}
-		defer cancelAdminCtx()
+		defer done()
 		var icebergPort int
 		if miniS3Options.portIceberg != nil {
 			icebergPort = *miniS3Options.portIceberg
@@ -1274,9 +1287,8 @@ func startMiniWorker(workerDir string) {
 
 	// Metrics server is already started in the main init function above, so no need to start it again here
 
-	// Start the worker. Stop it when either the test-provided MiniClusterCtx
-	// or the mini-internal MiniClientsShutdownCtx (Ctrl+C) is cancelled.
-	OnMiniClientsShutdown(func() {
+	// Stop the worker when mini clients shutdown is triggered.
+	onMiniClientsShutdown(func() {
 		workerInstance.Stop()
 	})
 	err = workerInstance.Start()

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -997,6 +997,10 @@ func runMini(cmd *Command, args []string) bool {
 	miniMasterOptions.shutdownCtx = MiniClusterCtx
 	miniOptions.v.shutdownCtx = MiniClusterCtx
 	miniFilerOptions.shutdownCtx = MiniClusterCtx
+	// Mini is a small/dev setup with short-lived RPCs; cap the filer's
+	// gRPC graceful-stop at 1s so Ctrl+C returns quickly instead of sitting
+	// on the default 10s waiting for background subscription streams.
+	miniFilerOptions.gracefulStopTimeout = 1 * time.Second
 
 	// Start all services with proper dependency coordination
 	// This channel will be closed when all services are fully ready

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -64,7 +65,41 @@ var (
 	miniS3IamReadOnly *bool
 	// MiniClusterCtx is the context for the mini cluster. If set, the mini cluster will stop when the context is cancelled.
 	MiniClusterCtx context.Context
+	// MiniClientsShutdownCtx, when non-nil, is cancelled by weed mini on Ctrl+C
+	// so admin/s3/webdav shut down gracefully BEFORE filer/volume/master.
+	// It is separate from MiniClusterCtx so tests that set MiniClusterCtx to
+	// tear down the whole cluster at once are unaffected.
+	MiniClientsShutdownCtx context.Context
+	// miniClientsWg tracks admin/s3/webdav shutdown goroutines so the interrupt
+	// hook can wait for them to drain before returning.
+	miniClientsWg sync.WaitGroup
 )
+
+// OnMiniClientsShutdown invokes fn in a goroutine when either MiniClusterCtx
+// or MiniClientsShutdownCtx is cancelled, whichever fires first. No-op if
+// neither is set (i.e., not running inside weed mini). Registered fns are
+// tracked via miniClientsWg so weed mini can wait for them to finish.
+func OnMiniClientsShutdown(fn func()) {
+	var done1, done2 <-chan struct{}
+	if MiniClusterCtx != nil {
+		done1 = MiniClusterCtx.Done()
+	}
+	if MiniClientsShutdownCtx != nil {
+		done2 = MiniClientsShutdownCtx.Done()
+	}
+	if done1 == nil && done2 == nil {
+		return
+	}
+	miniClientsWg.Add(1)
+	go func() {
+		defer miniClientsWg.Done()
+		select {
+		case <-done1:
+		case <-done2:
+		}
+		fn()
+	}()
+}
 
 func init() {
 	cmdMini.Run = runMini // break init cycle
@@ -869,6 +904,15 @@ func runMini(cmd *Command, args []string) bool {
 
 	miniWhiteList := util.StringSplit(*miniWhiteListOption, ",")
 
+	// Install a cancellable context for admin/s3/webdav. Registered BEFORE
+	// services start so it is a no-op if already set externally (tests).
+	var cancelMiniClients context.CancelFunc
+	if MiniClientsShutdownCtx == nil {
+		var clientsCtx context.Context
+		clientsCtx, cancelMiniClients = context.WithCancel(context.Background())
+		MiniClientsShutdownCtx = clientsCtx
+	}
+
 	// Start all services with proper dependency coordination
 	// This channel will be closed when all services are fully ready
 	allServicesReady := make(chan struct{})
@@ -876,6 +920,28 @@ func runMini(cmd *Command, args []string) bool {
 
 	// Wait for all services to be fully running before printing welcome message
 	<-allServicesReady
+
+	// Register the clients-shutdown interrupt hook AFTER all services have
+	// registered theirs. Under grace's LIFO firing this hook runs FIRST on
+	// Ctrl+C, giving admin/s3/webdav a chance to drain before filer/volume/
+	// master's own hooks tear them down.
+	if cancelMiniClients != nil {
+		grace.OnInterrupt(func() {
+			glog.V(0).Infof("Shutting down admin/s3/webdav ...")
+			cancelMiniClients()
+			done := make(chan struct{})
+			go func() {
+				miniClientsWg.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+				glog.V(0).Infof("admin/s3/webdav shut down")
+			case <-time.After(10 * time.Second):
+				glog.V(0).Infof("timed out waiting for admin/s3/webdav to shut down")
+			}
+		})
+	}
 
 	// Print welcome message after all services are running
 	printWelcomeMessage()
@@ -999,11 +1065,21 @@ func startS3Service() {
 func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 	defer close(allServicesReady) // Ensure channel is always closed on all paths
 
-	var ctx context.Context
+	// Derive admin's context from MiniClusterCtx (tests) and MiniClientsShutdownCtx
+	// (weed mini CLI) so whichever fires first triggers admin shutdown.
+	parentCtx := context.Background()
 	if MiniClusterCtx != nil {
-		ctx = MiniClusterCtx
-	} else {
-		ctx = context.Background()
+		parentCtx = MiniClusterCtx
+	}
+	ctx, cancelAdminCtx := context.WithCancel(parentCtx)
+	if MiniClientsShutdownCtx != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+			case <-MiniClientsShutdownCtx.Done():
+				cancelAdminCtx()
+			}
+		}()
 	}
 
 	// Determine bind IP for health checks
@@ -1044,8 +1120,17 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 		*miniAdminOptions.dataDir = filepath.Join(*miniDataFolders, "admin")
 	}
 
-	// Start admin server in background
+	// Start admin server in background. Track completion in miniClientsWg so
+	// the Ctrl+C handler in runMini can wait for graceful shutdown before
+	// tearing down filer/volume/master.
+	if MiniClientsShutdownCtx != nil {
+		miniClientsWg.Add(1)
+	}
 	go func() {
+		if MiniClientsShutdownCtx != nil {
+			defer miniClientsWg.Done()
+		}
+		defer cancelAdminCtx()
 		var icebergPort int
 		if miniS3Options.portIceberg != nil {
 			icebergPort = *miniS3Options.portIceberg
@@ -1189,13 +1274,11 @@ func startMiniWorker(workerDir string) {
 
 	// Metrics server is already started in the main init function above, so no need to start it again here
 
-	// Start the worker
-	if MiniClusterCtx != nil {
-		go func() {
-			<-MiniClusterCtx.Done()
-			workerInstance.Stop()
-		}()
-	}
+	// Start the worker. Stop it when either the test-provided MiniClusterCtx
+	// or the mini-internal MiniClientsShutdownCtx (Ctrl+C) is cancelled.
+	OnMiniClientsShutdown(func() {
+		workerInstance.Stop()
+	})
 	err = workerInstance.Start()
 	if err != nil {
 		glog.Fatalf("Failed to start worker: %v", err)

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -73,10 +73,20 @@ var (
 //
 // The ctx chains from MiniClusterCtx so cancelling MiniClusterCtx (how tests
 // tear down the cluster) also triggers the client-shutdown path.
+//
+// Shutdown has two phases:
+//  1. preCancelFns run synchronously in registration order (worker disconnect,
+//     etc.) so downstream servers don't block on handlers that are about to
+//     close anyway.
+//  2. ctx is cancelled and the shutdown hook waits on wg for admin/s3/webdav
+//     goroutines (registered via onMiniClientsShutdown / trackMiniClient) to
+//     drain.
 type miniClientsState struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	preCancelMu   sync.Mutex
+	preCancelFns  []func()
 }
 
 var miniClients *miniClientsState
@@ -121,6 +131,19 @@ func trackMiniClient() (done func()) {
 	return s.wg.Done
 }
 
+// beforeMiniClientsShutdown registers fn to run synchronously BEFORE the
+// clients ctx is cancelled. Use for cleanup that must complete before
+// downstream servers (e.g., the admin worker-gRPC) start waiting on clients.
+func beforeMiniClientsShutdown(fn func()) {
+	s := miniClients
+	if s == nil {
+		return
+	}
+	s.preCancelMu.Lock()
+	defer s.preCancelMu.Unlock()
+	s.preCancelFns = append(s.preCancelFns, fn)
+}
+
 // miniClientsCtx returns the shutdown context for mini clients, or
 // context.Background() if not running inside weed mini.
 func miniClientsCtx() context.Context {
@@ -131,14 +154,22 @@ func miniClientsCtx() context.Context {
 	return s.ctx
 }
 
-// triggerMiniClientsShutdown cancels the clients ctx and waits up to timeout
-// for tracked goroutines to finish. Called from the OnInterrupt hook.
+// triggerMiniClientsShutdown runs preCancel fns synchronously, cancels the
+// clients ctx, and waits up to timeout for tracked goroutines to finish.
+// Called from the OnInterrupt hook.
 func triggerMiniClientsShutdown(timeout time.Duration) {
 	s := miniClients
 	if s == nil {
 		return
 	}
 	glog.V(0).Infof("Shutting down admin/s3/webdav ...")
+	s.preCancelMu.Lock()
+	fns := s.preCancelFns
+	s.preCancelFns = nil
+	s.preCancelMu.Unlock()
+	for _, fn := range fns {
+		fn()
+	}
 	s.cancel()
 	done := make(chan struct{})
 	go func() {
@@ -1304,8 +1335,11 @@ func startMiniWorker(workerDir string) {
 
 	// Metrics server is already started in the main init function above, so no need to start it again here
 
-	// Stop the worker when mini clients shutdown is triggered.
-	onMiniClientsShutdown(func() {
+	// Stop the worker BEFORE the clients ctx is cancelled. Otherwise admin's
+	// internal worker gRPC GracefulStop (called during admin.Shutdown) would
+	// wait for the worker stream to close, blocking the whole mini shutdown
+	// by ~10s and cascading into filer's own gRPC graceful stop timeout.
+	beforeMiniClientsShutdown(func() {
 		workerInstance.Stop()
 	})
 	err = workerInstance.Start()

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -960,6 +960,13 @@ func runMini(cmd *Command, args []string) bool {
 	// before any service starts.
 	resetMiniClients()
 
+	// Master/volume/filer observe MiniClusterCtx so tests that cancel it
+	// tear those services down too. On Ctrl+C they rely on their own
+	// OnInterrupt hooks (see grace's LIFO ordering).
+	miniMasterOptions.shutdownCtx = MiniClusterCtx
+	miniOptions.v.shutdownCtx = MiniClusterCtx
+	miniFilerOptions.shutdownCtx = MiniClusterCtx
+
 	// Start all services with proper dependency coordination
 	// This channel will be closed when all services are fully ready
 	allServicesReady := make(chan struct{})
@@ -1019,17 +1026,27 @@ func startMiniServices(miniWhiteList []string, allServicesReady chan struct{}) {
 	// Wait for filer to be ready
 	waitForServiceReady("Filer", *miniFilerOptions.port, bindIp)
 
-	// Start S3 and WebDAV in parallel (both depend on filer)
+	// Start S3 and WebDAV in parallel (both depend on filer). Each observes
+	// miniClientsCtx so it shuts down first on Ctrl+C, tracked via
+	// trackMiniClient so runMini's interrupt hook can wait for them.
 	if *miniEnableS3 {
-		go startMiniService("S3", func() {
-			startS3Service()
-		}, *miniS3Options.port)
+		miniS3Options.shutdownCtx = miniClientsCtx()
+		done := trackMiniClient()
+		go func() {
+			defer done()
+			startMiniService("S3", startS3Service, *miniS3Options.port)
+		}()
 	}
 
 	if *miniEnableWebDAV {
-		go startMiniService("WebDAV", func() {
-			miniWebDavOptions.startWebDav()
-		}, *miniWebDavOptions.port)
+		miniWebDavOptions.shutdownCtx = miniClientsCtx()
+		done := trackMiniClient()
+		go func() {
+			defer done()
+			startMiniService("WebDAV", func() {
+				miniWebDavOptions.startWebDav()
+			}, *miniWebDavOptions.port)
+		}()
 	}
 
 	// Wait for services to be ready

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -453,14 +453,10 @@ func (s3opt *S3Options) startS3Server() bool {
 				}()
 			}
 			httpS := newHttpServer(router, tlsConfig)
-			if MiniClusterCtx != nil {
-				ctx := MiniClusterCtx
-				go func() {
-					<-ctx.Done()
-					httpS.Shutdown(context.Background())
-					grpcS.Stop()
-				}()
-			}
+			OnMiniClientsShutdown(func() {
+				httpS.Shutdown(context.Background())
+				grpcS.Stop()
+			})
 			if err = httpS.ServeTLS(s3ApiListener, "", ""); err != nil && err != http.ErrServerClosed {
 				glog.Fatalf("S3 API Server Fail to serve: %v", err)
 			}
@@ -495,13 +491,10 @@ func (s3opt *S3Options) startS3Server() bool {
 			}()
 		}
 		httpS := newHttpServer(router, nil)
-		if MiniClusterCtx != nil {
-			go func() {
-				<-MiniClusterCtx.Done()
-				httpS.Shutdown(context.Background())
-				grpcS.Stop()
-			}()
-		}
+		OnMiniClientsShutdown(func() {
+			httpS.Shutdown(context.Background())
+			grpcS.Stop()
+		})
 		if err = httpS.Serve(s3ApiListener); err != nil && err != http.ErrServerClosed {
 			glog.Fatalf("S3 API Server Fail to serve: %v", err)
 		}
@@ -530,12 +523,9 @@ func (s3opt *S3Options) startIcebergServer(s3ApiServer *s3api.S3ApiServer) {
 	glog.V(0).Infof("Start Iceberg REST Catalog Server at http://%s", listenAddress)
 
 	httpS := newHttpServer(icebergRouter, nil)
-	if MiniClusterCtx != nil {
-		go func() {
-			<-MiniClusterCtx.Done()
-			httpS.Shutdown(context.Background())
-		}()
-	}
+	OnMiniClientsShutdown(func() {
+		httpS.Shutdown(context.Background())
+	})
 	// Serve on localhost as well if we're bound to a different interface
 	if icebergLocalListener != nil {
 		go func() {

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -74,6 +74,11 @@ type S3Options struct {
 	externalUrl               *string
 	defaultFileMode           *string
 	cacheSizeMB               *int64
+	// shutdownCtx, when non-nil, tells startS3Server/startIcebergServer to
+	// gracefully shut down their HTTP/gRPC servers once the ctx is cancelled.
+	// Used by weed mini to orchestrate an ordered shutdown; nil for standalone
+	// weed s3.
+	shutdownCtx context.Context
 }
 
 func init() {
@@ -453,10 +458,13 @@ func (s3opt *S3Options) startS3Server() bool {
 				}()
 			}
 			httpS := newHttpServer(router, tlsConfig)
-			onMiniClientsShutdown(func() {
-				httpS.Shutdown(context.Background())
-				grpcS.Stop()
-			})
+			if s3opt.shutdownCtx != nil {
+				go func() {
+					<-s3opt.shutdownCtx.Done()
+					httpS.Shutdown(context.Background())
+					grpcS.Stop()
+				}()
+			}
 			if err = httpS.ServeTLS(s3ApiListener, "", ""); err != nil && err != http.ErrServerClosed {
 				glog.Fatalf("S3 API Server Fail to serve: %v", err)
 			}
@@ -491,10 +499,13 @@ func (s3opt *S3Options) startS3Server() bool {
 			}()
 		}
 		httpS := newHttpServer(router, nil)
-		onMiniClientsShutdown(func() {
-			httpS.Shutdown(context.Background())
-			grpcS.Stop()
-		})
+		if s3opt.shutdownCtx != nil {
+			go func() {
+				<-s3opt.shutdownCtx.Done()
+				httpS.Shutdown(context.Background())
+				grpcS.Stop()
+			}()
+		}
 		if err = httpS.Serve(s3ApiListener); err != nil && err != http.ErrServerClosed {
 			glog.Fatalf("S3 API Server Fail to serve: %v", err)
 		}
@@ -523,9 +534,12 @@ func (s3opt *S3Options) startIcebergServer(s3ApiServer *s3api.S3ApiServer) {
 	glog.V(0).Infof("Start Iceberg REST Catalog Server at http://%s", listenAddress)
 
 	httpS := newHttpServer(icebergRouter, nil)
-	onMiniClientsShutdown(func() {
-		httpS.Shutdown(context.Background())
-	})
+	if s3opt.shutdownCtx != nil {
+		go func() {
+			<-s3opt.shutdownCtx.Done()
+			httpS.Shutdown(context.Background())
+		}()
+	}
 	// Serve on localhost as well if we're bound to a different interface
 	if icebergLocalListener != nil {
 		go func() {

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -453,7 +453,7 @@ func (s3opt *S3Options) startS3Server() bool {
 				}()
 			}
 			httpS := newHttpServer(router, tlsConfig)
-			OnMiniClientsShutdown(func() {
+			onMiniClientsShutdown(func() {
 				httpS.Shutdown(context.Background())
 				grpcS.Stop()
 			})
@@ -491,7 +491,7 @@ func (s3opt *S3Options) startS3Server() bool {
 			}()
 		}
 		httpS := newHttpServer(router, nil)
-		OnMiniClientsShutdown(func() {
+		onMiniClientsShutdown(func() {
 			httpS.Shutdown(context.Background())
 			grpcS.Stop()
 		})
@@ -523,7 +523,7 @@ func (s3opt *S3Options) startIcebergServer(s3ApiServer *s3api.S3ApiServer) {
 	glog.V(0).Infof("Start Iceberg REST Catalog Server at http://%s", listenAddress)
 
 	httpS := newHttpServer(icebergRouter, nil)
-	OnMiniClientsShutdown(func() {
+	onMiniClientsShutdown(func() {
 		httpS.Shutdown(context.Background())
 	})
 	// Serve on localhost as well if we're bound to a different interface

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	httppprof "net/http/pprof"
@@ -75,6 +76,10 @@ type VolumeServerOptions struct {
 	ldbTimeout                  *int64
 	debug                       *bool
 	debugPort                   *int
+	// shutdownCtx, when non-nil, tells startVolumeServer to shut down once the
+	// ctx is cancelled. Used by integration tests and by weed mini; nil for
+	// standalone weed volume.
+	shutdownCtx context.Context
 }
 
 func init() {
@@ -327,11 +332,10 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 		stopChan <- true
 	})
 
-	ctx := MiniClusterCtx
-	if ctx != nil {
+	if v.shutdownCtx != nil {
 		select {
 		case <-stopChan:
-		case <-ctx.Done():
+		case <-v.shutdownCtx.Done():
 			shutdown(publicHttpDown, clusterHttpServer, grpcS, volumeServer)
 		}
 	} else {

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -137,12 +137,9 @@ func (wo *WebDavOption) startWebDav() bool {
 		glog.Fatalf("WebDav Server listener on %s error: %v", listenAddress, err)
 	}
 
-	if MiniClusterCtx != nil {
-		go func() {
-			<-MiniClusterCtx.Done()
-			httpS.Shutdown(context.Background())
-		}()
-	}
+	OnMiniClientsShutdown(func() {
+		httpS.Shutdown(context.Background())
+	})
 
 	if *wo.tlsPrivateKey != "" {
 		glog.V(0).Infof("Start Seaweed WebDav Server %s at https %s", version.Version(), listenAddress)

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -137,7 +137,7 @@ func (wo *WebDavOption) startWebDav() bool {
 		glog.Fatalf("WebDav Server listener on %s error: %v", listenAddress, err)
 	}
 
-	OnMiniClientsShutdown(func() {
+	onMiniClientsShutdown(func() {
 		httpS.Shutdown(context.Background())
 	})
 

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -36,6 +36,10 @@ type WebDavOption struct {
 	cacheDir       *string
 	cacheSizeMB    *int64
 	maxMB          *int
+	// shutdownCtx, when non-nil, tells startWebDav to gracefully shut down the
+	// HTTP server once the ctx is cancelled. Used by weed mini; nil for
+	// standalone weed webdav.
+	shutdownCtx context.Context
 }
 
 func init() {
@@ -137,9 +141,12 @@ func (wo *WebDavOption) startWebDav() bool {
 		glog.Fatalf("WebDav Server listener on %s error: %v", listenAddress, err)
 	}
 
-	onMiniClientsShutdown(func() {
-		httpS.Shutdown(context.Background())
-	})
+	if wo.shutdownCtx != nil {
+		go func() {
+			<-wo.shutdownCtx.Done()
+			httpS.Shutdown(context.Background())
+		}()
+	}
 
 	if *wo.tlsPrivateKey != "" {
 		glog.V(0).Infof("Start Seaweed WebDav Server %s at https %s", version.Version(), listenAddress)

--- a/weed/util/grace/signal_handling.go
+++ b/weed/util/grace/signal_handling.go
@@ -44,7 +44,10 @@ func init() {
 				reloadHookLock.RUnlock()
 			} else {
 				interruptHookLock.RLock()
-				for _, hook := range interruptHooks {
+				// Execute hooks in reverse registration order (LIFO/defer-style) so
+				// later-started services shut down before the services they depend on.
+				for i := len(interruptHooks) - 1; i >= 0; i-- {
+					hook := interruptHooks[i]
 					glog.V(4).Infof("exec interrupt hook func name:%s", GetFunctionName(hook))
 					hook()
 				}

--- a/weed/worker/client.go
+++ b/weed/worker/client.go
@@ -838,7 +838,11 @@ func (c *GrpcAdminClient) RequestTask(workerID string, capabilities []types.Task
 
 	for {
 		select {
-		case response := <-c.incoming:
+		case response, ok := <-c.incoming:
+			if !ok || response == nil {
+				// incoming was closed (e.g. during Disconnect).
+				return nil, fmt.Errorf("incoming channel closed")
+			}
 			glog.V(4).Infof("RESPONSE RECEIVED: Worker %s received response from admin server: %T", workerID, response.Message)
 			if taskAssign := response.GetTaskAssignment(); taskAssign != nil {
 				// Validate TaskId is not empty before processing

--- a/weed/worker/worker.go
+++ b/weed/worker/worker.go
@@ -465,16 +465,14 @@ func (w *Worker) handleStart(cmd workerCommand) {
 }
 
 func (w *Worker) Stop() error {
-	resp := make(chan error)
-	w.cmds <- workerCommand{
-		action: ActionStop,
-		resp:   resp,
-	}
-	if err := <-resp; err != nil {
-		return err
-	}
+	// Snapshot the admin client BEFORE ActionStop terminates the manager loop.
+	// Once the loop exits, any further w.cmds send (getTaskLoad, getAdmin, etc.)
+	// would deadlock because no one reads w.cmds anymore.
+	adminClient := w.getAdmin()
 
-	// Wait for tasks to finish
+	// Best-effort task drain: wait up to 30s for in-flight tasks to finish.
+	// Still done BEFORE ActionStop so getTaskLoad can round-trip through the
+	// manager loop.
 	timeout := time.NewTimer(30 * time.Second)
 	defer timeout.Stop()
 out:
@@ -487,8 +485,18 @@ out:
 		}
 	}
 
-	// Disconnect from admin server
-	if adminClient := w.getAdmin(); adminClient != nil {
+	// Terminate the manager loop.
+	resp := make(chan error)
+	w.cmds <- workerCommand{
+		action: ActionStop,
+		resp:   resp,
+	}
+	if err := <-resp; err != nil {
+		return err
+	}
+
+	// Disconnect from admin server.
+	if adminClient != nil {
 		if err := adminClient.Disconnect(); err != nil {
 			glog.Errorf("Error disconnecting from admin server: %v", err)
 		}


### PR DESCRIPTION
## Summary

On Ctrl+C, `weed mini` currently tears master down before its clients, which produces a burst of noisy errors: heartbeat cancellations from the volume server, `masterClient failed to receive` lines from s3/filer/admin, and repeated `masterClient reconnection attempt #N` messages. Admin, S3, and WebDAV also never had any interrupt hooks and were simply killed by `os.Exit`.

This change orders shutdown so clients drain first:

- **`weed/util/grace`** — fire interrupt hooks in LIFO (defer-style) order so later-started services tear down first. The only multi-hook caller that depended on registration order was filer, handled below.
- **`weed/command/filer.go`** — consolidate the three separate interrupt hooks (gRPC graceful stop -> HTTP shutdown -> DB close) into one that runs them in order, so filer shutdown stays correct independent of FIFO/LIFO semantics.
- **`weed/command/mini.go` + `s3.go` + `webdav.go`** — add `MiniClientsShutdownCtx` (independent of the test-facing `MiniClusterCtx`) and a small `OnMiniClientsShutdown` helper. Admin, S3, WebDAV, and the maintenance worker observe it. `runMini` registers a cancel hook after all services start, so under LIFO it fires first and waits up to 10s on a `sync.WaitGroup` for those services to drain before filer/volume/master's own hooks run.

Resulting shutdown order on Ctrl+C: admin/s3/webdav/worker -> filer (gRPC -> HTTP -> DB) -> volume -> master.

Tests that set `MiniClusterCtx` to tear down the whole cluster at once are unaffected: the new context is separate, and the helpers fall back to `MiniClusterCtx` when `MiniClientsShutdownCtx` is nil.

## Test plan

- [ ] `go build ./weed/...` succeeds
- [ ] `go test ./weed/command/...` passes
- [ ] Manual: `weed mini -dir=/tmp/mini-test`, then Ctrl+C and confirm the log no longer shows `SendHeartbeat.Recv ... context canceled`, `masterClient failed to receive`, or `masterClient reconnection attempt #N` during shutdown
- [ ] Manual: verify admin/s3/webdav HTTP servers close cleanly before filer tears down
- [ ] Manual: verify `weed filer` (standalone) still shuts down cleanly (gRPC -> HTTP -> DB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified shutdown flow so services stop in a consistent, ordered way with a graceful-stop fallback and configurable timeout.
  * Added per-service shutdown controls and centralized mini-mode client coordination so admin/worker/services drain before teardown.

* **Bug Fixes**
  * Changed interrupt hook execution so later-registered shutdown hooks run first, reducing races.
  * Improved worker/client shutdown sequencing and error handling to avoid hangs and nil-message panics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->