### PR TITLE
fix(weed/query/engine): check for nil pointers

### DIFF
--- a/weed/query/engine/hybrid_message_scanner.go
+++ b/weed/query/engine/hybrid_message_scanner.go
@@ -1156,6 +1156,12 @@ func (h *HybridMessageScanner) ReadParquetStatistics(partitionPath string) ([]*P
 
 // extractParquetFileStats extracts column statistics from a single parquet file
 func (h *HybridMessageScanner) extractParquetFileStats(entry *filer_pb.Entry, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunkCache *chunk_cache.ChunkCacheInMemory) (*ParquetFileStats, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("cannot operate on nil entry")
+	}
+	if chunkCache == nil {
+		return nil, fmt.Errorf("cannot operate on nil chunkCache")
+	}
 	// Create reader for the parquet file
 	fileSize := filer.FileSize(entry)
 	visibleIntervals, _ := filer.NonOverlappingVisibleIntervals(context.Background(), lookupFileIdFn, entry.Chunks, 0, int64(fileSize))


### PR DESCRIPTION
`(HybridMessageScanner).extractParquetFileStats()` has two different arguments that are pointers. This checks both at the beginning of the function to prevent panics.

The unit tests in `weed/query/engine` continue to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query engine stability with enhanced validation to prevent crashes when processing certain query conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->