### PR TITLE
fix(volume): tolerate v4 off-by-one in startup structural .idx check

### DIFF
--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -248,9 +248,15 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// disk I/O. A violation marks the volume read-only so a corrupt
 		// .idx left over from a crashed batched write does not silently
 		// power vacuum to drop reachable data. See issue #8928.
+		//
+		// Allow a single needle-padding cycle (NeedlePaddingSize) of slack
+		// to match the v4→v3 compaction off-by-one tolerance in
+		// readNeedleTail / ReadBytes: that bug can inflate MaximumNeedleEnd
+		// by up to one alignment unit per affected entry. Real corruption
+		// (issue #8928) overshoots by megabytes, not bytes.
 		if !v.HasRemoteFile() && v.nm != nil && v.DataBackend != nil {
 			if datSize, _, statErr := v.DataBackend.GetStat(); statErr == nil && datSize > 0 {
-				if maxEnd := v.nm.MaxNeedleEnd(); maxEnd > datSize {
+				if maxEnd := v.nm.MaxNeedleEnd(); maxEnd > datSize+int64(types.NeedlePaddingSize) {
 					v.noWriteOrDelete = true
 					glog.V(0).Infof("volume %d: idx references end=%d but .dat is %d bytes; marking readonly",
 						v.Id, maxEnd, datSize)


### PR DESCRIPTION
## Summary

Follow-up to #9115. The integrated `MaxNeedleEnd` check at volume load fires whenever the `.idx` claims `(offset + actual size)` past the `.dat` end. Enterprise has a v4→v3 compaction bug papered over by an off-by-one tolerance in `readNeedleTail` / `ReadBytes` that can inflate `MaxNeedleEnd` by up to one needle padding cycle (8 bytes) — small enough to be a known recoverable case, but enough to trip the structural check and mark affected volumes read-only.

Allow `NeedlePaddingSize` bytes of slack so the structural check matches the existing tolerance. Real corruption from #8928 overshoots by megabytes, not bytes, so the check still catches it.

## Test plan

- [x] `go test ./weed/storage/...` — green
- [x] Confirmed downstream enterprise tests (`TestOffByOneToleranceVolumeReload`) pass with the same change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined volume loading structural validation with adjusted tolerance thresholds to prevent unnecessary read-only status assignment while maintaining data integrity during storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->