### PR TITLE
ci(kafka-loadtest): switch off Ubuntu/Debian base images to avoid apt mirror flakes

### DIFF
--- a/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
@@ -21,14 +21,18 @@ FROM ubuntu:22.04
 
 # Install runtime dependencies. Acquire::Retries + Timeout survive transient
 # Ubuntu apt-mirror flakes that otherwise turn into outright build failures
-# in CI (matches the pattern PR #9106 used for pjdfstest).
+# in CI. --no-install-recommends / --no-install-suggests keep the image
+# small and the attack surface narrow (matches PR #9106's pjdfstest pattern).
 RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
     && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
+    --no-install-recommends \
+    --no-install-suggests \
     ca-certificates \
     curl \
     jq \
     bash \
     netcat \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy built binary from builder stage

--- a/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
@@ -19,8 +19,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /kafka-loadtest ./cmd/loadtest
 # Stage 2: Runtime
 FROM ubuntu:22.04
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+# Install runtime dependencies. Acquire::Retries + Timeout survive transient
+# Ubuntu apt-mirror flakes that otherwise turn into outright build failures
+# in CI (matches the pattern PR #9106 used for pjdfstest).
+RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
     ca-certificates \
     curl \
     jq \

--- a/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
@@ -17,23 +17,18 @@ COPY test/kafka/kafka-client-loadtest/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /kafka-loadtest ./cmd/loadtest
 
 # Stage 2: Runtime
-FROM ubuntu:22.04
+# Use alpine so we don't depend on Ubuntu apt mirrors, which intermittently
+# refuse connections from GitHub Actions runners and fail the CI build.
+# All runtime dependencies we need (ca-certificates, curl, jq, bash, nc)
+# are in the Alpine main repo.
+FROM alpine:3.20
 
-# Install runtime dependencies. Acquire::Retries + Timeout survive transient
-# Ubuntu apt-mirror flakes that otherwise turn into outright build failures
-# in CI. --no-install-recommends / --no-install-suggests keep the image
-# small and the attack surface narrow (matches PR #9106's pjdfstest pattern).
-RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
-    --no-install-recommends \
-    --no-install-suggests \
+RUN apk add --no-cache \
     ca-certificates \
     curl \
     jq \
     bash \
-    netcat \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    netcat-openbsd
 
 # Copy built binary from builder stage
 COPY --from=builder /kafka-loadtest /usr/local/bin/kafka-loadtest

--- a/test/kafka/kafka-client-loadtest/Dockerfile.seektest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.seektest
@@ -1,7 +1,10 @@
 FROM openjdk:11-jdk-slim
 
-# Install Maven
-RUN apt-get update && apt-get install -y maven && rm -rf /var/lib/apt/lists/*
+# Install Maven. Acquire::Retries + Timeout survive transient apt-mirror
+# flakes (matches the pattern PR #9106 used for pjdfstest).
+RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y maven \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/test/kafka/kafka-client-loadtest/Dockerfile.seektest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.seektest
@@ -1,9 +1,14 @@
 FROM openjdk:11-jdk-slim
 
 # Install Maven. Acquire::Retries + Timeout survive transient apt-mirror
-# flakes (matches the pattern PR #9106 used for pjdfstest).
+# flakes; --no-install-recommends / --no-install-suggests keep the image
+# small (matches PR #9106's pjdfstest pattern).
 RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y maven \
+    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
+    --no-install-recommends \
+    --no-install-suggests \
+    maven \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/test/kafka/kafka-client-loadtest/Dockerfile.seektest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.seektest
@@ -1,15 +1,8 @@
-FROM openjdk:11-jdk-slim
-
-# Install Maven. Acquire::Retries + Timeout survive transient apt-mirror
-# flakes; --no-install-recommends / --no-install-suggests keep the image
-# small (matches PR #9106's pjdfstest pattern).
-RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
-    --no-install-recommends \
-    --no-install-suggests \
-    maven \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Use the official Eclipse Temurin + Maven image so we don't depend on
+# Debian apt mirrors, which intermittently refuse connections from
+# GitHub Actions runners and fail the CI build. This image already has
+# JDK 11 and Maven installed.
+FROM maven:3.9-eclipse-temurin-11
 
 WORKDIR /app
 


### PR DESCRIPTION
# What problem are we solving?

The \`Kafka Quick Test (Load Test with Schema Registry)\` workflow on master keeps failing because the Docker build of \`Dockerfile.loadtest\` cannot reach the Ubuntu apt mirrors from the GitHub runner. Example from run [24551809614](https://github.com/seaweedfs/seaweedfs/actions/runs/24551809614/job/71779107178):

\`\`\`
#11 130.8   Connection failed [IP: 185.125.190.83 80]
#11 131.6 W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease
  Connection failed [IP: 185.125.190.83 80]
#11 ERROR: process \"/bin/sh -c apt-get ... install -y ... ca-certificates curl jq bash netcat ...\"
  did not complete successfully: exit code: 100
\`\`\`

Two custom images in \`test/kafka/kafka-client-loadtest/\` depend on apt:
- \`Dockerfile.loadtest\` — \`ubuntu:22.04\` + \`apt-get install ca-certificates curl jq bash netcat\`
- \`Dockerfile.seektest\` — \`openjdk:11-jdk-slim\` (Debian) + \`apt-get install maven\`

The first earlier attempt in this PR added \`Acquire::Retries=5 -o Acquire::http::Timeout=30 \` (mirroring #9106). That's not enough when the mirror is unreachable for minutes — the configured retries are consumed and the build still fails.

# How are we solving the problem?

Drop the Ubuntu/Debian dependency entirely:

- \`Dockerfile.loadtest\`: switch stage-2 runtime from \`ubuntu:22.04\` to \`alpine:3.20\`. All the runtime deps we need (\`ca-certificates\`, \`curl\`, \`jq\`, \`bash\`, \`netcat-openbsd\`) are in the Alpine main repo, fetched from Alpine's CDN rather than the Ubuntu archive.
- \`Dockerfile.seektest\`: switch from \`openjdk:11-jdk-slim\` + \`apt-get install maven\` to the official \`maven:3.9-eclipse-temurin-11\` image, which ships JDK 11 + Maven preinstalled. No apt call at all.

With no apt-get in either Dockerfile, the apt-related knobs (\`Acquire::Retries\`, \`DEBIAN_FRONTEND\`, \`apt-get clean\`, \`--no-install-recommends\`) become dead weight and are removed alongside the apt call they were configuring.

# How is the PR tested?

- Both Dockerfiles build locally against the new base images.
- The \`Kafka Quick Test\` workflow runs automatically on every push to this branch; once green it confirms the fix in CI.

# Checks
- [x] I have added unit tests if possible. (n/a — Dockerfile-only change)
- [ ] I will add related wiki document changes and link to this PR after merging.

Refs #9106 (apt-retry precedent — this PR abandons that approach for these particular images because the mirror outage outlasts any reasonable retry budget).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test container bases and package installation approach for load and seek test images to streamline builds.
  * Result: more consistent, smaller test images and simpler build steps, reducing transient failures and maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->