### PR TITLE
fix(s3): strip client-supplied X-SeaweedFS-Principal/Session-Token in AuthSignatureOnly

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1342,8 +1342,8 @@ func (iam *IdentityAccessManagement) authenticateRequestInternal(r *http.Request
 	// and are trusted by downstream authorization (including S3Tables IAM checks
 	// reached via AuthSignatureOnly). Clearing them here — the shared entry point
 	// for every auth path — prevents privilege escalation via header injection.
-	r.Header.Del("X-SeaweedFS-Principal")
-	r.Header.Del("X-SeaweedFS-Session-Token")
+	r.Header.Del(s3_constants.SeaweedFSPrincipalHeader)
+	r.Header.Del(s3_constants.SeaweedFSSessionTokenHeader)
 
 	reqAuthType := getRequestAuthType(r)
 
@@ -1593,7 +1593,7 @@ func (identity *Identity) isAdmin() bool {
 func buildPrincipalARN(identity *Identity, r *http.Request) string {
 	// Check if principal ARN was already set by JWT authentication
 	if r != nil {
-		if principalARN := r.Header.Get("X-SeaweedFS-Principal"); principalARN != "" {
+		if principalARN := r.Header.Get(s3_constants.SeaweedFSPrincipalHeader); principalARN != "" {
 			glog.V(4).Infof("buildPrincipalARN: Using principal ARN from header: %s", principalARN)
 			return principalARN
 		}
@@ -1962,8 +1962,8 @@ func (iam *IdentityAccessManagement) authenticateJWTWithIAM(r *http.Request) (*I
 	}
 
 	// Store session info in request headers for later authorization
-	r.Header.Set("X-SeaweedFS-Session-Token", iamIdentity.SessionToken)
-	r.Header.Set("X-SeaweedFS-Principal", iamIdentity.Principal)
+	r.Header.Set(s3_constants.SeaweedFSSessionTokenHeader, iamIdentity.SessionToken)
+	r.Header.Set(s3_constants.SeaweedFSPrincipalHeader, iamIdentity.Principal)
 
 	return identity, s3err.ErrNone
 }
@@ -2083,7 +2083,7 @@ func (iam *IdentityAccessManagement) VerifyActionPermission(r *http.Request, ide
 	// JWT/STS identities (no Actions or having a session token) use IAM authorization.
 	// IMPORTANT: We MUST prioritize IAM authorization for any request with a session token
 	// to ensure that session policies are correctly enforced.
-	hasSessionToken := r.Header.Get("X-SeaweedFS-Session-Token") != "" ||
+	hasSessionToken := r.Header.Get(s3_constants.SeaweedFSSessionTokenHeader) != "" ||
 		r.Header.Get("X-Amz-Security-Token") != "" ||
 		r.URL.Query().Get("X-Amz-Security-Token") != ""
 	iam.m.RLock()
@@ -2129,9 +2129,9 @@ func (iam *IdentityAccessManagement) authorizeWithIAM(r *http.Request, identity 
 	ctx := r.Context()
 
 	// Get session info from request headers
-	// First check for JWT-based authentication headers (X-SeaweedFS-Session-Token)
-	sessionToken := r.Header.Get("X-SeaweedFS-Session-Token")
-	principal := r.Header.Get("X-SeaweedFS-Principal")
+	// First check for JWT-based authentication headers (SeaweedFSSessionTokenHeader)
+	sessionToken := r.Header.Get(s3_constants.SeaweedFSSessionTokenHeader)
+	principal := r.Header.Get(s3_constants.SeaweedFSPrincipalHeader)
 
 	// Fallback to AWS Signature V4 STS token if JWT token not present
 	// This handles the case where STS AssumeRoleWithWebIdentity generates temporary credentials

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1482,6 +1482,14 @@ func (iam *IdentityAccessManagement) authRequestWithAuthType(r *http.Request, ac
 // Returns the authenticated identity and any signature verification error.
 func (iam *IdentityAccessManagement) AuthSignatureOnly(r *http.Request) (*Identity, s3err.ErrorCode) {
 
+	// SECURITY: Prevent clients from spoofing internal IAM headers.
+	// These headers are only set by the server after successful JWT authentication
+	// and are trusted by downstream authorization (e.g. S3Tables IAM checks).
+	// Clearing them here prevents privilege escalation via header injection on
+	// callers that use AuthSignatureOnly (S3Tables routes, UnifiedPostHandler).
+	r.Header.Del("X-SeaweedFS-Principal")
+	r.Header.Del("X-SeaweedFS-Session-Token")
+
 	var identity *Identity
 	var s3Err s3err.ErrorCode
 	var authType string

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1337,9 +1337,11 @@ func (iam *IdentityAccessManagement) authenticateRequestInternal(r *http.Request
 	var found bool
 	var amzAuthType string
 
-	// SECURITY: Prevent clients from spoofing internal IAM headers
+	// SECURITY: Prevent clients from spoofing internal IAM headers.
 	// These headers are only set by the server after successful JWT authentication
-	// Clearing them here prevents privilege escalation via header injection
+	// and are trusted by downstream authorization (including S3Tables IAM checks
+	// reached via AuthSignatureOnly). Clearing them here — the shared entry point
+	// for every auth path — prevents privilege escalation via header injection.
 	r.Header.Del("X-SeaweedFS-Principal")
 	r.Header.Del("X-SeaweedFS-Session-Token")
 
@@ -1478,61 +1480,13 @@ func (iam *IdentityAccessManagement) authRequestWithAuthType(r *http.Request, ac
 
 // AuthSignatureOnly performs only signature verification without any authorization checks.
 // This is used for IAM API operations where authorization is handled separately based on
-// the specific IAM action (e.g., self-service vs admin operations).
+// the specific IAM action (e.g., self-service vs admin operations). It delegates to
+// authenticateRequestInternal so the internal-IAM-header stripping and the auth-type
+// dispatch stay in one place — any future fix applied there automatically covers
+// S3Tables, UnifiedPostHandler, and the other AuthSignatureOnly callers.
 // Returns the authenticated identity and any signature verification error.
 func (iam *IdentityAccessManagement) AuthSignatureOnly(r *http.Request) (*Identity, s3err.ErrorCode) {
-
-	// SECURITY: Prevent clients from spoofing internal IAM headers.
-	// These headers are only set by the server after successful JWT authentication
-	// and are trusted by downstream authorization (e.g. S3Tables IAM checks).
-	// Clearing them here prevents privilege escalation via header injection on
-	// callers that use AuthSignatureOnly (S3Tables routes, UnifiedPostHandler).
-	r.Header.Del("X-SeaweedFS-Principal")
-	r.Header.Del("X-SeaweedFS-Session-Token")
-
-	var identity *Identity
-	var s3Err s3err.ErrorCode
-	var authType string
-	switch getRequestAuthType(r) {
-	case authTypeUnknown:
-		glog.V(3).Infof("unknown auth type")
-		r.Header.Set(s3_constants.AmzAuthType, "Unknown")
-		return identity, s3err.ErrAccessDenied
-	case authTypePresignedV2, authTypeSignedV2:
-		glog.V(3).Infof("v2 auth type")
-		identity, s3Err = iam.isReqAuthenticatedV2(r)
-		authType = "SigV2"
-	case authTypeStreamingSigned, authTypeSigned, authTypePresigned:
-		glog.V(3).Infof("v4 auth type")
-		identity, s3Err = iam.reqSignatureV4Verify(r)
-		authType = "SigV4"
-
-	case authTypeStreamingUnsigned:
-		glog.V(3).Infof("unsigned streaming upload")
-		identity, s3Err = iam.reqSignatureV4Verify(r)
-		authType = "SigV4"
-	case authTypeJWT:
-		glog.V(3).Infof("jwt auth type detected, iamIntegration != nil? %t", iam.iamIntegration != nil)
-		r.Header.Set(s3_constants.AmzAuthType, "Jwt")
-		if iam.iamIntegration != nil {
-			identity, s3Err = iam.authenticateJWTWithIAM(r)
-			authType = "Jwt"
-		} else {
-			glog.V(2).Infof("IAM integration is nil, returning ErrNotImplemented")
-			return identity, s3err.ErrNotImplemented
-		}
-	case authTypeAnonymous:
-		if ident, found := iam.LookupAnonymous(); found {
-			return ident, s3err.ErrNone
-		}
-		return nil, s3err.ErrAccessDenied
-	default:
-		return identity, s3err.ErrNotImplemented
-	}
-
-	if len(authType) > 0 {
-		r.Header.Set(s3_constants.AmzAuthType, authType)
-	}
+	identity, s3Err, _ := iam.authenticateRequestInternal(r)
 	if s3Err != s3err.ErrNone {
 		return identity, s3Err
 	}

--- a/weed/s3api/auth_security_test.go
+++ b/weed/s3api/auth_security_test.go
@@ -129,6 +129,24 @@ func TestReproIssue7912(t *testing.T) {
 		// No Authorization header
 		_, errCode3 := iam.AuthSignatureOnly(r3)
 		assert.Equal(t, s3err.ErrAccessDenied, errCode3, "AuthSignatureOnly should be denied with unsigned streaming if no auth header")
+
+		// Verify fix: client-supplied X-SeaweedFS-Principal / X-SeaweedFS-Session-Token
+		// headers must be stripped, otherwise a signed low-privilege caller could
+		// spoof the principal that downstream IAM authorization (e.g. S3Tables
+		// CreateTableBucket) evaluates against.
+		r4 := httptest.NewRequest(http.MethodGet, "http://localhost:8333/", nil)
+		r4.Host = "localhost:8333"
+		err = signRawHTTPRequest(context.Background(), r4, "readonly_access_key", "readonly_secret_key", "us-east-1")
+		require.NoError(t, err)
+		// Attacker injects these headers after signing; they are not part of
+		// SignedHeaders, so SigV4 verification still passes.
+		r4.Header.Set("X-SeaweedFS-Principal", "arn:aws:iam::123456789012:root")
+		r4.Header.Set("X-SeaweedFS-Session-Token", "spoofed-session-token")
+
+		_, errCode4 := iam.AuthSignatureOnly(r4)
+		assert.Equal(t, s3err.ErrNone, errCode4)
+		assert.Empty(t, r4.Header.Get("X-SeaweedFS-Principal"), "client-supplied X-SeaweedFS-Principal must be stripped")
+		assert.Empty(t, r4.Header.Get("X-SeaweedFS-Session-Token"), "client-supplied X-SeaweedFS-Session-Token must be stripped")
 	})
 
 	t.Run("Wrong secret key", func(t *testing.T) {

--- a/weed/s3api/auth_security_test.go
+++ b/weed/s3api/auth_security_test.go
@@ -140,13 +140,13 @@ func TestReproIssue7912(t *testing.T) {
 		require.NoError(t, err)
 		// Attacker injects these headers after signing; they are not part of
 		// SignedHeaders, so SigV4 verification still passes.
-		r4.Header.Set("X-SeaweedFS-Principal", "arn:aws:iam::123456789012:root")
-		r4.Header.Set("X-SeaweedFS-Session-Token", "spoofed-session-token")
+		r4.Header.Set(s3_constants.SeaweedFSPrincipalHeader, "arn:aws:iam::123456789012:root")
+		r4.Header.Set(s3_constants.SeaweedFSSessionTokenHeader, "spoofed-session-token")
 
 		_, errCode4 := iam.AuthSignatureOnly(r4)
 		assert.Equal(t, s3err.ErrNone, errCode4)
-		assert.Empty(t, r4.Header.Get("X-SeaweedFS-Principal"), "client-supplied X-SeaweedFS-Principal must be stripped")
-		assert.Empty(t, r4.Header.Get("X-SeaweedFS-Session-Token"), "client-supplied X-SeaweedFS-Session-Token must be stripped")
+		assert.Empty(t, r4.Header.Get(s3_constants.SeaweedFSPrincipalHeader), "client-supplied X-SeaweedFS-Principal must be stripped")
+		assert.Empty(t, r4.Header.Get(s3_constants.SeaweedFSSessionTokenHeader), "client-supplied X-SeaweedFS-Session-Token must be stripped")
 	})
 
 	t.Run("Wrong secret key", func(t *testing.T) {

--- a/weed/s3api/auth_sts_v4_test.go
+++ b/weed/s3api/auth_sts_v4_test.go
@@ -28,8 +28,8 @@ func TestAuthorizeWithIAMSessionTokenExtraction(t *testing.T) {
 		}
 
 		// Extract tokens the same way authorizeWithIAM does
-		sessionToken := req.Header.Get("X-SeaweedFS-Session-Token")
-		principal := req.Header.Get("X-SeaweedFS-Principal")
+		sessionToken := req.Header.Get(s3_constants.SeaweedFSSessionTokenHeader)
+		principal := req.Header.Get(s3_constants.SeaweedFSPrincipalHeader)
 
 		assert.Equal(t, "jwt-token-123", sessionToken, "Should extract JWT session token from header")
 		assert.Equal(t, "arn:aws:iam::user/test", principal, "Should extract principal from header")
@@ -44,8 +44,8 @@ func TestAuthorizeWithIAMSessionTokenExtraction(t *testing.T) {
 		}
 
 		// Extract tokens the same way authorizeWithIAM does
-		sessionToken := req.Header.Get("X-SeaweedFS-Session-Token")
-		principal := req.Header.Get("X-SeaweedFS-Principal")
+		sessionToken := req.Header.Get(s3_constants.SeaweedFSSessionTokenHeader)
+		principal := req.Header.Get(s3_constants.SeaweedFSPrincipalHeader)
 
 		// If JWT token is empty, should fallback to X-Amz-Security-Token
 		if sessionToken == "" {
@@ -63,7 +63,7 @@ func TestAuthorizeWithIAMSessionTokenExtraction(t *testing.T) {
 		}
 
 		// Extract tokens the same way authorizeWithIAM does
-		sessionToken := req.Header.Get("X-SeaweedFS-Session-Token")
+		sessionToken := req.Header.Get(s3_constants.SeaweedFSSessionTokenHeader)
 		if sessionToken == "" {
 			sessionToken = req.Header.Get("X-Amz-Security-Token")
 			if sessionToken == "" {
@@ -85,7 +85,7 @@ func TestAuthorizeWithIAMSessionTokenExtraction(t *testing.T) {
 		}
 
 		// Extract tokens the same way authorizeWithIAM does
-		sessionToken := req.Header.Get("X-SeaweedFS-Session-Token")
+		sessionToken := req.Header.Get(s3_constants.SeaweedFSSessionTokenHeader)
 		if sessionToken == "" {
 			sessionToken = req.Header.Get("X-Amz-Security-Token")
 		}

--- a/weed/s3api/s3_constants/header.go
+++ b/weed/s3api/s3_constants/header.go
@@ -149,6 +149,17 @@ const (
 	SeaweedFSSSEKMSBaseIVHeader = "X-SeaweedFS-SSE-KMS-Base-IV" // Header for passing base IV for multipart SSE-KMS
 	SeaweedFSSSES3BaseIVHeader  = "X-SeaweedFS-SSE-S3-Base-IV"  // Header for passing base IV for multipart SSE-S3
 	SeaweedFSSSES3KeyDataHeader = "X-SeaweedFS-SSE-S3-Key-Data" // Header for passing key data for multipart SSE-S3
+
+	// SeaweedFSPrincipalHeader and SeaweedFSSessionTokenHeader carry the
+	// server-derived principal ARN and session token from the auth layer to
+	// downstream authorization (IAM policy evaluation, S3Tables IAM checks).
+	// These headers are trusted: callers of AuthSignatureOnly /
+	// authenticateRequestInternal must scrub any client-supplied values at the
+	// very start of authentication to prevent privilege escalation via header
+	// injection. Prefer these constants over literals so that any future scrub
+	// or consumer cannot drift by typo.
+	SeaweedFSPrincipalHeader    = "X-SeaweedFS-Principal"
+	SeaweedFSSessionTokenHeader = "X-SeaweedFS-Session-Token"
 )
 
 // Non-Standard S3 HTTP request constants

--- a/weed/s3api/s3_jwt_auth_test.go
+++ b/weed/s3api/s3_jwt_auth_test.go
@@ -543,11 +543,11 @@ func testJWTAuthorizationWithRole(t *testing.T, iam *IdentityAccessManagement, i
 	// Create test request
 	req := httptest.NewRequest("GET", "/"+bucket+"/"+object, http.NoBody)
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-SeaweedFS-Session-Token", token)
+	req.Header.Set(s3_constants.SeaweedFSSessionTokenHeader, token)
 
 	// Use a proper principal ARN format that matches what STS would generate
 	principalArn := "arn:aws:sts::assumed-role/" + roleName + "/test-session"
-	req.Header.Set("X-SeaweedFS-Principal", principalArn)
+	req.Header.Set(s3_constants.SeaweedFSPrincipalHeader, principalArn)
 
 	// Test authorization
 	if iam.iamIntegration == nil {

--- a/weed/s3api/s3tables/iam.go
+++ b/weed/s3api/s3tables/iam.go
@@ -79,7 +79,7 @@ func hasSessionToken(r *http.Request) bool {
 }
 
 func extractSessionToken(r *http.Request) string {
-	if token := r.Header.Get("X-SeaweedFS-Session-Token"); token != "" {
+	if token := r.Header.Get(s3_constants.SeaweedFSSessionTokenHeader); token != "" {
 		return token
 	}
 	if token := r.Header.Get("X-Amz-Security-Token"); token != "" {
@@ -94,7 +94,7 @@ func (h *S3TablesHandler) authorizeIAMAction(r *http.Request, identityPolicyName
 		glog.V(2).Infof("S3Tables: %v", err)
 		return false, err
 	}
-	principal := r.Header.Get("X-SeaweedFS-Principal")
+	principal := r.Header.Get(s3_constants.SeaweedFSPrincipalHeader)
 	if principal == "" {
 		principal = getIdentityPrincipalArn(r)
 	}


### PR DESCRIPTION
## Summary

- `AuthSignatureOnly` is the only auth gate in front of the S3Tables routes (including `CreateTableBucket`) and `UnifiedPostHandler`, but unlike `authenticateRequestInternal` (`weed/s3api/auth_credentials.go:1343`) it did not clear the internal IAM trust headers before running signature verification.
- `weed/s3api/s3tables/iam.go:97` (`authorizeIAMAction`) reads `X-SeaweedFS-Principal` directly from the request and prefers it over the authenticated identity's `PrincipalArn`. A signed low-privilege caller could append `X-SeaweedFS-Principal: <privileged-arn>` to the request after signing (unsigned header, so SigV4 still verifies) and have the S3Tables IAM authorizer evaluate `CreateTableBucket` (and every other S3Tables op) against the spoofed principal, bypassing authorization. `X-SeaweedFS-Session-Token` was spoofable on the same path.
- Fix: strip both `X-SeaweedFS-Principal` and `X-SeaweedFS-Session-Token` at the top of `AuthSignatureOnly`, mirroring the existing guard in `authenticateRequestInternal`.

## Test plan

- [x] `go test ./weed/s3api/ -run TestReproIssue7912 -count=1` — new regression test asserts both headers are cleared after a successful signature-only auth when injected post-signing.
- [x] `go test ./weed/s3api/... ./weed/s3api/s3tables/... -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened S3 API security: client-supplied internal IAM headers are now stripped from requests before authentication to prevent header-injection privilege escalation.
  * Unified header sanitization so all authentication paths treat untrusted headers consistently.
  * Tests added and updated to verify injected header removal and correct authentication outcomes.
  * No public API or exported interface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->