### PR TITLE
fix(s3): return 403 on POST policy violation instead of 307 redirect

### DIFF
--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -98,7 +98,7 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 		// Make sure formValues adhere to policy restrictions.
 		if err = policy.CheckPostPolicy(formValues, postPolicyForm); err != nil {
 			glog.V(3).Infof("PostPolicy check failed for bucket %s: %v", bucket, err)
-			s3err.WriteErrorResponse(w, r, s3err.ErrAccessDenied)
+			s3err.WriteErrorResponseWithMessage(w, r, s3err.ErrAccessDenied, err.Error())
 			return
 		}
 

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -97,8 +97,8 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 
 		// Make sure formValues adhere to policy restrictions.
 		if err = policy.CheckPostPolicy(formValues, postPolicyForm); err != nil {
-			w.Header().Set("Location", r.URL.Path)
-			w.WriteHeader(http.StatusTemporaryRedirect)
+			glog.V(3).Infof("PostPolicy check failed for bucket %s: %v", bucket, err)
+			s3err.WriteErrorResponse(w, r, s3err.ErrAccessDenied)
 			return
 		}
 

--- a/weed/s3api/s3api_object_handlers_postpolicy_test.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy_test.go
@@ -2,15 +2,19 @@ package s3api
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/policy"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -382,4 +386,45 @@ func TestPostPolicyBucketHandlerKeyExtraction(t *testing.T) {
 				"Path should contain properly separated bucket and key")
 		})
 	}
+}
+
+// TestPostPolicyFailureReturns403 verifies that when CheckPostPolicy rejects a
+// request, the handler branch writes HTTP 403 AccessDenied instead of the old
+// 307 Temporary Redirect. The 307 behavior caused clients to re-POST and
+// obscured the policy violation; 403 is the correct AWS S3 response.
+func TestPostPolicyFailureReturns403(t *testing.T) {
+	// Build a POST policy that requires key == "required.txt".
+	expiration := time.Now().UTC().Add(1 * time.Hour)
+	policyJSON := fmt.Sprintf(
+		`{"expiration":"%s","conditions":[["eq","$bucket","test-bucket"],["eq","$key","required.txt"]]}`,
+		expiration.Format("2006-01-02T15:04:05.000Z"),
+	)
+
+	postPolicyForm, err := policy.ParsePostPolicyForm(policyJSON)
+	assert.NoError(t, err, "policy should parse")
+
+	// Form sends a different key, violating the eq $key condition.
+	formValues := make(http.Header)
+	formValues.Set("Bucket", "test-bucket")
+	formValues.Set("Key", "wrong.txt")
+
+	err = policy.CheckPostPolicy(formValues, postPolicyForm)
+	assert.Error(t, err, "CheckPostPolicy should reject mismatched key")
+
+	// Verify the handler branch's response: WriteErrorResponse with
+	// ErrAccessDenied produces a 403 status, not 307.
+	req := httptest.NewRequest(http.MethodPost, "/test-bucket", nil)
+	req = mux.SetURLVars(req, map[string]string{"bucket": "test-bucket"})
+	rec := httptest.NewRecorder()
+
+	s3err.WriteErrorResponse(rec, req, s3err.ErrAccessDenied)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"CheckPostPolicy failures must map to 403 AccessDenied, not 307 redirect")
+	assert.NotEqual(t, http.StatusTemporaryRedirect, rec.Code,
+		"must not return 307 Temporary Redirect on policy violation")
+	assert.Empty(t, rec.Header().Get("Location"),
+		"403 response must not set a redirect Location header")
+	assert.Contains(t, rec.Body.String(), "AccessDenied",
+		"response body should identify AccessDenied")
 }

--- a/weed/s3api/s3api_object_handlers_postpolicy_test.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy_test.go
@@ -488,6 +488,8 @@ func TestPostPolicyBucketHandler_PolicyViolationReturns403(t *testing.T) {
 		"403 response must not set a redirect Location header")
 	assert.Contains(t, rec.Body.String(), "AccessDenied",
 		"response body should identify AccessDenied; actual body: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "Policy Condition failed",
+		"response body should carry the specific policy-failure message; actual body: %s", rec.Body.String())
 	// Guard against the signing setup silently failing before the policy
 	// branch ever runs, which would make the 403 assertion meaningless.
 	assert.NotContains(t, rec.Body.String(), "SignatureDoesNotMatch",

--- a/weed/s3api/s3api_object_handlers_postpolicy_test.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy_test.go
@@ -2,19 +2,21 @@ package s3api
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/policy"
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -388,43 +390,108 @@ func TestPostPolicyBucketHandlerKeyExtraction(t *testing.T) {
 	}
 }
 
-// TestPostPolicyFailureReturns403 verifies that when CheckPostPolicy rejects a
-// request, the handler branch writes HTTP 403 AccessDenied instead of the old
-// 307 Temporary Redirect. The 307 behavior caused clients to re-POST and
-// obscured the policy violation; 403 is the correct AWS S3 response.
-func TestPostPolicyFailureReturns403(t *testing.T) {
-	// Build a POST policy that requires key == "required.txt".
-	expiration := time.Now().UTC().Add(1 * time.Hour)
-	policyJSON := fmt.Sprintf(
-		`{"expiration":"%s","conditions":[["eq","$bucket","test-bucket"],["eq","$key","required.txt"]]}`,
-		expiration.Format("2006-01-02T15:04:05.000Z"),
+// TestPostPolicyBucketHandler_PolicyViolationReturns403 drives the handler
+// end-to-end with a signed multipart POST whose policy conditions cannot be
+// satisfied by the form fields. It verifies the handler responds 403
+// AccessDenied with no Location redirect, rather than the old 307 Temporary
+// Redirect that obscured the policy failure.
+func TestPostPolicyBucketHandler_PolicyViolationReturns403(t *testing.T) {
+	const (
+		accessKey  = "AKIATESTTESTTEST"
+		secretKey  = "secret-key-for-tests"
+		region     = "us-east-1"
+		service    = "s3"
+		testBucket = "test-bucket"
 	)
 
-	postPolicyForm, err := policy.ParsePostPolicyForm(policyJSON)
-	assert.NoError(t, err, "policy should parse")
+	iam := &IdentityAccessManagement{
+		hashes:       make(map[string]*sync.Pool),
+		hashCounters: make(map[string]*int32),
+	}
+	err := iam.loadS3ApiConfiguration(&iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{{
+			Name:        "tester",
+			Credentials: []*iam_pb.Credential{{AccessKey: accessKey, SecretKey: secretKey}},
+			Actions:     []string{"Admin", "Read", "Write"},
+		}},
+	})
+	assert.NoError(t, err, "loadS3ApiConfiguration should succeed")
 
-	// Form sends a different key, violating the eq $key condition.
-	formValues := make(http.Header)
-	formValues.Set("Bucket", "test-bucket")
-	formValues.Set("Key", "wrong.txt")
+	s3a := &S3ApiServer{
+		option: &S3ApiServerOption{BucketsPath: "/buckets"},
+		iam:    iam,
+	}
+	// Pre-populate the bucket registry so validateTableBucketObjectPath sees
+	// a non-table bucket without needing a live filer connection.
+	s3a.bucketRegistry = &BucketRegistry{
+		metadataCache: map[string]*BucketMetaData{
+			testBucket: {Name: testBucket, IsTableBucket: false},
+		},
+		notFound: make(map[string]struct{}),
+		s3a:      s3a,
+	}
 
-	err = policy.CheckPostPolicy(formValues, postPolicyForm)
-	assert.Error(t, err, "CheckPostPolicy should reject mismatched key")
+	now := time.Now().UTC()
+	amzDate := now.Format(iso8601Format)
+	yyyymmddStr := now.Format(yyyymmdd)
+	credential := fmt.Sprintf("%s/%s/%s/%s/aws4_request", accessKey, yyyymmddStr, region, service)
+	expiration := now.Add(1 * time.Hour).Format("2006-01-02T15:04:05.000Z")
 
-	// Verify the handler branch's response: WriteErrorResponse with
-	// ErrAccessDenied produces a 403 status, not 307.
-	req := httptest.NewRequest(http.MethodPost, "/test-bucket", nil)
-	req = mux.SetURLVars(req, map[string]string{"bucket": "test-bucket"})
+	policyJSON := fmt.Sprintf(
+		`{"expiration":"%s","conditions":[`+
+			`["eq","$bucket","%s"],`+
+			`["eq","$key","required.txt"],`+
+			`["eq","$x-amz-credential","%s"],`+
+			`["eq","$x-amz-algorithm","AWS4-HMAC-SHA256"],`+
+			`["eq","$x-amz-date","%s"]`+
+			`]}`,
+		expiration, testBucket, credential, amzDate,
+	)
+	encodedPolicy := base64.StdEncoding.EncodeToString([]byte(policyJSON))
+
+	signingKey := getSigningKey(secretKey, yyyymmddStr, region, service)
+	signature := getSignature(signingKey, encodedPolicy)
+	// Sanity-check: the signature must be valid hex of the expected length so
+	// that doesPolicySignatureV4Match does not trip on formatting.
+	_, decodeErr := hex.DecodeString(signature)
+	assert.NoError(t, decodeErr, "computed signature should be hex-encoded")
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	assert.NoError(t, writer.WriteField("bucket", testBucket))
+	// Deliberately mismatch the policy's required key to force a violation.
+	assert.NoError(t, writer.WriteField("key", "wrong.txt"))
+	assert.NoError(t, writer.WriteField("x-amz-credential", credential))
+	assert.NoError(t, writer.WriteField("x-amz-algorithm", "AWS4-HMAC-SHA256"))
+	assert.NoError(t, writer.WriteField("x-amz-date", amzDate))
+	assert.NoError(t, writer.WriteField("policy", encodedPolicy))
+	assert.NoError(t, writer.WriteField("x-amz-signature", signature))
+
+	filePart, err := writer.CreateFormFile("file", "payload.txt")
+	assert.NoError(t, err)
+	_, err = filePart.Write([]byte("contents that should never be uploaded"))
+	assert.NoError(t, err)
+	assert.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/"+testBucket, &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req = mux.SetURLVars(req, map[string]string{"bucket": testBucket})
 	rec := httptest.NewRecorder()
 
-	s3err.WriteErrorResponse(rec, req, s3err.ErrAccessDenied)
+	s3a.PostPolicyBucketHandler(rec, req)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code,
-		"CheckPostPolicy failures must map to 403 AccessDenied, not 307 redirect")
+		"policy violation must return 403, actual body: %s", rec.Body.String())
 	assert.NotEqual(t, http.StatusTemporaryRedirect, rec.Code,
 		"must not return 307 Temporary Redirect on policy violation")
 	assert.Empty(t, rec.Header().Get("Location"),
 		"403 response must not set a redirect Location header")
 	assert.Contains(t, rec.Body.String(), "AccessDenied",
-		"response body should identify AccessDenied")
+		"response body should identify AccessDenied; actual body: %s", rec.Body.String())
+	// Guard against the signing setup silently failing before the policy
+	// branch ever runs, which would make the 403 assertion meaningless.
+	assert.NotContains(t, rec.Body.String(), "SignatureDoesNotMatch",
+		"signature must match so the handler reaches the policy-check branch")
+	assert.NotContains(t, rec.Body.String(), "InvalidAccessKeyId",
+		"access key must be known so the handler reaches the policy-check branch")
 }

--- a/weed/s3api/s3err/error_handler.go
+++ b/weed/s3api/s3err/error_handler.go
@@ -40,25 +40,14 @@ func WriteEmptyResponse(w http.ResponseWriter, r *http.Request, statusCode int) 
 }
 
 func WriteErrorResponse(w http.ResponseWriter, r *http.Request, errorCode ErrorCode) {
-	r, reqID := request_id.Ensure(r)
-	vars := mux.Vars(r)
-	bucket := vars["bucket"]
-	object := vars["object"]
-	if strings.HasPrefix(object, "/") {
-		object = object[1:]
-	}
-
-	apiError := GetAPIError(errorCode)
-	errorResponse := getRESTErrorResponse(apiError, r.URL.Path, bucket, object, reqID)
-	WriteXMLResponse(w, r, apiError.HTTPStatusCode, errorResponse)
-	PostLog(r, apiError.HTTPStatusCode, errorCode)
+	WriteErrorResponseWithMessage(w, r, errorCode, "")
 }
 
 // WriteErrorResponseWithMessage writes an S3 error response that uses the
-// standard error code mapping (status + Code) but overrides the default
-// Message with a caller-supplied description. Useful when the generic
-// Description hides why the request was rejected (e.g. which POST policy
-// condition failed).
+// standard error code mapping (status + Code). When message is non-empty,
+// it overrides the default Message field so the caller can surface why the
+// request was rejected (e.g. which POST policy condition failed) instead
+// of the generic APIError Description.
 func WriteErrorResponseWithMessage(w http.ResponseWriter, r *http.Request, errorCode ErrorCode, message string) {
 	r, reqID := request_id.Ensure(r)
 	vars := mux.Vars(r)

--- a/weed/s3api/s3err/error_handler.go
+++ b/weed/s3api/s3err/error_handler.go
@@ -54,6 +54,29 @@ func WriteErrorResponse(w http.ResponseWriter, r *http.Request, errorCode ErrorC
 	PostLog(r, apiError.HTTPStatusCode, errorCode)
 }
 
+// WriteErrorResponseWithMessage writes an S3 error response that uses the
+// standard error code mapping (status + Code) but overrides the default
+// Message with a caller-supplied description. Useful when the generic
+// Description hides why the request was rejected (e.g. which POST policy
+// condition failed).
+func WriteErrorResponseWithMessage(w http.ResponseWriter, r *http.Request, errorCode ErrorCode, message string) {
+	r, reqID := request_id.Ensure(r)
+	vars := mux.Vars(r)
+	bucket := vars["bucket"]
+	object := vars["object"]
+	if strings.HasPrefix(object, "/") {
+		object = object[1:]
+	}
+
+	apiError := GetAPIError(errorCode)
+	errorResponse := getRESTErrorResponse(apiError, r.URL.Path, bucket, object, reqID)
+	if message != "" {
+		errorResponse.Message = message
+	}
+	WriteXMLResponse(w, r, apiError.HTTPStatusCode, errorResponse)
+	PostLog(r, apiError.HTTPStatusCode, errorCode)
+}
+
 func getRESTErrorResponse(err APIError, resource string, bucket, object, requestID string) RESTErrorResponse {
 	return RESTErrorResponse{
 		Code:       err.Code,


### PR DESCRIPTION
## Summary
- `CheckPostPolicy` failures previously responded with HTTP 307 Temporary Redirect to the request URL. Clients following the Location header re-POST the same body, so the failure is obscured and can loop.
- Return `403 AccessDenied` (via `s3err.WriteErrorResponse`) to match AWS S3 POST Object behavior. Added a `glog.V(3)` line so operators can still trace which condition failed.

## Test plan
- [x] `cd weed/s3api && go build ./...`
- [x] `cd weed/s3api && go test ./... -run PostPolicy -count=1` (new `TestPostPolicyFailureReturns403` passes; existing tests unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * POST policy violations now return AWS-compatible 403 Forbidden with AccessDenied and an explicit policy-failure message in the XML response, and no longer send a redirect or Location header.
* **Tests**
  * Added an end-to-end test verifying policy-violation responses return 403, include AccessDenied and policy-failure details, omit redirects/Location headers, and do not misattribute failures to signature or access-key errors.
* **Improvements**
  * Error responses can include optional custom messages and now log bucket/object and failure reasons for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->