### PR TITLE
fix(s3api): self-heal stale .versions latest-version pointer on read

### DIFF
--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -1339,11 +1339,13 @@ func selectLatestVersion(entries []*filer_pb.Entry) (latestEntry *filer_pb.Entry
 }
 
 // healStaleLatestVersionPointer is invoked when the .versions directory metadata
-// points to a version file that no longer exists. It rescans the directory,
-// picks the newest remaining content version, updates the directory pointer
-// metadata best-effort, and returns the rescanned entry. If no content version
-// remains (only delete markers or an empty directory) an error is returned and
-// the caller treats the object as not found.
+// points to a version file that no longer exists. It paginates the directory,
+// picks the chronologically newest remaining entry (content version or delete
+// marker), updates the directory pointer metadata best-effort, and returns the
+// rescanned entry. Downstream handlers detect ExtDeleteMarkerKey on the
+// returned entry and render NoSuchKey, so promoting a delete marker preserves
+// correct S3 semantics. If no version-tagged entry remains an error is
+// returned and the caller surfaces it as not found.
 func (s3a *S3ApiServer) healStaleLatestVersionPointer(bucket, normalizedObject string, versionsEntry *filer_pb.Entry, stalePointerFile string) (*filer_pb.Entry, error) {
 	bucketDir := s3a.bucketDir(bucket)
 	versionsObjectPath := normalizedObject + s3_constants.VersionsFolder
@@ -1351,17 +1353,42 @@ func (s3a *S3ApiServer) healStaleLatestVersionPointer(bucket, normalizedObject s
 
 	glog.Warningf("healStaleLatestVersionPointer: stale pointer for %s/%s - version file %q missing, rescanning %s", bucket, normalizedObject, stalePointerFile, versionsDir)
 
-	entries, _, err := s3a.list(versionsDir, "", "", false, 1000)
-	if err != nil {
-		return nil, fmt.Errorf("list %s: %w", versionsDir, err)
-	}
-
+	// Paginate through all version entries and keep a running best candidate.
+	// A single-shot list would miss the true latest when old-format (raw
+	// timestamp) version ids spill past one page, since filesystem order is
+	// lexicographic-ascending = oldest-first for that format.
+	//
 	// Pick the chronologically newest entry regardless of type. Promoting a
 	// delete marker is correct: S3 semantics treat it as the current version
 	// and the caller renders NoSuchKey (with x-amz-delete-marker) from the
 	// returned entry. Restricting to content versions here would "undelete"
 	// the object by promoting an older content version over a newer marker.
-	latestEntry, latestVersionId, latestVersionFileName, isDeleteMarker := selectLatestVersion(entries)
+	var (
+		latestEntry           *filer_pb.Entry
+		latestVersionId       string
+		latestVersionFileName string
+		isDeleteMarker        bool
+		startFrom             string
+	)
+	for {
+		entries, isLast, err := s3a.list(versionsDir, "", startFrom, false, filer.PaginationSize)
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %w", versionsDir, err)
+		}
+		if pageEntry, pageId, pageFile, pageDM := selectLatestVersion(entries); pageEntry != nil {
+			if latestEntry == nil || compareVersionIds(pageId, latestVersionId) < 0 {
+				latestEntry = pageEntry
+				latestVersionId = pageId
+				latestVersionFileName = pageFile
+				isDeleteMarker = pageDM
+			}
+		}
+		if isLast || len(entries) == 0 {
+			break
+		}
+		startFrom = entries[len(entries)-1].Name
+	}
+
 	if latestEntry == nil {
 		return nil, fmt.Errorf("no remaining version in %s", versionsDir)
 	}

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -1291,42 +1291,6 @@ func (s3a *S3ApiServer) doGetLatestObjectVersion(bucket, object string, maxRetri
 	return latestVersionEntry, nil
 }
 
-// selectLatestContentVersion walks the provided .versions directory entries and
-// returns the newest non-delete-marker entry together with its version id and
-// file name. Delete markers are tracked separately so callers can distinguish
-// "no content version remains" from "directory is empty". Returns nil for
-// latestEntry when no content version is present.
-//
-// This mirrors the existing post-deletion semantics used by
-// updateLatestVersionAfterDeletion, which deliberately limits the pointer to a
-// content version so that list output continues to show a live "latest".
-func selectLatestContentVersion(entries []*filer_pb.Entry) (latestEntry *filer_pb.Entry, latestVersionId, latestVersionFileName string, hasDeleteMarkers bool) {
-	for _, entry := range entries {
-		if entry == nil || entry.Extended == nil {
-			continue
-		}
-
-		versionIdBytes, hasVersionId := entry.Extended[s3_constants.ExtVersionIdKey]
-		if !hasVersionId {
-			continue
-		}
-
-		if string(entry.Extended[s3_constants.ExtDeleteMarkerKey]) == "true" {
-			hasDeleteMarkers = true
-			continue
-		}
-
-		versionId := string(versionIdBytes)
-		// compareVersionIds returns negative when the first arg is newer
-		if latestVersionId == "" || compareVersionIds(versionId, latestVersionId) < 0 {
-			latestVersionId = versionId
-			latestVersionFileName = entry.Name
-			latestEntry = entry
-		}
-	}
-	return
-}
-
 // selectLatestVersion returns the chronologically newest entry with a version
 // id, including delete markers. isDeleteMarker reflects whether the selected
 // entry is a delete marker. Returns nil for latestEntry when the directory

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -21,6 +21,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	s3_constants "github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ErrDeleteMarker is returned when the latest version is a delete marker (expected condition)
@@ -1052,41 +1054,10 @@ func (s3a *S3ApiServer) updateLatestVersionAfterDeletion(bucket, object string) 
 
 	glog.V(1).Infof("updateLatestVersionAfterDeletion: found %d entries in %s", len(entries), versionsDir)
 
-	// Find the most recent remaining version (latest timestamp in version ID)
-	var latestVersionId string
-	var latestVersionFileName string
-	var latestVersionEntry *filer_pb.Entry
-	hasDeleteMarkers := false
-
-	for _, entry := range entries {
-		if entry.Extended == nil {
-			continue
-		}
-
-		versionIdBytes, hasVersionId := entry.Extended[s3_constants.ExtVersionIdKey]
-		if !hasVersionId {
-			continue
-		}
-
-		versionId := string(versionIdBytes)
-
-		// Skip delete markers when finding latest content version
-		isDeleteMarkerBytes, _ := entry.Extended[s3_constants.ExtDeleteMarkerKey]
-		if string(isDeleteMarkerBytes) == "true" {
-			hasDeleteMarkers = true
-			continue
-		}
-
-		// Compare version IDs chronologically using unified comparator (handles both old and new formats)
-		// compareVersionIds returns negative if first arg is newer
-		if latestVersionId == "" || compareVersionIds(versionId, latestVersionId) < 0 {
-			glog.V(1).Infof("updateLatestVersionAfterDeletion: found newer version %s (file: %s)", versionId, entry.Name)
-			latestVersionId = versionId
-			latestVersionFileName = entry.Name
-			latestVersionEntry = entry
-		} else {
-			glog.V(1).Infof("updateLatestVersionAfterDeletion: skipping older or equal version %s", versionId)
-		}
+	// Find the most recent remaining non-delete-marker version.
+	latestVersionEntry, latestVersionId, latestVersionFileName, hasDeleteMarkers := selectLatestContentVersion(entries)
+	if latestVersionEntry != nil {
+		glog.V(1).Infof("updateLatestVersionAfterDeletion: selected latest content version %s (file: %s)", latestVersionId, latestVersionFileName)
 	}
 
 	// Update the .versions directory metadata
@@ -1283,10 +1254,97 @@ func (s3a *S3ApiServer) doGetLatestObjectVersion(bucket, object string, maxRetri
 	latestVersionPath := versionsObjectPath + "/" + latestVersionFile
 	latestVersionEntry, err := s3a.getEntry(bucketDir, latestVersionPath)
 	if err != nil {
+		// The pointer refers to a version file that no longer exists. Rather than
+		// surfacing a hard error that requires manual repair, rescan the .versions
+		// directory and self-heal the pointer to whatever remains.
+		if errors.Is(err, filer_pb.ErrNotFound) || status.Code(err) == codes.NotFound {
+			healed, healErr := s3a.healStaleLatestVersionPointer(bucket, normalizedObject, versionsEntry, latestVersionFile)
+			if healErr == nil {
+				return healed, nil
+			}
+			return nil, fmt.Errorf("stale latest-version pointer for %s/%s (file %s) could not self-heal: %w", bucket, normalizedObject, latestVersionFile, healErr)
+		}
 		return nil, fmt.Errorf("failed to get latest version file %s: %v", latestVersionPath, err)
 	}
 
 	return latestVersionEntry, nil
+}
+
+// selectLatestContentVersion walks the provided .versions directory entries and
+// returns the newest non-delete-marker entry together with its version id and
+// file name. Delete markers are tracked separately so callers can distinguish
+// "no content version remains" from "directory is empty". Returns nil for
+// latestEntry when no content version is present.
+func selectLatestContentVersion(entries []*filer_pb.Entry) (latestEntry *filer_pb.Entry, latestVersionId, latestVersionFileName string, hasDeleteMarkers bool) {
+	for _, entry := range entries {
+		if entry == nil || entry.Extended == nil {
+			continue
+		}
+
+		versionIdBytes, hasVersionId := entry.Extended[s3_constants.ExtVersionIdKey]
+		if !hasVersionId {
+			continue
+		}
+
+		if string(entry.Extended[s3_constants.ExtDeleteMarkerKey]) == "true" {
+			hasDeleteMarkers = true
+			continue
+		}
+
+		versionId := string(versionIdBytes)
+		// compareVersionIds returns negative when the first arg is newer
+		if latestVersionId == "" || compareVersionIds(versionId, latestVersionId) < 0 {
+			latestVersionId = versionId
+			latestVersionFileName = entry.Name
+			latestEntry = entry
+		}
+	}
+	return
+}
+
+// healStaleLatestVersionPointer is invoked when the .versions directory metadata
+// points to a version file that no longer exists. It rescans the directory,
+// picks the newest remaining content version, updates the directory pointer
+// metadata best-effort, and returns the rescanned entry. If no content version
+// remains (only delete markers or an empty directory) an error is returned and
+// the caller treats the object as not found.
+func (s3a *S3ApiServer) healStaleLatestVersionPointer(bucket, normalizedObject string, versionsEntry *filer_pb.Entry, stalePointerFile string) (*filer_pb.Entry, error) {
+	bucketDir := s3a.bucketDir(bucket)
+	versionsObjectPath := normalizedObject + s3_constants.VersionsFolder
+	versionsDir := bucketDir + "/" + versionsObjectPath
+
+	glog.Warningf("healStaleLatestVersionPointer: stale pointer for %s/%s - version file %q missing, rescanning %s", bucket, normalizedObject, stalePointerFile, versionsDir)
+
+	entries, _, err := s3a.list(versionsDir, "", "", false, 1000)
+	if err != nil {
+		return nil, fmt.Errorf("list %s: %w", versionsDir, err)
+	}
+
+	latestEntry, latestVersionId, latestVersionFileName, _ := selectLatestContentVersion(entries)
+	if latestEntry == nil {
+		return nil, fmt.Errorf("no remaining content version in %s", versionsDir)
+	}
+
+	if versionsEntry.Extended == nil {
+		versionsEntry.Extended = make(map[string][]byte)
+	}
+	versionsEntry.Extended[s3_constants.ExtLatestVersionIdKey] = []byte(latestVersionId)
+	versionsEntry.Extended[s3_constants.ExtLatestVersionFileNameKey] = []byte(latestVersionFileName)
+	setCachedListMetadata(versionsEntry, latestEntry)
+
+	if mkErr := s3a.mkFile(bucketDir, versionsObjectPath, versionsEntry.Chunks, func(updatedEntry *filer_pb.Entry) {
+		updatedEntry.Extended = versionsEntry.Extended
+		updatedEntry.Attributes = versionsEntry.Attributes
+		updatedEntry.Chunks = versionsEntry.Chunks
+	}); mkErr != nil {
+		// Persisting the repair is best-effort. Surface a warning but still
+		// return the rescanned entry so the read succeeds; a subsequent write
+		// on the object will persist a fresh pointer.
+		glog.Warningf("healStaleLatestVersionPointer: failed to persist repaired pointer for %s/%s: %v (returning rescanned entry)", bucket, normalizedObject, mkErr)
+	} else {
+		glog.V(1).Infof("healStaleLatestVersionPointer: repaired pointer for %s/%s to version %s (file %s)", bucket, normalizedObject, latestVersionId, latestVersionFileName)
+	}
+	return latestEntry, nil
 }
 
 // getLatestVersionEntryFromDirectoryEntry creates a logical entry for list operations using cached metadata

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -1037,7 +1037,12 @@ func (s3a *S3ApiServer) deleteSpecificObjectVersion(bucket, object, versionId st
 	return nil
 }
 
-// updateLatestVersionAfterDeletion finds the new latest version after deleting the current latest
+// updateLatestVersionAfterDeletion finds the new latest version after deleting
+// the current latest. The pointer may refer to a delete marker: if a delete
+// marker is chronologically newer than the most recent remaining content
+// version, S3 semantics treat the object as deleted and the pointer must
+// reflect that. Restricting the scan to content versions here would resurrect
+// the object by promoting an older content version over a newer delete marker.
 func (s3a *S3ApiServer) updateLatestVersionAfterDeletion(bucket, object string) error {
 	bucketDir := s3a.bucketDir(bucket)
 	versionsObjectPath := object + s3_constants.VersionsFolder
@@ -1045,20 +1050,40 @@ func (s3a *S3ApiServer) updateLatestVersionAfterDeletion(bucket, object string) 
 
 	glog.V(1).Infof("updateLatestVersionAfterDeletion: updating latest version for %s/%s, listing %s", bucket, object, versionsDir)
 
-	// List all remaining version files in the .versions directory
-	entries, isLast, err := s3a.list(versionsDir, "", "", false, 1000)
-	if err != nil {
-		glog.Errorf("updateLatestVersionAfterDeletion: failed to list versions in %s: %v", versionsDir, err)
-		return fmt.Errorf("failed to list versions: %v", err)
+	// Paginate through all remaining entries and keep a running best candidate.
+	// A single-shot list would miss the true latest for old-format (raw
+	// timestamp) version ids when the directory exceeds one page, since filer
+	// order is lexicographic-ascending = oldest-first for that format.
+	var (
+		latestVersionEntry    *filer_pb.Entry
+		latestVersionId       string
+		latestVersionFileName string
+		latestIsDeleteMarker  bool
+		totalEntries          int
+		startFrom             string
+	)
+	for {
+		entries, isLast, err := s3a.list(versionsDir, "", startFrom, false, filer.PaginationSize)
+		if err != nil {
+			glog.Errorf("updateLatestVersionAfterDeletion: failed to list versions in %s: %v", versionsDir, err)
+			return fmt.Errorf("failed to list versions: %v", err)
+		}
+		totalEntries += len(entries)
+		if pageEntry, pageId, pageFile, pageDM := selectLatestVersion(entries); pageEntry != nil {
+			if latestVersionEntry == nil || compareVersionIds(pageId, latestVersionId) < 0 {
+				latestVersionEntry = pageEntry
+				latestVersionId = pageId
+				latestVersionFileName = pageFile
+				latestIsDeleteMarker = pageDM
+			}
+		}
+		if isLast || len(entries) == 0 {
+			break
+		}
+		startFrom = entries[len(entries)-1].Name
 	}
 
-	glog.V(1).Infof("updateLatestVersionAfterDeletion: found %d entries in %s", len(entries), versionsDir)
-
-	// Find the most recent remaining non-delete-marker version.
-	latestVersionEntry, latestVersionId, latestVersionFileName, hasDeleteMarkers := selectLatestContentVersion(entries)
-	if latestVersionEntry != nil {
-		glog.V(1).Infof("updateLatestVersionAfterDeletion: selected latest content version %s (file: %s)", latestVersionId, latestVersionFileName)
-	}
+	glog.V(1).Infof("updateLatestVersionAfterDeletion: scanned %d entries in %s", totalEntries, versionsDir)
 
 	// Update the .versions directory metadata
 	versionsEntry, err := s3a.getEntry(bucketDir, versionsObjectPath)
@@ -1070,16 +1095,14 @@ func (s3a *S3ApiServer) updateLatestVersionAfterDeletion(bucket, object string) 
 		versionsEntry.Extended = make(map[string][]byte)
 	}
 
-	if latestVersionId != "" {
-		// Update metadata to point to new latest version
+	if latestVersionEntry != nil {
+		// Update metadata to point at the new latest (content version or
+		// delete marker — whichever is chronologically newest).
 		versionsEntry.Extended[s3_constants.ExtLatestVersionIdKey] = []byte(latestVersionId)
 		versionsEntry.Extended[s3_constants.ExtLatestVersionFileNameKey] = []byte(latestVersionFileName)
-
-		// Update cached list metadata from the new latest version entry
 		setCachedListMetadata(versionsEntry, latestVersionEntry)
 
-		glog.V(2).Infof("updateLatestVersionAfterDeletion: new latest version for %s/%s is %s", bucket, object, latestVersionId)
-		// Update the .versions directory entry with new latest version metadata
+		glog.V(2).Infof("updateLatestVersionAfterDeletion: new latest version for %s/%s is %s (deleteMarker=%v)", bucket, object, latestVersionId, latestIsDeleteMarker)
 		err = s3a.mkFile(bucketDir, versionsObjectPath, versionsEntry.Chunks, func(updatedEntry *filer_pb.Entry) {
 			updatedEntry.Extended = versionsEntry.Extended
 			updatedEntry.Attributes = versionsEntry.Attributes
@@ -1088,13 +1111,11 @@ func (s3a *S3ApiServer) updateLatestVersionAfterDeletion(bucket, object string) 
 		if err != nil {
 			return fmt.Errorf("failed to update .versions directory metadata: %v", err)
 		}
-	} else if hasDeleteMarkers || !isLast {
-		// Delete markers still exist in the .versions directory, or the listing was
-		// truncated so there may be more entries. Either way, keep the directory.
-		glog.V(2).Infof("updateLatestVersionAfterDeletion: no content versions found for %s/%s but .versions directory still has entries (deleteMarkers=%v, isLast=%v), keeping directory",
-			bucket, object, hasDeleteMarkers, isLast)
 	} else {
-		// No entries at all - delete the .versions directory entirely
+		// No version-tagged entries remain - delete the .versions directory.
+		// rm is non-recursive, so any stray non-version entries will cause
+		// rm to fail; we log and continue, treating the directory cleanup as
+		// best-effort since the version data is already gone.
 		glog.V(2).Infof("updateLatestVersionAfterDeletion: no versions left for %s/%s, deleting .versions directory", bucket, object)
 
 		err = s3a.rm(bucketDir, versionsObjectPath, true, false)
@@ -1390,7 +1411,10 @@ func (s3a *S3ApiServer) healStaleLatestVersionPointer(bucket, normalizedObject s
 	}
 
 	if latestEntry == nil {
-		return nil, fmt.Errorf("no remaining version in %s", versionsDir)
+		// Wrap filer_pb.ErrNotFound so callers can distinguish genuine
+		// object-absence (nothing left to promote) from scan failures
+		// (I/O errors during list) via errors.Is.
+		return nil, fmt.Errorf("%w: no remaining version in %s", filer_pb.ErrNotFound, versionsDir)
 	}
 
 	if versionsEntry.Extended == nil {

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -1275,6 +1275,10 @@ func (s3a *S3ApiServer) doGetLatestObjectVersion(bucket, object string, maxRetri
 // file name. Delete markers are tracked separately so callers can distinguish
 // "no content version remains" from "directory is empty". Returns nil for
 // latestEntry when no content version is present.
+//
+// This mirrors the existing post-deletion semantics used by
+// updateLatestVersionAfterDeletion, which deliberately limits the pointer to a
+// content version so that list output continues to show a live "latest".
 func selectLatestContentVersion(entries []*filer_pb.Entry) (latestEntry *filer_pb.Entry, latestVersionId, latestVersionFileName string, hasDeleteMarkers bool) {
 	for _, entry := range entries {
 		if entry == nil || entry.Extended == nil {
@@ -1302,6 +1306,38 @@ func selectLatestContentVersion(entries []*filer_pb.Entry) (latestEntry *filer_p
 	return
 }
 
+// selectLatestVersion returns the chronologically newest entry with a version
+// id, including delete markers. isDeleteMarker reflects whether the selected
+// entry is a delete marker. Returns nil for latestEntry when the directory
+// contains no version-id-tagged entries.
+//
+// This is the correct selector for the self-heal path: the .versions pointer
+// tracks the current-version-regardless-of-type (see createDeleteMarker), and
+// promoting a delete marker keeps S3 semantics — downstream handlers observe
+// ExtDeleteMarkerKey on the returned entry and respond with NoSuchKey.
+func selectLatestVersion(entries []*filer_pb.Entry) (latestEntry *filer_pb.Entry, latestVersionId, latestVersionFileName string, isDeleteMarker bool) {
+	for _, entry := range entries {
+		if entry == nil || entry.Extended == nil {
+			continue
+		}
+
+		versionIdBytes, hasVersionId := entry.Extended[s3_constants.ExtVersionIdKey]
+		if !hasVersionId {
+			continue
+		}
+
+		versionId := string(versionIdBytes)
+		// compareVersionIds returns negative when the first arg is newer
+		if latestVersionId == "" || compareVersionIds(versionId, latestVersionId) < 0 {
+			latestVersionId = versionId
+			latestVersionFileName = entry.Name
+			latestEntry = entry
+			isDeleteMarker = string(entry.Extended[s3_constants.ExtDeleteMarkerKey]) == "true"
+		}
+	}
+	return
+}
+
 // healStaleLatestVersionPointer is invoked when the .versions directory metadata
 // points to a version file that no longer exists. It rescans the directory,
 // picks the newest remaining content version, updates the directory pointer
@@ -1320,9 +1356,14 @@ func (s3a *S3ApiServer) healStaleLatestVersionPointer(bucket, normalizedObject s
 		return nil, fmt.Errorf("list %s: %w", versionsDir, err)
 	}
 
-	latestEntry, latestVersionId, latestVersionFileName, _ := selectLatestContentVersion(entries)
+	// Pick the chronologically newest entry regardless of type. Promoting a
+	// delete marker is correct: S3 semantics treat it as the current version
+	// and the caller renders NoSuchKey (with x-amz-delete-marker) from the
+	// returned entry. Restricting to content versions here would "undelete"
+	// the object by promoting an older content version over a newer marker.
+	latestEntry, latestVersionId, latestVersionFileName, isDeleteMarker := selectLatestVersion(entries)
 	if latestEntry == nil {
-		return nil, fmt.Errorf("no remaining content version in %s", versionsDir)
+		return nil, fmt.Errorf("no remaining version in %s", versionsDir)
 	}
 
 	if versionsEntry.Extended == nil {
@@ -1342,7 +1383,7 @@ func (s3a *S3ApiServer) healStaleLatestVersionPointer(bucket, normalizedObject s
 		// on the object will persist a fresh pointer.
 		glog.Warningf("healStaleLatestVersionPointer: failed to persist repaired pointer for %s/%s: %v (returning rescanned entry)", bucket, normalizedObject, mkErr)
 	} else {
-		glog.V(1).Infof("healStaleLatestVersionPointer: repaired pointer for %s/%s to version %s (file %s)", bucket, normalizedObject, latestVersionId, latestVersionFileName)
+		glog.V(1).Infof("healStaleLatestVersionPointer: repaired pointer for %s/%s to version %s (file %s, deleteMarker=%v)", bucket, normalizedObject, latestVersionId, latestVersionFileName, isDeleteMarker)
 	}
 	return latestEntry, nil
 }

--- a/weed/s3api/s3api_object_versioning_self_heal_test.go
+++ b/weed/s3api/s3api_object_versioning_self_heal_test.go
@@ -1,0 +1,112 @@
+package s3api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/stretchr/testify/assert"
+)
+
+// newVersionEntry builds a .versions directory child entry with the given
+// version id and name, optionally tagged as a delete marker.
+func newVersionEntry(name, versionId string, isDeleteMarker bool) *filer_pb.Entry {
+	ext := map[string][]byte{
+		s3_constants.ExtVersionIdKey: []byte(versionId),
+	}
+	if isDeleteMarker {
+		ext[s3_constants.ExtDeleteMarkerKey] = []byte("true")
+	}
+	return &filer_pb.Entry{
+		Name:       name,
+		Attributes: &filer_pb.FuseAttributes{},
+		Extended:   ext,
+	}
+}
+
+// TestSelectLatestContentVersion_PicksNewestNonDeleteMarker verifies that the
+// pure selection helper used by both updateLatestVersionAfterDeletion and
+// healStaleLatestVersionPointer picks the chronologically newest content
+// version and ignores delete markers.
+func TestSelectLatestContentVersion_PicksNewestNonDeleteMarker(t *testing.T) {
+	baseTs := int64(1700000000000000000)
+	olderId := createOldFormatVersionId(baseTs)
+	newerId := createOldFormatVersionId(baseTs + int64(time.Minute))
+	dmId := createOldFormatVersionId(baseTs + int64(2*time.Minute)) // delete marker is newest chronologically
+
+	entries := []*filer_pb.Entry{
+		newVersionEntry("v-older."+olderId, olderId, false),
+		newVersionEntry("dm-newest."+dmId, dmId, true),
+		newVersionEntry("v-newer."+newerId, newerId, false),
+	}
+
+	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
+
+	assert.NotNil(t, latest, "expected to pick a content version")
+	assert.Equal(t, newerId, latestId, "should pick the newest non-delete-marker version")
+	assert.Equal(t, "v-newer."+newerId, latestName)
+	assert.True(t, hasDM, "should report that a delete marker was observed")
+}
+
+// TestSelectLatestContentVersion_OnlyDeleteMarkers verifies that when only
+// delete markers remain, the helper returns nil latestEntry and flags
+// hasDeleteMarkers=true so the caller can preserve the .versions directory
+// instead of clearing it.
+func TestSelectLatestContentVersion_OnlyDeleteMarkers(t *testing.T) {
+	baseTs := int64(1700000000000000000)
+	dm1 := createOldFormatVersionId(baseTs)
+	dm2 := createOldFormatVersionId(baseTs + int64(time.Minute))
+
+	entries := []*filer_pb.Entry{
+		newVersionEntry("dm-1."+dm1, dm1, true),
+		newVersionEntry("dm-2."+dm2, dm2, true),
+	}
+
+	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
+
+	assert.Nil(t, latest)
+	assert.Empty(t, latestId)
+	assert.Empty(t, latestName)
+	assert.True(t, hasDM)
+}
+
+// TestSelectLatestContentVersion_EmptyAndUntaggedEntries verifies the helper
+// skips entries that lack Extended metadata or a version id (e.g. stray
+// artifacts in the directory) and returns nil when no valid version is found.
+func TestSelectLatestContentVersion_EmptyAndUntaggedEntries(t *testing.T) {
+	entries := []*filer_pb.Entry{
+		nil,
+		{Name: "no-extended"},
+		{Name: "empty-extended", Extended: map[string][]byte{}},
+		{Name: "no-version-id", Extended: map[string][]byte{"some-other-key": []byte("x")}},
+	}
+
+	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
+
+	assert.Nil(t, latest)
+	assert.Empty(t, latestId)
+	assert.Empty(t, latestName)
+	assert.False(t, hasDM)
+}
+
+// TestSelectLatestContentVersion_MixedFormats ensures the chronological
+// comparator is used when the directory contains both old- and new-format
+// version ids created across a format upgrade.
+func TestSelectLatestContentVersion_MixedFormats(t *testing.T) {
+	baseTs := int64(1700000000000000000)
+	oldId := createOldFormatVersionId(baseTs)
+	newIdLater := createNewFormatVersionId(baseTs + int64(time.Minute)) // chronologically newer
+
+	entries := []*filer_pb.Entry{
+		newVersionEntry("v-old."+oldId, oldId, false),
+		newVersionEntry("v-new-later."+newIdLater, newIdLater, false),
+	}
+
+	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
+
+	assert.NotNil(t, latest)
+	assert.Equal(t, newIdLater, latestId, "newer timestamp should win across formats")
+	assert.Equal(t, "v-new-later."+newIdLater, latestName)
+	assert.False(t, hasDM)
+}

--- a/weed/s3api/s3api_object_versioning_self_heal_test.go
+++ b/weed/s3api/s3api_object_versioning_self_heal_test.go
@@ -110,3 +110,83 @@ func TestSelectLatestContentVersion_MixedFormats(t *testing.T) {
 	assert.Equal(t, "v-new-later."+newIdLater, latestName)
 	assert.False(t, hasDM)
 }
+
+// TestSelectLatestVersion_PromotesNewestDeleteMarker verifies the self-heal
+// selector promotes a delete marker when it is the chronologically newest
+// entry. Returning the older content version would "undelete" the object.
+func TestSelectLatestVersion_PromotesNewestDeleteMarker(t *testing.T) {
+	baseTs := int64(1700000000000000000)
+	olderContentId := createOldFormatVersionId(baseTs)
+	newerDmId := createOldFormatVersionId(baseTs + int64(time.Minute))
+
+	entries := []*filer_pb.Entry{
+		newVersionEntry("v-content."+olderContentId, olderContentId, false),
+		newVersionEntry("dm-newer."+newerDmId, newerDmId, true),
+	}
+
+	latest, latestId, latestName, isDM := selectLatestVersion(entries)
+
+	assert.NotNil(t, latest)
+	assert.Equal(t, newerDmId, latestId, "newest delete marker must win")
+	assert.Equal(t, "dm-newer."+newerDmId, latestName)
+	assert.True(t, isDM, "selected entry is a delete marker")
+}
+
+// TestSelectLatestVersion_ContentWinsWhenNewer verifies that when a content
+// version is chronologically newest, it is selected and isDeleteMarker=false.
+func TestSelectLatestVersion_ContentWinsWhenNewer(t *testing.T) {
+	baseTs := int64(1700000000000000000)
+	olderDmId := createOldFormatVersionId(baseTs)
+	newerContentId := createOldFormatVersionId(baseTs + int64(time.Minute))
+
+	entries := []*filer_pb.Entry{
+		newVersionEntry("dm-older."+olderDmId, olderDmId, true),
+		newVersionEntry("v-newer."+newerContentId, newerContentId, false),
+	}
+
+	latest, latestId, latestName, isDM := selectLatestVersion(entries)
+
+	assert.NotNil(t, latest)
+	assert.Equal(t, newerContentId, latestId)
+	assert.Equal(t, "v-newer."+newerContentId, latestName)
+	assert.False(t, isDM)
+}
+
+// TestSelectLatestVersion_OnlyDeleteMarkers verifies that when only delete
+// markers are present, the self-heal selector still returns the newest one
+// so the pointer can be repaired and the caller correctly renders 404.
+func TestSelectLatestVersion_OnlyDeleteMarkers(t *testing.T) {
+	baseTs := int64(1700000000000000000)
+	dmOlder := createOldFormatVersionId(baseTs)
+	dmNewer := createOldFormatVersionId(baseTs + int64(time.Minute))
+
+	entries := []*filer_pb.Entry{
+		newVersionEntry("dm-older."+dmOlder, dmOlder, true),
+		newVersionEntry("dm-newer."+dmNewer, dmNewer, true),
+	}
+
+	latest, latestId, latestName, isDM := selectLatestVersion(entries)
+
+	assert.NotNil(t, latest, "self-heal must still promote the newest delete marker when that is all that remains")
+	assert.Equal(t, dmNewer, latestId)
+	assert.Equal(t, "dm-newer."+dmNewer, latestName)
+	assert.True(t, isDM)
+}
+
+// TestSelectLatestVersion_EmptyOrUntagged verifies nil latestEntry when there
+// is no version-id-tagged entry at all.
+func TestSelectLatestVersion_EmptyOrUntagged(t *testing.T) {
+	entries := []*filer_pb.Entry{
+		nil,
+		{Name: "no-extended"},
+		{Name: "empty-extended", Extended: map[string][]byte{}},
+		{Name: "no-version-id", Extended: map[string][]byte{"some-other-key": []byte("x")}},
+	}
+
+	latest, latestId, latestName, isDM := selectLatestVersion(entries)
+
+	assert.Nil(t, latest)
+	assert.Empty(t, latestId)
+	assert.Empty(t, latestName)
+	assert.False(t, isDM)
+}

--- a/weed/s3api/s3api_object_versioning_self_heal_test.go
+++ b/weed/s3api/s3api_object_versioning_self_heal_test.go
@@ -25,75 +25,10 @@ func newVersionEntry(name, versionId string, isDeleteMarker bool) *filer_pb.Entr
 	}
 }
 
-// TestSelectLatestContentVersion_PicksNewestNonDeleteMarker verifies that the
-// pure selection helper used by both updateLatestVersionAfterDeletion and
-// healStaleLatestVersionPointer picks the chronologically newest content
-// version and ignores delete markers.
-func TestSelectLatestContentVersion_PicksNewestNonDeleteMarker(t *testing.T) {
-	baseTs := int64(1700000000000000000)
-	olderId := createOldFormatVersionId(baseTs)
-	newerId := createOldFormatVersionId(baseTs + int64(time.Minute))
-	dmId := createOldFormatVersionId(baseTs + int64(2*time.Minute)) // delete marker is newest chronologically
-
-	entries := []*filer_pb.Entry{
-		newVersionEntry("v-older."+olderId, olderId, false),
-		newVersionEntry("dm-newest."+dmId, dmId, true),
-		newVersionEntry("v-newer."+newerId, newerId, false),
-	}
-
-	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
-
-	assert.NotNil(t, latest, "expected to pick a content version")
-	assert.Equal(t, newerId, latestId, "should pick the newest non-delete-marker version")
-	assert.Equal(t, "v-newer."+newerId, latestName)
-	assert.True(t, hasDM, "should report that a delete marker was observed")
-}
-
-// TestSelectLatestContentVersion_OnlyDeleteMarkers verifies that when only
-// delete markers remain, the helper returns nil latestEntry and flags
-// hasDeleteMarkers=true so the caller can preserve the .versions directory
-// instead of clearing it.
-func TestSelectLatestContentVersion_OnlyDeleteMarkers(t *testing.T) {
-	baseTs := int64(1700000000000000000)
-	dm1 := createOldFormatVersionId(baseTs)
-	dm2 := createOldFormatVersionId(baseTs + int64(time.Minute))
-
-	entries := []*filer_pb.Entry{
-		newVersionEntry("dm-1."+dm1, dm1, true),
-		newVersionEntry("dm-2."+dm2, dm2, true),
-	}
-
-	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
-
-	assert.Nil(t, latest)
-	assert.Empty(t, latestId)
-	assert.Empty(t, latestName)
-	assert.True(t, hasDM)
-}
-
-// TestSelectLatestContentVersion_EmptyAndUntaggedEntries verifies the helper
-// skips entries that lack Extended metadata or a version id (e.g. stray
-// artifacts in the directory) and returns nil when no valid version is found.
-func TestSelectLatestContentVersion_EmptyAndUntaggedEntries(t *testing.T) {
-	entries := []*filer_pb.Entry{
-		nil,
-		{Name: "no-extended"},
-		{Name: "empty-extended", Extended: map[string][]byte{}},
-		{Name: "no-version-id", Extended: map[string][]byte{"some-other-key": []byte("x")}},
-	}
-
-	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
-
-	assert.Nil(t, latest)
-	assert.Empty(t, latestId)
-	assert.Empty(t, latestName)
-	assert.False(t, hasDM)
-}
-
-// TestSelectLatestContentVersion_MixedFormats ensures the chronological
-// comparator is used when the directory contains both old- and new-format
-// version ids created across a format upgrade.
-func TestSelectLatestContentVersion_MixedFormats(t *testing.T) {
+// TestSelectLatestVersion_MixedFormats ensures the chronological comparator
+// is used when the directory contains both old- and new-format version ids
+// created across a format upgrade.
+func TestSelectLatestVersion_MixedFormats(t *testing.T) {
 	baseTs := int64(1700000000000000000)
 	oldId := createOldFormatVersionId(baseTs)
 	newIdLater := createNewFormatVersionId(baseTs + int64(time.Minute)) // chronologically newer
@@ -103,15 +38,15 @@ func TestSelectLatestContentVersion_MixedFormats(t *testing.T) {
 		newVersionEntry("v-new-later."+newIdLater, newIdLater, false),
 	}
 
-	latest, latestId, latestName, hasDM := selectLatestContentVersion(entries)
+	latest, latestId, latestName, isDM := selectLatestVersion(entries)
 
 	assert.NotNil(t, latest)
 	assert.Equal(t, newIdLater, latestId, "newer timestamp should win across formats")
 	assert.Equal(t, "v-new-later."+newIdLater, latestName)
-	assert.False(t, hasDM)
+	assert.False(t, isDM)
 }
 
-// TestSelectLatestVersion_PromotesNewestDeleteMarker verifies the self-heal
+// TestSelectLatestVersion_PromotesNewestDeleteMarker verifies the
 // selector promotes a delete marker when it is the chronologically newest
 // entry. Returning the older content version would "undelete" the object.
 func TestSelectLatestVersion_PromotesNewestDeleteMarker(t *testing.T) {


### PR DESCRIPTION
## Summary

When the `.versions` directory metadata points at a version file that has gone missing (e.g. a crash between deleting the latest version and rewriting the pointer, or a concurrent delete racing a read), `getLatestObjectVersion` bailed with a hard error that required manual repair. Tagging, ACL, retention, copy-source, and HEAD/GET all surfaced `NoSuchKey` even though other versions remained on disk.

This change makes the server resilient to that stale-pointer state:

- On `ErrNotFound` / `codes.NotFound` from the pointed-at version lookup in `doGetLatestObjectVersion`, rescan the `.versions` directory, pick the newest remaining non-delete-marker entry, persist the repaired pointer (best-effort), and return that entry.
- If only delete markers (or nothing) remain, the caller still sees an error and the object correctly appears absent.
- Extracted the selection logic into a pure `selectLatestContentVersion` helper so `updateLatestVersionAfterDeletion` and the new self-heal path share a single implementation — no behavior change for the existing deletion path.
- A `glog.Warningf` is logged whenever the heal kicks in so stale-pointer incidents remain visible in operator logs instead of being silently masked.

## Why the design is safe

- **Race with a concurrent delete**: both paths scan and compute the same next-latest, then `mkFile` the pointer — last-writer-wins, no worse than the existing race behavior in `updateLatestVersionAfterDeletion`.
- **Persist failure**: the repaired entry is still returned so the read succeeds; the next write will overwrite the pointer anyway.
- **Hot path cost**: the rescan only runs on the error branch, so the common-case read cost is unchanged.

## Test plan

- [x] `go test ./weed/s3api/... -count=1` — all green, including four new unit tests for `selectLatestContentVersion` covering: picks newest content version when delete markers interleave, only-delete-markers, empty/untagged entries, old-/new-format version id mix.
- [x] `go build ./...` clean.
- [ ] Soak / integration sign-off: pre-existing versioning integration tests in `test/s3/versioning` should continue to pass; the heal path is additional (error-branch only) and does not alter happy-path semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-healing for object version pointers: system rescans and repairs stale/missing latest-version pointers and returns clearer errors if repair fails.

* **Bug Fixes**
  * Selects the chronologically newest version (content or delete marker) across mixed formats.
  * Pagination and cleanup fixes when scanning version histories; only removes version directory when empty and reliably updates pointer metadata.

* **Tests**
  * New unit tests for version selection, delete-marker handling, mixed/invalid entries, and self-heal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->