### PR TITLE
feat(filer.backup): -initialSnapshot seeds destination from live tree

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -179,7 +179,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	// the walk leave no trace, so a re-backup after wiping the destination
 	// reflects what is actually live on the source instead of an empty tree.
 	if *backupOption.initialSnapshot && isFreshSync {
-		snapshotTsNs, err := runInitialSnapshot(sourceFiler.ToGrpcAddress(), filerSource, sourcePath, targetPath, excludePaths, reExcludeFileName, excludeFileNames, excludePathPatterns, dataSink)
+		snapshotTsNs, err := runInitialSnapshot(sourceFiler.ToGrpcAddress(), filerSource, sourcePath, targetPath, excludePaths, reExcludeFileName, excludeFileNames, excludePathPatterns, dataSink, *backupOption.ignore404Error)
 		if err != nil {
 			return fmt.Errorf("initial snapshot: %w", err)
 		}
@@ -335,9 +335,15 @@ func runInitialSnapshot(
 	excludeFileNames []*wildcard.WildcardMatcher,
 	excludePathPatterns []*wildcard.WildcardMatcher,
 	dataSink sink.ReplicationSink,
+	ignore404Error bool,
 ) (int64, error) {
-	snapshotTsNs := time.Now().UnixNano()
-	glog.V(0).Infof("initialSnapshot: walking %s on %s -> %s (snapshotTsNs=%d)", sourcePath, grpcAddress, targetPath, snapshotTsNs)
+	// Metadata events are stamped server-side, so the backup host clock may be
+	// ahead of the filer's. Take `now - 1min` as the subscription watermark so
+	// a fast client clock can't skip events that fire during/right-after the
+	// walk. meta_aggregator.go uses the same 1-minute margin on initial peer
+	// traversal; see the note there on why duplicate replay is harmless.
+	snapshotTsNs := time.Now().Add(-time.Minute).UnixNano()
+	glog.V(0).Infof("initialSnapshot: walking %s on %s -> %s (snapshotTsNs=%d, -1m skew margin applied)", sourcePath, grpcAddress, targetPath, snapshotTsNs)
 
 	// TraverseBfs fans the callback out across 5 worker goroutines, so counter
 	// updates and the progress-log gate need to be safe under concurrent access.
@@ -351,23 +357,38 @@ func runInitialSnapshot(
 
 	err := filer_pb.TraverseBfs(ctx, filerSource, util.FullPath(sourcePath), func(parentPath util.FullPath, entry *filer_pb.Entry) error {
 		parent := string(parentPath)
-		if parent == filer.SystemLogDir || strings.HasPrefix(parent, filer.SystemLogDir+"/") {
+		sourceKey := parentPath.Child(entry.Name)
+		source := string(sourceKey)
+		// Check exclusion on the entry's own path too — otherwise a walked
+		// directory whose full path is SystemLogDir or a user-excluded path
+		// still gets seeded (only its children would be skipped by the parent
+		// check).
+		if parent == filer.SystemLogDir || strings.HasPrefix(parent, filer.SystemLogDir+"/") ||
+			source == filer.SystemLogDir || strings.HasPrefix(source, filer.SystemLogDir+"/") {
 			return nil
 		}
-		if matchesExcludePath(parent, excludePaths) {
+		if matchesExcludePath(parent, excludePaths) || matchesExcludePath(source, excludePaths) {
 			return nil
 		}
 		if isEntryExcluded(parent, entry, reExcludeFileName, excludeFileNames, excludePathPatterns) {
 			return nil
 		}
 
-		sourceKey := parentPath.Child(entry.Name)
-		if !util.IsEqualOrUnder(string(sourceKey), sourcePath) {
+		if !util.IsEqualOrUnder(source, sourcePath) {
 			return nil
 		}
 
 		targetKey := initialSnapshotTargetKey(dataSink, targetPath, sourcePath, sourceKey, entry)
 		if err := dataSink.CreateEntry(targetKey, entry, nil); err != nil {
+			// A file can be listed by TraverseBfs and then deleted before
+			// CreateEntry reads its chunks. The follow phase ignores 404s when
+			// -ignore404Error is set; apply the same policy here so the walk
+			// doesn't abort (and trigger a full re-walk on retry) just because
+			// a single entry disappeared mid-snapshot.
+			if ignore404Error && isIgnorable404(err) {
+				glog.V(0).Infof("initialSnapshot: source entry %s disappeared, ignore it: %s", sourceKey, err.Error())
+				return nil
+			}
 			return fmt.Errorf("seed %s: %w", targetKey, err)
 		}
 

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -183,7 +183,11 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		if err != nil {
 			return fmt.Errorf("initial snapshot: %w", err)
 		}
-		if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId), snapshotTsNs); err != nil {
+		// The walk can take hours on large trees; retry the tiny KV write a
+		// handful of times before giving up so a flaky filer KV doesn't force
+		// the whole walk to repeat on the next retry loop iteration.
+		if err := persistSnapshotOffset(grpcDialOption, sourceFiler, int32(sinkId), snapshotTsNs); err != nil {
+			glog.Errorf("initialSnapshot: FAILED to persist offset %d for sinkId %d after retries: %v — the next retry will redo the full walk", snapshotTsNs, sinkId, err)
 			return fmt.Errorf("persist initial snapshot offset: %w", err)
 		}
 		startFrom = time.Unix(0, snapshotTsNs)
@@ -280,6 +284,31 @@ func isIgnorable404(err error) bool {
 	return strings.Contains(errStr, ignorable404ErrString) ||
 		strings.Contains(errStr, "LookupFileId") ||
 		(strings.Contains(errStr, "volume id") && strings.Contains(errStr, "not found"))
+}
+
+// persistSnapshotOffset writes the snapshot high-water mark to the source
+// filer's KV, retrying a few times with exponential backoff on transient
+// errors. Losing this write forces a full re-walk on the next retry loop
+// iteration, so a small retry budget here is far cheaper than paying the
+// walk cost again on a large tree.
+func persistSnapshotOffset(grpcDialOption grpc.DialOption, sourceFiler pb.ServerAddress, sinkId int32, tsNs int64) error {
+	const attempts = 4
+	backoff := 500 * time.Millisecond
+	var lastErr error
+	for i := 1; i <= attempts; i++ {
+		if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, sinkId, tsNs); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			if i == attempts {
+				break
+			}
+			glog.V(0).Infof("initialSnapshot: setOffset attempt %d/%d failed: %v (retrying in %v)", i, attempts, err, backoff)
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+	return lastErr
 }
 
 // runInitialSnapshot walks the live filer tree under sourcePath and seeds the

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	nethttp "net/http"
@@ -8,10 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/replication/repl_util"
+	"github.com/seaweedfs/seaweedfs/weed/replication/sink"
 	"github.com/seaweedfs/seaweedfs/weed/replication/source"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -35,6 +38,7 @@ type FilerBackupOptions struct {
 	ignore404Error      *bool
 	timeAgo             *time.Duration
 	retentionDays       *int
+	initialSnapshot     *bool
 }
 
 var (
@@ -57,6 +61,7 @@ func init() {
 	filerBackupOptions.retentionDays = cmdFilerBackup.Flag.Int("retentionDays", 0, "incremental backup retention days")
 	filerBackupOptions.disableErrorRetry = cmdFilerBackup.Flag.Bool("disableErrorRetry", false, "disables errors retry, only logs will print")
 	filerBackupOptions.ignore404Error = cmdFilerBackup.Flag.Bool("ignore404Error", true, "ignore 404 errors from filer")
+	filerBackupOptions.initialSnapshot = cmdFilerBackup.Flag.Bool("initialSnapshot", false, "before subscribing to metadata updates, walk the live filer tree under -filerPath and seed the destination. Only runs on a fresh sync (no prior checkpoint and -timeAgo is 0). After the walk, subscription starts from the walk-start timestamp so concurrent changes are still captured.")
 }
 
 var cmdFilerBackup = &Command{
@@ -69,6 +74,11 @@ var cmdFilerBackup = &Command{
 
 	If restarted and "-timeAgo" is not set, the synchronization will resume from the previous checkpoints, persisted every minute.
 	A fresh sync will start from the earliest metadata logs. To reset the checkpoints, just set "-timeAgo" to a high value.
+
+	On a fresh sync the metadata event log only re-materializes files that still exist on the source; entries that were
+	created and later deleted are replayed as a create-then-delete pair and therefore never appear on the destination.
+	Pass "-initialSnapshot" to walk the live filer tree first and seed the destination with the current tree, then
+	subscribe from the walk-start timestamp. The walk only runs when there is no prior checkpoint.
 
 `,
 }
@@ -123,17 +133,22 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 
 	// get start time for the data sink
 	startFrom := time.Unix(0, 0)
+	isFreshSync := true
 	sinkId := util.HashStringToLong(dataSink.GetName() + dataSink.GetSinkToDirectory())
 	if timeAgo.Milliseconds() == 0 {
 		lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
 		if err != nil {
 			glog.V(0).Infof("starting from %v", startFrom)
-		} else {
+		} else if lastOffsetTsNs > 0 {
 			startFrom = time.Unix(0, lastOffsetTsNs)
+			isFreshSync = false
 			glog.V(0).Infof("resuming from %v", startFrom)
+		} else {
+			glog.V(0).Infof("starting from %v (no prior checkpoint)", startFrom)
 		}
 	} else {
 		startFrom = time.Now().Add(-timeAgo)
+		isFreshSync = false
 		glog.V(0).Infof("start time is set to %v", startFrom)
 	}
 
@@ -149,6 +164,24 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		return fmt.Errorf("SSE initialization failed: %v", err)
 	}
 	dataSink.SetSourceFiler(filerSource)
+
+	// When the destination has no prior checkpoint and the user opted in to an
+	// initial snapshot, walk the live filer tree first and seed the destination
+	// with the current entries. This avoids the "only new files appear" pitfall
+	// of replaying the metadata event log: entries created-then-deleted before
+	// the walk leave no trace, so a re-backup after wiping the destination
+	// reflects what is actually live on the source instead of an empty tree.
+	if *backupOption.initialSnapshot && isFreshSync {
+		snapshotTsNs, err := runInitialSnapshot(sourceFiler.ToGrpcAddress(), filerSource, sourcePath, targetPath, excludePaths, reExcludeFileName, excludeFileNames, excludePathPatterns, dataSink)
+		if err != nil {
+			return fmt.Errorf("initial snapshot: %w", err)
+		}
+		if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId), snapshotTsNs); err != nil {
+			return fmt.Errorf("persist initial snapshot offset: %w", err)
+		}
+		startFrom = time.Unix(0, snapshotTsNs)
+		glog.V(0).Infof("initialSnapshot done; subscribing from %v", startFrom)
+	}
 
 	var processEventFn func(*filer_pb.SubscribeMetadataResponse) error
 	if *backupOption.ignore404Error {
@@ -240,4 +273,91 @@ func isIgnorable404(err error) bool {
 	return strings.Contains(errStr, ignorable404ErrString) ||
 		strings.Contains(errStr, "LookupFileId") ||
 		(strings.Contains(errStr, "volume id") && strings.Contains(errStr, "not found"))
+}
+
+// runInitialSnapshot walks the live filer tree under sourcePath and seeds the
+// destination via the sink. The snapshot timestamp is captured before the walk
+// starts so any create/update/delete that races with the walk is still caught
+// by the subscription that runs afterward (sink CreateEntry is idempotent for
+// all builtin sinks, so replaying a concurrent create from the subscription
+// over an entry already written by the walk is safe).
+func runInitialSnapshot(
+	grpcAddress string,
+	filerSource *source.FilerSource,
+	sourcePath string,
+	targetPath string,
+	excludePaths []string,
+	reExcludeFileName *regexp.Regexp,
+	excludeFileNames []*wildcard.WildcardMatcher,
+	excludePathPatterns []*wildcard.WildcardMatcher,
+	dataSink sink.ReplicationSink,
+) (int64, error) {
+	snapshotTsNs := time.Now().UnixNano()
+	glog.V(0).Infof("initialSnapshot: walking %s on %s -> %s (snapshotTsNs=%d)", sourcePath, grpcAddress, targetPath, snapshotTsNs)
+
+	var entryCount, byteCount int64
+	start := time.Now()
+	lastLog := start
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := filer_pb.TraverseBfs(ctx, filerSource, util.FullPath(sourcePath), func(parentPath util.FullPath, entry *filer_pb.Entry) error {
+		parent := string(parentPath)
+		if parent == filer.SystemLogDir || strings.HasPrefix(parent, filer.SystemLogDir+"/") {
+			return nil
+		}
+		if matchesExcludePath(parent, excludePaths) {
+			return nil
+		}
+		if isEntryExcluded(parent, entry, reExcludeFileName, excludeFileNames, excludePathPatterns) {
+			return nil
+		}
+
+		sourceKey := parentPath.Child(entry.Name)
+		if !util.IsEqualOrUnder(string(sourceKey), sourcePath) {
+			return nil
+		}
+
+		targetKey := initialSnapshotTargetKey(dataSink, targetPath, sourcePath, sourceKey, entry)
+		if err := dataSink.CreateEntry(targetKey, entry, nil); err != nil {
+			return fmt.Errorf("seed %s: %w", targetKey, err)
+		}
+
+		entryCount++
+		if entry.Attributes != nil {
+			byteCount += int64(entry.Attributes.FileSize)
+		}
+		if now := time.Now(); now.Sub(lastLog) >= 5*time.Second {
+			lastLog = now
+			elapsed := now.Sub(start).Seconds()
+			if elapsed == 0 {
+				elapsed = 1
+			}
+			glog.V(0).Infof("initialSnapshot: %d entries / %d bytes seeded (%.1f/sec)", entryCount, byteCount, float64(entryCount)/elapsed)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	glog.V(0).Infof("initialSnapshot: done — %d entries / %d bytes in %v", entryCount, byteCount, time.Since(start))
+	return snapshotTsNs, nil
+}
+
+// initialSnapshotTargetKey mirrors buildKey from filer_sync.go but works from a
+// raw (sourceKey, entry) pair instead of an EventNotification. Kept close to
+// runInitialSnapshot so the mapping from source path to destination key stays
+// in one place for the seed path.
+func initialSnapshotTargetKey(dataSink sink.ReplicationSink, targetPath, sourcePath string, sourceKey util.FullPath, entry *filer_pb.Entry) string {
+	relative := string(sourceKey)[len(sourcePath):]
+	if !dataSink.IsIncremental() {
+		return escapeKey(util.Join(targetPath, relative))
+	}
+	var mTime int64
+	if entry.Attributes != nil {
+		mTime = entry.Attributes.Mtime
+	}
+	dateKey := time.Unix(mTime, 0).Format("2006-01-02")
+	return escapeKey(util.Join(targetPath, dateKey, relative))
 }

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -7,6 +7,8 @@ import (
 	nethttp "net/http"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -295,8 +297,11 @@ func runInitialSnapshot(
 	snapshotTsNs := time.Now().UnixNano()
 	glog.V(0).Infof("initialSnapshot: walking %s on %s -> %s (snapshotTsNs=%d)", sourcePath, grpcAddress, targetPath, snapshotTsNs)
 
-	var entryCount, byteCount int64
+	// TraverseBfs fans the callback out across 5 worker goroutines, so counter
+	// updates and the progress-log gate need to be safe under concurrent access.
+	var entryCount, byteCount atomic.Int64
 	start := time.Now()
+	var logMu sync.Mutex
 	lastLog := start
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -324,24 +329,34 @@ func runInitialSnapshot(
 			return fmt.Errorf("seed %s: %w", targetKey, err)
 		}
 
-		entryCount++
+		curEntries := entryCount.Add(1)
+		var curBytes int64
 		if entry.Attributes != nil {
-			byteCount += int64(entry.Attributes.FileSize)
+			curBytes = byteCount.Add(int64(entry.Attributes.FileSize))
+		} else {
+			curBytes = byteCount.Load()
 		}
-		if now := time.Now(); now.Sub(lastLog) >= 5*time.Second {
+
+		now := time.Now()
+		logMu.Lock()
+		shouldLog := now.Sub(lastLog) >= 5*time.Second
+		if shouldLog {
 			lastLog = now
+		}
+		logMu.Unlock()
+		if shouldLog {
 			elapsed := now.Sub(start).Seconds()
 			if elapsed == 0 {
 				elapsed = 1
 			}
-			glog.V(0).Infof("initialSnapshot: %d entries / %d bytes seeded (%.1f/sec)", entryCount, byteCount, float64(entryCount)/elapsed)
+			glog.V(0).Infof("initialSnapshot: %d entries / %d bytes seeded (%.1f/sec)", curEntries, curBytes, float64(curEntries)/elapsed)
 		}
 		return nil
 	})
 	if err != nil {
 		return 0, err
 	}
-	glog.V(0).Infof("initialSnapshot: done — %d entries / %d bytes in %v", entryCount, byteCount, time.Since(start))
+	glog.V(0).Infof("initialSnapshot: done — %d entries / %d bytes in %v", entryCount.Load(), byteCount.Load(), time.Since(start))
 	return snapshotTsNs, nil
 }
 

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -140,7 +140,12 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	if timeAgo.Milliseconds() == 0 {
 		lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
 		if err != nil {
-			glog.V(0).Infof("starting from %v", startFrom)
+			// A KV read failure is ambiguous — a checkpoint may well exist but the
+			// source filer is temporarily unreachable. Don't treat that as a fresh
+			// sync; otherwise runFilerBackup's retry loop would redo the full
+			// -initialSnapshot walk on every transient error.
+			isFreshSync = false
+			glog.V(0).Infof("starting from %v (offset read failed: %v)", startFrom, err)
 		} else if lastOffsetTsNs > 0 {
 			startFrom = time.Unix(0, lastOffsetTsNs)
 			isFreshSync = false
@@ -283,6 +288,14 @@ func isIgnorable404(err error) bool {
 // by the subscription that runs afterward (sink CreateEntry is idempotent for
 // all builtin sinks, so replaying a concurrent create from the subscription
 // over an entry already written by the walk is safe).
+//
+// Note on excludes: TraverseBfs enumerates every directory and enqueues its
+// children unconditionally before the callback runs, so the exclude filters
+// below only prevent *processing* of excluded entries — they do not prune the
+// listing RPCs for excluded subtrees. For small system excludes (SystemLogDir)
+// that is fine; for large user-supplied excludes (say an archive directory
+// with millions of files), the listing cost can dominate the snapshot. A
+// proper prune signal through TraverseBfs is a separate change.
 func runInitialSnapshot(
 	grpcAddress string,
 	filerSource *source.FilerSource,
@@ -365,7 +378,20 @@ func runInitialSnapshot(
 // runInitialSnapshot so the mapping from source path to destination key stays
 // in one place for the seed path.
 func initialSnapshotTargetKey(dataSink sink.ReplicationSink, targetPath, sourcePath string, sourceKey util.FullPath, entry *filer_pb.Entry) string {
-	relative := string(sourceKey)[len(sourcePath):]
+	// Normalize to a trailing-slash base so trimming never depends on whether
+	// the caller passed sourcePath with or without one, and never indexes past
+	// the end of sourceKey (IsEqualOrUnder upstream admits the equal case).
+	base := strings.TrimSuffix(sourcePath, "/") + "/"
+	sk := string(sourceKey)
+	var relative string
+	switch {
+	case strings.HasPrefix(sk, base):
+		relative = sk[len(base):]
+	case sk == strings.TrimSuffix(sourcePath, "/"):
+		relative = ""
+	default:
+		relative = strings.TrimPrefix(sk, "/")
+	}
 	if !dataSink.IsIncremental() {
 		return escapeKey(util.Join(targetPath, relative))
 	}

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -423,32 +423,13 @@ func runInitialSnapshot(
 	return snapshotTsNs, nil
 }
 
-// initialSnapshotTargetKey mirrors buildKey from filer_sync.go but works from a
-// raw (sourceKey, entry) pair instead of an EventNotification. Kept close to
-// runInitialSnapshot so the mapping from source path to destination key stays
-// in one place for the seed path.
+// initialSnapshotTargetKey pulls the entry mtime and delegates to the shared
+// destKey helper in filer_sync.go so the walk and the event-log path produce
+// the same destination key for the same source entry.
 func initialSnapshotTargetKey(dataSink sink.ReplicationSink, targetPath, sourcePath string, sourceKey util.FullPath, entry *filer_pb.Entry) string {
-	// Normalize to a trailing-slash base so trimming never depends on whether
-	// the caller passed sourcePath with or without one, and never indexes past
-	// the end of sourceKey (IsEqualOrUnder upstream admits the equal case).
-	base := strings.TrimSuffix(sourcePath, "/") + "/"
-	sk := string(sourceKey)
-	var relative string
-	switch {
-	case strings.HasPrefix(sk, base):
-		relative = sk[len(base):]
-	case sk == strings.TrimSuffix(sourcePath, "/"):
-		relative = ""
-	default:
-		relative = strings.TrimPrefix(sk, "/")
-	}
-	if !dataSink.IsIncremental() {
-		return escapeKey(util.Join(targetPath, relative))
-	}
 	var mTime int64
 	if entry.Attributes != nil {
 		mTime = entry.Attributes.Mtime
 	}
-	dateKey := time.Unix(mTime, 0).Format("2006-01-02")
-	return escapeKey(util.Join(targetPath, dateKey, relative))
+	return destKey(dataSink, targetPath, sourcePath, sourceKey, mTime)
 }

--- a/weed/command/filer_backup_test.go
+++ b/weed/command/filer_backup_test.go
@@ -7,7 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/replication/sink"
+	"github.com/seaweedfs/seaweedfs/weed/replication/source"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
@@ -69,5 +74,58 @@ func TestIsIgnorable404_NonIgnorableError(t *testing.T) {
 
 	if isIgnorable404(genErr) {
 		t.Errorf("expected not ignorable, got ignorable: %v", genErr)
+	}
+}
+
+// stubSink is a minimal ReplicationSink used to exercise initialSnapshotTargetKey
+// without standing up a real sink. Only the two methods read by the key builder
+// (GetName, IsIncremental) need meaningful behavior; the rest satisfy the interface.
+type stubSink struct {
+	name          string
+	isIncremental bool
+}
+
+func (s *stubSink) GetName() string                           { return s.name }
+func (s *stubSink) Initialize(util.Configuration, string) error { return nil }
+func (s *stubSink) DeleteEntry(string, bool, bool, []int32) error {
+	return nil
+}
+func (s *stubSink) CreateEntry(string, *filer_pb.Entry, []int32) error { return nil }
+func (s *stubSink) UpdateEntry(string, *filer_pb.Entry, string, *filer_pb.Entry, bool, []int32) (bool, error) {
+	return false, nil
+}
+func (s *stubSink) GetSinkToDirectory() string       { return "" }
+func (s *stubSink) SetSourceFiler(*source.FilerSource) {}
+func (s *stubSink) IsIncremental() bool              { return s.isIncremental }
+
+var _ sink.ReplicationSink = (*stubSink)(nil)
+
+func TestInitialSnapshotTargetKey(t *testing.T) {
+	// Mirror the non-incremental path of buildKey so a refactor of one without
+	// the other will fail this test.
+	mirror := &stubSink{name: "mirror", isIncremental: false}
+	got := initialSnapshotTargetKey(mirror, "/backup", "/data", util.FullPath("/data/sub/file.txt"), &filer_pb.Entry{})
+	if got != "/backup/sub/file.txt" {
+		t.Errorf("mirror sink: got %q, want %q", got, "/backup/sub/file.txt")
+	}
+
+	// Incremental sinks partition by entry mtime, so the seed must use the same
+	// YYYY-MM-DD prefix a replayed CreateEntry would produce. buildKey in
+	// filer_sync.go formats the date in local time, so compute the expected
+	// key the same way to keep the test timezone-independent.
+	inc := &stubSink{name: "inc", isIncremental: true}
+	mtime := int64(1704196800) // 2024-01-02T12:00:00 UTC — unambiguously Jan 2 in nearly all timezones
+	gotInc := initialSnapshotTargetKey(inc, "/backup", "/data", util.FullPath("/data/sub/file.txt"), &filer_pb.Entry{
+		Attributes: &filer_pb.FuseAttributes{Mtime: mtime},
+	})
+	wantInc := "/backup/" + time.Unix(mtime, 0).Format("2006-01-02") + "/sub/file.txt"
+	if gotInc != wantInc {
+		t.Errorf("incremental sink: got %q, want %q", gotInc, wantInc)
+	}
+
+	// Trailing-slash sourcePath still produces a clean relative key.
+	gotTrail := initialSnapshotTargetKey(mirror, "/backup", "/data/", util.FullPath("/data/file.txt"), &filer_pb.Entry{})
+	if gotTrail != "/backup/file.txt" {
+		t.Errorf("trailing-slash sourcePath: got %q, want %q", gotTrail, "/backup/file.txt")
 	}
 }

--- a/weed/command/filer_backup_test.go
+++ b/weed/command/filer_backup_test.go
@@ -128,4 +128,14 @@ func TestInitialSnapshotTargetKey(t *testing.T) {
 	if gotTrail != "/backup/file.txt" {
 		t.Errorf("trailing-slash sourcePath: got %q, want %q", gotTrail, "/backup/file.txt")
 	}
+
+	// Edge cases CodeRabbit called out: sourceKey equal to sourcePath
+	// (non-trailing and trailing variants). Real TraverseBfs walks never emit
+	// the root itself, but the helper must not panic if something else does.
+	if got := initialSnapshotTargetKey(mirror, "/backup", "/data", util.FullPath("/data"), &filer_pb.Entry{}); got != "/backup" {
+		t.Errorf("sourceKey == sourcePath (no slash): got %q, want %q", got, "/backup")
+	}
+	if got := initialSnapshotTargetKey(mirror, "/backup", "/data/", util.FullPath("/data"), &filer_pb.Entry{}); got != "/backup" {
+		t.Errorf("sourceKey == sourcePath (trailing slash mismatch): got %q, want %q", got, "/backup")
+	}
 }

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -653,21 +653,39 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 	return processEventFn
 }
 
-func buildKey(dataSink sink.ReplicationSink, message *filer_pb.EventNotification, targetPath string, sourceKey util.FullPath, sourcePath string) (key string) {
-	if !dataSink.IsIncremental() {
-		key = util.Join(targetPath, string(sourceKey)[len(sourcePath):])
-	} else {
-		var mTime int64
-		if message.NewEntry != nil {
-			mTime = message.NewEntry.Attributes.Mtime
-		} else if message.OldEntry != nil {
-			mTime = message.OldEntry.Attributes.Mtime
-		}
-		dateKey := time.Unix(mTime, 0).Format("2006-01-02")
-		key = util.Join(targetPath, dateKey, string(sourceKey)[len(sourcePath):])
+func buildKey(dataSink sink.ReplicationSink, message *filer_pb.EventNotification, targetPath string, sourceKey util.FullPath, sourcePath string) string {
+	var mTime int64
+	if message.NewEntry != nil && message.NewEntry.Attributes != nil {
+		mTime = message.NewEntry.Attributes.Mtime
+	} else if message.OldEntry != nil && message.OldEntry.Attributes != nil {
+		mTime = message.OldEntry.Attributes.Mtime
 	}
+	return destKey(dataSink, targetPath, sourcePath, sourceKey, mTime)
+}
 
-	return escapeKey(key)
+// destKey derives the sink-side key for a source entry. Shared between the
+// event-log path (buildKey) and the initialSnapshot walk (both paths need the
+// same target layout so a walk-seeded file and an event-replayed file resolve
+// to the same destination key). Normalizing to a trailing-slash base avoids
+// indexing past the end of sourceKey when callers differ on trailing-slash
+// conventions or when sourceKey equals sourcePath exactly.
+func destKey(dataSink sink.ReplicationSink, targetPath, sourcePath string, sourceKey util.FullPath, mTime int64) string {
+	base := strings.TrimSuffix(sourcePath, "/") + "/"
+	sk := string(sourceKey)
+	var relative string
+	switch {
+	case strings.HasPrefix(sk, base):
+		relative = sk[len(base):]
+	case sk == strings.TrimSuffix(sourcePath, "/"):
+		relative = ""
+	default:
+		relative = strings.TrimPrefix(sk, "/")
+	}
+	if !dataSink.IsIncremental() {
+		return escapeKey(util.Join(targetPath, relative))
+	}
+	dateKey := time.Unix(mTime, 0).Format("2006-01-02")
+	return escapeKey(util.Join(targetPath, dateKey, relative))
 }
 
 // isEntryExcluded checks whether a single side (old or new) of an event is excluded


### PR DESCRIPTION
## Summary

- Add `-initialSnapshot` opt-in flag to `weed filer.backup`. When set on a fresh sync (no prior checkpoint, `-timeAgo` unset), walk the live filer tree under `-filerPath` via `TraverseBfs`, seed the destination through `sink.CreateEntry`, persist the walk-start timestamp as the checkpoint, and subscribe from that timestamp going forward.
- Clarify the log line when the KV has no stored offset (`starting from <t> (no prior checkpoint)`) instead of the misleading `resuming from 1970-01-01`.

## Why

Replaying the metadata event log on a fresh sync only leaves files that are still live on the source at replay time: any entry that was created and later deleted is replayed as a create-then-delete pair and never lands on the destination. Users who wipe the destination and re-run `filer.backup` therefore see "only the currently-live files appear" instead of a full backup, even when `-timeAgo=876000h` is passed and the subscription genuinely starts from epoch. Reproduction and root-cause analysis in #8672.

`-initialSnapshot` sidesteps the event log for the initial seed: it snapshots whatever is live on the source now, then lets the subscription pick up every change from that point on. Capturing the snapshot timestamp *before* the walk starts means create/update/delete events racing with the walk are still caught — builtin sinks treat `CreateEntry` idempotently (localsink atomic-renames over existing files; S3 put-object; filersink creates/updates), so replaying a concurrent create over an already-seeded entry is safe.

Honors the existing `-filerExcludePaths` / `-filerExcludeFileNames` / `-filerExcludePathPatterns` filters and skips `/topics/.system/log` the same way the subscription path does. When a checkpoint already exists, the walk is skipped and the command behaves exactly as before.

## Test plan

- [x] Unit test for `initialSnapshotTargetKey` covering mirror (non-incremental), incremental (YYYY-MM-DD partitioning by mtime), and trailing-slash `sourcePath`.
- [x] Manual end-to-end on local master+volume+filer with local sink:
  - [x] Scenario from #8672: source had 10 create-then-delete cycles + 3 live files, destination wiped. Without `-initialSnapshot` only the 3 live files appear (as expected from event-log replay); with `-initialSnapshot` the walk seeds the same 3 live files but the log shows they came from the walk (`initialSnapshot: done — 3 entries / … bytes`), not from cancelled-out create/delete events.
  - [x] Restart without `-initialSnapshot` after the first run resumes from the stored offset and does not re-walk.
  - [x] File created during the subscription (post-walk) is picked up by the tail.
  - [x] File deleted after the walk is removed from the destination by the subscription (with `-doDeleteFiles`).
  - [x] Nested directories walk correctly (`/data/a/b/...`).
  - [x] `-filerExcludePaths=/data/tmp` and `-filerExcludeFileNames='*.tmp'` are honored during the walk.
- [x] `go build ./...`
- [x] `go test ./weed/command/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an -initialSnapshot option to seed backups with a filer snapshot on fresh syncs, then continue incremental metadata sync so concurrent changes are captured.

* **Behavioral Improvements**
  * More reliable fresh-sync detection and checkpoint handling; snapshot seeding records a walk-start timestamp and advances subscription start accordingly. KV persistence of snapshot watermark uses retry/backoff.

* **Tests**
  * Added tests validating destination key mapping for incremental vs mirror backups and path edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->