### PR TITLE
peer chunk sharing 8/8: Prometheus metrics + operator docs

### DIFF
--- a/weed/mount/filehandle_read.go
+++ b/weed/mount/filehandle_read.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 )
 
 func (fh *FileHandle) lockForRead(startOffset int64, size int) {
@@ -84,6 +85,7 @@ func (fh *FileHandle) readFromChunksWithContext(ctx context.Context, buff []byte
 			glog.V(4).Infof("peer read successful for %s [%d,%d] %d", fileFullPath, offset, offset+int64(totalRead), totalRead)
 			return int64(totalRead), ts, nil
 		}
+		stats.MountPeerFallbackTotal.Inc()
 		glog.V(4).Infof("peer read failed for %s, falling back to volume: %v", fileFullPath, err)
 	}
 

--- a/weed/mount/peer_fetcher.go
+++ b/weed/mount/peer_fetcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/mount_peer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -93,8 +94,18 @@ func (fh *FileHandle) tryPeerRead(ctx context.Context, fileSize int64, buff []by
 		data, ferr := fetchChunkFromPeer(ctx, dial, h.addr, targetChunk.FileId, targetChunk.Size, targetChunk.ETag)
 		if ferr != nil {
 			glog.V(2).Infof("peer-fetch %s from %s: %v", targetChunk.FileId, h.addr, ferr)
+			switch {
+			case status.Code(ferr) == codes.NotFound || ferr.Error() == "peer not cached":
+				stats.MountPeerFetchTotal.WithLabelValues("not_found").Inc()
+			case isEtagMismatch(ferr):
+				stats.MountPeerFetchTotal.WithLabelValues("etag_mismatch").Inc()
+			default:
+				stats.MountPeerFetchTotal.WithLabelValues("error").Inc()
+			}
 			continue
 		}
+		stats.MountPeerFetchTotal.WithLabelValues("success").Inc()
+		stats.MountPeerFetchBytesTotal.Add(float64(len(data)))
 		fh.wfs.chunkCache.SetChunk(targetChunk.FileId, data)
 		if fh.wfs.peerAnnouncer != nil {
 			fh.wfs.peerAnnouncer.EnqueueAnnounce(targetChunk.FileId)
@@ -248,4 +259,8 @@ func fetchChunkFromPeer(ctx context.Context, dial MountPeerDialer, peerAddr, fid
 		}
 	}
 	return buf, nil
+}
+
+func isEtagMismatch(err error) bool {
+	return err != nil && len(err.Error()) >= 13 && err.Error()[:13] == "etag mismatch"
 }

--- a/weed/mount/peer_grpc.go
+++ b/weed/mount/peer_grpc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/mount_peer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util/chunk_cache"
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
 	"google.golang.org/grpc"
@@ -150,6 +151,7 @@ func (s *PeerGrpcServer) FetchChunk(req *mount_peer_pb.FetchChunkRequest, stream
 
 	n, err := s.cache.ReadChunkAt(buf, fid, 0)
 	if err != nil || n <= 0 {
+		stats.MountPeerServeTotal.WithLabelValues("miss").Inc()
 		return status.Errorf(codes.NotFound, "fid %s not cached", fid)
 	}
 
@@ -164,6 +166,8 @@ func (s *PeerGrpcServer) FetchChunk(req *mount_peer_pb.FetchChunkRequest, stream
 			return sendErr
 		}
 	}
+	stats.MountPeerServeTotal.WithLabelValues("hit").Inc()
+	stats.MountPeerServeBytesTotal.Add(float64(n))
 	return nil
 }
 
@@ -190,5 +194,7 @@ func (wfs *WFS) runPeerDirectorySweeper() {
 		if evicted := dir.Sweep(); evicted > 0 {
 			glog.V(2).Infof("peer directory: evicted %d expired entries", evicted)
 		}
+		_, _, _, _, entries := dir.Stats()
+		stats.MountPeerDirectoryEntries.Set(float64(entries))
 	}
 }

--- a/weed/server/filer_grpc_server_mount_peer.go
+++ b/weed/server/filer_grpc_server_mount_peer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 )
 
 // mountPeerRegistrySweepInterval is how often the filer evicts expired mount
@@ -25,6 +26,7 @@ func (fs *FilerServer) runMountPeerRegistrySweeper() {
 		if evicted := fs.mountPeerRegistry.Sweep(); evicted > 0 {
 			glog.V(2).Infof("peer registry: evicted %d stale entries", evicted)
 		}
+		stats.FilerMountRegistryEntries.Set(float64(fs.mountPeerRegistry.Len()))
 	}
 }
 
@@ -40,6 +42,7 @@ func (fs *FilerServer) MountRegister(ctx context.Context, req *filer_pb.MountReg
 	}
 	ttl := time.Duration(req.TtlSeconds) * time.Second
 	fs.mountPeerRegistry.Register(req.PeerAddr, req.DataCenter, req.Rack, ttl)
+	stats.FilerMountRegistryEntries.Set(float64(fs.mountPeerRegistry.Len()))
 	return &filer_pb.MountRegisterResponse{}, nil
 }
 

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -489,6 +489,64 @@ var (
 			Name:      "upload_error_total",
 			Help:      "Counter of upload errors by HTTP status code. Code 0 means transport error (no response received).",
 		}, []string{"code"})
+
+	// ── Peer chunk sharing (design-weed-mount-peer-chunk-sharing.md) ──
+
+	MountPeerFetchTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "mount_peer",
+			Name:      "fetch_total",
+			Help:      "Outgoing peer FetchChunk attempts by outcome (success|not_found|etag_mismatch|error).",
+		}, []string{"result"})
+
+	MountPeerFetchBytesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "mount_peer",
+			Name:      "fetch_bytes_total",
+			Help:      "Total chunk bytes received from peers via FetchChunk.",
+		})
+
+	MountPeerServeTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "mount_peer",
+			Name:      "serve_total",
+			Help:      "Inbound FetchChunk requests by outcome (hit|miss).",
+		}, []string{"result"})
+
+	MountPeerServeBytesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "mount_peer",
+			Name:      "serve_bytes_total",
+			Help:      "Total chunk bytes served to peers via FetchChunk.",
+		})
+
+	MountPeerFallbackTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "mount_peer",
+			Name:      "fallback_to_volume_total",
+			Help:      "Count of reads that tried tryPeerRead and fell through to the volume-server path.",
+		})
+
+	MountPeerDirectoryEntries = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "mount_peer",
+			Name:      "directory_entries",
+			Help:      "Number of (fid, holder) entries this mount is currently tracking as an HRW directory owner.",
+		})
+
+	FilerMountRegistryEntries = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "filer",
+			Name:      "mount_registry_entries",
+			Help:      "Number of live mount servers currently registered in the filer's peer registry.",
+		})
 )
 
 func init() {
@@ -554,6 +612,14 @@ func init() {
 	Gather.MustRegister(S3BucketObjectCountGauge)
 
 	Gather.MustRegister(UploadErrorCounter)
+
+	Gather.MustRegister(MountPeerFetchTotal)
+	Gather.MustRegister(MountPeerFetchBytesTotal)
+	Gather.MustRegister(MountPeerServeTotal)
+	Gather.MustRegister(MountPeerServeBytesTotal)
+	Gather.MustRegister(MountPeerFallbackTotal)
+	Gather.MustRegister(MountPeerDirectoryEntries)
+	Gather.MustRegister(FilerMountRegistryEntries)
 
 	go bucketMetricTTLControl()
 }


### PR DESCRIPTION
## Summary
Final PR of the peer chunk sharing stack.

Metrics (exposed via the existing Prometheus \`Gather\` in \`weed/stats\`):

Mount-side:
- \`seaweedfs_mount_peer_serve_total{result=hit|miss}\`
- \`seaweedfs_mount_peer_serve_bytes_total\`
- \`seaweedfs_mount_peer_fetch_total{result=success|404|etag_mismatch|error}\`
- \`seaweedfs_mount_peer_fallback_to_volume_total\`
- \`seaweedfs_mount_peer_directory_entries\` (gauge)

Filer-side:
- \`seaweedfs_filer_mount_registry_entries\` (gauge)

Increments are wired at existing instrumentation points: peer_server (serve side), peer_fetcher (fetch + ETag mismatch classification), filehandle_read (fallback counter), and filer_grpc_server_peer (registry size refresh on register + sweeper tick). Internal atomic counters stay intact so existing tests still exercise them.

Wiki operator page authored in a separate commit at \`~/dev/seaweedfs.wiki/Peer-Chunk-Sharing-Between-weed-mount-Clients.md\` (not in this repo — wiki is a separate git repo). Sidebar entry added under Machine Learning.

Part of the peer chunk sharing series (8/8). Stacks on #9136.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./weed/mount ./weed/filer ./weed/server -run "TestPeer|TestMountRegister|TestOwnerFor|TestFetch"\`
- [ ] Reviewer confirms Prometheus label cardinality (the \`result\` labels are bounded small sets)
- [ ] Operator doc reads cleanly end-to-end; flag reference matches the code