### PR TITLE
fix(shell): volume.fsck keeps going past a single broken chunk manifest

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -45,18 +45,19 @@ const (
 )
 
 type commandVolumeFsck struct {
-	env                      *CommandEnv
-	writer                   io.Writer
-	bucketsPath              string
-	collection               *string
-	volumeIds                map[uint32]bool
-	tempFolder               string
-	verbose                  *bool
-	forcePurging             *bool
-	skipEcVolumes            *bool
-	findMissingChunksInFiler *bool
-	verifyNeedle             *bool
-	filerSigningKey          string
+	env                       *CommandEnv
+	writer                    io.Writer
+	bucketsPath               string
+	collection                *string
+	volumeIds                 map[uint32]bool
+	tempFolder                string
+	verbose                   *bool
+	forcePurging              *bool
+	skipEcVolumes             *bool
+	findMissingChunksInFiler  *bool
+	verifyNeedle              *bool
+	filerSigningKey           string
+	unresolvedManifestEntries int
 }
 
 func (c *commandVolumeFsck) Name() string {
@@ -219,8 +220,19 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 		if err = c.collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo, false, 0, 0); err != nil {
 			return fmt.Errorf("failed to collect file ids from filer: %w", err)
 		}
+		// If any entry's manifest could not be resolved, our in-use fid set
+		// is missing the sub-chunks behind it. Purging orphans now would
+		// delete live data referenced only via the unresolved manifest, so
+		// disable -reallyDeleteFromVolume for this run and tell the operator
+		// to fix the broken entries first.
+		applyPurgingEffective := *applyPurging
+		if c.unresolvedManifestEntries > 0 && applyPurgingEffective {
+			fmt.Fprintf(c.writer, "WARNING: %d entry(ies) had unresolvable chunk manifests; refusing to apply -reallyDeleteFromVolume to avoid deleting live sub-chunks. Fix the entries listed above (e.g. delete or repair them) and re-run.\n",
+				c.unresolvedManifestEntries)
+			applyPurgingEffective = false
+		}
 		// volume file ids subtract filer file ids
-		if err = c.findExtraChunksInVolumeServers(dataNodeVolumeIdToVInfo, *applyPurging, uint64(collectModifyFromAtNs), uint64(collectCutoffFromAtNs)); err != nil {
+		if err = c.findExtraChunksInVolumeServers(dataNodeVolumeIdToVInfo, applyPurgingEffective, uint64(collectModifyFromAtNs), uint64(collectCutoffFromAtNs)); err != nil {
 			return fmt.Errorf("findExtraChunksInVolumeServers: %w", err)
 		}
 	}
@@ -259,7 +271,19 @@ func (c *commandVolumeFsck) collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo m
 			}
 			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(context.Background(), filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64)
 			if resolveErr != nil {
-				return fmt.Errorf("failed to ResolveChunkManifest: %+v", resolveErr)
+				// A single broken manifest used to abort the whole traversal,
+				// leaving the operator with no way to identify orphans without
+				// first fixing the broken file. Instead, record only the
+				// top-level chunk fids (data chunks plus the manifest needles
+				// themselves — sub-chunks behind the unreadable manifest are
+				// unknown), warn, and keep going. The unresolved counter blocks
+				// any purge step downstream so we never delete a sub-chunk we
+				// couldn't account for.
+				fmt.Fprintf(c.writer, "WARNING: ResolveChunkManifest failed for %s: %v — recording top-level chunk fids only; purging will be disabled\n",
+					util.NewFullPath(entry.Dir, entry.Entry.Name), resolveErr)
+				c.unresolvedManifestEntries++
+				dataChunks = entry.Entry.GetChunks()
+				manifestChunks = nil
 			}
 			dataChunks = append(dataChunks, manifestChunks...)
 			for _, chunk := range dataChunks {

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -115,6 +115,12 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 		return nil
 	}
 
+	// The command struct is a singleton registered in init(), so any state
+	// not bound to a flag persists across shell invocations. Reset the
+	// unresolved-manifest counter so a previous failed run can't permanently
+	// suppress -reallyDeleteFromVolume in this session.
+	c.unresolvedManifestEntries.Store(0)
+
 	if err = commandEnv.confirmIsLocked(args); err != nil {
 		return
 	}
@@ -272,6 +278,13 @@ func (c *commandVolumeFsck) collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo m
 			}
 			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(ctx, filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64)
 			if resolveErr != nil {
+				// Cancellation/deadline isn't manifest corruption; surface it
+				// so the BFS bails out cleanly without polluting the
+				// unresolved-manifest counter (which would otherwise block
+				// purges and mislead the operator about the failure cause).
+				if errors.Is(resolveErr, context.Canceled) || errors.Is(resolveErr, context.DeadlineExceeded) {
+					return resolveErr
+				}
 				// A single broken manifest used to abort the whole traversal,
 				// leaving the operator with no way to identify orphans without
 				// first fixing the broken file. Instead, record only the

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -57,7 +58,7 @@ type commandVolumeFsck struct {
 	findMissingChunksInFiler  *bool
 	verifyNeedle              *bool
 	filerSigningKey           string
-	unresolvedManifestEntries int
+	unresolvedManifestEntries atomic.Int64
 }
 
 func (c *commandVolumeFsck) Name() string {
@@ -226,9 +227,9 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 		// disable -reallyDeleteFromVolume for this run and tell the operator
 		// to fix the broken entries first.
 		applyPurgingEffective := *applyPurging
-		if c.unresolvedManifestEntries > 0 && applyPurgingEffective {
+		if unresolved := c.unresolvedManifestEntries.Load(); unresolved > 0 && applyPurgingEffective {
 			fmt.Fprintf(c.writer, "WARNING: %d entry(ies) had unresolvable chunk manifests; refusing to apply -reallyDeleteFromVolume to avoid deleting live sub-chunks. Fix the entries listed above (e.g. delete or repair them) and re-run.\n",
-				c.unresolvedManifestEntries)
+				unresolved)
 			applyPurgingEffective = false
 		}
 		// volume file ids subtract filer file ids
@@ -269,7 +270,7 @@ func (c *commandVolumeFsck) collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo m
 			if *c.verbose && entry.Entry.IsDirectory {
 				fmt.Fprintf(c.writer, "checking directory %s\n", util.NewFullPath(entry.Dir, entry.Entry.Name))
 			}
-			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(context.Background(), filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64)
+			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(ctx, filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64)
 			if resolveErr != nil {
 				// A single broken manifest used to abort the whole traversal,
 				// leaving the operator with no way to identify orphans without
@@ -281,7 +282,7 @@ func (c *commandVolumeFsck) collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo m
 				// couldn't account for.
 				fmt.Fprintf(c.writer, "WARNING: ResolveChunkManifest failed for %s: %v — recording top-level chunk fids only; purging will be disabled\n",
 					util.NewFullPath(entry.Dir, entry.Entry.Name), resolveErr)
-				c.unresolvedManifestEntries++
+				c.unresolvedManifestEntries.Add(1)
 				dataChunks = entry.Entry.GetChunks()
 				manifestChunks = nil
 			}


### PR DESCRIPTION
## Summary

- A single entry whose chunk manifest can't be resolved (e.g. the manifest needle is missing, or its sub-chunks point at a now-gone volume) currently makes `volume.fsck` bail out of `collectFilerFileIdAndPaths` with `failed to ResolveChunkManifest`. The whole run fails — so an operator with even one corrupted file can't use fsck to find or clean orphans on other volumes until they locate and delete the bad entry first, blind.
- Log the resolution failure with the entry's full path, fall back to recording only the top-level chunk fids that entry references (data fids and the manifest needle fids themselves — sub-chunks behind the unreadable manifest stay unknown), and keep traversing.
- Track the count of unresolved entries on `commandVolumeFsck` and force `-reallyDeleteFromVolume` off for the run when it's non-zero, since the in-use fid set is incomplete. Without this gate, a follow-up purge could delete live sub-chunks that only the unresolvable manifest knows about.

Discovered while diagnosing #9116, where a user had two files with dangling manifest pointers blocking fsck. Read-only fsck now produces a (conservatively over-reported) orphan listing so the operator can see and repair the broken entries first, then re-run with apply.

## Test plan

- [ ] Build: `go build ./weed/shell/...`
- [ ] Vet: `go vet ./weed/shell/...`
- [ ] Manual: create an entry whose chunk manifest fid points at a deleted needle. Run `volume.fsck` (read-only) — expect a `WARNING: ResolveChunkManifest failed for ...` line and a normal orphan report covering the rest of the tree.
- [ ] Manual: run `volume.fsck -reallyDeleteFromVolume -forcePurging` against the same state — expect the warning plus `refusing to apply -reallyDeleteFromVolume to avoid deleting live sub-chunks`, and no purge.
- [ ] Regression: run `volume.fsck` on a healthy filer — expect identical behavior to before (no warnings, purge proceeds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Volume fsck now continues processing when manifest resolution fails, logs warnings, and avoids aborting the run for single broken manifests.
  * Purge operations are disabled for runs with unresolved manifest entries to prevent unsafe deletions.
  * Command run state is reset between invocations to avoid carry-over from prior runs.

* **Monitoring**
  * Unresolved manifest occurrences are counted per run and surfaced in logs; context cancellation/timeout errors still terminate the run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->