### PR TITLE
fix(mount): retry saveEntry on transient filer errors; stop mismapping Canceled to EIO

### DIFF
--- a/weed/mount/error_classifier.go
+++ b/weed/mount/error_classifier.go
@@ -47,3 +47,28 @@ func grpcErrorToFuseStatus(err error) fuse.Status {
 
 	return fuse.EIO
 }
+
+// isRetryableFilerError reports whether a filer RPC error looks transient
+// enough to retry. It takes a conservative whitelist approach: only errors
+// that clearly describe a permanent application-level failure
+// (NotFound/AlreadyExists/InvalidArgument/PermissionDenied/Unauthenticated/
+// FailedPrecondition) short-circuit the retry loop. Everything else —
+// transport errors, Canceled/Unavailable/ResourceExhausted, or errors with no
+// gRPC status — is treated as potentially transient and retried.
+func isRetryableFilerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		case codes.NotFound,
+			codes.AlreadyExists,
+			codes.InvalidArgument,
+			codes.PermissionDenied,
+			codes.Unauthenticated,
+			codes.FailedPrecondition:
+			return false
+		}
+	}
+	return true
+}

--- a/weed/mount/error_classifier_test.go
+++ b/weed/mount/error_classifier_test.go
@@ -1,9 +1,11 @@
 package mount
 
 import (
+	"errors"
 	"fmt"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/go-fuse/v2/fuse"
 	"google.golang.org/grpc/codes"
@@ -38,5 +40,87 @@ func TestGrpcErrorToFuseStatusDropsCanceledThroughPercentV(t *testing.T) {
 	got := grpcErrorToFuseStatus(wrapped)
 	if got != fuse.EIO {
 		t.Fatalf("grpcErrorToFuseStatus(canceled wrapped with %%v) = %v, want EIO (regression guard)", got)
+	}
+}
+
+func TestIsRetryableFilerError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"canceled", status.Error(codes.Canceled, "grpc: the client connection is closing"), true},
+		{"unavailable", status.Error(codes.Unavailable, "connection refused"), true},
+		{"deadline_exceeded", status.Error(codes.DeadlineExceeded, "deadline exceeded"), true},
+		{"resource_exhausted", status.Error(codes.ResourceExhausted, "too many concurrent requests"), true},
+		{"internal", status.Error(codes.Internal, "server crashed"), true},
+		{"not_found", status.Error(codes.NotFound, "entry missing"), false},
+		{"already_exists", status.Error(codes.AlreadyExists, "duplicate"), false},
+		{"invalid_argument", status.Error(codes.InvalidArgument, "bad request"), false},
+		{"permission_denied", status.Error(codes.PermissionDenied, "no access"), false},
+		{"unauthenticated", status.Error(codes.Unauthenticated, "missing creds"), false},
+		{"failed_precondition", status.Error(codes.FailedPrecondition, "not empty"), false},
+		{"plain_error_retries", errors.New("random network glitch"), true},
+		{"wrapped_canceled_still_retries", fmt.Errorf("ctx: %w", status.Error(codes.Canceled, "closing")), true},
+		{"wrapped_not_found_still_skipped", fmt.Errorf("ctx: %w", status.Error(codes.NotFound, "gone")), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableFilerError(tc.err); got != tc.want {
+				t.Fatalf("isRetryableFilerError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// retryMetadataFlushIf must short-circuit on non-retryable errors so that
+// synchronous FUSE ops (chmod/utimes/xattr) don't hang for ~7s on ENOENT/
+// EACCES/EINVAL.
+func TestRetryMetadataFlushIfShortCircuitsOnPermanentError(t *testing.T) {
+	originalSleep := metadataFlushSleep
+	t.Cleanup(func() {
+		metadataFlushSleep = originalSleep
+	})
+	metadataFlushSleep = func(_ time.Duration) {
+		t.Fatal("sleep should not be called when shouldRetry returns false")
+	}
+
+	attempts := 0
+	permanent := status.Error(codes.NotFound, "entry missing")
+	err := retryMetadataFlushIf(func() error {
+		attempts++
+		return permanent
+	}, isRetryableFilerError, nil)
+
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (permanent error should short-circuit)", attempts)
+	}
+	if !errors.Is(err, permanent) {
+		t.Fatalf("err = %v, want permanent sentinel", err)
+	}
+}
+
+// Transient errors must keep retrying up to the attempt cap even when a
+// predicate is supplied.
+func TestRetryMetadataFlushIfRetriesTransientErrors(t *testing.T) {
+	originalSleep := metadataFlushSleep
+	t.Cleanup(func() {
+		metadataFlushSleep = originalSleep
+	})
+	metadataFlushSleep = func(_ time.Duration) {}
+
+	attempts := 0
+	transient := status.Error(codes.Canceled, "grpc: the client connection is closing")
+	err := retryMetadataFlushIf(func() error {
+		attempts++
+		return transient
+	}, isRetryableFilerError, nil)
+
+	if attempts != metadataFlushRetries+1 {
+		t.Fatalf("attempts = %d, want %d", attempts, metadataFlushRetries+1)
+	}
+	if !errors.Is(err, transient) {
+		t.Fatalf("err = %v, want transient sentinel", err)
 	}
 }

--- a/weed/mount/error_classifier_test.go
+++ b/weed/mount/error_classifier_test.go
@@ -1,0 +1,42 @@
+package mount
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/seaweedfs/go-fuse/v2/fuse"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Regression: wfs_save.go used to wrap the gRPC error with fmt.Errorf(... %v ...)
+// which stringified the status and made status.FromError fall through to the
+// default EIO mapping. Wrapping with %w must preserve the code so that
+// codes.Canceled from a closing filer connection surfaces as ETIMEDOUT (a
+// retryable hint for FUSE callers) rather than EIO.
+func TestGrpcErrorToFuseStatusUnwrapsCanceledThroughFmtErrorf(t *testing.T) {
+	grpcErr := status.Error(codes.Canceled, "grpc: the client connection is closing")
+
+	wrapped := fmt.Errorf("UpdateEntry dir /some/path: %w", grpcErr)
+
+	got := grpcErrorToFuseStatus(wrapped)
+	want := fuse.Status(syscall.ETIMEDOUT)
+	if got != want {
+		t.Fatalf("grpcErrorToFuseStatus(canceled wrapped with %%w) = %v, want %v", got, want)
+	}
+}
+
+// Guard against regressing the wrap verb: %v loses the gRPC status and the
+// classifier must fall through to EIO. This test documents that behavior so
+// anyone reverting the %w change sees the intent.
+func TestGrpcErrorToFuseStatusDropsCanceledThroughPercentV(t *testing.T) {
+	grpcErr := status.Error(codes.Canceled, "grpc: the client connection is closing")
+
+	wrapped := fmt.Errorf("UpdateEntry dir /some/path: %v", grpcErr)
+
+	got := grpcErrorToFuseStatus(wrapped)
+	if got != fuse.EIO {
+		t.Fatalf("grpcErrorToFuseStatus(canceled wrapped with %%v) = %v, want EIO (regression guard)", got)
+	}
+}

--- a/weed/mount/metadata_flush_retry.go
+++ b/weed/mount/metadata_flush_retry.go
@@ -7,6 +7,15 @@ const metadataFlushRetries = 3
 var metadataFlushSleep = time.Sleep
 
 func retryMetadataFlush(flush func() error, onRetry func(nextAttempt, totalAttempts int, backoff time.Duration, err error)) error {
+	return retryMetadataFlushIf(flush, nil, onRetry)
+}
+
+// retryMetadataFlushIf is retryMetadataFlush with an optional shouldRetry
+// predicate. If shouldRetry is nil or returns true, the flush is retried with
+// exponential backoff; if it returns false, the error is returned immediately
+// so callers don't pay retry latency on clearly permanent errors (e.g.
+// ENOENT/EACCES/EINVAL from a synchronous setattr).
+func retryMetadataFlushIf(flush func() error, shouldRetry func(error) bool, onRetry func(nextAttempt, totalAttempts int, backoff time.Duration, err error)) error {
 	totalAttempts := metadataFlushRetries + 1
 	var err error
 	for attempt := 1; attempt <= totalAttempts; attempt++ {
@@ -15,6 +24,9 @@ func retryMetadataFlush(flush func() error, onRetry func(nextAttempt, totalAttem
 			break
 		}
 		if attempt == totalAttempts {
+			break
+		}
+		if shouldRetry != nil && !shouldRetry(err) {
 			break
 		}
 

--- a/weed/mount/wfs_save.go
+++ b/weed/mount/wfs_save.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"syscall"
+	"time"
 
 	"github.com/seaweedfs/go-fuse/v2/fuse"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -25,21 +26,22 @@ func (wfs *WFS) saveEntry(path util.FullPath, entry *filer_pb.Entry) (code fuse.
 	}
 
 	glog.V(1).Infof("save entry: %v", request)
-	resp, err := wfs.streamUpdateEntry(context.Background(), request)
+
+	var resp *filer_pb.UpdateEntryResponse
+	err := retryMetadataFlush(func() error {
+		var callErr error
+		resp, callErr = wfs.streamUpdateEntry(context.Background(), request)
+		return callErr
+	}, func(nextAttempt, totalAttempts int, backoff time.Duration, err error) {
+		glog.Warningf("saveEntry %s: retrying UpdateEntry (attempt %d/%d) after %v: %v",
+			path, nextAttempt, totalAttempts, backoff, err)
+	})
+
 	if err != nil {
-		err = fmt.Errorf("UpdateEntry dir %s: %v", path, err)
-	} else {
-		event := resp.GetMetadataEvent()
-		if event == nil {
-			event = metadataUpdateEvent(parentDir, entry)
-		}
-		if applyErr := wfs.applyLocalMetadataEvent(context.Background(), event); applyErr != nil {
-			glog.Warningf("saveEntry %s: best-effort metadata apply failed: %v", path, applyErr)
-			wfs.inodeToPath.InvalidateChildrenCache(util.FullPath(parentDir))
-		}
-	}
-	if err != nil {
-		// glog.V(0).Infof("saveEntry %s: %v", path, err)
+		// Wrap with %w so grpcErrorToFuseStatus can still unwrap the gRPC status
+		// (e.g. codes.Canceled → ETIMEDOUT). Using %v would stringify the error and
+		// status.FromError would fall through to the default EIO.
+		err = fmt.Errorf("UpdateEntry dir %s: %w", path, err)
 		fuseStatus := grpcErrorToFuseStatus(err)
 		if fuseStatus == fuse.EIO {
 			glog.Errorf("saveEntry failed for %s: %v (returning EIO)", path, err)
@@ -47,6 +49,15 @@ func (wfs *WFS) saveEntry(path util.FullPath, entry *filer_pb.Entry) (code fuse.
 			glog.V(1).Infof("saveEntry failed for %s: %v (returning %v)", path, err, fuseStatus)
 		}
 		return fuseStatus
+	}
+
+	event := resp.GetMetadataEvent()
+	if event == nil {
+		event = metadataUpdateEvent(parentDir, entry)
+	}
+	if applyErr := wfs.applyLocalMetadataEvent(context.Background(), event); applyErr != nil {
+		glog.Warningf("saveEntry %s: best-effort metadata apply failed: %v", path, applyErr)
+		wfs.inodeToPath.InvalidateChildrenCache(util.FullPath(parentDir))
 	}
 
 	return fuse.OK

--- a/weed/mount/wfs_save.go
+++ b/weed/mount/wfs_save.go
@@ -28,11 +28,11 @@ func (wfs *WFS) saveEntry(path util.FullPath, entry *filer_pb.Entry) (code fuse.
 	glog.V(1).Infof("save entry: %v", request)
 
 	var resp *filer_pb.UpdateEntryResponse
-	err := retryMetadataFlush(func() error {
+	err := retryMetadataFlushIf(func() error {
 		var callErr error
 		resp, callErr = wfs.streamUpdateEntry(context.Background(), request)
 		return callErr
-	}, func(nextAttempt, totalAttempts int, backoff time.Duration, err error) {
+	}, isRetryableFilerError, func(nextAttempt, totalAttempts int, backoff time.Duration, err error) {
 		glog.Warningf("saveEntry %s: retrying UpdateEntry (attempt %d/%d) after %v: %v",
 			path, nextAttempt, totalAttempts, backoff, err)
 	})


### PR DESCRIPTION
## Summary
- `saveEntry` now wraps its `streamUpdateEntry` call in `retryMetadataFlush` (same pattern as `doFlush` and `completeAsyncFlush`), so a single filer connection flap no longer explodes into walls of EIOs for setattr / utimes / chmod / xattr / rename-driven updates.
- Switches the error-wrap verb in `wfs_save.go` from `%v` to `%w` so `grpcErrorToFuseStatus` can still unwrap the gRPC code. Previously every `codes.Canceled` fell through to the default EIO because `status.FromError` couldn't see through the stringified wrap — the `Canceled → ETIMEDOUT` branch in `error_classifier.go` was effectively dead code via this path.

## Context — issue #9139
Users running rclone with `-concurrentWriters=1024` saw hundreds of simultaneous `wfs_save.go:45 saveEntry failed ... rpc error: code = Canceled desc = grpc: the client connection is closing (returning EIO)` lines at the exact same millisecond whenever the mount's gRPC stream closed.

rclone's default is to upload to `NAME.<hash>.partial` and rename on completion (`fs/operations/copy.go`), which doubles the metadata ops per file — so any connection flap during a big copy surfaces as a large burst of failed `UpdateEntry` calls. The retry-less `saveEntry` path turned every one of them into EIO.

After this change:
- Transient `Canceled` / `Unavailable` / transport errors get retried up to 4 attempts with exponential backoff (1s, 2s, 4s) before propagating.
- If retries are exhausted, the user sees `ETIMEDOUT` (retryable hint) rather than `EIO`.
- `doFlush`'s existing retry behavior is unchanged; this just closes the parity gap.

## Test plan
- [x] `go test ./weed/mount/ -count=1` passes
- [x] New `error_classifier_test.go` covers both the `%w` success path (Canceled → ETIMEDOUT) and a regression guard for `%v` (to make intent explicit if someone reverts)
- [x] Existing `metadata_flush_retry_test.go` still passes
- [ ] Manual: run rclone bulk copy while bouncing one of the filers — expect retry warnings in logs, no user-facing EIO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced metadata flush operations with intelligent retry logic that distinguishes between transient and permanent errors, improving filesystem reliability during unstable network conditions.
  * Improved gRPC error preservation to ensure proper error status reporting through the filesystem layer.

* **Tests**
  * Added comprehensive test coverage for error classification, retry behavior, and metadata flush operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->