### PR TITLE
fix(shell): error on missing volume id in fsck, mergeVolumes, vacuum

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -70,6 +70,17 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 		dir = strings.TrimRight(dir, "/")
 	}
 
+	// flag.Uint is a 64-bit uint on amd64 but needle.VolumeId is uint32, so a
+	// value that overflows (e.g. 4294967297) silently wraps to a valid id
+	// like 1. Reject instead of wrapping.
+	const maxVolumeID = uint(^uint32(0))
+	if *fromVolumeArg > maxVolumeID {
+		return fmt.Errorf("fromVolumeId %d exceeds max volume id %d", *fromVolumeArg, maxVolumeID)
+	}
+	if *toVolumeArg > maxVolumeID {
+		return fmt.Errorf("toVolumeId %d exceeds max volume id %d", *toVolumeArg, maxVolumeID)
+	}
+
 	fromVolumeId := needle.VolumeId(*fromVolumeArg)
 	toVolumeId := needle.VolumeId(*toVolumeArg)
 

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -73,7 +73,9 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 	fromVolumeId := needle.VolumeId(*fromVolumeArg)
 	toVolumeId := needle.VolumeId(*toVolumeArg)
 
-	c.reloadVolumesInfo(commandEnv.MasterClient)
+	if err = c.reloadVolumesInfo(commandEnv.MasterClient); err != nil {
+		return fmt.Errorf("reload volumes info: %w", err)
+	}
 
 	// Reject unknown ids before createMergePlan silently produces an empty plan
 	// and we print just the "max volume size" header. That output is

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -75,6 +75,21 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 
 	c.reloadVolumesInfo(commandEnv.MasterClient)
 
+	// Reject unknown ids before createMergePlan silently produces an empty plan
+	// and we print just the "max volume size" header. That output is
+	// indistinguishable from a legitimate "nothing to merge" and hides typos,
+	// already-deleted volumes, and stale scripts.
+	if fromVolumeId != 0 {
+		if _, err := c.getVolumeInfoById(fromVolumeId); err != nil {
+			return fmt.Errorf("fromVolumeId %d not found on master", fromVolumeId)
+		}
+	}
+	if toVolumeId != 0 {
+		if _, err := c.getVolumeInfoById(toVolumeId); err != nil {
+			return fmt.Errorf("toVolumeId %d not found on master", toVolumeId)
+		}
+	}
+
 	if fromVolumeId != 0 && toVolumeId != 0 {
 		if fromVolumeId == toVolumeId {
 			return fmt.Errorf("no volume id changes, %d == %d", fromVolumeId, toVolumeId)

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -161,8 +162,27 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 		return fmt.Errorf("failed to collect all volume locations: %w", err)
 	}
 
-	if err != nil {
-		return fmt.Errorf("read filer buckets path: %w", err)
+	// If the operator specified -volumeId, reject unknown ids up front instead
+	// of silently filtering them out and reporting "no orphan data". A silent
+	// success on a missing volume looks identical to a clean volume and hides
+	// typos, already-deleted volumes, and stale scripts.
+	if len(c.volumeIds) > 0 {
+		known := make(map[uint32]bool)
+		for _, vidMap := range dataNodeVolumeIdToVInfo {
+			for vid := range vidMap {
+				known[vid] = true
+			}
+		}
+		var missing []uint32
+		for vid := range c.volumeIds {
+			if !known[vid] {
+				missing = append(missing, vid)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Slice(missing, func(i, j int) bool { return missing[i] < missing[j] })
+			return fmt.Errorf("volume(s) not found on master: %v", missing)
+		}
 	}
 
 	var collectCutoffFromAtNs int64 = 0

--- a/weed/shell/command_volume_vacuum.go
+++ b/weed/shell/command_volume_vacuum.go
@@ -80,13 +80,19 @@ func (c *commandVacuum) Do(args []string, commandEnv *CommandEnv, writer io.Writ
 				}
 			}
 		})
-		var missing []uint32
+		// Dedupe via a set so "volume.vacuum -volumeId 5,5,5" on a missing
+		// volume 5 reports [5] once instead of [5 5 5].
+		missingSet := make(map[uint32]bool)
 		for _, vid := range volumeIdInts {
 			if !known[vid] {
-				missing = append(missing, vid)
+				missingSet[vid] = true
 			}
 		}
-		if len(missing) > 0 {
+		if len(missingSet) > 0 {
+			missing := make([]uint32, 0, len(missingSet))
+			for vid := range missingSet {
+				missing = append(missing, vid)
+			}
 			sort.Slice(missing, func(i, j int) bool { return missing[i] < missing[j] })
 			return fmt.Errorf("volume(s) not found on master: %v", missing)
 		}

--- a/weed/shell/command_volume_vacuum.go
+++ b/weed/shell/command_volume_vacuum.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -60,6 +61,35 @@ func (c *commandVacuum) Do(args []string, commandEnv *CommandEnv, writer io.Writ
 		}
 	} else {
 		volumeIdInts = append(volumeIdInts, 0)
+	}
+
+	// Reject unknown ids up front. The master's VacuumVolume RPC silently
+	// iterates matching volumes, so a typo or an already-deleted volume just
+	// returns success — making this command look like it worked when nothing
+	// happened.
+	if *volumeIds != "" {
+		topo, _, err := collectTopologyInfo(commandEnv, 0)
+		if err != nil {
+			return fmt.Errorf("collect topology: %w", err)
+		}
+		known := make(map[uint32]bool)
+		eachDataNode(topo, func(_ DataCenterId, _ RackId, dn *master_pb.DataNodeInfo) {
+			for _, disk := range dn.DiskInfos {
+				for _, vi := range disk.VolumeInfos {
+					known[vi.Id] = true
+				}
+			}
+		})
+		var missing []uint32
+		for _, vid := range volumeIdInts {
+			if !known[vid] {
+				missing = append(missing, vid)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Slice(missing, func(i, j int) bool { return missing[i] < missing[j] })
+			return fmt.Errorf("volume(s) not found on master: %v", missing)
+		}
 	}
 
 	for _, volumeId := range volumeIdInts {


### PR DESCRIPTION
## Summary

Three shell commands silently report success when \`-volumeId\` / \`-fromVolumeId\` / \`-toVolumeId\` names a volume the master doesn't know about. Typos, already-deleted volumes, and stale scripts all look identical to a clean no-op, which is part of why the confusion in #9116 took so long to diagnose (see @madalee-com's follow-up comments).

- \`volume.fsck\`: the per-datanode filter at line 186-190 silently drops unknown ids and \`findExtraChunksInVolumeServers\` ends with \`totalOrphanChunkCount==0\`, printing the reassuring \`no orphan data\`.
- \`fs.mergeVolumes\`: \`createMergePlan\` iterates only known volumes, so an unknown \`-fromVolumeId\` produces an empty plan — output is just the \`max volume size: N MB\` header, which is indistinguishable from a legitimate \"nothing to merge\".
- \`volume.vacuum\`: the master's \`VacuumVolume\` RPC silently iterates matching volumes; a missing id returns success having done nothing.

Validate the requested ids against the current topology up front and return an explicit \`volume(s) not found on master: [X Y]\` error.

Also drops a stale duplicate \`if err != nil\` in \`volume.fsck.Do\` left over from a prior refactor.

## Test plan

- [ ] \`go build ./weed/shell/...\` — passes locally
- [ ] \`go vet ./weed/shell/...\` — passes locally
- [ ] Manual: \`volume.fsck -volumeId 999999\` on a cluster → expect \`volume(s) not found on master: [999999]\` instead of \`no orphan data\`
- [ ] Manual: \`fs.mergeVolumes -fromVolumeId 999999 -apply\` → expect \`fromVolumeId 999999 not found on master\` instead of just the volume-size header
- [ ] Manual: \`volume.vacuum -volumeId 999999\` → expect \`volume(s) not found on master: [999999]\`
- [ ] Regression: existing valid ids still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for volume management commands to catch invalid or out-of-range IDs (prevents numeric overflow) and to verify volumes exist on the master before proceeding.
  * Commands now return clear, deterministic errors listing any missing or duplicate volume IDs instead of silently succeeding.
  * Improved error handling so failures abort early with explanatory messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->