### PR TITLE
refactor(shell): run volume.fsck purge once per volume, after all replicas

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -366,11 +366,20 @@ func (c *commandVolumeFsck) findFilerChunksMissingInVolumeServers(volumeIdToVInf
 func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVInfo map[string]map[uint32]VInfo, applyPurging bool, modifyFrom, cutoffFrom uint64) error {
 
 	var totalInUseCount, totalOrphanChunkCount, totalOrphanDataSize uint64
-	volumeIdOrphanFileIds := make(map[uint32]map[string]bool)
-	isSeveralReplicas := make(map[uint32]bool)
+	// map[volumeId]map[fid]replicaCount — counts how many replicas reported
+	// this fid as orphan. A fid is safe to purge without -forcePurging only
+	// when replicaCount == volumeReplicaCounts[volumeId] (i.e. every replica
+	// agrees it's orphan). The previous bool-based tracking treated "seen on
+	// any 2 replicas" as "seen on all replicas", which was wrong for
+	// 3+-replica volumes.
+	volumeIdOrphanFileIds := make(map[uint32]map[string]int)
+	volumeReplicaCounts := make(map[uint32]int)
 	isEcVolumeReplicas := make(map[uint32]bool)
-	isReadOnlyReplicas := make(map[uint32]bool)
-	serverReplicas := make(map[uint32][]pb.ServerAddress)
+	// Track which specific replicas were read-only so we only flip those
+	// back on exit. The old `isReadOnlyReplicas[volumeId] = bool` leaked
+	// read-only state across replicas: if one replica was RO and another RW,
+	// the deferred cleanup would mark the originally-RW replica RO too.
+	readOnlyServerReplicas := make(map[uint32][]pb.ServerAddress)
 	// Phase 1: collect orphan fids from every replica of every volume.
 	// The purge step runs in Phase 2, AFTER every replica has contributed.
 	// Running purge inside this loop (as the original code did) meant the
@@ -384,19 +393,12 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 			if checkErr != nil {
 				return fmt.Errorf("failed to collect file ids from volume %d on %s: %v", volumeId, vinfo.server, checkErr)
 			}
-			isSeveralReplicas[volumeId] = false
 			if _, found := volumeIdOrphanFileIds[volumeId]; !found {
-				volumeIdOrphanFileIds[volumeId] = make(map[string]bool)
-			} else {
-				isSeveralReplicas[volumeId] = true
+				volumeIdOrphanFileIds[volumeId] = make(map[string]int)
 			}
+			volumeReplicaCounts[volumeId]++
 			for _, fid := range orphanFileIds {
-				if isSeveralReplicas[volumeId] {
-					if _, found := volumeIdOrphanFileIds[volumeId][fid]; !found {
-						continue
-					}
-				}
-				volumeIdOrphanFileIds[volumeId][fid] = isSeveralReplicas[volumeId]
+				volumeIdOrphanFileIds[volumeId][fid]++
 			}
 
 			totalInUseCount += inUseCount
@@ -409,60 +411,30 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 				}
 			}
 			isEcVolumeReplicas[volumeId] = vinfo.isEcVolume
-			if isReadOnly, found := isReadOnlyReplicas[volumeId]; !(found && isReadOnly) {
-				isReadOnlyReplicas[volumeId] = vinfo.isReadOnly
+			if vinfo.isReadOnly {
+				readOnlyServerReplicas[volumeId] = append(readOnlyServerReplicas[volumeId], vinfo.server)
 			}
-			serverReplicas[volumeId] = append(serverReplicas[volumeId], vinfo.server)
 		}
 	}
 
 	// Phase 2: purge. At most one call to purgeFileIdsForOneVolume per
 	// volume — that helper already fans out to all replica locations via
-	// MasterClient.GetLocations, so iterating serverReplicas here (as the
-	// old code did) would issue N*N delete RPCs for N replicas.
+	// MasterClient.GetLocations, so iterating per replica here (as the old
+	// code did) would issue N*N delete RPCs for N replicas.
 	if applyPurging {
 		for volumeId, orphanReplicaFileIds := range volumeIdOrphanFileIds {
 			if len(orphanReplicaFileIds) == 0 {
 				continue
 			}
-			orphanFileIds := make([]string, 0, len(orphanReplicaFileIds))
-			for fid, foundInAllReplicas := range orphanReplicaFileIds {
-				if !isSeveralReplicas[volumeId] || *c.forcePurging || foundInAllReplicas {
-					orphanFileIds = append(orphanFileIds, fid)
-				}
-			}
-			if len(orphanFileIds) == 0 {
-				continue
-			}
-			if *c.verbose {
-				fmt.Fprintf(c.writer, "purging process for volume %d.\n", volumeId)
-			}
-
 			if isEcVolumeReplicas[volumeId] {
 				fmt.Fprintf(c.writer, "skip purging for Erasure Coded volume %d.\n", volumeId)
 				continue
 			}
-
-			if isReadOnlyReplicas[volumeId] {
-				// Every replica needs to be writable before the purge RPC
-				// fans out; revert each one on return regardless of where
-				// we bail out.
-				needleVID := needle.VolumeId(volumeId)
-				for _, server := range serverReplicas[volumeId] {
-					if err := markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, true, false); err != nil {
-						return fmt.Errorf("mark volume %d on %v read/write: %v", volumeId, server, err)
-					}
-					fmt.Fprintf(c.writer, "temporarily marked %d on server %v writable for forced purge\n", volumeId, server)
-					defer markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, false, false)
-				}
-			}
-
-			if *c.verbose {
-				fmt.Fprintf(c.writer, "purging files from volume %d\n", volumeId)
-			}
-
-			if err := c.purgeFileIdsForOneVolume(volumeId, orphanFileIds); err != nil {
-				return fmt.Errorf("purging volume %d: %v", volumeId, err)
+			// Call out to a closure per volume so the deferred "mark
+			// readonly again" fires between volumes instead of piling up
+			// until findExtraChunksInVolumeServers returns.
+			if err := c.purgeOneVolume(volumeId, orphanReplicaFileIds, volumeReplicaCounts[volumeId], readOnlyServerReplicas[volumeId]); err != nil {
+				return err
 			}
 		}
 	}
@@ -484,6 +456,47 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 		fmt.Fprintf(c.writer, "no orphan data\n")
 	}
 
+	return nil
+}
+
+// purgeOneVolume picks the orphan fids to delete for a single volume and
+// fires the delete RPC. It's split out of findExtraChunksInVolumeServers so
+// the `defer markVolumeWritable(..., false, false)` at the bottom fires
+// between volumes — putting that defer inside the caller's for-loop would
+// leave every processed volume writable until the whole fsck run finished.
+func (c *commandVolumeFsck) purgeOneVolume(volumeId uint32, orphanReplicaFileIds map[string]int, replicaCount int, readOnlyReplicas []pb.ServerAddress) error {
+	orphanFileIds := make([]string, 0, len(orphanReplicaFileIds))
+	for fid, foundInReplicaCount := range orphanReplicaFileIds {
+		// Default safety net: only purge fids every replica reported as
+		// orphan. -forcePurging bypasses this for operators who've already
+		// decided they're OK with the single-replica evidence.
+		if foundInReplicaCount == replicaCount || *c.forcePurging {
+			orphanFileIds = append(orphanFileIds, fid)
+		}
+	}
+	if len(orphanFileIds) == 0 {
+		return nil
+	}
+	if *c.verbose {
+		fmt.Fprintf(c.writer, "purging process for volume %d.\n", volumeId)
+	}
+
+	needleVID := needle.VolumeId(volumeId)
+	for _, server := range readOnlyReplicas {
+		if err := markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, true, false); err != nil {
+			return fmt.Errorf("mark volume %d on %v read/write: %v", volumeId, server, err)
+		}
+		fmt.Fprintf(c.writer, "temporarily marked %d on server %v writable for forced purge\n", volumeId, server)
+		defer markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, false, false)
+	}
+
+	if *c.verbose {
+		fmt.Fprintf(c.writer, "purging files from volume %d\n", volumeId)
+	}
+
+	if err := c.purgeFileIdsForOneVolume(volumeId, orphanFileIds); err != nil {
+		return fmt.Errorf("purging volume %d: %v", volumeId, err)
+	}
 	return nil
 }
 

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -371,6 +371,13 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 	isEcVolumeReplicas := make(map[uint32]bool)
 	isReadOnlyReplicas := make(map[uint32]bool)
 	serverReplicas := make(map[uint32][]pb.ServerAddress)
+	// Phase 1: collect orphan fids from every replica of every volume.
+	// The purge step runs in Phase 2, AFTER every replica has contributed.
+	// Running purge inside this loop (as the original code did) meant the
+	// first replica's orphans were deleted before later replicas could
+	// participate in the intersection — so the "only purge fids seen on
+	// all replicas" safety net only worked by accident, and purge also
+	// fired multiple times per volume (once per data-node iteration).
 	for dataNodeId, volumeIdToVInfo := range dataNodeVolumeIdToVInfo {
 		for volumeId, vinfo := range volumeIdToVInfo {
 			inUseCount, orphanFileIds, orphanDataSize, checkErr := c.oneVolumeFileIdsSubtractFilerFileIds(dataNodeId, volumeId, &vinfo, modifyFrom, cutoffFrom)
@@ -407,18 +414,24 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 			}
 			serverReplicas[volumeId] = append(serverReplicas[volumeId], vinfo.server)
 		}
+	}
 
+	// Phase 2: purge. At most one call to purgeFileIdsForOneVolume per
+	// volume — that helper already fans out to all replica locations via
+	// MasterClient.GetLocations, so iterating serverReplicas here (as the
+	// old code did) would issue N*N delete RPCs for N replicas.
+	if applyPurging {
 		for volumeId, orphanReplicaFileIds := range volumeIdOrphanFileIds {
-			if !(applyPurging && len(orphanReplicaFileIds) > 0) {
+			if len(orphanReplicaFileIds) == 0 {
 				continue
 			}
-			orphanFileIds := []string{}
+			orphanFileIds := make([]string, 0, len(orphanReplicaFileIds))
 			for fid, foundInAllReplicas := range orphanReplicaFileIds {
-				if !isSeveralReplicas[volumeId] || *c.forcePurging || (isSeveralReplicas[volumeId] && foundInAllReplicas) {
+				if !isSeveralReplicas[volumeId] || *c.forcePurging || foundInAllReplicas {
 					orphanFileIds = append(orphanFileIds, fid)
 				}
 			}
-			if !(len(orphanFileIds) > 0) {
+			if len(orphanFileIds) == 0 {
 				continue
 			}
 			if *c.verbose {
@@ -429,27 +442,27 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 				fmt.Fprintf(c.writer, "skip purging for Erasure Coded volume %d.\n", volumeId)
 				continue
 			}
-			for _, server := range serverReplicas[volumeId] {
-				needleVID := needle.VolumeId(volumeId)
 
-				if isReadOnlyReplicas[volumeId] {
-					err := markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, true, false)
-					if err != nil {
-						return fmt.Errorf("mark volume %d read/write: %v", volumeId, err)
+			if isReadOnlyReplicas[volumeId] {
+				// Every replica needs to be writable before the purge RPC
+				// fans out; revert each one on return regardless of where
+				// we bail out.
+				needleVID := needle.VolumeId(volumeId)
+				for _, server := range serverReplicas[volumeId] {
+					if err := markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, true, false); err != nil {
+						return fmt.Errorf("mark volume %d on %v read/write: %v", volumeId, server, err)
 					}
 					fmt.Fprintf(c.writer, "temporarily marked %d on server %v writable for forced purge\n", volumeId, server)
 					defer markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, false, false)
-
-					fmt.Fprintf(c.writer, "marked %d on server %v writable for forced purge\n", volumeId, server)
 				}
+			}
 
-				if *c.verbose {
-					fmt.Fprintf(c.writer, "purging files from volume %d\n", volumeId)
-				}
+			if *c.verbose {
+				fmt.Fprintf(c.writer, "purging files from volume %d\n", volumeId)
+			}
 
-				if err := c.purgeFileIdsForOneVolume(volumeId, orphanFileIds); err != nil {
-					return fmt.Errorf("purging volume %d: %v", volumeId, err)
-				}
+			if err := c.purgeFileIdsForOneVolume(volumeId, orphanFileIds); err != nil {
+				return fmt.Errorf("purging volume %d: %v", volumeId, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

\`findExtraChunksInVolumeServers\` nested its purge step inside the outer \`for dataNodeId\` loop, so purging fired once per data-node iteration instead of once total. Two consequences:

- **Replica intersection was broken.** The code marks a fid \"found in all replicas\" only after every replica has contributed, but the purge ran after the first data node, so fids contributed only by later replicas never got the \`true\` flag in time. Without \`-forcePurging\` that meant some legitimate orphans were never purged; with \`-forcePurging\` the flag was ignored so the bug was hidden.
- **Noisy, redundant RPCs.** Users saw \`purging orphan data for volume X...\` 2-3 times per volume. \`purgeFileIdsForOneVolume\` already fans out to every replica location via \`MasterClient.GetLocations\`, but the caller was also iterating \`serverReplicas\` — so for N replicas the code issued N*N delete RPCs to the same locations.

Split into two explicit phases: collect orphans from every replica first, purge each volume exactly once. The per-replica loop around \`purgeFileIdsForOneVolume\` is gone (redundant), but the per-replica \`markVolumeWritable\` loop stays (each replica's readonly bit still has to be flipped before the purge RPC fans out to it).

Also simplifies \`isSeveralReplicas && foundInAllReplicas\` (redundant given the preceding \`!isSeveralReplicas\` branch) and replaces \`!(X > 0)\` with \`len(X) == 0\`.

Related to the #9116 follow-up where @madalee-com needed two \`volume.fsck\` passes to fully clean a volume.

## Test plan

- [ ] \`go build ./weed/shell/...\` — passes
- [ ] \`go vet ./weed/shell/...\` — passes
- [ ] \`go test ./weed/shell/...\` — passes locally
- [ ] Manual: run fsck with \`-reallyDeleteFromVolume -forcePurging\` on a replicated volume with known orphans; expect exactly one \`purging orphan data for volume X...\` line per replica (from \`purgeFileIdsForOneVolume\`), not 2-3.
- [ ] Manual: run fsck without \`-forcePurging\` on a 2-replica volume; verify only fids present on both replicas are purged (now that the intersection actually has time to converge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume fsck utility to more reliably detect and preserve orphan files across replicas and avoid premature deletions.
  * Better handling of read-only replicas during cleanup to ensure safe state restoration after purging.

* **New Features**
  * Purging now runs once per volume for safer, more deterministic cleanup; includes an option to force purging that bypasses replica-consensus checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->