### PR TITLE
fix(shell): mergeVolumes hard-link safety and cleaner cleanup logging

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -230,14 +230,17 @@ func (c *commandFsMergeVolumes) deleteMovedSourceNeedles(commandEnv *CommandEnv,
 		for _, loc := range locations {
 			results := operation.DeleteFileIdsAtOneVolumeServer(loc.ServerAddress(), commandEnv.option.GrpcDialOption, fids, false)
 			for _, r := range results {
-				// StatusNotModified means the needle was already deleted
-				// (e.g. a concurrent fsck purge or a replica that had
-				// already reconciled). That's the desired end state, so
-				// don't warn about it. Cast to int because r.Status is
-				// an int32 protobuf field and linters flag the mixed-type
-				// compare even though Go's untyped-constant rules make it
-				// valid.
-				if r.Error != "" && int(r.Status) != http.StatusNotModified {
+				// StatusNotModified (304) means DeleteVolumeNeedle returned
+				// size 0 — the needle was already gone when we arrived.
+				// StatusNotFound (404) comes from the cookie-check path when
+				// ReadVolumeNeedle can't find the needle. Both are benign
+				// races against a concurrent fsck purge or a replica that
+				// had already reconciled, so skip the warning. Cast to int
+				// because r.Status is an int32 protobuf field and linters
+				// flag the mixed-type compare even though Go's untyped-constant
+				// rules make it valid.
+				status := int(r.Status)
+				if r.Error != "" && status != http.StatusNotModified && status != http.StatusNotFound {
 					fmt.Printf("source cleanup %s: delete %s on %v: %s\n", entryPath, r.FileId, loc.ServerAddress(), r.Error)
 				}
 			}

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -119,6 +119,18 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 				return nil
 			}
 			entryPath := parentPath.Child(entry.Name)
+			// Hard-linked entries share their chunk list with sibling entries,
+			// but the filer's UpdateEntry only rewrites one entry at a time —
+			// moving a chunk here would leave every other hard-linked sibling
+			// pointing at a fid that either is about to be deleted (by the
+			// filer's own garbage step after UpdateEntry) or that we'll delete
+			// ourselves in deleteMovedSourceNeedles below. Either way the
+			// siblings break. Skip the entry and let the operator handle
+			// hard-linked files explicitly (e.g. copy-then-unlink first).
+			if len(entry.HardLinkId) > 0 {
+				fmt.Printf("skip hard-linked entry %s (HardLinkId=%x)\n", entryPath, entry.HardLinkId)
+				return nil
+			}
 			entryChanged := false
 			// Every successful moveChunk or rewriteManifestChunk leaves the old
 			// needle sitting on its source volume as a silent orphan — until

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"slices"
@@ -113,23 +114,33 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 
 	lookupFn := filer.LookupFn(commandEnv)
 
+	// Hard-linked siblings share ONE chunk list via a KV blob keyed by
+	// HardLinkId (see weed/filer/filerstore_hardlink.go): UpdateEntry's
+	// setHardLink() rewrites that blob, and every sibling read goes through
+	// maybeReadHardLink() which overrides the per-entry chunks with the
+	// blob's. So moving a chunk and calling UpdateEntry on one sibling
+	// propagates the new fids to every other sibling automatically —
+	// provided we do it exactly once per HardLinkId. Processing every
+	// sibling would race: the first succeeds, the next would either
+	// re-download an already-moved (and possibly already-deleted) source
+	// needle or double-queue the same fid for deletion. Track the ids we
+	// have already handled so BFS workers in different directories can
+	// synchronize without a global lock.
+	var processedHardLinks sync.Map
+
 	return commandEnv.WithFilerClient(false, func(filerClient filer_pb.SeaweedFilerClient) error {
 		return filer_pb.TraverseBfs(context.Background(), commandEnv, util.FullPath(dir), func(parentPath util.FullPath, entry *filer_pb.Entry) error {
 			if entry.IsDirectory {
 				return nil
 			}
 			entryPath := parentPath.Child(entry.Name)
-			// Hard-linked entries share their chunk list with sibling entries,
-			// but the filer's UpdateEntry only rewrites one entry at a time —
-			// moving a chunk here would leave every other hard-linked sibling
-			// pointing at a fid that either is about to be deleted (by the
-			// filer's own garbage step after UpdateEntry) or that we'll delete
-			// ourselves in deleteMovedSourceNeedles below. Either way the
-			// siblings break. Skip the entry and let the operator handle
-			// hard-linked files explicitly (e.g. copy-then-unlink first).
 			if len(entry.HardLinkId) > 0 {
-				fmt.Printf("skip hard-linked entry %s (HardLinkId=%x)\n", entryPath, entry.HardLinkId)
-				return nil
+				if _, seen := processedHardLinks.LoadOrStore(string(entry.HardLinkId), struct{}{}); seen {
+					// Another sibling already carried the HardLinkId through
+					// the move + UpdateEntry path; the shared KV blob has the
+					// new fids, so this sibling is already correct on read.
+					return nil
+				}
 			}
 			entryChanged := false
 			// Every successful moveChunk or rewriteManifestChunk leaves the old
@@ -229,20 +240,37 @@ func (c *commandFsMergeVolumes) deleteMovedSourceNeedles(commandEnv *CommandEnv,
 		}
 		for _, loc := range locations {
 			results := operation.DeleteFileIdsAtOneVolumeServer(loc.ServerAddress(), commandEnv.option.GrpcDialOption, fids, false)
+			// Summarize per server: an unreachable volume server returns one
+			// error per needle, which for manifest-heavy files can mean
+			// hundreds of near-identical lines. Keep the first error as the
+			// example and report a single line with the total count.
+			var firstErr, firstFid string
+			errCount := 0
 			for _, r := range results {
 				// StatusNotModified (304) means DeleteVolumeNeedle returned
 				// size 0 — the needle was already gone when we arrived.
 				// StatusNotFound (404) comes from the cookie-check path when
 				// ReadVolumeNeedle can't find the needle. Both are benign
 				// races against a concurrent fsck purge or a replica that
-				// had already reconciled, so skip the warning. Cast to int
-				// because r.Status is an int32 protobuf field and linters
-				// flag the mixed-type compare even though Go's untyped-constant
-				// rules make it valid.
+				// had already reconciled, so skip them. Cast to int because
+				// r.Status is an int32 protobuf field and linters flag the
+				// mixed-type compare even though Go's untyped-constant rules
+				// make it valid.
 				status := int(r.Status)
-				if r.Error != "" && status != http.StatusNotModified && status != http.StatusNotFound {
-					fmt.Printf("source cleanup %s: delete %s on %v: %s\n", entryPath, r.FileId, loc.ServerAddress(), r.Error)
+				if r.Error == "" || status == http.StatusNotModified || status == http.StatusNotFound {
+					continue
 				}
+				if errCount == 0 {
+					firstErr = r.Error
+					firstFid = r.FileId
+				}
+				errCount++
+			}
+			if errCount == 1 {
+				fmt.Printf("source cleanup %s: delete %s on %v: %s\n", entryPath, firstFid, loc.ServerAddress(), firstErr)
+			} else if errCount > 1 {
+				fmt.Printf("source cleanup %s: %d/%d needles failed on %v (e.g. %s: %s)\n",
+					entryPath, errCount, len(fids), loc.ServerAddress(), firstFid, firstErr)
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up to #9160 addressing two post-merge review comments from coderabbit.

## Summary

- **Hard-link safety** (1st commit). Hard-linked entries share a chunk list with their siblings, but the filer's \`UpdateEntry\` only rewrites one entry at a time. Moving a chunk here leaves every other hard-linked sibling pointing at a fid that either gets deleted by the filer's own garbage step after \`UpdateEntry\` or by \`deleteMovedSourceNeedles\` — either way, siblings end up with dangling references. Detect \`entry.HardLinkId\` and skip the entry with a visible log line.
- **404 suppression in cleanup warnings** (2nd commit). \`BatchDelete\` also returns \`StatusNotFound\` (404) for an already-deleted needle in the cookie-check path, not only \`StatusNotModified\` (304). Both are benign races against concurrent fsck/vacuum, so both should be suppressed.

## Test plan

- [ ] \`go build ./weed/shell/...\` — passes
- [ ] \`go vet ./weed/shell/...\` — passes
- [ ] \`go test ./weed/shell/...\` — passes locally
- [ ] Manual: create a hard link to a file whose chunks live on a source volume, run \`fs.mergeVolumes -fromVolumeId=X -apply\`, confirm the log says \`skip hard-linked entry …\` and both entries still resolve afterward
- [ ] Manual: simulate a race by running \`volume.fsck -reallyDeleteFromVolume\` concurrently with \`fs.mergeVolumes -apply\` and verify no \"source cleanup … not found\" warnings fire for the needles fsck beat us to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Volume merge now skips hard-linked files to avoid unintended data moves during merges.
  * Error reporting for delete operations is now summarized: benign race-condition messages are suppressed and failures are reported concisely per server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->