### PR TITLE
fix(topology): drop per-disk task-type conflict map (#9147)

### DIFF
--- a/weed/admin/topology/active_topology_test.go
+++ b/weed/admin/topology/active_topology_test.go
@@ -261,11 +261,11 @@ func TestTargetSelectionScenarios(t *testing.T) {
 			expectedTargets: 4,  // All 4 disks available
 		},
 		{
-			name:            "Vacuum task - avoid conflicting disks",
+			name:            "Vacuum task - cross-type tasks do not block per disk",
 			topology:        createTopologyWithConflicts(),
 			taskType:        TaskTypeVacuum,
 			excludeNode:     "",
-			expectedTargets: 1, // Only 1 disk without conflicts (conflicts exclude more disks)
+			expectedTargets: 4, // All 4 disks available; per-volume safety is enforced by HasAnyTask
 		},
 	}
 
@@ -279,8 +279,6 @@ func TestTargetSelectionScenarios(t *testing.T) {
 			for _, disk := range availableDisks {
 				assert.NotEqual(t, tt.excludeNode, disk.NodeID,
 					"Available disk should not be on excluded node")
-
-				assert.Less(t, disk.LoadCount, 2, "Disk load should be less than 2")
 			}
 		})
 	}
@@ -353,12 +351,18 @@ func TestDiskLoadCalculation(t *testing.T) {
 	assert.Equal(t, 1, targetDisk.LoadCount)
 }
 
-// TestTaskConflictDetection tests task conflict detection
-func TestTaskConflictDetection(t *testing.T) {
+// TestCrossTypeTasksDoNotBlockPerDisk verifies that an in-flight task of one
+// type on a disk does not exclude the disk from accepting tasks of a different
+// type. Per-volume safety is the responsibility of HasAnyTask at detection time.
+//
+// This guards against the regression in #9147, where a per-disk Balance↔EC
+// conflict on a small cluster permanently blocked auto-EC any time an unrelated
+// balance task was retrying.
+func TestCrossTypeTasksDoNotBlockPerDisk(t *testing.T) {
 	topology := NewActiveTopology(10)
 	topology.UpdateTopology(createSampleTopology())
 
-	// Add a balance task
+	// Assign a balance task using disk 10.0.0.1:8080:0 as source.
 	err := topology.AddPendingTask(TaskSpec{
 		TaskID:     "balance1",
 		TaskType:   TaskTypeBalance,
@@ -371,13 +375,12 @@ func TestTaskConflictDetection(t *testing.T) {
 			{ServerID: "10.0.0.2:8080", DiskID: 1},
 		},
 	})
-	assert.NoError(t, err, "Should add balance task successfully")
-	topology.AssignTask("balance1")
+	require.NoError(t, err)
+	require.NoError(t, topology.AssignTask("balance1"))
 
-	// Try to get available disks for vacuum (conflicts with balance)
+	// A vacuum (different type, different volume) must still see the source
+	// disk as a candidate.
 	availableDisks := topology.GetAvailableDisks(TaskTypeVacuum, "")
-
-	// Source disk should not be available due to conflict
 	sourceDiskAvailable := false
 	for _, disk := range availableDisks {
 		if disk.NodeID == "10.0.0.1:8080" && disk.DiskID == 0 {
@@ -385,7 +388,38 @@ func TestTaskConflictDetection(t *testing.T) {
 			break
 		}
 	}
-	assert.False(t, sourceDiskAvailable, "Source disk should not be available due to task conflict")
+	assert.True(t, sourceDiskAvailable,
+		"Source disk should remain available for an unrelated task type")
+}
+
+// TestECPlanningNotBlockedByUnrelatedBalance is the direct regression test for
+// #9147: a 4-disk cluster with one in-flight balance task must still expose all
+// 4 disks to EC placement so MinTotalDisks can be satisfied.
+func TestECPlanningNotBlockedByUnrelatedBalance(t *testing.T) {
+	topology := NewActiveTopology(10)
+	topology.UpdateTopology(createSampleTopology()) // 2 nodes x 2 disks = 4 disks
+
+	// One in-flight balance moving an unrelated volume.
+	err := topology.AddPendingTask(TaskSpec{
+		TaskID:     "balance1",
+		TaskType:   TaskTypeBalance,
+		VolumeID:   42,
+		VolumeSize: 1024 * 1024 * 1024,
+		Sources: []TaskSourceSpec{
+			{ServerID: "10.0.0.1:8080", DiskID: 0},
+		},
+		Destinations: []TaskDestinationSpec{
+			{ServerID: "10.0.0.2:8080", DiskID: 0},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, topology.AssignTask("balance1"))
+
+	// EC must still see all 4 disks. Pre-fix, the per-disk Balance↔EC conflict
+	// pruned the source and destination of the balance task, leaving only 2.
+	ecCandidates := topology.GetDisksWithEffectiveCapacity(TaskTypeErasureCoding, "", 0)
+	assert.Equal(t, 4, len(ecCandidates),
+		"EC must still see all 4 disks even with an unrelated in-flight balance")
 }
 
 // TestPublicInterfaces tests the public interface methods

--- a/weed/admin/topology/active_topology_test.go
+++ b/weed/admin/topology/active_topology_test.go
@@ -351,18 +351,10 @@ func TestDiskLoadCalculation(t *testing.T) {
 	assert.Equal(t, 1, targetDisk.LoadCount)
 }
 
-// TestCrossTypeTasksDoNotBlockPerDisk verifies that an in-flight task of one
-// type on a disk does not exclude the disk from accepting tasks of a different
-// type. Per-volume safety is the responsibility of HasAnyTask at detection time.
-//
-// This guards against the regression in #9147, where a per-disk Balance↔EC
-// conflict on a small cluster permanently blocked auto-EC any time an unrelated
-// balance task was retrying.
 func TestCrossTypeTasksDoNotBlockPerDisk(t *testing.T) {
 	topology := NewActiveTopology(10)
 	topology.UpdateTopology(createSampleTopology())
 
-	// Assign a balance task using disk 10.0.0.1:8080:0 as source.
 	err := topology.AddPendingTask(TaskSpec{
 		TaskID:     "balance1",
 		TaskType:   TaskTypeBalance,
@@ -378,8 +370,6 @@ func TestCrossTypeTasksDoNotBlockPerDisk(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, topology.AssignTask("balance1"))
 
-	// A vacuum (different type, different volume) must still see the source
-	// disk as a candidate.
 	availableDisks := topology.GetAvailableDisks(TaskTypeVacuum, "")
 	sourceDiskAvailable := false
 	for _, disk := range availableDisks {
@@ -392,14 +382,12 @@ func TestCrossTypeTasksDoNotBlockPerDisk(t *testing.T) {
 		"Source disk should remain available for an unrelated task type")
 }
 
-// TestECPlanningNotBlockedByUnrelatedBalance is the direct regression test for
-// #9147: a 4-disk cluster with one in-flight balance task must still expose all
-// 4 disks to EC placement so MinTotalDisks can be satisfied.
+// Regression for #9147: a 4-disk cluster with one in-flight balance task must
+// still expose all 4 disks to EC placement so MinTotalDisks can be satisfied.
 func TestECPlanningNotBlockedByUnrelatedBalance(t *testing.T) {
 	topology := NewActiveTopology(10)
-	topology.UpdateTopology(createSampleTopology()) // 2 nodes x 2 disks = 4 disks
+	topology.UpdateTopology(createSampleTopology()) // 2 nodes x 2 disks
 
-	// One in-flight balance moving an unrelated volume.
 	err := topology.AddPendingTask(TaskSpec{
 		TaskID:     "balance1",
 		TaskType:   TaskTypeBalance,
@@ -415,8 +403,6 @@ func TestECPlanningNotBlockedByUnrelatedBalance(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, topology.AssignTask("balance1"))
 
-	// EC must still see all 4 disks. Pre-fix, the per-disk Balance↔EC conflict
-	// pruned the source and destination of the balance task, leaving only 2.
 	ecCandidates := topology.GetDisksWithEffectiveCapacity(TaskTypeErasureCoding, "", 0)
 	assert.Equal(t, 4, len(ecCandidates),
 		"EC must still see all 4 disks even with an unrelated in-flight balance")

--- a/weed/admin/topology/capacity.go
+++ b/weed/admin/topology/capacity.go
@@ -236,15 +236,13 @@ func (at *ActiveTopology) getPlanningCapacityUnsafe(disk *activeDisk) StorageSlo
 	}
 }
 
-// isDiskAvailableForPlanning checks if disk can accept new tasks considering pending load.
-// See isDiskAvailable for why per-disk cross-task-type conflicts are not enforced.
+// isDiskAvailableForPlanning checks if disk can accept new tasks considering
+// pending load. See isDiskAvailable for the cross-type policy.
 func (at *ActiveTopology) isDiskAvailableForPlanning(disk *activeDisk, taskType TaskType) bool {
-	// Check total load including pending tasks
 	totalLoad := len(disk.pendingTasks) + len(disk.assignedTasks)
 	if MaxTotalTaskLoadPerDisk > 0 && totalLoad >= MaxTotalTaskLoadPerDisk {
 		return false
 	}
-
 	return true
 }
 

--- a/weed/admin/topology/capacity.go
+++ b/weed/admin/topology/capacity.go
@@ -236,19 +236,13 @@ func (at *ActiveTopology) getPlanningCapacityUnsafe(disk *activeDisk) StorageSlo
 	}
 }
 
-// isDiskAvailableForPlanning checks if disk can accept new tasks considering pending load
+// isDiskAvailableForPlanning checks if disk can accept new tasks considering pending load.
+// See isDiskAvailable for why per-disk cross-task-type conflicts are not enforced.
 func (at *ActiveTopology) isDiskAvailableForPlanning(disk *activeDisk, taskType TaskType) bool {
 	// Check total load including pending tasks
 	totalLoad := len(disk.pendingTasks) + len(disk.assignedTasks)
 	if MaxTotalTaskLoadPerDisk > 0 && totalLoad >= MaxTotalTaskLoadPerDisk {
 		return false
-	}
-
-	// Check for conflicting task types in active tasks only
-	for _, task := range disk.assignedTasks {
-		if at.areTaskTypesConflicting(task.TaskType, taskType) {
-			return false
-		}
 	}
 
 	return true

--- a/weed/admin/topology/internal.go
+++ b/weed/admin/topology/internal.go
@@ -64,24 +64,14 @@ func (at *ActiveTopology) assignTaskToDisk(task *taskState) {
 	}
 }
 
-// isDiskAvailable checks if a disk can accept new tasks.
-//
-// Cross-task-type conflicts are intentionally NOT checked here. Different job
-// types (Balance, ErasureCoding, Vacuum) operate on different volumes — the
-// per-volume safety guarantee is enforced one layer up by HasAnyTask at task
-// detection time. Per-disk load shaping is handled separately by
-// MaxConcurrentTasksPerDisk and capacity reservation.
-//
-// A previous implementation declared Balance/EC/Vacuum mutually exclusive per
-// disk, which on small clusters could permanently exclude a disk from EC
-// placement whenever any unrelated balance task was in flight (see #9147).
+// isDiskAvailable checks if a disk can accept new tasks. Per-volume safety is
+// enforced by HasAnyTask at detection time, so cross-type tasks on the same
+// disk are intentionally not considered conflicting (see #9147).
 func (at *ActiveTopology) isDiskAvailable(disk *activeDisk, taskType TaskType) bool {
-	// Check if disk has too many pending and active tasks
 	activeLoad := len(disk.pendingTasks) + len(disk.assignedTasks)
 	if MaxConcurrentTasksPerDisk > 0 && activeLoad >= MaxConcurrentTasksPerDisk {
 		return false
 	}
-
 	return true
 }
 

--- a/weed/admin/topology/internal.go
+++ b/weed/admin/topology/internal.go
@@ -64,7 +64,17 @@ func (at *ActiveTopology) assignTaskToDisk(task *taskState) {
 	}
 }
 
-// isDiskAvailable checks if a disk can accept new tasks
+// isDiskAvailable checks if a disk can accept new tasks.
+//
+// Cross-task-type conflicts are intentionally NOT checked here. Different job
+// types (Balance, ErasureCoding, Vacuum) operate on different volumes — the
+// per-volume safety guarantee is enforced one layer up by HasAnyTask at task
+// detection time. Per-disk load shaping is handled separately by
+// MaxConcurrentTasksPerDisk and capacity reservation.
+//
+// A previous implementation declared Balance/EC/Vacuum mutually exclusive per
+// disk, which on small clusters could permanently exclude a disk from EC
+// placement whenever any unrelated balance task was in flight (see #9147).
 func (at *ActiveTopology) isDiskAvailable(disk *activeDisk, taskType TaskType) bool {
 	// Check if disk has too many pending and active tasks
 	activeLoad := len(disk.pendingTasks) + len(disk.assignedTasks)
@@ -72,34 +82,7 @@ func (at *ActiveTopology) isDiskAvailable(disk *activeDisk, taskType TaskType) b
 		return false
 	}
 
-	// Check for conflicting task types
-	for _, task := range disk.assignedTasks {
-		if at.areTaskTypesConflicting(task.TaskType, taskType) {
-			return false
-		}
-	}
-
 	return true
-}
-
-// areTaskTypesConflicting checks if two task types conflict
-func (at *ActiveTopology) areTaskTypesConflicting(existing, new TaskType) bool {
-	// Examples of conflicting task types
-	conflictMap := map[TaskType][]TaskType{
-		TaskTypeVacuum:        {TaskTypeBalance, TaskTypeErasureCoding},
-		TaskTypeBalance:       {TaskTypeVacuum, TaskTypeErasureCoding},
-		TaskTypeErasureCoding: {TaskTypeVacuum, TaskTypeBalance},
-	}
-
-	if conflicts, exists := conflictMap[existing]; exists {
-		for _, conflictType := range conflicts {
-			if conflictType == new {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // cleanupRecentTasks removes old recent tasks


### PR DESCRIPTION
## Summary

Fixes #9147 — auto-EC permanently blocked on small clusters whenever a `volume_balance` task is retrying.

The root cause is the cross-type conflict map in `weed/admin/topology/internal.go`:

```go
TaskTypeBalance:       {TaskTypeVacuum, TaskTypeErasureCoding},
TaskTypeErasureCoding: {TaskTypeVacuum, TaskTypeBalance},
TaskTypeVacuum:        {TaskTypeBalance, TaskTypeErasureCoding},
```

`isDiskAvailable` consulted this map to declare a disk unusable for any task of a conflicting type while another type was assigned. `GetDisksWithEffectiveCapacity` then filtered EC candidates accordingly. On a 4-disk cluster, one in-flight balance pruned the source/destination disks, leaving 3 EC candidates — below `MinTotalDisks = 4` — and EC failed every cycle:

```
W Failed to plan EC destinations for volume 4:
  found 3 disks, but could not find 4 suitable destinations for EC placement
```

The map adds no correctness guarantee. Different job types operate on different volumes, and per-volume safety is already enforced one layer up by `ActiveTopology.HasAnyTask(volumeID)` at task detection time (`weed/worker/tasks/balance/detection.go:322` and the EC equivalent). Per-disk load shaping, if needed, is the job of `MaxConcurrentTasksPerDisk` (already wired up in `types.go`, currently `0`).

## Changes

- Delete `areTaskTypesConflicting` and the loops in `isDiskAvailable` / `isDiskAvailableForPlanning` that called it.
- Update `TestTargetSelectionScenarios` "Vacuum task" subtest to reflect that cross-type tasks no longer prune disks.
- Replace `TestTaskConflictDetection` with `TestCrossTypeTasksDoNotBlockPerDisk`, asserting the new contract.
- Add `TestECPlanningNotBlockedByUnrelatedBalance` — the direct regression for #9147 (4 disks, 1 in-flight balance, EC must still see 4 candidates).

## Test plan

- [x] `go test ./weed/admin/topology/...` — passes.
- [x] `go test ./weed/worker/tasks/...` — passes (balance, ec_balance, erasure_coding).
- [x] `go test ./weed/admin/maintenance/...` — passes.
- [x] `go build ./...` — clean.
- [ ] Reproduce the original scenario on a 4-disk cluster: trigger a balance retry, confirm EC detection now finds 4 destinations.

## Notes

The 240s context-cancel that kills large balance copies, and the unbounded re-creation loop where balance detection re-issues the same task after permanent failure, are separate bugs and intentionally out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated task planning validation tests to reflect improved disk availability logic.
  * Added regression tests for erasure coding task planning scenarios.

* **Improvements**
  * Simplified task scheduling logic to allow unrelated task types to coexist on the same disk, improving resource utilization and task planning efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->