### PR TITLE
chore(upload): log offset/bytes-read context on chunk ReadFrom errors

### DIFF
--- a/weed/operation/upload_chunked.go
+++ b/weed/operation/upload_chunked.go
@@ -99,12 +99,16 @@ uploadLoop:
 		// Read one chunk
 		dataSize, err := bytesBuffer.ReadFrom(limitedReader)
 		if err != nil {
-			glog.V(2).Infof("UploadReaderInChunks: read error at offset %d: %v", chunkOffset, err)
+			// Attach offset + bytes-read to distinguish client disconnect
+			// before any data (offset=0,got=0) from mid-stream truncation.
+			// A bare io.ErrUnexpectedEOF is not actionable on its own (see #9149).
+			wrapped := fmt.Errorf("read chunk at offset %d (got %d bytes): %w", chunkOffset, dataSize, err)
+			glog.V(2).Infof("UploadReaderInChunks: %v", wrapped)
 			chunkBufferPool.Put(bytesBuffer)
 			<-bytesBufferLimitChan
 			uploadErrLock.Lock()
 			if uploadErr == nil {
-				uploadErr = err
+				uploadErr = wrapped
 			}
 			uploadErrLock.Unlock()
 			break


### PR DESCRIPTION
## Summary

- Wrap `bytesBuffer.ReadFrom` errors in `UploadReaderInChunks` with `"read chunk at offset N (got M bytes): ..."` so logs distinguish "client disconnected before sending any data" (offset=0, got=0) from "body truncated mid-stream" (got<chunkSize). A bare `unexpected EOF` isn't actionable.
- Context for issue #9149 ("Upload of file fails on 4.21"): I could not reliably reproduce the `unexpected EOF` on a single-box test with default config (200 MB upload @ 795 MiB/s succeeds). With a small volume size limit (`-master.volumeSizeLimitMB=16`) the upload triggers ~26 volume growths and some volumes reach `effective=20971524 (limit=16777216)` — over-committed by one 8 MB assign — which slows the master under burst load; the aws CLI then times out and the server logs the bare `unexpected EOF` on the truncated body. This PR only improves the log line so the next occurrence is diagnosable.

Verified at this stage that `expectedDataSize` is already threaded correctly at every hop:
- `weed/operation/upload_chunked.go:157` — passes `uint64(size)` where `size` is actual bytes from `ReadFrom` (8 MB for a full chunk, smaller for a partial tail).
- `weed/s3api/s3api_object_handlers_put.go:467` — forwards to `filer_pb.AssignVolumeRequest.ExpectedDataSize`.
- `weed/server/filer_grpc_server.go:398` — forwards `req.ExpectedDataSize` to `operation.Assign`.
- `weed/operation/assign_file_id.go:105` — forwards to `master_pb.AssignRequest.ExpectedDataSize`.
- `weed/server/master_grpc_server_assign.go:114` — passes to `PickForWrite`, charges `count * expectedDataSize` into `effectiveSize`.

No behavioral change to what the master receives.

## Test plan

- [x] `go build ./weed/...`
- [x] `go test ./weed/operation/ -run UploadReaderInChunks -v -count=1` — PASS; the simulated read-failure test now logs `read chunk at offset 8192 (got 1808 bytes): simulated read failure`, confirming the wrapping.
- [x] Reproduction: 200 MB aws-cli upload against `weed mini -master.volumeSizeLimitMB=16` — succeeds; server log shows the expected volume-full events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting during chunked file uploads to include additional diagnostic information such as the chunk offset and the number of bytes successfully read before the error occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->