### PR TITLE
fix(volume): write state.pb into a real dir when -dir.idx is unset

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -154,8 +154,14 @@ func NewStore(
 	}
 	wg.Wait()
 
+	// Fall back to the first disk location when -dir.idx is unset, so state.pb
+	// is not written as a relative path against the process CWD (issue #9173).
+	stateDir := idxFolder
+	if stateDir == "" && len(s.Locations) > 0 {
+		stateDir = s.Locations[0].IdxDirectory
+	}
 	var err error
-	s.State, err = NewState(idxFolder)
+	s.State, err = NewState(stateDir)
 	if err != nil {
 		glog.Fatalf("failed to resolve state for volume %s: %v", id, err)
 	}

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -154,11 +154,14 @@ func NewStore(
 	}
 	wg.Wait()
 
-	// Fall back to the first disk location when -dir.idx is unset, so state.pb
-	// is not written as a relative path against the process CWD (issue #9173).
+	// Resolve state.pb's directory via the first disk location so it inherits
+	// the same `~` expansion and empty-idxFolder fallback used for .idx files,
+	// and is never written as a relative path against the process CWD (#9173).
 	stateDir := idxFolder
-	if stateDir == "" && len(s.Locations) > 0 {
+	if len(s.Locations) > 0 {
 		stateDir = s.Locations[0].IdxDirectory
+	} else if stateDir != "" {
+		stateDir = util.ResolvePath(stateDir)
 	}
 	var err error
 	s.State, err = NewState(stateDir)


### PR DESCRIPTION
## Summary
- `NewStore` passed the default empty `-dir.idx` value straight into `NewState`, so `filepath.Join("", "state.pb")` became the relative path `state.pb` and got written against the process CWD. Under systemd that is usually `/`, producing `open state.pb: permission denied` for commands like `volumeServer.state -maintenanceOn` even when the data dirs are owned by the service user.
- Fall back to the first disk location's `IdxDirectory` when `-dir.idx` is unset, so `state.pb` lives next to the volume data (same directory that already holds `vol_dir.uuid`).

Fixes #9173

## Test plan
- [ ] `go build ./...`
- [ ] `go vet ./weed/storage/...`
- [ ] Run a volume server without `-dir.idx`, issue `volumeServer.state -maintenanceOn`, and confirm `state.pb` is created inside the data directory (not CWD).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * State initialization now consistently uses the resolved disk location directory when available, ensuring the on-disk state is created in the same location as the primary index storage.
  * Prevents unintended relative-path state creation when an index folder is provided but a disk location is present, improving reliability across multi-disk setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->