### PR TITLE
feat(security): hot-reload HTTPS certs without restart (k8s cert-manager)

### DIFF
--- a/.github/workflows/tls-rotation-tests.yml
+++ b/.github/workflows/tls-rotation-tests.yml
@@ -1,0 +1,56 @@
+name: "TLS Rotation Integration Tests"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  tls-rotation-tests:
+    name: TLS Rotation Integration Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v6
+      with:
+        go-version: ^1.25
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
+    - name: Build weed binary
+      run: |
+        cd weed && go build -o weed .
+
+    - name: Run TLS Rotation Integration Tests
+      working-directory: test/tls_rotation
+      run: |
+        go test -v -count=1 -timeout 5m
+
+    - name: Collect server logs on failure
+      if: failure()
+      run: |
+        echo "Collecting master logs from temp directories..."
+        mkdir -p /tmp/tls-rotation-test-logs
+        find /tmp -maxdepth 1 -type d -name "TestMasterHTTPS*" 2>/dev/null | while read dir; do
+          if [ -d "$dir" ]; then
+            echo "Found test directory: $dir"
+            cp -r "$dir" /tmp/tls-rotation-test-logs/ 2>/dev/null || true
+          fi
+        done
+        echo "Collected logs:"
+        find /tmp/tls-rotation-test-logs -type f -name "*.log" 2>/dev/null || echo "No logs found"
+
+    - name: Archive logs
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: tls-rotation-test-logs
+        path: /tmp/tls-rotation-test-logs/
+        retention-days: 14

--- a/test/tls_rotation/tls_rotation_integration_test.go
+++ b/test/tls_rotation/tls_rotation_integration_test.go
@@ -78,6 +78,12 @@ func TestMasterHTTPSCertRotation(t *testing.T) {
 	)
 	cmd.Dir = masterDir
 	cmd.Env = append(os.Environ(),
+		// Isolate HOME so the subprocess cannot pick up a developer's
+		// ~/.seaweedfs/security.toml. Viper's AddConfigPath uses the
+		// literal string "$HOME/.seaweedfs" without env expansion today,
+		// so this is only belt-and-braces — but it insures us against a
+		// future viper upgrade that does expand env vars.
+		"HOME="+dir,
 		"WEED_HTTPS_MASTER_CERT="+certPath,
 		"WEED_HTTPS_MASTER_KEY="+keyPath,
 		// Short refresh window so rotation completes in seconds.
@@ -124,8 +130,9 @@ func TestMasterHTTPSCertRotation(t *testing.T) {
 	waitForCert(t, addr, caPool, leafSerial1, 30*time.Second, "initial cert")
 
 	// Sanity: same handshake twice still observes the initial leaf.
-	if got := peekServerCert(t, addr, caPool); got == nil || got.SerialNumber.Cmp(leafSerial1) != 0 {
-		t.Fatalf("second probe before rotation did not return initial leaf: %v", got)
+	got, err := peekServerCert(addr, caPool)
+	if err != nil || got == nil || got.SerialNumber.Cmp(leafSerial1) != 0 {
+		t.Fatalf("second probe before rotation did not return initial leaf: cert=%v err=%v", got, err)
 	}
 
 	// 2. Rotate on disk. pemfile watches mtime, so each file's write is
@@ -140,14 +147,19 @@ func TestMasterHTTPSCertRotation(t *testing.T) {
 
 // waitForCert polls until a TLS handshake against addr yields a peer
 // cert with the expected serial, or fails the test at the deadline.
+// The last handshake error is surfaced in the fatal message so that a
+// CI flake makes the root cause obvious (master didn't come up, TLS
+// handshake rejected, CA pool mismatch, etc.).
 func waitForCert(t *testing.T, addr string, caPool *x509.CertPool, wantSerial *big.Int, within time.Duration, label string) {
 	t.Helper()
 	deadline := time.Now().Add(within)
 	var lastErr error
 	var lastSerial *big.Int
 	for time.Now().Before(deadline) {
-		cert := peekServerCert(t, addr, caPool)
-		if cert != nil {
+		cert, err := peekServerCert(addr, caPool)
+		if err != nil {
+			lastErr = err
+		} else if cert != nil {
 			lastSerial = cert.SerialNumber
 			if cert.SerialNumber.Cmp(wantSerial) == 0 {
 				return
@@ -158,25 +170,26 @@ func waitForCert(t *testing.T, addr string, caPool *x509.CertPool, wantSerial *b
 	t.Fatalf("timeout waiting for %s (want serial %s, last seen %v, last err %v)", label, wantSerial, lastSerial, lastErr)
 }
 
-// peekServerCert opens a one-shot TLS connection, returns the leaf, and
-// closes the connection. Returning nil means the handshake failed; the
-// caller treats that as "not ready yet" and keeps polling.
-func peekServerCert(t *testing.T, addr string, caPool *x509.CertPool) *x509.Certificate {
-	t.Helper()
+// peekServerCert opens a one-shot TLS connection and returns the leaf.
+// Errors (dial failure, handshake rejection, empty peer chain) are
+// returned rather than swallowed, so the caller can surface them when
+// the test times out.
+func peekServerCert(addr string, caPool *x509.CertPool) (*x509.Certificate, error) {
 	d := &net.Dialer{Timeout: 2 * time.Second}
 	conn, err := tls.DialWithDialer(d, "tcp", addr, &tls.Config{
 		RootCAs:    caPool,
 		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
 	})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer conn.Close()
 	state := conn.ConnectionState()
 	if len(state.PeerCertificates) == 0 {
-		return nil
+		return nil, fmt.Errorf("handshake returned empty peer chain")
 	}
-	return state.PeerCertificates[0]
+	return state.PeerCertificates[0], nil
 }
 
 func getFreeTCPPort(t *testing.T) int {

--- a/test/tls_rotation/tls_rotation_integration_test.go
+++ b/test/tls_rotation/tls_rotation_integration_test.go
@@ -1,0 +1,310 @@
+// Package tls_rotation exercises HTTPS certificate rotation end-to-end:
+// start a real `weed master` with an HTTPS listener, capture the leaf
+// served at handshake time, rewrite the cert/key files on disk, and
+// assert that a subsequent handshake sees the new leaf — all without
+// stopping the master process. The test shortens the reloader's refresh
+// window to ~half a second via WEED_TLS_CERT_REFRESH_INTERVAL so it
+// completes in seconds rather than hours.
+package tls_rotation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestMasterHTTPSCertRotation boots `weed master` with HTTPS, confirms
+// the initial leaf is served, rotates the cert/key pair on disk, and
+// asserts the rotated leaf is served on subsequent TLS handshakes.
+func TestMasterHTTPSCertRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTPS rotation integration test in -short mode")
+	}
+
+	weedBin := findWeedBinary(t)
+
+	dir := t.TempDir()
+	tlsDir := filepath.Join(dir, "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatalf("mkdir tls: %v", err)
+	}
+	certPath := filepath.Join(tlsDir, "server.crt")
+	keyPath := filepath.Join(tlsDir, "server.key")
+
+	ca, caKey := generateCA(t)
+	leafSerial1 := big.NewInt(10001)
+	leafSerial2 := big.NewInt(10002)
+
+	// Initial leaf on disk.
+	writeLeaf(t, certPath, keyPath, ca, caKey, leafSerial1)
+
+	masterDir := filepath.Join(dir, "master")
+	if err := os.MkdirAll(masterDir, 0o755); err != nil {
+		t.Fatalf("mkdir master: %v", err)
+	}
+	// Empty security.toml so the master doesn't pick up a user's
+	// ~/.seaweedfs/security.toml during the test.
+	if err := os.WriteFile(filepath.Join(masterDir, "security.toml"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("write security.toml: %v", err)
+	}
+
+	// Master auto-derives gRPC port as port+10000 when -port.grpc is
+	// unset, so both must fit in uint16. Pin both explicitly.
+	port, grpcPort := getFreeTCPPort(t), getFreeTCPPort(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, weedBin, "master",
+		"-ip", "127.0.0.1",
+		"-port", strconv.Itoa(port),
+		"-port.grpc", strconv.Itoa(grpcPort),
+		"-mdir", masterDir,
+	)
+	cmd.Dir = masterDir
+	cmd.Env = append(os.Environ(),
+		"WEED_HTTPS_MASTER_CERT="+certPath,
+		"WEED_HTTPS_MASTER_KEY="+keyPath,
+		// Short refresh window so rotation completes in seconds.
+		"WEED_TLS_CERT_REFRESH_INTERVAL=500ms",
+	)
+	logPath := filepath.Join(masterDir, "master.log")
+	logOut, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("create master log: %v", err)
+	}
+	cmd.Stdout = logOut
+	cmd.Stderr = logOut
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start master: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+			done := make(chan struct{})
+			go func() { _ = cmd.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				_ = cmd.Process.Kill()
+				<-done
+			}
+		}
+		_ = logOut.Close()
+		if t.Failed() {
+			if b, readErr := os.ReadFile(logPath); readErr == nil {
+				t.Logf("master.log:\n%s", string(b))
+			}
+		}
+	})
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(ca)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	// 1. Wait for the initial leaf to appear. Master takes a few seconds
+	//    to open its HTTPS listener.
+	waitForCert(t, addr, caPool, leafSerial1, 30*time.Second, "initial cert")
+
+	// Sanity: same handshake twice still observes the initial leaf.
+	if got := peekServerCert(t, addr, caPool); got == nil || got.SerialNumber.Cmp(leafSerial1) != 0 {
+		t.Fatalf("second probe before rotation did not return initial leaf: %v", got)
+	}
+
+	// 2. Rotate on disk. pemfile watches mtime, so each file's write is
+	//    an atomic rename (tempfile in the same directory).
+	writeLeaf(t, certPath, keyPath, ca, caKey, leafSerial2)
+
+	// 3. Wait for new leaf to take over. With a 500ms refresh and no
+	//    connection pooling (tls.Dial opens a fresh conn each time), this
+	//    should take a couple of seconds.
+	waitForCert(t, addr, caPool, leafSerial2, 15*time.Second, "rotated cert")
+}
+
+// waitForCert polls until a TLS handshake against addr yields a peer
+// cert with the expected serial, or fails the test at the deadline.
+func waitForCert(t *testing.T, addr string, caPool *x509.CertPool, wantSerial *big.Int, within time.Duration, label string) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	var lastErr error
+	var lastSerial *big.Int
+	for time.Now().Before(deadline) {
+		cert := peekServerCert(t, addr, caPool)
+		if cert != nil {
+			lastSerial = cert.SerialNumber
+			if cert.SerialNumber.Cmp(wantSerial) == 0 {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s (want serial %s, last seen %v, last err %v)", label, wantSerial, lastSerial, lastErr)
+}
+
+// peekServerCert opens a one-shot TLS connection, returns the leaf, and
+// closes the connection. Returning nil means the handshake failed; the
+// caller treats that as "not ready yet" and keeps polling.
+func peekServerCert(t *testing.T, addr string, caPool *x509.CertPool) *x509.Certificate {
+	t.Helper()
+	d := &net.Dialer{Timeout: 2 * time.Second}
+	conn, err := tls.DialWithDialer(d, "tcp", addr, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+	})
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return nil
+	}
+	return state.PeerCertificates[0]
+}
+
+func getFreeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen ephemeral: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+func findWeedBinary(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		"../../weed/weed",
+		"../weed/weed",
+		"./weed",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			abs, absErr := filepath.Abs(c)
+			if absErr == nil {
+				return abs
+			}
+			return c
+		}
+	}
+	if path, err := exec.LookPath("weed"); err == nil {
+		return path
+	}
+	t.Skip("weed binary not found — build with `cd weed && go build` first")
+	return ""
+}
+
+// --- cert fixtures -------------------------------------------------------
+
+// generateCA returns a self-signed CA cert and its private key.
+func generateCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tls-rotation-test-CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	return parsed, key
+}
+
+// writeLeaf signs a new leaf cert with the given serial and writes it
+// plus its key to the given paths via atomic rename — the pattern
+// Kubernetes (cert-manager → Secret volume mount) produces in practice.
+func writeLeaf(t *testing.T, certPath, keyPath string, ca *x509.Certificate, caKey *ecdsa.PrivateKey, serial *big.Int) {
+	t.Helper()
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+
+	atomicWritePEM(t, certPath, "CERTIFICATE", der)
+
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	atomicWritePEM(t, keyPath, "EC PRIVATE KEY", keyDER)
+}
+
+// atomicWritePEM writes a PEM file via tempfile-in-same-directory plus
+// rename, matching what kubelet does when it swaps the ..data symlink
+// for a renewed Secret. Ensures the reader never sees a truncated file.
+func atomicWritePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tls-*")
+	if err != nil {
+		t.Fatalf("create tempfile: %v", err)
+	}
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+	if err := pem.Encode(tmp, &pem.Block{Type: blockType, Bytes: der}); err != nil {
+		tmp.Close()
+		t.Fatalf("pem encode: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close tempfile: %v", err)
+	}
+	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
+		t.Fatalf("chmod tempfile: %v", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		t.Fatalf("rename tempfile onto %s: %v", path, err)
+	}
+	ok = true
+}

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"net"
@@ -441,7 +442,16 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 
 		if useTLS {
 			log.Printf("Starting SeaweedFS Admin Server with TLS on port %d", *options.port)
-			err = server.ListenAndServeTLS(certFile, keyFile)
+			getCert, _, certErr := security.NewReloadingServerCertificate(certFile, keyFile)
+			if certErr != nil {
+				log.Printf("Failed to load admin HTTPS certificate: %v", certErr)
+				return
+			}
+			if server.TLSConfig == nil {
+				server.TLSConfig = &tls.Config{}
+			}
+			server.TLSConfig.GetCertificate = getCert
+			err = server.ListenAndServeTLS("", "")
 		} else {
 			err = server.ListenAndServe()
 		}

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -412,52 +412,57 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 		Handler: handler,
 	}
 
+	// Decide TLS configuration BEFORE launching the server goroutine, so a
+	// bad cert or a missing key surfaces as a startup error instead of a
+	// silently returned goroutine that leaves startAdminServer blocked on
+	// ctx.Done() with no listener.
+	var (
+		clientCertFile,
+		certFile,
+		keyFile string
+	)
+	useTLS := false
+	useMTLS := false
+
+	if viper.GetString("https.admin.key") != "" {
+		useTLS = true
+		certFile = viper.GetString("https.admin.cert")
+		keyFile = viper.GetString("https.admin.key")
+	}
+
+	if viper.GetString("https.admin.ca") != "" {
+		useMTLS = true
+		clientCertFile = viper.GetString("https.admin.ca")
+	}
+
+	if useMTLS {
+		server.TLSConfig = security.LoadClientTLSHTTP(clientCertFile)
+	}
+
+	if useTLS {
+		getCert, certProvider, certErr := security.NewReloadingServerCertificate(certFile, keyFile)
+		if certErr != nil {
+			return fmt.Errorf("load admin HTTPS certificate: %w", certErr)
+		}
+		defer certProvider.Close()
+		if server.TLSConfig == nil {
+			server.TLSConfig = &tls.Config{}
+		}
+		server.TLSConfig.GetCertificate = getCert
+	}
+
 	// Start server
 	go func() {
 		log.Printf("Starting SeaweedFS Admin Server on port %d", *options.port)
-
-		// start http or https server with security.toml
-		var (
-			clientCertFile,
-			certFile,
-			keyFile string
-		)
-		useTLS := false
-		useMTLS := false
-
-		if viper.GetString("https.admin.key") != "" {
-			useTLS = true
-			certFile = viper.GetString("https.admin.cert")
-			keyFile = viper.GetString("https.admin.key")
-		}
-
-		if viper.GetString("https.admin.ca") != "" {
-			useMTLS = true
-			clientCertFile = viper.GetString("https.admin.ca")
-		}
-
-		if useMTLS {
-			server.TLSConfig = security.LoadClientTLSHTTP(clientCertFile)
-		}
-
+		var serveErr error
 		if useTLS {
 			log.Printf("Starting SeaweedFS Admin Server with TLS on port %d", *options.port)
-			getCert, _, certErr := security.NewReloadingServerCertificate(certFile, keyFile)
-			if certErr != nil {
-				log.Printf("Failed to load admin HTTPS certificate: %v", certErr)
-				return
-			}
-			if server.TLSConfig == nil {
-				server.TLSConfig = &tls.Config{}
-			}
-			server.TLSConfig.GetCertificate = getCert
-			err = server.ListenAndServeTLS("", "")
+			serveErr = server.ListenAndServeTLS("", "")
 		} else {
-			err = server.ListenAndServe()
+			serveErr = server.ListenAndServe()
 		}
-
-		if err != nil && err != http.ErrServerClosed {
-			log.Printf("Failed to start server: %v", err)
+		if serveErr != nil && serveErr != http.ErrServerClosed {
+			log.Printf("Failed to start server: %v", serveErr)
 		}
 	}()
 

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -488,10 +488,11 @@ func (fo *FilerOptions) startFiler() {
 		caCertFile := viper.GetString("https.filer.ca")
 		disbaleTlsVerifyClientCert := viper.GetBool("https.filer.disable_tls_verify_client_cert")
 
-		getCert, _, err := security.NewReloadingServerCertificate(certFile, keyFile)
+		getCert, certProvider, err := security.NewReloadingServerCertificate(certFile, keyFile)
 		if err != nil {
 			glog.Fatalf("Filer failed to load HTTPS certificate: %v", err)
 		}
+		defer certProvider.Close()
 
 		caCertPool := x509.NewCertPool()
 		if caCertFile != "" {

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -15,8 +15,6 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-	"google.golang.org/grpc/credentials/tls/certprovider"
-	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/seaweedfs/seaweedfs/weed/credential"
@@ -82,7 +80,6 @@ type FilerOptions struct {
 	allowedOrigins            *string
 	exposeDirectoryData       *bool
 	tusBasePath               *string
-	certProvider              certprovider.Provider
 	s3ConfigFile              *string // optional path to static S3 identity config
 	mountPeerRegistryEnable        *bool   // accept MountRegister/MountList RPCs (peer chunk sharing tier 1)
 	// shutdownCtx, when non-nil, tells startFiler to gracefully shut down its
@@ -315,15 +312,6 @@ func runFiler(cmd *Command, args []string) bool {
 	return true
 }
 
-// GetCertificateWithUpdate Auto refreshing TSL certificate
-func (fo *FilerOptions) GetCertificateWithUpdate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	certs, err := fo.certProvider.KeyMaterial(context.Background())
-	if certs == nil {
-		return nil, err
-	}
-	return &certs.Certs[0], err
-}
-
 func (fo *FilerOptions) startFiler() {
 
 	defaultMux := http.NewServeMux()
@@ -500,13 +488,9 @@ func (fo *FilerOptions) startFiler() {
 		caCertFile := viper.GetString("https.filer.ca")
 		disbaleTlsVerifyClientCert := viper.GetBool("https.filer.disable_tls_verify_client_cert")
 
-		pemfileOptions := pemfile.Options{
-			CertFile:        certFile,
-			KeyFile:         keyFile,
-			RefreshDuration: security.CredRefreshingInterval,
-		}
-		if fo.certProvider, err = pemfile.NewProvider(pemfileOptions); err != nil {
-			glog.Fatalf("pemfile.NewProvider(%v) failed: %v", pemfileOptions, err)
+		getCert, _, err := security.NewReloadingServerCertificate(certFile, keyFile)
+		if err != nil {
+			glog.Fatalf("Filer failed to load HTTPS certificate: %v", err)
 		}
 
 		caCertPool := x509.NewCertPool()
@@ -524,7 +508,7 @@ func (fo *FilerOptions) startFiler() {
 		}
 
 		tlsConfig := &tls.Config{
-			GetCertificate: fo.GetCertificateWithUpdate,
+			GetCertificate: getCert,
 			ClientAuth:     clientAuth,
 			ClientCAs:      caCertPool,
 		}

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -328,10 +328,15 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	}
 
 	if useTLS {
-		getCert, _, err := security.NewReloadingServerCertificate(certFile, keyFile)
+		getCert, certProvider, err := security.NewReloadingServerCertificate(certFile, keyFile)
 		if err != nil {
 			glog.Fatalf("failed to load master HTTPS certificate: %v", err)
 		}
+		// Master runs ServeTLS in a goroutine and this function then blocks
+		// on shutdownCtx / select{}; tie the pem refresh goroutine to the
+		// existing interrupt hook instead of a local defer that would fire
+		// while the server is still running.
+		grace.OnInterrupt(certProvider.Close)
 		if tlsConfig == nil {
 			tlsConfig = &tls.Config{}
 		}

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -328,7 +328,15 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	}
 
 	if useTLS {
-		go newHttpServer(r, tlsConfig).ServeTLS(masterListener, certFile, keyFile)
+		getCert, _, err := security.NewReloadingServerCertificate(certFile, keyFile)
+		if err != nil {
+			glog.Fatalf("failed to load master HTTPS certificate: %v", err)
+		}
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{}
+		}
+		tlsConfig.GetCertificate = getCert
+		go newHttpServer(r, tlsConfig).ServeTLS(masterListener, "", "")
 	} else {
 		go newHttpServer(r, nil).Serve(masterListener)
 	}

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -403,10 +403,11 @@ func (s3opt *S3Options) startS3Server() bool {
 			glog.Fatalf("S3 API Server error: -s3.port.https (%d) cannot be the same as -s3.port (%d)", *s3opt.portHttps, *s3opt.port)
 		}
 
-		getCert, _, err := security.NewReloadingServerCertificate(*s3opt.tlsCertificate, *s3opt.tlsPrivateKey)
+		getCert, certProvider, err := security.NewReloadingServerCertificate(*s3opt.tlsCertificate, *s3opt.tlsPrivateKey)
 		if err != nil {
 			glog.Fatalf("S3 API Server failed to load HTTPS certificate: %v", err)
 		}
+		grace.OnInterrupt(certProvider.Close)
 
 		caCertPool := x509.NewCertPool()
 		if *s3opt.tlsCACertificate != "" {

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -15,8 +15,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"google.golang.org/grpc/credentials/tls/certprovider"
-	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -62,7 +60,6 @@ type S3Options struct {
 	localFilerSocket          *string
 	dataCenter                *string
 	localSocket               *string
-	certProvider              certprovider.Provider
 	idleTimeout               *int
 	concurrentUploadLimitMB   *int
 	concurrentFileUploadLimit *int
@@ -226,15 +223,6 @@ func runS3(cmd *Command, args []string) bool {
 
 	return s3StandaloneOptions.startS3Server()
 
-}
-
-// GetCertificateWithUpdate Auto refreshing TSL certificate
-func (s3opt *S3Options) GetCertificateWithUpdate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	certs, err := s3opt.certProvider.KeyMaterial(context.Background())
-	if certs == nil {
-		return nil, err
-	}
-	return &certs.Certs[0], err
 }
 
 // resolveExternalUrl returns the external URL from the flag or falls back to the S3_EXTERNAL_URL env var.
@@ -415,13 +403,9 @@ func (s3opt *S3Options) startS3Server() bool {
 			glog.Fatalf("S3 API Server error: -s3.port.https (%d) cannot be the same as -s3.port (%d)", *s3opt.portHttps, *s3opt.port)
 		}
 
-		pemfileOptions := pemfile.Options{
-			CertFile:        *s3opt.tlsCertificate,
-			KeyFile:         *s3opt.tlsPrivateKey,
-			RefreshDuration: security.CredRefreshingInterval,
-		}
-		if s3opt.certProvider, err = pemfile.NewProvider(pemfileOptions); err != nil {
-			glog.Fatalf("pemfile.NewProvider(%v) failed: %v", pemfileOptions, err)
+		getCert, _, err := security.NewReloadingServerCertificate(*s3opt.tlsCertificate, *s3opt.tlsPrivateKey)
+		if err != nil {
+			glog.Fatalf("S3 API Server failed to load HTTPS certificate: %v", err)
 		}
 
 		caCertPool := x509.NewCertPool()
@@ -440,7 +424,7 @@ func (s3opt *S3Options) startS3Server() bool {
 		}
 
 		tlsConfig := &tls.Config{
-			GetCertificate: s3opt.GetCertificateWithUpdate,
+			GetCertificate: getCert,
 			ClientAuth:     clientAuth,
 			ClientCAs:      caCertPool,
 		}

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -313,7 +313,7 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 	}
 
 	// starting the cluster http server
-	clusterHttpServer := v.startClusterHttpService(volumeMux)
+	clusterHttpServer, closeCert := v.startClusterHttpService(volumeMux)
 
 	grace.OnReload(volumeServer.LoadNewVolumes)
 	grace.OnReload(volumeServer.Reload)
@@ -330,6 +330,9 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 		}
 
 		shutdown(publicHttpDown, clusterHttpServer, grpcS, volumeServer)
+		if closeCert != nil {
+			closeCert()
+		}
 		stopChan <- true
 	})
 
@@ -338,6 +341,9 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 		case <-stopChan:
 		case <-v.shutdownCtx.Done():
 			shutdown(publicHttpDown, clusterHttpServer, grpcS, volumeServer)
+			if closeCert != nil {
+				closeCert()
+			}
 		}
 	} else {
 		select {
@@ -443,7 +449,13 @@ func (v VolumeServerOptions) startPublicHttpService(handler http.Handler) httpdo
 	return publicHttpDown
 }
 
-func (v VolumeServerOptions) startClusterHttpService(handler http.Handler) httpdown.Server {
+// startClusterHttpService starts the volume cluster HTTP server and
+// returns it along with a close func for the cert reloader's refresh
+// goroutine (nil when HTTPS is disabled). The caller is responsible
+// for invoking the close func on every shutdown path — both the
+// SIGTERM/grace.OnInterrupt path and the shutdownCtx path used by
+// mini/integration tests.
+func (v VolumeServerOptions) startClusterHttpService(handler http.Handler) (httpdown.Server, func()) {
 	var (
 		certFile, keyFile string
 	)
@@ -471,15 +483,13 @@ func (v VolumeServerOptions) startClusterHttpService(handler http.Handler) httpd
 		security.FixTlsConfig(util.GetViper(), httpS.TLSConfig)
 	}
 
+	var closeCert func()
 	if certFile != "" && keyFile != "" {
 		getCert, certProvider, err := security.NewReloadingServerCertificate(certFile, keyFile)
 		if err != nil {
 			glog.Fatalf("Volume server failed to load TLS certificate: %v", err)
 		}
-		// This helper returns while the server is still running; hook the
-		// provider close into the global interrupt so the refresh goroutine
-		// is torn down on shutdown rather than leaked.
-		grace.OnInterrupt(certProvider.Close)
+		closeCert = certProvider.Close
 		if httpS.TLSConfig == nil {
 			httpS.TLSConfig = &tls.Config{}
 		}
@@ -492,5 +502,5 @@ func (v VolumeServerOptions) startClusterHttpService(handler http.Handler) httpd
 			glog.Fatalf("Volume server fail to serve: %v", e)
 		}
 	}()
-	return clusterHttpServer
+	return clusterHttpServer, closeCert
 }

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	httppprof "net/http/pprof"
@@ -461,14 +462,24 @@ func (v VolumeServerOptions) startClusterHttpService(handler http.Handler) httpd
 	httpDown := httpdown.HTTP{
 		KillTimeout: time.Minute,
 		StopTimeout: 30 * time.Second,
-		CertFile:    certFile,
-		KeyFile:     keyFile}
+	}
 	httpS := &http.Server{Handler: handler}
 
 	if viper.GetString("https.volume.ca") != "" {
 		clientCertFile := viper.GetString("https.volume.ca")
 		httpS.TLSConfig = security.LoadClientTLSHTTP(clientCertFile)
 		security.FixTlsConfig(util.GetViper(), httpS.TLSConfig)
+	}
+
+	if certFile != "" && keyFile != "" {
+		getCert, _, err := security.NewReloadingServerCertificate(certFile, keyFile)
+		if err != nil {
+			glog.Fatalf("Volume server failed to load TLS certificate: %v", err)
+		}
+		if httpS.TLSConfig == nil {
+			httpS.TLSConfig = &tls.Config{}
+		}
+		httpS.TLSConfig.GetCertificate = getCert
 	}
 
 	clusterHttpServer := httpDown.Serve(httpS, listener)

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -472,10 +472,14 @@ func (v VolumeServerOptions) startClusterHttpService(handler http.Handler) httpd
 	}
 
 	if certFile != "" && keyFile != "" {
-		getCert, _, err := security.NewReloadingServerCertificate(certFile, keyFile)
+		getCert, certProvider, err := security.NewReloadingServerCertificate(certFile, keyFile)
 		if err != nil {
 			glog.Fatalf("Volume server failed to load TLS certificate: %v", err)
 		}
+		// This helper returns while the server is still running; hook the
+		// provider close into the global interrupt so the refresh goroutine
+		// is torn down on shutdown rather than leaked.
+		grace.OnInterrupt(certProvider.Close)
 		if httpS.TLSConfig == nil {
 			httpS.TLSConfig = &tls.Config{}
 		}

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -151,10 +151,11 @@ func (wo *WebDavOption) startWebDav() bool {
 
 	if *wo.tlsPrivateKey != "" {
 		glog.V(0).Infof("Start Seaweed WebDav Server %s at https %s", version.Version(), listenAddress)
-		getCert, _, err := security.NewReloadingServerCertificate(*wo.tlsCertificate, *wo.tlsPrivateKey)
+		getCert, certProvider, err := security.NewReloadingServerCertificate(*wo.tlsCertificate, *wo.tlsPrivateKey)
 		if err != nil {
 			glog.Fatalf("WebDav Server failed to load TLS certificate: %v", err)
 		}
+		defer certProvider.Close()
 		httpS.TLSConfig = &tls.Config{GetCertificate: getCert}
 		if err = httpS.ServeTLS(webDavListener, "", ""); err != nil && err != http.ErrServerClosed {
 			glog.Fatalf("WebDav Server Fail to serve: %v", err)

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -150,7 +151,12 @@ func (wo *WebDavOption) startWebDav() bool {
 
 	if *wo.tlsPrivateKey != "" {
 		glog.V(0).Infof("Start Seaweed WebDav Server %s at https %s", version.Version(), listenAddress)
-		if err = httpS.ServeTLS(webDavListener, *wo.tlsCertificate, *wo.tlsPrivateKey); err != nil && err != http.ErrServerClosed {
+		getCert, _, err := security.NewReloadingServerCertificate(*wo.tlsCertificate, *wo.tlsPrivateKey)
+		if err != nil {
+			glog.Fatalf("WebDav Server failed to load TLS certificate: %v", err)
+		}
+		httpS.TLSConfig = &tls.Config{GetCertificate: getCert}
+		if err = httpS.ServeTLS(webDavListener, "", ""); err != nil && err != http.ErrServerClosed {
 			glog.Fatalf("WebDav Server Fail to serve: %v", err)
 		}
 	} else {

--- a/weed/security/certreload/certreload.go
+++ b/weed/security/certreload/certreload.go
@@ -38,8 +38,15 @@ func newServerGetCertificate(certFile, keyFile string, refresh time.Duration) (f
 	if err != nil {
 		return nil, nil, err
 	}
-	get := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-		return current(provider, certFile)
+	get := func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		// KeyMaterial blocks until the pemfile provider has read the files
+		// for the first time. Use the handshake context so a stuck read
+		// bounds the handshake instead of hanging it forever.
+		ctx := context.Background()
+		if hello != nil {
+			ctx = hello.Context()
+		}
+		return current(ctx, provider, certFile)
 	}
 	return get, provider, nil
 }
@@ -57,8 +64,12 @@ func newClientGetCertificate(certFile, keyFile string, refresh time.Duration) (f
 	if err != nil {
 		return nil, nil, err
 	}
-	get := func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-		return current(provider, certFile)
+	get := func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		ctx := context.Background()
+		if cri != nil {
+			ctx = cri.Context()
+		}
+		return current(ctx, provider, certFile)
 	}
 	return get, provider, nil
 }
@@ -78,8 +89,8 @@ func newProvider(certFile, keyFile string, refresh time.Duration) (certprovider.
 	return provider, nil
 }
 
-func current(provider certprovider.Provider, certFile string) (*tls.Certificate, error) {
-	km, err := provider.KeyMaterial(context.Background())
+func current(ctx context.Context, provider certprovider.Provider, certFile string) (*tls.Certificate, error) {
+	km, err := provider.KeyMaterial(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/weed/security/certreload/certreload.go
+++ b/weed/security/certreload/certreload.go
@@ -1,0 +1,91 @@
+// Package certreload wraps grpc's pemfile.Provider so both TLS servers
+// (weed/security) and TLS clients (weed/util/http/client) can share one
+// reloading cert implementation without an import cycle between them.
+//
+// Lives in its own subpackage because weed/security already imports
+// weed/util/http/client (for LoadHTTPClientFromFile).
+package certreload
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
+)
+
+// DefaultRefreshInterval is the cadence at which the pemfile provider
+// stats cert/key files on disk. It re-parses only when mtime/contents
+// change, so the hot path (KeyMaterial() on each TLS handshake) stays
+// cheap.
+//
+// 5 hours matches the prior constant used for gRPC mTLS.
+const DefaultRefreshInterval = 5 * time.Hour
+
+// NewServerGetCertificate returns a callback suitable for
+// tls.Config.GetCertificate. It reloads certFile and keyFile from disk
+// on each refresh tick so rotated certs (e.g. from k8s cert-manager)
+// are picked up without a restart. Caller should Close() the returned
+// provider at shutdown.
+func NewServerGetCertificate(certFile, keyFile string) (func(*tls.ClientHelloInfo) (*tls.Certificate, error), certprovider.Provider, error) {
+	return newServerGetCertificate(certFile, keyFile, DefaultRefreshInterval)
+}
+
+func newServerGetCertificate(certFile, keyFile string, refresh time.Duration) (func(*tls.ClientHelloInfo) (*tls.Certificate, error), certprovider.Provider, error) {
+	provider, err := newProvider(certFile, keyFile, refresh)
+	if err != nil {
+		return nil, nil, err
+	}
+	get := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return current(provider, certFile)
+	}
+	return get, provider, nil
+}
+
+// NewClientGetCertificate returns a callback suitable for
+// tls.Config.GetClientCertificate. Fires per TLS handshake, so long-lived
+// HTTPS clients (FUSE mount, backup, filer→volume, etc.) pick up rotated
+// client mTLS certs as pooled connections recycle.
+func NewClientGetCertificate(certFile, keyFile string) (func(*tls.CertificateRequestInfo) (*tls.Certificate, error), certprovider.Provider, error) {
+	return newClientGetCertificate(certFile, keyFile, DefaultRefreshInterval)
+}
+
+func newClientGetCertificate(certFile, keyFile string, refresh time.Duration) (func(*tls.CertificateRequestInfo) (*tls.Certificate, error), certprovider.Provider, error) {
+	provider, err := newProvider(certFile, keyFile, refresh)
+	if err != nil {
+		return nil, nil, err
+	}
+	get := func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return current(provider, certFile)
+	}
+	return get, provider, nil
+}
+
+func newProvider(certFile, keyFile string, refresh time.Duration) (certprovider.Provider, error) {
+	if certFile == "" || keyFile == "" {
+		return nil, fmt.Errorf("both certFile and keyFile are required")
+	}
+	provider, err := pemfile.NewProvider(pemfile.Options{
+		CertFile:        certFile,
+		KeyFile:         keyFile,
+		RefreshDuration: refresh,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pemfile.NewProvider: %w", err)
+	}
+	return provider, nil
+}
+
+func current(provider certprovider.Provider, certFile string) (*tls.Certificate, error) {
+	km, err := provider.KeyMaterial(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if km == nil || len(km.Certs) == 0 {
+		return nil, fmt.Errorf("no TLS key material available for %s", certFile)
+	}
+	cert := km.Certs[0]
+	return &cert, nil
+}

--- a/weed/security/certreload/certreload.go
+++ b/weed/security/certreload/certreload.go
@@ -10,19 +10,37 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"time"
 
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 )
 
+// RefreshIntervalEnv names an environment variable that overrides the
+// refresh cadence. Accepts any time.ParseDuration value (e.g. "30m",
+// "500ms"). Primarily a hook for integration tests that need rotation
+// to complete in seconds, but also useful in production when paired
+// with short-lived certs (e.g. Vault-issued).
+const RefreshIntervalEnv = "WEED_TLS_CERT_REFRESH_INTERVAL"
+
 // DefaultRefreshInterval is the cadence at which the pemfile provider
 // stats cert/key files on disk. It re-parses only when mtime/contents
 // change, so the hot path (KeyMaterial() on each TLS handshake) stays
 // cheap.
 //
-// 5 hours matches the prior constant used for gRPC mTLS.
-const DefaultRefreshInterval = 5 * time.Hour
+// 5 hours matches the prior constant used for gRPC mTLS. Resolved once
+// at process start from RefreshIntervalEnv if set.
+var DefaultRefreshInterval = resolveRefreshInterval(5 * time.Hour)
+
+func resolveRefreshInterval(fallback time.Duration) time.Duration {
+	if s := os.Getenv(RefreshIntervalEnv); s != "" {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+	}
+	return fallback
+}
 
 // NewServerGetCertificate returns a callback suitable for
 // tls.Config.GetCertificate. It reloads certFile and keyFile from disk

--- a/weed/security/certreload/certreload_test.go
+++ b/weed/security/certreload/certreload_test.go
@@ -52,22 +52,30 @@ func TestServerGetCertificatePicksUpNewFile(t *testing.T) {
 		t.Fatalf("write second cert: %v", err)
 	}
 
+	// The pemfile poller can briefly observe a mismatched cert/key pair
+	// during rotation (cert written before key). Tolerate transient errors
+	// and only fail at the deadline; keep the last error for diagnostics.
+	var lastErr error
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		c2, err := getCert(nil)
 		if err != nil {
-			t.Fatalf("getCert after rotation: %v", err)
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
 		parsed, err := x509.ParseCertificate(c2.Certificate[0])
 		if err != nil {
-			t.Fatalf("parse rotated cert: %v", err)
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
 		if parsed.Subject.CommonName == "second" {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatalf("reloader did not pick up rotated cert within timeout")
+	t.Fatalf("reloader did not pick up rotated cert within timeout; last error: %v", lastErr)
 }
 
 func writeSelfSigned(certPath, keyPath, commonName string) error {

--- a/weed/security/certreload/certreload_test.go
+++ b/weed/security/certreload/certreload_test.go
@@ -1,4 +1,4 @@
-package security
+package certreload
 
 import (
 	"crypto/ecdsa"
@@ -14,12 +14,10 @@ import (
 	"time"
 )
 
-// TestReloadingServerCertificatePicksUpNewFile writes an initial cert/key
-// pair, starts the reloader, then overwrites the files with a new pair and
-// asserts that the callback eventually returns the new certificate. The
-// test shortens CredRefreshingInterval via the pemfile poll loop by writing
-// new files to disk and waiting.
-func TestReloadingServerCertificatePicksUpNewFile(t *testing.T) {
+// TestServerGetCertificatePicksUpNewFile writes an initial cert/key
+// pair, starts the reloader, then overwrites the files with a new pair
+// and asserts that the callback eventually returns the new certificate.
+func TestServerGetCertificatePicksUpNewFile(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "tls.crt")
 	keyPath := filepath.Join(dir, "tls.key")
@@ -29,9 +27,9 @@ func TestReloadingServerCertificatePicksUpNewFile(t *testing.T) {
 	}
 
 	// Use a short refresh window so the test doesn't wait 5h.
-	getCert, provider, err := newReloadingServerCertificate(certPath, keyPath, 100*time.Millisecond)
+	getCert, provider, err := newServerGetCertificate(certPath, keyPath, 100*time.Millisecond)
 	if err != nil {
-		t.Fatalf("NewReloadingServerCertificate: %v", err)
+		t.Fatalf("newServerGetCertificate: %v", err)
 	}
 	defer provider.Close()
 

--- a/weed/security/tls.go
+++ b/weed/security/tls.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/spf13/viper"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/security/certreload"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	util_http_client "github.com/seaweedfs/seaweedfs/weed/util/http/client"
 	"google.golang.org/grpc"
@@ -24,7 +24,11 @@ import (
 	"google.golang.org/grpc/security/advancedtls"
 )
 
-const CredRefreshingInterval = time.Duration(5) * time.Hour
+// CredRefreshingInterval is the refresh cadence for gRPC mTLS certs.
+// Shares its source of truth with certreload.DefaultRefreshInterval so
+// a single WEED_TLS_CERT_REFRESH_INTERVAL env var tunes both gRPC and
+// HTTPS cert reload.
+var CredRefreshingInterval = certreload.DefaultRefreshInterval
 
 type Authenticator struct {
 	AllowedWildcardDomain string

--- a/weed/security/tls_reload.go
+++ b/weed/security/tls_reload.go
@@ -1,0 +1,52 @@
+package security
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
+)
+
+// NewReloadingServerCertificate watches certFile and keyFile on disk and
+// returns a GetCertificate callback suitable for tls.Config.GetCertificate.
+// The callback picks up rotated certificates without restarting the server,
+// which is required under Kubernetes cert-manager.
+//
+// The refresh cadence is controlled by CredRefreshingInterval. The provider
+// re-reads the files only when their mtime/contents change, so the callback
+// is cheap on the hot path.
+//
+// Callers that keep a handle to the provider should Close() it at shutdown
+// to stop the background goroutine.
+func NewReloadingServerCertificate(certFile, keyFile string) (func(*tls.ClientHelloInfo) (*tls.Certificate, error), certprovider.Provider, error) {
+	return newReloadingServerCertificate(certFile, keyFile, CredRefreshingInterval)
+}
+
+func newReloadingServerCertificate(certFile, keyFile string, refresh time.Duration) (func(*tls.ClientHelloInfo) (*tls.Certificate, error), certprovider.Provider, error) {
+	if certFile == "" || keyFile == "" {
+		return nil, nil, fmt.Errorf("both certFile and keyFile are required")
+	}
+	provider, err := pemfile.NewProvider(pemfile.Options{
+		CertFile:        certFile,
+		KeyFile:         keyFile,
+		RefreshDuration: refresh,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("pemfile.NewProvider: %w", err)
+	}
+	get := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		km, err := provider.KeyMaterial(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		if km == nil || len(km.Certs) == 0 {
+			return nil, fmt.Errorf("no TLS key material available for %s", certFile)
+		}
+		cert := km.Certs[0]
+		return &cert, nil
+	}
+	return get, provider, nil
+}

--- a/weed/security/tls_reload.go
+++ b/weed/security/tls_reload.go
@@ -1,52 +1,20 @@
 package security
 
 import (
-	"context"
 	"crypto/tls"
-	"fmt"
-	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/security/certreload"
 	"google.golang.org/grpc/credentials/tls/certprovider"
-	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 )
 
-// NewReloadingServerCertificate watches certFile and keyFile on disk and
-// returns a GetCertificate callback suitable for tls.Config.GetCertificate.
-// The callback picks up rotated certificates without restarting the server,
-// which is required under Kubernetes cert-manager.
+// NewReloadingServerCertificate returns a GetCertificate callback for
+// tls.Config.GetCertificate, backed by a refreshing pem provider so
+// rotated certs (e.g. from Kubernetes cert-manager) are picked up
+// without a restart.
 //
-// The refresh cadence is controlled by CredRefreshingInterval. The provider
-// re-reads the files only when their mtime/contents change, so the callback
-// is cheap on the hot path.
-//
-// Callers that keep a handle to the provider should Close() it at shutdown
-// to stop the background goroutine.
+// Thin wrapper over certreload; the shared implementation lives in the
+// subpackage so both server TLS (this package) and HTTP client TLS
+// (weed/util/http/client) can use it without an import cycle.
 func NewReloadingServerCertificate(certFile, keyFile string) (func(*tls.ClientHelloInfo) (*tls.Certificate, error), certprovider.Provider, error) {
-	return newReloadingServerCertificate(certFile, keyFile, CredRefreshingInterval)
-}
-
-func newReloadingServerCertificate(certFile, keyFile string, refresh time.Duration) (func(*tls.ClientHelloInfo) (*tls.Certificate, error), certprovider.Provider, error) {
-	if certFile == "" || keyFile == "" {
-		return nil, nil, fmt.Errorf("both certFile and keyFile are required")
-	}
-	provider, err := pemfile.NewProvider(pemfile.Options{
-		CertFile:        certFile,
-		KeyFile:         keyFile,
-		RefreshDuration: refresh,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("pemfile.NewProvider: %w", err)
-	}
-	get := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-		km, err := provider.KeyMaterial(context.Background())
-		if err != nil {
-			return nil, err
-		}
-		if km == nil || len(km.Certs) == 0 {
-			return nil, fmt.Errorf("no TLS key material available for %s", certFile)
-		}
-		cert := km.Certs[0]
-		return &cert, nil
-	}
-	return get, provider, nil
+	return certreload.NewServerGetCertificate(certFile, keyFile)
 }

--- a/weed/security/tls_reload_test.go
+++ b/weed/security/tls_reload_test.go
@@ -1,0 +1,116 @@
+package security
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestReloadingServerCertificatePicksUpNewFile writes an initial cert/key
+// pair, starts the reloader, then overwrites the files with a new pair and
+// asserts that the callback eventually returns the new certificate. The
+// test shortens CredRefreshingInterval via the pemfile poll loop by writing
+// new files to disk and waiting.
+func TestReloadingServerCertificatePicksUpNewFile(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+
+	if err := writeSelfSigned(certPath, keyPath, "first"); err != nil {
+		t.Fatalf("write first cert: %v", err)
+	}
+
+	// Use a short refresh window so the test doesn't wait 5h.
+	getCert, provider, err := newReloadingServerCertificate(certPath, keyPath, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewReloadingServerCertificate: %v", err)
+	}
+	defer provider.Close()
+
+	c1, err := getCert(nil)
+	if err != nil {
+		t.Fatalf("initial getCert: %v", err)
+	}
+	first, err := x509.ParseCertificate(c1.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse first cert: %v", err)
+	}
+	if first.Subject.CommonName != "first" {
+		t.Fatalf("want CN=first, got %q", first.Subject.CommonName)
+	}
+
+	// Rotate the files. pemfile watches mtime; sleep so the new files have
+	// a later mtime even on filesystems with 1s granularity.
+	time.Sleep(1100 * time.Millisecond)
+	if err := writeSelfSigned(certPath, keyPath, "second"); err != nil {
+		t.Fatalf("write second cert: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c2, err := getCert(nil)
+		if err != nil {
+			t.Fatalf("getCert after rotation: %v", err)
+		}
+		parsed, err := x509.ParseCertificate(c2.Certificate[0])
+		if err != nil {
+			t.Fatalf("parse rotated cert: %v", err)
+		}
+		if parsed.Subject.CommonName == "second" {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("reloader did not pick up rotated cert within timeout")
+}
+
+func writeSelfSigned(certPath, keyPath, commonName string) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return err
+	}
+	certOut, err := os.Create(certPath)
+	if err != nil {
+		return err
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		certOut.Close()
+		return err
+	}
+	if err := certOut.Close(); err != nil {
+		return err
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return err
+	}
+	keyOut, err := os.Create(keyPath)
+	if err != nil {
+		return err
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		keyOut.Close()
+		return err
+	}
+	return keyOut.Close()
+}

--- a/weed/util/http/client/http_client.go
+++ b/weed/util/http/client/http_client.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/grpc/credentials/tls/certprovider"
+
 	"github.com/seaweedfs/seaweedfs/weed/security/certreload"
 	util "github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/spf13/viper"
@@ -24,6 +26,25 @@ type HTTPClient struct {
 	Client            *http.Client
 	Transport         *http.Transport
 	expectHttpsScheme bool
+	// certProvider, when non-nil, owns a background refresh goroutine for
+	// the client mTLS cert/key pair. Close() must be called to stop it.
+	certProvider certprovider.Provider
+}
+
+// Close stops any background cert refresh goroutine. Safe to call on a
+// client that was constructed without mTLS. Existing pooled connections
+// are also closed via CloseIdleConnections.
+func (httpClient *HTTPClient) Close() {
+	if httpClient == nil {
+		return
+	}
+	if httpClient.certProvider != nil {
+		httpClient.certProvider.Close()
+		httpClient.certProvider = nil
+	}
+	if httpClient.Client != nil {
+		httpClient.Client.CloseIdleConnections()
+	}
 }
 
 func (httpClient *HTTPClient) Do(req *http.Request) (*http.Response, error) {
@@ -123,11 +144,12 @@ func NewHttpClient(clientName ClientName, opts ...HttpClientOpt) (*HTTPClient, e
 			}
 
 			if hasClientCert {
-				getClientCert, _, err := certreload.NewClientGetCertificate(certFileName, keyFileName)
+				getClientCert, provider, err := certreload.NewClientGetCertificate(certFileName, keyFileName)
 				if err != nil {
 					return nil, fmt.Errorf("error loading client certificate and key: %s", err)
 				}
 				tlsConfig.GetClientCertificate = getClientCert
+				httpClient.certProvider = provider
 			}
 		}
 
@@ -214,21 +236,33 @@ func NewHttpClientWithTLS(certFile, keyFile, caFile string, insecureSkipVerify b
 
 	var getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 	if certFile != "" && keyFile != "" {
-		cb, _, err := certreload.NewClientGetCertificate(certFile, keyFile)
+		cb, provider, err := certreload.NewClientGetCertificate(certFile, keyFile)
 		if err != nil {
 			return nil, fmt.Errorf("error loading client certificate and key: %s", err)
 		}
 		getClientCert = cb
+		httpClient.certProvider = provider
+	}
+	// closeProviderOnError ensures the cert reloader's background refresh
+	// goroutine is shut down if any subsequent step fails before we hand
+	// the client back to the caller.
+	closeProviderOnError := func() {
+		if httpClient.certProvider != nil {
+			httpClient.certProvider.Close()
+			httpClient.certProvider = nil
+		}
 	}
 
 	var caCertPool *x509.CertPool
 	if caFile != "" {
 		caCert, err := os.ReadFile(caFile)
 		if err != nil {
+			closeProviderOnError()
 			return nil, fmt.Errorf("error reading CA cert %s: %s", caFile, err)
 		}
 		caCertPool, err = createHTTPClientCertPool(caCert, caFile)
 		if err != nil {
+			closeProviderOnError()
 			return nil, err
 		}
 	}

--- a/weed/util/http/client/http_client.go
+++ b/weed/util/http/client/http_client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/seaweedfs/seaweedfs/weed/security/certreload"
 	util "github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/spf13/viper"
 )
@@ -100,7 +101,7 @@ func NewHttpClient(clientName ClientName, opts ...HttpClientOpt) (*HTTPClient, e
 	var tlsConfig *tls.Config = nil
 
 	if httpClient.expectHttpsScheme {
-		clientCertPair, err := getClientCertPair(clientName)
+		certFileName, keyFileName, hasClientCert, err := clientCertPaths(clientName)
 		if err != nil {
 			return nil, err
 		}
@@ -110,20 +111,23 @@ func NewHttpClient(clientName ClientName, opts ...HttpClientOpt) (*HTTPClient, e
 			return nil, err
 		}
 
-		if clientCertPair != nil || len(clientCaCert) != 0 {
+		if hasClientCert || len(clientCaCert) != 0 {
 			caCertPool, err := createHTTPClientCertPool(clientCaCert, clientCaCertName)
 			if err != nil {
 				return nil, err
 			}
 
 			tlsConfig = &tls.Config{
-				Certificates:       []tls.Certificate{},
 				RootCAs:            caCertPool,
 				InsecureSkipVerify: false,
 			}
 
-			if clientCertPair != nil {
-				tlsConfig.Certificates = append(tlsConfig.Certificates, *clientCertPair)
+			if hasClientCert {
+				getClientCert, _, err := certreload.NewClientGetCertificate(certFileName, keyFileName)
+				if err != nil {
+					return nil, fmt.Errorf("error loading client certificate and key: %s", err)
+				}
+				tlsConfig.GetClientCertificate = getClientCert
 			}
 		}
 
@@ -175,20 +179,20 @@ func getFileContentFromSecurityConfiguration(clientName ClientName, fileType str
 	return nil, "", nil
 }
 
-func getClientCertPair(clientName ClientName) (*tls.Certificate, error) {
-	certFileName := getStringOptionFromSecurityConfiguration(clientName, "cert")
-	keyFileName := getStringOptionFromSecurityConfiguration(clientName, "key")
-	if certFileName == "" && keyFileName == "" {
-		return nil, nil
+// clientCertPaths reads the https.<clientName>.{cert,key} paths from the
+// security config, validates they're either both set or both empty, and
+// returns them along with a hasClientCert flag. Loading is deferred to
+// certreload so the cert/key pair is picked up from disk on rotation.
+func clientCertPaths(clientName ClientName) (certFile, keyFile string, hasClientCert bool, err error) {
+	certFile = getStringOptionFromSecurityConfiguration(clientName, "cert")
+	keyFile = getStringOptionFromSecurityConfiguration(clientName, "key")
+	if certFile == "" && keyFile == "" {
+		return "", "", false, nil
 	}
-	if certFileName != "" && keyFileName != "" {
-		clientCert, err := tls.LoadX509KeyPair(certFileName, keyFileName)
-		if err != nil {
-			return nil, fmt.Errorf("error loading client certificate and key: %s", err)
-		}
-		return &clientCert, nil
+	if certFile == "" || keyFile == "" {
+		return "", "", false, fmt.Errorf("https.%s: both cert and key must be set (got cert=%q key=%q)", clientName.LowerCaseString(), certFile, keyFile)
 	}
-	return nil, fmt.Errorf("error loading key pair: key `%s` and certificate `%s`", keyFileName, certFileName)
+	return certFile, keyFile, true, nil
 }
 
 func getClientCaCert(clientName ClientName) ([]byte, string, error) {
@@ -208,13 +212,13 @@ func NewHttpClientWithTLS(certFile, keyFile, caFile string, insecureSkipVerify b
 		return nil, fmt.Errorf("both cert and key are required for mTLS, got cert=%q key=%q", certFile, keyFile)
 	}
 
-	var clientCert *tls.Certificate
+	var getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 	if certFile != "" && keyFile != "" {
-		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		cb, _, err := certreload.NewClientGetCertificate(certFile, keyFile)
 		if err != nil {
 			return nil, fmt.Errorf("error loading client certificate and key: %s", err)
 		}
-		clientCert = &cert
+		getClientCert = cb
 	}
 
 	var caCertPool *x509.CertPool
@@ -229,14 +233,11 @@ func NewHttpClientWithTLS(certFile, keyFile, caFile string, insecureSkipVerify b
 		}
 	}
 
-	if clientCert != nil || caCertPool != nil || insecureSkipVerify {
+	if getClientCert != nil || caCertPool != nil || insecureSkipVerify {
 		tlsConfig = &tls.Config{
-			Certificates:       []tls.Certificate{},
-			RootCAs:            caCertPool,
-			InsecureSkipVerify: insecureSkipVerify,
-		}
-		if clientCert != nil {
-			tlsConfig.Certificates = append(tlsConfig.Certificates, *clientCert)
+			GetClientCertificate: getClientCert,
+			RootCAs:              caCertPool,
+			InsecureSkipVerify:   insecureSkipVerify,
 		}
 	}
 

--- a/weed/util/httpdown/http_down.go
+++ b/weed/util/httpdown/http_down.go
@@ -289,10 +289,15 @@ func (s *server) manage() {
 
 func (s *server) serve() {
 	stats.BumpSum(s.stats, "serve", 1)
-	if s.certFile == "" && s.keyFile == "" {
-		s.serveErr <- s.server.Serve(s.listener)
-	} else {
+	switch {
+	case s.certFile != "" || s.keyFile != "":
 		s.serveErr <- s.server.ServeTLS(s.listener, s.certFile, s.keyFile)
+	case s.server.TLSConfig != nil && (len(s.server.TLSConfig.Certificates) > 0 || s.server.TLSConfig.GetCertificate != nil):
+		// TLSConfig carries the certificate source (e.g. a hot-reloading
+		// GetCertificate callback). Pass empty file args so ServeTLS uses it.
+		s.serveErr <- s.server.ServeTLS(s.listener, "", "")
+	default:
+		s.serveErr <- s.server.Serve(s.listener)
 	}
 	close(s.serveDone)
 	close(s.serveErr)


### PR DESCRIPTION
## Summary

- Adds `security.NewReloadingServerCertificate` helper that wraps `pemfile.Provider` and returns a `tls.Config.GetCertificate` closure so HTTPS servers pick up rotated cert/key files on disk without a process restart.
- Wires it into the HTTPS entry points that were previously loading certs once at startup: `weed master`, `weed volume`, `weed webdav`, and `weed admin`. (S3 and filer already used the same pattern.)
- Updates `weed/util/httpdown` to call `ServeTLS` when the embedded `http.Server`'s `TLSConfig` populates `GetCertificate`/`Certificates` but `CertFile`/`KeyFile` are empty, so the volume server can pre-populate `TLSConfig` and still go through httpdown.

## Why

In Kubernetes, cert-manager renews certs by atomically updating the mounted `Secret` — the file paths stay stable, but the contents change. Until this PR, only gRPC mTLS and the s3/filer HTTPS surfaces survived a rotation; rotating certs on master/volume/webdav/admin required a rolling restart. This closes that gap.

Refresh cadence is `security.CredRefreshingInterval` (5h), consistent with the existing gRPC mTLS path.

## What rotates without restart after this PR

| Surface | Before | After |
|---|---|---|
| gRPC mTLS (all roles) | Yes | Yes |
| HTTPS s3, filer | Yes | Yes |
| HTTPS master | No | **Yes** |
| HTTPS volume | No | **Yes** |
| HTTPS webdav | No | **Yes** |
| HTTPS admin | No | **Yes** |
| HTTPS client (`[https.client]`) | No | No (follow-up) |

Client-side mTLS cert rotation is out of scope for this PR — they're loaded once by `tls.LoadX509KeyPair` in `weed/util/http/client/http_client.go`. Happy to do that in a follow-up using `GetClientCertificate`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./weed/security/...`
- [x] New unit test `TestReloadingServerCertificatePicksUpNewFile` rotates cert files on disk with a 100ms refresh window and asserts the `GetCertificate` callback returns the new certificate.
- [ ] Manual verification in a k8s cluster with cert-manager (maintainers / users with the setup).

## Wiki

Docs updated in [seaweedfs.wiki](https://github.com/seaweedfs/seaweedfs/wiki) — new "Certificate Rotation Without Restarts (k8s cert-manager)" section on the Security Configuration page, with a cert-manager example and the caveats about refresh window and in-flight connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTPS certificates now reload dynamically for servers and clients without restarts, with coordinated lifecycle handling.

* **Bug Fixes**
  * Fail-fast TLS startup and improved TLS config initialization to prevent serving with invalid or missing certificate material.
  * Proper cleanup on shutdown to avoid resource leaks.

* **Tests**
  * Added unit and integration tests validating certificate hot-reload and rotation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->