### PR TITLE
chore(filer): remove -mount.p2p flag; registry is always on

### DIFF
--- a/test/fuse_p2p/framework_test.go
+++ b/test/fuse_p2p/framework_test.go
@@ -208,8 +208,6 @@ func (c *p2pTestCluster) startFiler(configDir string) error {
 		"-port.grpc="+strconv.Itoa(c.filerGrpcPort),
 		"-master="+c.masterAddress(),
 		"-defaultStoreDir="+filerDir,
-		// default is -mount.p2p=true; be explicit so the intent is grep-able.
-		"-mount.p2p=true",
 	)
 	return c.startCmd(c.filerCmd, "filer")
 }

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -81,7 +81,6 @@ type FilerOptions struct {
 	exposeDirectoryData       *bool
 	tusBasePath               *string
 	s3ConfigFile              *string // optional path to static S3 identity config
-	mountPeerRegistryEnable        *bool   // accept MountRegister/MountList RPCs (peer chunk sharing tier 1)
 	// shutdownCtx, when non-nil, tells startFiler to gracefully shut down its
 	// HTTP/gRPC servers once the ctx is cancelled. Used by integration tests
 	// and by weed mini; nil for standalone weed filer.
@@ -124,7 +123,6 @@ func init() {
 	f.allowedOrigins = cmdFiler.Flag.String("allowedOrigins", "*", "comma separated list of allowed origins")
 	f.exposeDirectoryData = cmdFiler.Flag.Bool("exposeDirectoryData", true, "whether to return directory metadata and content in Filer UI")
 	f.tusBasePath = cmdFiler.Flag.String("tusBasePath", "/.tus", "TUS resumable upload endpoint base path (e.g., /.tus)")
-	f.mountPeerRegistryEnable = cmdFiler.Flag.Bool("mount.p2p", true, "accept MountRegister/MountList RPCs from weed mount clients for peer chunk sharing (tier 1). Idle cost is near-zero; set false to disable.")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -376,7 +374,6 @@ func (fo *FilerOptions) startFiler() {
 		AllowedOrigins:            strings.Split(*fo.allowedOrigins, ","),
 		TusBasePath:               *fo.tusBasePath,
 		CredentialManager:         credentialManager,
-		MountPeerRegistryEnabled:       fo.mountPeerRegistryEnable != nil && *fo.mountPeerRegistryEnable,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -311,7 +311,6 @@ func initMiniFilerFlags() {
 	miniFilerOptions.allowedOrigins = cmdMini.Flag.String("filer.allowedOrigins", "*", "comma separated list of allowed origins")
 	miniFilerOptions.exposeDirectoryData = cmdMini.Flag.Bool("filer.exposeDirectoryData", true, "whether to return directory metadata and content in Filer UI")
 	miniFilerOptions.tusBasePath = cmdMini.Flag.String("filer.tusBasePath", "/.tus", "TUS resumable upload endpoint base path")
-	miniFilerOptions.mountPeerRegistryEnable = cmdMini.Flag.Bool("filer.mount.p2p", true, "accept MountRegister/MountList RPCs from weed mount clients for peer chunk sharing (tier 1). Idle cost is near-zero; set false to disable.")
 }
 
 // initMiniVolumeFlags initializes Volume server flag options

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -130,7 +130,6 @@ func init() {
 	filerOptions.diskType = cmdServer.Flag.String("filer.disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
 	filerOptions.exposeDirectoryData = cmdServer.Flag.Bool("filer.exposeDirectoryData", true, "expose directory data via filer. If false, filer UI will be innaccessible.")
 	filerOptions.tusBasePath = cmdServer.Flag.String("filer.tusBasePath", "/.tus", "TUS resumable upload endpoint base path (e.g., /.tus)")
-	filerOptions.mountPeerRegistryEnable = cmdServer.Flag.Bool("filer.mount.p2p", true, "accept MountRegister/MountList RPCs from weed mount clients for peer chunk sharing (tier 1). Idle cost is near-zero; set false to disable.")
 
 	serverOptions.v.port = cmdServer.Flag.Int("volume.port", 8080, "volume server http listen port")
 	serverOptions.v.portGrpc = cmdServer.Flag.Int("volume.port.grpc", 0, "volume server grpc listen port")

--- a/weed/server/filer_grpc_server_mount_peer.go
+++ b/weed/server/filer_grpc_server_mount_peer.go
@@ -13,15 +13,11 @@ import (
 // memory bounded on long-running filers with high churn.
 const mountPeerRegistrySweepInterval = 60 * time.Second
 
-// runMountPeerRegistrySweeper runs for the lifetime of the FilerServer when
-// peer registry is enabled.
+// runMountPeerRegistrySweeper runs for the lifetime of the FilerServer.
 func (fs *FilerServer) runMountPeerRegistrySweeper() {
 	ticker := time.NewTicker(mountPeerRegistrySweepInterval)
 	defer ticker.Stop()
 	for range ticker.C {
-		if fs.mountPeerRegistry == nil {
-			return
-		}
 		if evicted := fs.mountPeerRegistry.Sweep(); evicted > 0 {
 			glog.V(2).Infof("peer registry: evicted %d stale entries", evicted)
 		}
@@ -31,13 +27,7 @@ func (fs *FilerServer) runMountPeerRegistrySweeper() {
 // MountRegister records (or refreshes) the caller as a live mount server in
 // the filer's peer registry. Returns an empty response; the caller is
 // expected to heartbeat before the TTL expires.
-//
-// Requests are silently dropped when the registry is disabled (default), so
-// clients can safely probe without breaking older filers.
 func (fs *FilerServer) MountRegister(ctx context.Context, req *filer_pb.MountRegisterRequest) (*filer_pb.MountRegisterResponse, error) {
-	if fs.mountPeerRegistry == nil {
-		return &filer_pb.MountRegisterResponse{}, nil
-	}
 	ttl := time.Duration(req.TtlSeconds) * time.Second
 	fs.mountPeerRegistry.Register(req.PeerAddr, req.DataCenter, req.Rack, ttl)
 	return &filer_pb.MountRegisterResponse{}, nil
@@ -46,9 +36,6 @@ func (fs *FilerServer) MountRegister(ctx context.Context, req *filer_pb.MountReg
 // MountList returns the current set of live mounts for callers building
 // their HRW seed view.
 func (fs *FilerServer) MountList(ctx context.Context, req *filer_pb.MountListRequest) (*filer_pb.MountListResponse, error) {
-	if fs.mountPeerRegistry == nil {
-		return &filer_pb.MountListResponse{}, nil
-	}
 	entries := fs.mountPeerRegistry.List()
 	resp := &filer_pb.MountListResponse{
 		Mounts: make([]*filer_pb.MountInfo, 0, len(entries)),

--- a/weed/server/filer_grpc_server_mount_peer_test.go
+++ b/weed/server/filer_grpc_server_mount_peer_test.go
@@ -8,24 +8,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
-func TestMountRegister_DisabledIsNoOp(t *testing.T) {
-	fs := &FilerServer{} // mountPeerRegistry nil → registry disabled
-	_, err := fs.MountRegister(context.Background(), &filer_pb.MountRegisterRequest{
-		PeerAddr:   "mount-a:18080",
-		TtlSeconds: 30,
-	})
-	if err != nil {
-		t.Fatalf("MountRegister returned error with disabled registry: %v", err)
-	}
-	resp, err := fs.MountList(context.Background(), &filer_pb.MountListRequest{})
-	if err != nil {
-		t.Fatalf("MountList returned error with disabled registry: %v", err)
-	}
-	if len(resp.Mounts) != 0 {
-		t.Errorf("expected empty list from disabled registry, got %d", len(resp.Mounts))
-	}
-}
-
 func TestMountRegister_EnabledStoresAndLists(t *testing.T) {
 	fs := &FilerServer{mountPeerRegistry: filer.NewMountPeerRegistry()}
 

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -84,7 +84,6 @@ type FilerOption struct {
 	TusBasePath               string
 	S3ConfigFile              string // optional path to static S3 identity config file
 	CredentialManager         *credential.CredentialManager
-	MountPeerRegistryEnabled       bool // opt-in: accept MountRegister/MountList RPCs
 }
 
 type FilerServer struct {
@@ -122,8 +121,8 @@ type FilerServer struct {
 	// credential manager for IAM operations
 	CredentialManager *credential.CredentialManager
 
-	// mountPeerRegistry is nil unless FilerOption.MountPeerRegistryEnabled is true.
-	// When populated, it backs the MountRegister / MountList RPCs.
+	// mountPeerRegistry backs the MountRegister / MountList RPCs for peer
+	// chunk sharing (tier 1). Always populated.
 	mountPeerRegistry *filer.MountPeerRegistry
 }
 
@@ -164,10 +163,8 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		recentCopyRequests:    make(map[string]recentCopyRequest),
 		CredentialManager:     option.CredentialManager,
 	}
-	if option.MountPeerRegistryEnabled {
-		fs.mountPeerRegistry = filer.NewMountPeerRegistry()
-		go fs.runMountPeerRegistrySweeper()
-	}
+	fs.mountPeerRegistry = filer.NewMountPeerRegistry()
+	go fs.runMountPeerRegistrySweeper()
 	fs.listenersCond = sync.NewCond(&fs.listenersLock)
 
 	option.Masters.RefreshBySrvIfAvailable()


### PR DESCRIPTION
## Summary
- The filer-side mount peer registry (tier 1 of peer chunk sharing) was gated behind `-mount.p2p` (default `true`). Idle cost is negligible — a tiny in-memory map plus a 60s sweeper — so the opt-out is not worth the surface area.
- Removes `-mount.p2p` from `weed filer`, `-filer.mount.p2p` from `weed server` and `weed mini`, the `MountPeerRegistryEnabled` field on `FilerOption`, and the now-dead nil guards in `MountRegister` / `MountList` / the sweeper.
- Drops `TestMountRegister_DisabledIsNoOp` since there's no disabled state to exercise. Updates the `fuse_p2p` framework to stop passing the removed flag.
- Wiki page `P2P-reading-in-weed-mount.md` updated to reflect that the filer registry is always on.

## Test plan
- [x] `go build ./...`
- [x] `go test ./weed/server/ -run 'MountRegister|MountList|MountPeer' -count=1`
- [ ] `test/fuse_p2p` integration workflow on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mount peer registry is now always enabled. Configuration flags to disable this feature have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->