### PR TITLE
fix(erasure_coding): surface replica delete failures from EC task (#9184)

### DIFF
--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -596,7 +596,6 @@ func (t *ErasureCodingTask) deleteOriginalVolume(ctx context.Context) error {
 		}
 	}
 
-	// Report results
 	if len(deleteErrors) > 0 {
 		t.GetLogger().WithFields(map[string]interface{}{
 			"volume_id":      t.volumeID,
@@ -605,15 +604,18 @@ func (t *ErasureCodingTask) deleteOriginalVolume(ctx context.Context) error {
 			"total_replicas": len(replicas),
 			"success_rate":   float64(successCount) / float64(len(replicas)) * 100,
 			"errors":         deleteErrors,
-		}).Warning("Some volume deletions failed")
-		// Don't return error - EC task should still be considered successful if shards are mounted
-	} else {
-		t.GetLogger().WithFields(map[string]interface{}{
-			"volume_id":       t.volumeID,
-			"replica_count":   len(replicas),
-			"replica_servers": replicas,
-		}).Info("Successfully deleted volume from all replica servers")
+		}).Error("Failed to delete some original volume replicas after EC encoding")
+		// A surviving source replica lets a later detection scan re-propose
+		// EC on the same volume, which retries over mounted shards.
+		return fmt.Errorf("failed to delete %d of %d original volume replicas for volume %d: %s",
+			len(deleteErrors), len(replicas), t.volumeID, strings.Join(deleteErrors, "; "))
 	}
+
+	t.GetLogger().WithFields(map[string]interface{}{
+		"volume_id":       t.volumeID,
+		"replica_count":   len(replicas),
+		"replica_servers": replicas,
+	}).Info("Successfully deleted volume from all replica servers")
 
 	return nil
 }

--- a/weed/worker/tasks/erasure_coding/ec_task_delete_swallow_test.go
+++ b/weed/worker/tasks/erasure_coding/ec_task_delete_swallow_test.go
@@ -3,6 +3,7 @@ package erasure_coding
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,20 +16,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// TestDeleteOriginalVolumeSwallowsReplicaFailures reproduces the error-
-// swallowing behavior described in
-// https://github.com/seaweedfs/seaweedfs/issues/9184: when any replica
-// VolumeDelete call fails, ErasureCodingTask.deleteOriginalVolume logs the
-// error but returns nil. The EC task therefore reports success to the admin,
-// the surviving replica stays on disk, and a later detection scan re-proposes
-// the same volume for EC encoding — which in turn drives the retry-truncates-
-// mounted-shard corruption also tracked by that issue.
-//
-// The test points the task at one reachable replica (so at least one delete
-// can succeed) plus one unreachable replica (address that refuses to dial).
-// The current implementation returns nil; when the fix lands the function
-// must surface the failure and this test needs to be inverted.
-func TestDeleteOriginalVolumeSwallowsReplicaFailures(t *testing.T) {
+// One reachable replica + one unreachable: the reachable delete still
+// succeeds, and the function surfaces an error naming the failure.
+func TestDeleteOriginalVolumeSurfacesReplicaFailures(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -43,21 +33,18 @@ func TestDeleteOriginalVolumeSwallowsReplicaFailures(t *testing.T) {
 	httpClient := framework.NewHTTPClient()
 	fid := framework.NewFileID(volumeID, 918420, 0x91842042)
 	uploadResp := framework.UploadBytes(t, httpClient, clusterHarness.VolumeAdminURL(), fid,
-		[]byte("delete-swallow-content-for-issue-9184"))
+		[]byte("delete-surface-content-for-issue-9184"))
 	_ = framework.ReadAllAndClose(t, uploadResp)
 	require.Equal(t, http.StatusCreated, uploadResp.StatusCode)
 
 	task := NewErasureCodingTask(
-		"delete-swallow-repro",
+		"delete-surface-fix",
 		clusterHarness.VolumeServerAddress(),
 		volumeID,
 		"",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 
-	// Two replicas: the real volume server (reachable) and a bogus address
-	// that will refuse connections. deleteOriginalVolume iterates sources
-	// and attempts VolumeDelete on each.
 	unreachable := "127.0.0.1:1"
 	task.sources = []*worker_pb.TaskSource{
 		{
@@ -73,22 +60,54 @@ func TestDeleteOriginalVolumeSwallowsReplicaFailures(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// BUG #9184: deleteOriginalVolume returns nil even though one replica
-	// failed. That means the EC task reports overall success, which is what
-	// lets the stale replica on the unreachable server become a retry
-	// candidate (or, if the delete had been on the reachable side, leaves a
-	// surviving original volume). The fix must return an error so the task
-	// is retried without reporting success. Until then, pin the current
-	// behavior here.
 	err := task.deleteOriginalVolume(ctx)
-	require.NoError(t, err, "bug #9184 regression: deleteOriginalVolume should currently swallow the replica error; got: %v", err)
+	require.Error(t, err, "deleteOriginalVolume must surface replica delete failures (#9184)")
+	require.Contains(t, err.Error(), unreachable,
+		"returned error should name the replica that failed: %v", err)
+	require.True(t,
+		strings.Contains(err.Error(), "failed to delete"),
+		"returned error should describe what failed: %v", err)
 
-	// Double-check the reachable replica really was deleted, so we know the
-	// test is exercising the "some-succeeded, some-failed" branch and not
-	// e.g. a silent no-op. VolumeStatus errors for unknown volumes.
 	_, statusErr := grpcClient.VolumeStatus(ctx, &volume_server_pb.VolumeStatusRequest{VolumeId: volumeID})
 	require.Error(t, statusErr,
-		"bug #9184 invariant: reachable replica %d should have been deleted before the failure was swallowed", volumeID)
+		"reachable replica %d should have been deleted before failure was surfaced", volumeID)
+}
 
-	t.Logf("bug #9184 reproduced: deleteOriginalVolume returned nil even though delete on %s failed", unreachable)
+func TestDeleteOriginalVolumeSucceedsWhenAllReplicasReachable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	clusterHarness := framework.StartVolumeCluster(t, matrix.P1())
+	conn, grpcClient := framework.DialVolumeServer(t, clusterHarness.VolumeGRPCAddress())
+	defer conn.Close()
+
+	const volumeID = uint32(91844)
+	framework.AllocateVolume(t, grpcClient, volumeID, "")
+
+	httpClient := framework.NewHTTPClient()
+	fid := framework.NewFileID(volumeID, 918440, 0x91844042)
+	uploadResp := framework.UploadBytes(t, httpClient, clusterHarness.VolumeAdminURL(), fid,
+		[]byte("delete-happy-path-content-for-issue-9184"))
+	_ = framework.ReadAllAndClose(t, uploadResp)
+	require.Equal(t, http.StatusCreated, uploadResp.StatusCode)
+
+	task := NewErasureCodingTask(
+		"delete-happy-path",
+		clusterHarness.VolumeServerAddress(),
+		volumeID,
+		"",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	task.sources = []*worker_pb.TaskSource{
+		{Node: clusterHarness.VolumeServerAddress(), VolumeId: volumeID},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, task.deleteOriginalVolume(ctx))
+
+	_, statusErr := grpcClient.VolumeStatus(ctx, &volume_server_pb.VolumeStatusRequest{VolumeId: volumeID})
+	require.Error(t, statusErr, "volume %d should be gone after successful delete", volumeID)
 }

--- a/weed/worker/tasks/erasure_coding/ec_task_delete_swallow_test.go
+++ b/weed/worker/tasks/erasure_coding/ec_task_delete_swallow_test.go
@@ -1,0 +1,94 @@
+package erasure_coding
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/test/volume_server/framework"
+	"github.com/seaweedfs/seaweedfs/test/volume_server/matrix"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TestDeleteOriginalVolumeSwallowsReplicaFailures reproduces the error-
+// swallowing behavior described in
+// https://github.com/seaweedfs/seaweedfs/issues/9184: when any replica
+// VolumeDelete call fails, ErasureCodingTask.deleteOriginalVolume logs the
+// error but returns nil. The EC task therefore reports success to the admin,
+// the surviving replica stays on disk, and a later detection scan re-proposes
+// the same volume for EC encoding — which in turn drives the retry-truncates-
+// mounted-shard corruption also tracked by that issue.
+//
+// The test points the task at one reachable replica (so at least one delete
+// can succeed) plus one unreachable replica (address that refuses to dial).
+// The current implementation returns nil; when the fix lands the function
+// must surface the failure and this test needs to be inverted.
+func TestDeleteOriginalVolumeSwallowsReplicaFailures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	clusterHarness := framework.StartVolumeCluster(t, matrix.P1())
+	conn, grpcClient := framework.DialVolumeServer(t, clusterHarness.VolumeGRPCAddress())
+	defer conn.Close()
+
+	const volumeID = uint32(91842)
+	framework.AllocateVolume(t, grpcClient, volumeID, "")
+
+	httpClient := framework.NewHTTPClient()
+	fid := framework.NewFileID(volumeID, 918420, 0x91842042)
+	uploadResp := framework.UploadBytes(t, httpClient, clusterHarness.VolumeAdminURL(), fid,
+		[]byte("delete-swallow-content-for-issue-9184"))
+	_ = framework.ReadAllAndClose(t, uploadResp)
+	require.Equal(t, http.StatusCreated, uploadResp.StatusCode)
+
+	task := NewErasureCodingTask(
+		"delete-swallow-repro",
+		clusterHarness.VolumeServerAddress(),
+		volumeID,
+		"",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+
+	// Two replicas: the real volume server (reachable) and a bogus address
+	// that will refuse connections. deleteOriginalVolume iterates sources
+	// and attempts VolumeDelete on each.
+	unreachable := "127.0.0.1:1"
+	task.sources = []*worker_pb.TaskSource{
+		{
+			Node:     clusterHarness.VolumeServerAddress(),
+			VolumeId: volumeID,
+		},
+		{
+			Node:     unreachable,
+			VolumeId: volumeID,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// BUG #9184: deleteOriginalVolume returns nil even though one replica
+	// failed. That means the EC task reports overall success, which is what
+	// lets the stale replica on the unreachable server become a retry
+	// candidate (or, if the delete had been on the reachable side, leaves a
+	// surviving original volume). The fix must return an error so the task
+	// is retried without reporting success. Until then, pin the current
+	// behavior here.
+	err := task.deleteOriginalVolume(ctx)
+	require.NoError(t, err, "bug #9184 regression: deleteOriginalVolume should currently swallow the replica error; got: %v", err)
+
+	// Double-check the reachable replica really was deleted, so we know the
+	// test is exercising the "some-succeeded, some-failed" branch and not
+	// e.g. a silent no-op. VolumeStatus errors for unknown volumes.
+	_, statusErr := grpcClient.VolumeStatus(ctx, &volume_server_pb.VolumeStatusRequest{VolumeId: volumeID})
+	require.Error(t, statusErr,
+		"bug #9184 invariant: reachable replica %d should have been deleted before the failure was swallowed", volumeID)
+
+	t.Logf("bug #9184 reproduced: deleteOriginalVolume returned nil even though delete on %s failed", unreachable)
+}


### PR DESCRIPTION
## Summary

- `ErasureCodingTask.deleteOriginalVolume` now returns an error describing the failing replicas when any `VolumeDelete` fails, instead of logging a warning and returning `nil`.
- Per-replica progress is preserved — successful deletes still go through; only the final return changes.

## Why

Reported in #9184. Previously the function swallowed per-replica errors so the EC task reported overall success even when a source replica survived on disk. The next detection scan saw that replica and re-proposed the volume for EC, and on retry the plugin-worker `ReceiveFile` path silently truncated the already-mounted shard files on the target servers — the \"missing parts\" corruption described in the issue.

Combined with #9186 (ReceiveFile mount safety), a stuck delete now produces a loud, actionable failure instead of silent corruption.

## Test plan

- [x] New integration test `TestDeleteOriginalVolumeSurfacesReplicaFailures`: reachable + unreachable replicas, asserts the returned error names the failed replica and the reachable replica still got deleted.
- [x] New integration test `TestDeleteOriginalVolumeSucceedsWhenAllReplicasReachable` pins the happy path.
- [x] `go build ./...` clean.

Related to #9184. Complements #9185 (disk_id placement) and #9186 (ReceiveFile mount safety).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Erasure coding tasks now surface deletion failures for original volume replicas. When replica deletions fail, the operation returns a clear error with the number of failed replicas, volume ID, and specific failure details instead of only logging a warning.

* **Tests**
  * Added integration tests verifying replica-deletion failure is reported and that deletion succeeds when all replicas are reachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->