### PR TITLE
fix(filer.meta.tail): fail fast when -es is used without elastic build tag

### DIFF
--- a/weed/command/filer_meta_tail_non_elastic.go
+++ b/weed/command/filer_meta_tail_non_elastic.go
@@ -3,11 +3,11 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
 func sendToElasticSearchFunc(servers string, esIndex string) (func(resp *filer_pb.SubscribeMetadataResponse) error, error) {
-	return func(resp *filer_pb.SubscribeMetadataResponse) error {
-		return nil
-	}, nil
+	return nil, fmt.Errorf("this weed binary was built without Elasticsearch support. Rebuild with `-tags elastic` (see docker/Dockerfile.go_build) to use -es/-es.index")
 }


### PR DESCRIPTION
## Summary
- Fixes #9190
- `weed filer.meta.tail -es=...` silently dropped every event in the default `chrislusf/seaweedfs` image because the image is built without the `elastic` build tag (the `olivere/elastic/v7` dep is excluded for binary size — see `weed/filer/elastic/v7/doc.go`). The non-elastic stub returned a function that did nothing, so users saw the subscription wire up in filer logs but nothing ever reached Elasticsearch.
- The stub now returns an error pointing at the build tag. The caller (`weed/command/filer_meta_tail.go:99-102`) already prints it and exits, so users get an immediate, actionable message.

## Test plan
- [x] `go build ./weed/command/` (non-elastic path)
- [x] `go build -tags elastic ./weed/command/` (elastic path)
- [ ] Manually run `weed filer.meta.tail -es=http://...` on a non-elastic build and confirm the error shows up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when Elasticsearch support is unavailable in the binary. The system now returns a clear error message instead of silently failing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->