### PR TITLE
fix(filer/remote): keep re-cache work alive past caller cancellation (#9174)

### DIFF
--- a/weed/server/filer_grpc_server_remote.go
+++ b/weed/server/filer_grpc_server_remote.go
@@ -25,14 +25,10 @@ func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req 
 	// This benefits all clients: S3 API, filer HTTP, Hadoop, etc.
 	cacheKey := req.Directory + "/" + req.Name
 
-	// Detach from caller ctx: on failure doCacheRemoteObjectToLocalCluster
-	// deletes every chunk already written, so cancelling mid-download (e.g.
-	// caller's 30s wait elapses, boto3 retries and tears down siblings)
-	// throws away all progress and the retry starts over. For blobs too big
-	// to finish before the next tear-down the loop never converges. Letting
-	// the download run to completion means subsequent waiters — via
-	// singleflight, or a fresh retry landing after completion — find the
-	// cached entry.
+	// Detach from caller ctx: on failure the error path deletes every chunk
+	// already written, so cancelling mid-download loses all progress. For
+	// blobs large enough that the download outlasts the caller's timeout
+	// the retry loop never converges.
 	bgCtx := context.WithoutCancel(ctx)
 
 	result, err, shared := fs.remoteCacheGroup.Do(cacheKey, func() (interface{}, error) {

--- a/weed/server/filer_grpc_server_remote.go
+++ b/weed/server/filer_grpc_server_remote.go
@@ -25,8 +25,18 @@ func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req 
 	// This benefits all clients: S3 API, filer HTTP, Hadoop, etc.
 	cacheKey := req.Directory + "/" + req.Name
 
+	// Detach from caller ctx: on failure doCacheRemoteObjectToLocalCluster
+	// deletes every chunk already written, so cancelling mid-download (e.g.
+	// caller's 30s wait elapses, boto3 retries and tears down siblings)
+	// throws away all progress and the retry starts over. For blobs too big
+	// to finish before the next tear-down the loop never converges. Letting
+	// the download run to completion means subsequent waiters — via
+	// singleflight, or a fresh retry landing after completion — find the
+	// cached entry.
+	bgCtx := context.WithoutCancel(ctx)
+
 	result, err, shared := fs.remoteCacheGroup.Do(cacheKey, func() (interface{}, error) {
-		return fs.doCacheRemoteObjectToLocalCluster(ctx, req)
+		return fs.doCacheRemoteObjectToLocalCluster(bgCtx, req)
 	})
 
 	if shared {

--- a/weed/server/filer_grpc_server_remote.go
+++ b/weed/server/filer_grpc_server_remote.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error) {
-	// Use singleflight to deduplicate concurrent caching requests for the same object
+	// Use singleflight to deduplicate concurrent caching requests for the same object.
 	// This benefits all clients: S3 API, filer HTTP, Hadoop, etc.
 	cacheKey := req.Directory + "/" + req.Name
 
@@ -31,26 +31,34 @@ func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req 
 	// the retry loop never converges.
 	bgCtx := context.WithoutCancel(ctx)
 
-	result, err, shared := fs.remoteCacheGroup.Do(cacheKey, func() (interface{}, error) {
+	// DoChan (vs Do) so the caller can bail out on ctx.Done() while the
+	// singleflight goroutine keeps caching on bgCtx; otherwise this handler
+	// goroutine stays blocked for the full download after the client is gone.
+	ch := fs.remoteCacheGroup.DoChan(cacheKey, func() (interface{}, error) {
 		return fs.doCacheRemoteObjectToLocalCluster(bgCtx, req)
 	})
 
-	if shared {
-		glog.V(2).Infof("CacheRemoteObjectToLocalCluster: shared result for %s", cacheKey)
+	select {
+	case <-ctx.Done():
+		// Caller gave up; the detached cache keeps running and a later
+		// request will find the entry cached (or join the same singleflight).
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Shared {
+			glog.V(2).Infof("CacheRemoteObjectToLocalCluster: shared result for %s", cacheKey)
+		}
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		if res.Val == nil {
+			return nil, fmt.Errorf("unexpected nil result from singleflight")
+		}
+		resp, ok := res.Val.(*filer_pb.CacheRemoteObjectToLocalClusterResponse)
+		if !ok {
+			return nil, fmt.Errorf("unexpected result type from singleflight")
+		}
+		return resp, nil
 	}
-
-	if err != nil {
-		return nil, err
-	}
-	if result == nil {
-		return nil, fmt.Errorf("unexpected nil result from singleflight")
-	}
-
-	resp, ok := result.(*filer_pb.CacheRemoteObjectToLocalClusterResponse)
-	if !ok {
-		return nil, fmt.Errorf("unexpected result type from singleflight")
-	}
-	return resp, nil
 }
 
 // doCacheRemoteObjectToLocalCluster performs the actual caching operation.


### PR DESCRIPTION
## Summary

Follow-up to #9179 for the failure reported in discussion [#9174](https://github.com/seaweedfs/seaweedfs/discussions/9174#discussioncomment-16670672): even with the Azure-side parallel block fix, re-caching a ~3 GB Azure blob through the S3 gateway still fails in a loop with `grpc: the client connection is closing` / `context deadline exceeded`, while disk usage on the volume server grows ~500 MB and is then reclaimed by vacuum before converging.

### Root cause

1. `cacheRemoteObjectWithDedup` (`weed/s3api/s3api_object_handlers.go:2996`) wraps the filer's `CacheRemoteObjectToLocalCluster` gRPC call in a 30 s bounded timeout.
2. For a 3 GB blob the filer's chunked download (~32 chunks × ~96 MB) does not finish inside 30 s.
3. When the 30 s fires, the S3 gateway's gRPC ctx cancellation propagates into `doCacheRemoteObjectToLocalCluster`. The first chunk whose `operation.Assign(ctx, …)` sees the canceled ctx sets `fetchAndWriteErr`, and the error path deletes every chunk written so far via `DeleteUncommittedChunks` (`filer_grpc_server_remote.go:281`).
4. boto3's first range GET surfaces as an ETag/InternalError at the 30 s mark; boto3 closes that connection and retries its sibling ranges. The sibling goroutines in the S3 gateway fall through to `cacheRemoteObjectForStreaming`, which uses `r.Context()` — already canceled by boto3's tear-down — so the follow-up gRPC call fails immediately with `Canceled: the client connection is closing`.
5. The retry starts the full download from scratch. It never finishes before the next client-side tear-down, so the loop never converges. The disk growth / vacuum cycle in the log is exactly this.

This pattern is invisible for small blobs (they finish inside 30 s), visible at 2 GB (borderline) and consistently broken at 3 GB+.

### Fix

Inside `CacheRemoteObjectToLocalCluster`, detach the caller ctx with `context.WithoutCancel` before entering the singleflight function. The download now runs to completion regardless of client cancellations, and the cached entry is persisted via `UpdateEntry` (already using `context.Background()`). Subsequent waiters — either singleflight followers, or a fresh retry landing after completion — observe the cached chunks and stream normally.

Same detach pattern is already used elsewhere in the filer/volume write paths (`filer_server_handlers_write.go:53`, `volume_server_handlers_write.go:51`, `filerstore_wrapper.go`, etc.) for exactly this reason: client disconnect must not undo server-side work that later requests will rely on.

Request-scoped values (trace IDs, etc.) are preserved via `WithoutCancel`.

### Not addressed here

- The reporter's secondary observation that there is no guard against unsync/uncache racing with an in-flight cache is a distinct bug — scoping that to its own change.
- No knob added for the S3 gateway's 30 s cap: with this fix, hitting the cap is benign (the fallback streaming path waits on `r.Context()` and joins the in-flight singleflight, or a fresh retry post-completion finds the cached entry).

## Test plan

- [x] `go build ./weed/server/... ./weed/s3api/... ./weed/filer/...`
- [x] `go vet ./weed/server/...` (only pre-existing complaints in unrelated files)
- [x] `go test -short ./weed/server/...`
- [ ] End-to-end validation on the #9174 repro: mount Azure remote, `remote.meta.sync`, GET a 3 GB blob via S3 after `unsync`, confirm the first GET succeeds (possibly after a client-side retry interval long enough for the background cache to finish) and the second GET hits local chunks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience of cache operations. Caching processes now continue in the background even when clients disconnect unexpectedly, ensuring cache completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->