### PR TITLE
fix(storage): use ceil division for EC shard slots in maxVolumeCount

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -807,7 +807,7 @@ func (s *Store) MaybeAdjustVolumeMax() (hasChanges bool) {
 			}
 			volCount := diskLocation.VolumesLen()
 			ecShardCount := diskLocation.EcShardCount()
-			maxVolumeCount := int32(volCount) + int32((ecShardCount+erasure_coding.DataShardsCount)/erasure_coding.DataShardsCount)
+			maxVolumeCount := int32(volCount) + int32((ecShardCount+erasure_coding.DataShardsCount-1)/erasure_coding.DataShardsCount)
 			if unclaimedSpaces > int64(volumeSizeLimit) {
 				maxVolumeCount += int32(uint64(unclaimedSpaces)/volumeSizeLimit) - 1
 			}

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -67,7 +67,7 @@ func (d *DiskUsages) ToDiskInfo() map[string]*master_pb.DiskInfo {
 		m := &master_pb.DiskInfo{
 			VolumeCount:       diskUsageCounts.volumeCount,
 			MaxVolumeCount:    diskUsageCounts.maxVolumeCount,
-			FreeVolumeCount:   diskUsageCounts.maxVolumeCount - (diskUsageCounts.volumeCount - diskUsageCounts.remoteVolumeCount) - (diskUsageCounts.ecShardCount+1)/erasure_coding.DataShardsCount,
+			FreeVolumeCount:   diskUsageCounts.maxVolumeCount - (diskUsageCounts.volumeCount - diskUsageCounts.remoteVolumeCount) - (diskUsageCounts.ecShardCount+erasure_coding.DataShardsCount-1)/erasure_coding.DataShardsCount,
 			ActiveVolumeCount: diskUsageCounts.activeVolumeCount,
 			RemoteVolumeCount: diskUsageCounts.remoteVolumeCount,
 		}
@@ -112,9 +112,7 @@ func (a *DiskUsageCounts) addDiskUsageCounts(b *DiskUsageCounts) {
 
 func (a *DiskUsageCounts) FreeSpace() int64 {
 	freeVolumeSlotCount := a.maxVolumeCount + a.remoteVolumeCount - a.volumeCount
-	if a.ecShardCount > 0 {
-		freeVolumeSlotCount = freeVolumeSlotCount - a.ecShardCount/erasure_coding.DataShardsCount - 1
-	}
+	freeVolumeSlotCount -= (a.ecShardCount + erasure_coding.DataShardsCount - 1) / erasure_coding.DataShardsCount
 	return freeVolumeSlotCount
 }
 
@@ -265,7 +263,7 @@ func (d *Disk) ToDiskInfo() *master_pb.DiskInfo {
 		Type:              string(d.Id()),
 		VolumeCount:       diskUsage.volumeCount,
 		MaxVolumeCount:    diskUsage.maxVolumeCount,
-		FreeVolumeCount:   diskUsage.maxVolumeCount - (diskUsage.volumeCount - diskUsage.remoteVolumeCount) - (diskUsage.ecShardCount+1)/erasure_coding.DataShardsCount,
+		FreeVolumeCount:   diskUsage.maxVolumeCount - (diskUsage.volumeCount - diskUsage.remoteVolumeCount) - (diskUsage.ecShardCount+erasure_coding.DataShardsCount-1)/erasure_coding.DataShardsCount,
 		ActiveVolumeCount: diskUsage.activeVolumeCount,
 		RemoteVolumeCount: diskUsage.remoteVolumeCount,
 		DiskId:            diskId,

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -23,6 +23,12 @@ type Disk struct {
 	ecShardsLock sync.RWMutex
 }
 
+// ecShardSlots returns the number of volume slots consumed by the given
+// number of EC shards, rounded up to whole-volume equivalents.
+func ecShardSlots(ecShardCount int64) int64 {
+	return (ecShardCount + erasure_coding.DataShardsCount - 1) / erasure_coding.DataShardsCount
+}
+
 func NewDisk(diskType string) *Disk {
 	s := &Disk{}
 	s.id = NodeId(diskType)
@@ -67,7 +73,7 @@ func (d *DiskUsages) ToDiskInfo() map[string]*master_pb.DiskInfo {
 		m := &master_pb.DiskInfo{
 			VolumeCount:       diskUsageCounts.volumeCount,
 			MaxVolumeCount:    diskUsageCounts.maxVolumeCount,
-			FreeVolumeCount:   diskUsageCounts.maxVolumeCount - (diskUsageCounts.volumeCount - diskUsageCounts.remoteVolumeCount) - (diskUsageCounts.ecShardCount+erasure_coding.DataShardsCount-1)/erasure_coding.DataShardsCount,
+			FreeVolumeCount:   diskUsageCounts.maxVolumeCount - (diskUsageCounts.volumeCount - diskUsageCounts.remoteVolumeCount) - ecShardSlots(diskUsageCounts.ecShardCount),
 			ActiveVolumeCount: diskUsageCounts.activeVolumeCount,
 			RemoteVolumeCount: diskUsageCounts.remoteVolumeCount,
 		}
@@ -111,9 +117,7 @@ func (a *DiskUsageCounts) addDiskUsageCounts(b *DiskUsageCounts) {
 }
 
 func (a *DiskUsageCounts) FreeSpace() int64 {
-	freeVolumeSlotCount := a.maxVolumeCount + a.remoteVolumeCount - a.volumeCount
-	freeVolumeSlotCount -= (a.ecShardCount + erasure_coding.DataShardsCount - 1) / erasure_coding.DataShardsCount
-	return freeVolumeSlotCount
+	return a.maxVolumeCount + a.remoteVolumeCount - a.volumeCount - ecShardSlots(a.ecShardCount)
 }
 
 func (du *DiskUsages) getOrCreateDisk(diskType types.DiskType) *DiskUsageCounts {
@@ -263,7 +267,7 @@ func (d *Disk) ToDiskInfo() *master_pb.DiskInfo {
 		Type:              string(d.Id()),
 		VolumeCount:       diskUsage.volumeCount,
 		MaxVolumeCount:    diskUsage.maxVolumeCount,
-		FreeVolumeCount:   diskUsage.maxVolumeCount - (diskUsage.volumeCount - diskUsage.remoteVolumeCount) - (diskUsage.ecShardCount+erasure_coding.DataShardsCount-1)/erasure_coding.DataShardsCount,
+		FreeVolumeCount:   diskUsage.maxVolumeCount - (diskUsage.volumeCount - diskUsage.remoteVolumeCount) - ecShardSlots(diskUsage.ecShardCount),
 		ActiveVolumeCount: diskUsage.activeVolumeCount,
 		RemoteVolumeCount: diskUsage.remoteVolumeCount,
 		DiskId:            diskId,

--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -273,9 +273,7 @@ func (n *NodeImpl) AvailableSpaceFor(option *VolumeGrowOption) int64 {
 	t := n.getOrCreateDisk(option.DiskType)
 	freeVolumeSlotCount := atomic.LoadInt64(&t.maxVolumeCount) + atomic.LoadInt64(&t.remoteVolumeCount) - atomic.LoadInt64(&t.volumeCount)
 	ecShardCount := atomic.LoadInt64(&t.ecShardCount)
-	if ecShardCount > 0 {
-		freeVolumeSlotCount = freeVolumeSlotCount - ecShardCount/erasure_coding.DataShardsCount - 1
-	}
+	freeVolumeSlotCount -= (ecShardCount + erasure_coding.DataShardsCount - 1) / erasure_coding.DataShardsCount
 	return freeVolumeSlotCount
 }
 

--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/stats"
-	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 )
@@ -272,8 +271,7 @@ func (n *NodeImpl) getOrCreateDisk(diskType types.DiskType) *DiskUsageCounts {
 func (n *NodeImpl) AvailableSpaceFor(option *VolumeGrowOption) int64 {
 	t := n.getOrCreateDisk(option.DiskType)
 	freeVolumeSlotCount := atomic.LoadInt64(&t.maxVolumeCount) + atomic.LoadInt64(&t.remoteVolumeCount) - atomic.LoadInt64(&t.volumeCount)
-	ecShardCount := atomic.LoadInt64(&t.ecShardCount)
-	freeVolumeSlotCount -= (ecShardCount + erasure_coding.DataShardsCount - 1) / erasure_coding.DataShardsCount
+	freeVolumeSlotCount -= ecShardSlots(atomic.LoadInt64(&t.ecShardCount))
 	return freeVolumeSlotCount
 }
 


### PR DESCRIPTION
# What problem are we solving?
#9195

# How are we solving the problem?
maxVolumeCount := int32(volCount) + int32((ecShardCount+erasure_coding.DataShardsCount-1)/erasure_coding.DataShardsCount)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of storage capacity and free-space reporting by correcting erasure-coding overhead calculations.
  * Aligned per-disk and aggregated usage metrics so free-volume and available-space figures are consistent.
  * Ensures max-volume counters and heartbeat metrics reflect the updated calculations to reduce misleading utilization signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->