### PR TITLE
fix(upload): keep Content-MD5 on 204 unchanged writes

### DIFF
--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -455,6 +455,7 @@ func (uploader *Uploader) upload_content(ctx context.Context, fillBufferFunction
 	etag := getEtag(resp)
 	if resp.StatusCode == http.StatusNoContent {
 		ret.ETag = etag
+		ret.ContentMd5 = resp.Header.Get("Content-MD5")
 		return &ret, nil
 	}
 

--- a/weed/server/volume_server_handlers_write.go
+++ b/weed/server/volume_server_handlers_write.go
@@ -57,6 +57,7 @@ func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 	// http 204 status code does not allow body
 	if writeError == nil && isUnchanged {
 		SetEtag(w, reqNeedle.Etag())
+		w.Header().Set("Content-MD5", contentMd5)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}


### PR DESCRIPTION
Return Content-MD5 in the volume unchanged-write response and read it in the uploader 204 path so multipart chunk ETag metadata is preserved.

# What problem are we solving?



# How are we solving the problem?


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent handling of content MD5 checksums in upload responses. The `Content-MD5` header is now consistently included across all response paths, ensuring reliable data integrity verification for upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->