### PR TITLE
fix(filer.meta.tail): include extended metadata in Elasticsearch docs

### DIFF
--- a/weed/command/filer_meta_tail_elastic.go
+++ b/weed/command/filer_meta_tail_elastic.go
@@ -4,7 +4,9 @@ package command
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
+	"unicode/utf8"
 
 	jsoniter "github.com/json-iterator/go"
 	elastic "github.com/olivere/elastic/v7"
@@ -13,16 +15,17 @@ import (
 )
 
 type EsDocument struct {
-	Dir         string `json:"dir,omitempty"`
-	Name        string `json:"name,omitempty"`
-	IsDirectory bool   `json:"isDir,omitempty"`
-	Size        uint64 `json:"size,omitempty"`
-	Uid         uint32 `json:"uid,omitempty"`
-	Gid         uint32 `json:"gid,omitempty"`
-	UserName    string `json:"userName,omitempty"`
-	Crtime      int64  `json:"crtime,omitempty"`
-	Mtime       int64  `json:"mtime,omitempty"`
-	Mime        string `json:"mime,omitempty"`
+	Dir         string            `json:"dir,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	IsDirectory bool              `json:"isDir,omitempty"`
+	Size        uint64            `json:"size,omitempty"`
+	Uid         uint32            `json:"uid,omitempty"`
+	Gid         uint32            `json:"gid,omitempty"`
+	UserName    string            `json:"userName,omitempty"`
+	Crtime      int64             `json:"crtime,omitempty"`
+	Mtime       int64             `json:"mtime,omitempty"`
+	Mime        string            `json:"mime,omitempty"`
+	Extended    map[string]string `json:"extended,omitempty"`
 }
 
 func toEsEntry(event *filer_pb.EventNotification) (*EsDocument, string) {
@@ -40,8 +43,28 @@ func toEsEntry(event *filer_pb.EventNotification) (*EsDocument, string) {
 		Crtime:      entry.Attributes.Crtime,
 		Mtime:       entry.Attributes.Mtime,
 		Mime:        entry.Attributes.Mime,
+		Extended:    toExtendedStrings(entry.Extended),
 	}
 	return esEntry, id
+}
+
+// toExtendedStrings converts the xattr map (e.g. S3 user metadata like
+// X-Amz-Meta-*) to string values so Elasticsearch indexes them as text
+// instead of base64-encoding the raw bytes. Non-UTF-8 values fall back to
+// base64 so the document still round-trips.
+func toExtendedStrings(extended map[string][]byte) map[string]string {
+	if len(extended) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(extended))
+	for k, v := range extended {
+		if utf8.Valid(v) {
+			result[k] = string(v)
+		} else {
+			result[k] = base64.StdEncoding.EncodeToString(v)
+		}
+	}
+	return result
 }
 
 func sendToElasticSearchFunc(servers string, esIndex string) (func(resp *filer_pb.SubscribeMetadataResponse) error, error) {

--- a/weed/command/filer_meta_tail_elastic.go
+++ b/weed/command/filer_meta_tail_elastic.go
@@ -50,8 +50,9 @@ func toEsEntry(event *filer_pb.EventNotification) (*EsDocument, string) {
 
 // toExtendedStrings converts the xattr map (e.g. S3 user metadata like
 // X-Amz-Meta-*) to string values so Elasticsearch indexes them as text
-// instead of base64-encoding the raw bytes. Non-UTF-8 values fall back to
-// base64 so the document still round-trips.
+// instead of base64-encoding the raw bytes. Non-UTF-8 values are prefixed
+// with "base64:" so consumers can distinguish encoded bytes from plain
+// strings that happen to look like base64.
 func toExtendedStrings(extended map[string][]byte) map[string]string {
 	if len(extended) == 0 {
 		return nil
@@ -61,7 +62,7 @@ func toExtendedStrings(extended map[string][]byte) map[string]string {
 		if utf8.Valid(v) {
 			result[k] = string(v)
 		} else {
-			result[k] = base64.StdEncoding.EncodeToString(v)
+			result[k] = "base64:" + base64.StdEncoding.EncodeToString(v)
 		}
 	}
 	return result


### PR DESCRIPTION
## Summary
- Follow-up to #9190 / #9191 — user reported that after rebuilding with `-tags elastic` only `attributes` made it to Elasticsearch and `extended` (xattrs / S3 `X-Amz-Meta-*` user metadata) was dropped.
- The `-es` sink serializes `EsDocument`, which flattened only a subset of the FUSE attributes and had no field for `Extended` at all. This PR adds it.
- `map[string][]byte` → `map[string]string` so ES indexes values as text. Non-UTF-8 values fall back to base64 so the document still round-trips.

Ref: https://github.com/seaweedfs/seaweedfs/issues/9190#issuecomment-4303887316

## Test plan
- [x] `go build ./weed/command/` (non-elastic path)
- [x] `go build -tags elastic ./weed/command/` (elastic path)
- [ ] Manually run `weed filer.meta.tail -es=http://...` against an S3-uploaded object with `X-Amz-Meta-*` and confirm `extended.*` fields appear in the ES doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended metadata attributes are now indexed and stored with files. Each metadata entry is converted into a per-key string: UTF-8-valid bytes are stored as plain text, and non-UTF-8 bytes are preserved using a base64-prefixed encoding. Extended metadata is included alongside existing file fields in search and indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->