### PR TITLE
fix(helm): gate S3 TLS cert args on httpsPort to stop probe failures (#9202)

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -217,6 +217,93 @@ jobs:
           print("✓ No blank lines in security+S3 command blocks")
           PYEOF
 
+          echo ""
+          echo "=== Testing security+S3: -cert.file/-key.file gated on httpsPort (issue #9202) ==="
+          # Regression test: when enableSecurity=true but *.httpsPort is 0 (the default),
+          # the chart must NOT emit -cert.file / -key.file to the S3 frontend. Passing
+          # them promotes weed s3's main -port to HTTPS (see weed/command/s3.go), which
+          # makes the HTTP readinessProbe spam "TLS handshake error ... client sent an
+          # HTTP request to an HTTPS server" into the pod log.
+          #
+          # When *.httpsPort > 0, both -port.https and cert/key args MUST be emitted
+          # together so the opt-in HTTPS listener actually has credentials.
+          python3 - "$CHART_DIR" <<'PYEOF'
+          import subprocess, sys, yaml
+          chart = sys.argv[1]
+
+          def render(values):
+              args = ["helm", "template", "test", chart]
+              for k, v in values.items():
+                  args += ["--set", f"{k}={v}"]
+              return subprocess.check_output(args, text=True)
+
+          def script_of(manifest, kind_name):
+              for doc in yaml.safe_load_all(manifest):
+                  if not doc or doc.get("kind") not in ("Deployment", "StatefulSet"):
+                      continue
+                  if doc["metadata"]["name"] != kind_name:
+                      continue
+                  for c in doc["spec"]["template"]["spec"]["containers"]:
+                      cmd = c.get("command", [])
+                      if len(cmd) >= 3 and cmd[0] == "/bin/sh" and cmd[1] == "-ec":
+                          return cmd[2]
+              raise AssertionError(f"no container script for {kind_name}")
+
+          cases = [
+              # (values, workload-name, httpsPort-set?, arg-prefix)
+              ({"global.seaweedfs.enableSecurity": "true",
+                "s3.enabled": "true"},
+               "test-seaweedfs-s3", False, ""),
+              ({"global.seaweedfs.enableSecurity": "true",
+                "s3.enabled": "true",
+                "s3.httpsPort": "8443"},
+               "test-seaweedfs-s3", True, ""),
+              ({"global.seaweedfs.enableSecurity": "true",
+                "filer.s3.enabled": "true"},
+               "test-seaweedfs-filer", False, "s3."),
+              ({"global.seaweedfs.enableSecurity": "true",
+                "filer.s3.enabled": "true",
+                "filer.s3.httpsPort": "8444"},
+               "test-seaweedfs-filer", True, "s3."),
+              ({"global.seaweedfs.enableSecurity": "true",
+                "allInOne.enabled": "true",
+                "allInOne.s3.enabled": "true"},
+               "test-seaweedfs-all-in-one", False, "s3."),
+              ({"global.seaweedfs.enableSecurity": "true",
+                "allInOne.enabled": "true",
+                "allInOne.s3.enabled": "true",
+                "allInOne.s3.httpsPort": "8445"},
+               "test-seaweedfs-all-in-one", True, "s3."),
+          ]
+
+          failed = False
+          for values, name, https_on, prefix in cases:
+              script = script_of(render(values), name)
+              cert_flag = f"-{prefix}cert.file="
+              key_flag = f"-{prefix}key.file="
+              https_flag = f"-{prefix}port.https="
+              has_cert = cert_flag in script
+              has_key = key_flag in script
+              has_https = https_flag in script
+              label = f"{name} (httpsPort {'set' if https_on else 'unset'})"
+              if https_on:
+                  if not (has_cert and has_key and has_https):
+                      print(f"FAIL: {label}: expected {cert_flag}, {key_flag}, {https_flag} all present "
+                            f"(got cert={has_cert} key={has_key} https={has_https})", file=sys.stderr)
+                      failed = True
+                  else:
+                      print(f"✓ {label}: cert/key/https args emitted together")
+              else:
+                  if has_cert or has_key or has_https:
+                      print(f"FAIL: {label}: expected none of {cert_flag}/{key_flag}/{https_flag}; "
+                            f"main S3 -port would silently become HTTPS and break HTTP probes "
+                            f"(got cert={has_cert} key={has_key} https={has_https})", file=sys.stderr)
+                      failed = True
+                  else:
+                      print(f"✓ {label}: no TLS args emitted, main -port stays HTTP")
+          sys.exit(1 if failed else 0)
+          PYEOF
+
           echo "✅ All template rendering tests passed!"
 
       - name: Create kind cluster

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -301,6 +301,19 @@ jobs:
                       failed = True
                   else:
                       print(f"✓ {label}: no TLS args emitted, main -port stays HTTP")
+
+              # bash -n: pin down that the rendered script parses. Guards against
+              # a future helper change that leaves a dangling `\` with nothing
+              # after it (every current caller already exits cleanly because
+              # bash treats trailing `\<newline><EOF>` as line-continuation to
+              # an empty line — but keep the contract explicit).
+              parse = subprocess.run(["bash", "-n"], input=script, text=True,
+                                     capture_output=True)
+              if parse.returncode != 0:
+                  print(f"FAIL: {label}: bash -n rejected rendered script: {parse.stderr.strip()}",
+                        file=sys.stderr)
+                  failed = True
+
           sys.exit(1 if failed else 0)
           PYEOF
 

--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -247,8 +247,8 @@ spec:
               {{- $httpsPort := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
               {{- if $httpsPort }}
               -s3.port.https={{ $httpsPort }} \
-              {{- end }}
               {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "s3.") | nindent 14 }}
+              {{- end }}
               {{- end }}
               {{- if or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth }}
               -s3.config=/etc/sw/s3/seaweedfs_s3_config \

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -200,8 +200,8 @@ spec:
               {{- if .Values.global.seaweedfs.enableSecurity }}
               {{- if .Values.filer.s3.httpsPort }}
               -s3.port.https={{ .Values.filer.s3.httpsPort }} \
-              {{- end }}
               {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "s3.") | nindent 14 }}
+              {{- end }}
               {{- end }}
               {{- if .Values.filer.s3.enableAuth }}
               -s3.config=/etc/sw/seaweedfs_s3_config \

--- a/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -127,8 +127,8 @@ spec:
               {{- if .Values.global.seaweedfs.enableSecurity }}
               {{- if .Values.s3.httpsPort }}
               -port.https={{ .Values.s3.httpsPort }} \
-              {{- end }}
               {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
+              {{- end }}
               {{- end }}
               {{- if .Values.s3.domainName }}
               -domainName={{ .Values.s3.domainName }} \


### PR DESCRIPTION
## Summary

Fixes #9202. With `global.seaweedfs.enableSecurity=true` and the default `s3.httpsPort=0`, the chart unconditionally passed `-cert.file` / `-key.file` to the S3 frontend. In [`weed/command/s3.go`](https://github.com/seaweedfs/seaweedfs/blob/master/weed/command/s3.go), when `tlsPrivateKey != ""` *and* `portHttps == 0`, the server promotes its main `-port` (8333 by default) into an HTTPS listener. The pod's readiness / liveness probes still use `scheme: HTTP`, so every kubelet probe logs:

```
http: TLS handshake error from <node-ip>:<port>: client sent an HTTP request to an HTTPS server
```

(The `10.244.0.1` source IP in the issue is the node / kubelet, not another SeaweedFS component.)

`enableSecurity=true` is supposed to activate security.toml / gRPC mTLS — it shouldn't silently flip the S3 HTTP port to HTTPS.

### Fix

Move the `seaweedfs.s3.tlsArgs` include **inside** the `if httpsPort` guard in all three templates that wire up an S3 frontend:

- `k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml`
- `k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml`
- `k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml`

The TLS cert args are now emitted only when the user explicitly opts into an HTTPS port via `s3.httpsPort` / `filer.s3.httpsPort` / `allInOne.s3.httpsPort`. The main `-port` stays HTTP so HTTP probes work.

### Behavior matrix

| `enableSecurity` | `httpsPort` | Before | After |
|---|---|---|---|
| `false` | — | HTTP on `-port`, no TLS args | unchanged |
| `true` | `0` (default) | **HTTPS on `-port` — probes spam TLS errors** | HTTP on `-port`, gRPC mTLS via security.toml, probes work |
| `true` | `> 0` | HTTP on `-port`, HTTPS on `-port.https` | unchanged |

## Test plan

- [x] `helm lint k8s/charts/seaweedfs` clean
- [x] Added regression test in `.github/workflows/helm_ci.yml` that renders each of the three S3 frontend templates with and without `httpsPort` and asserts `-cert.file` / `-key.file` / `-port.https` are emitted together or not at all
- [x] Verified new test passes on the fixed templates (6/6 cases) and fails if the template fix is reverted
- [ ] `ct install` in the kind-based CI job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure S3 workloads only emit TLS certificate/HTTPS port flags when HTTPS is explicitly enabled, and omit them when unset.

* **Tests**
  * Added CI regression step that validates generated S3 startup script for correct presence/absence of TLS and HTTPS flags and verifies the script parses cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->