### PR TITLE
fix(iam): accept bare "*" resource in PutUserPolicy (#9209)

### DIFF
--- a/weed/s3api/s3api_embedded_iam.go
+++ b/weed/s3api/s3api_embedded_iam.go
@@ -819,9 +819,18 @@ func (e *EmbeddedIamApi) getActions(policy *policy_engine.PolicyDocument) ([]str
 			return nil, fmt.Errorf("not a valid effect: '%s'. Only 'Allow' is possible", statement.Effect)
 		}
 		for _, resource := range statement.Resource.Strings() {
-			res := strings.Split(resource, ":")
-			if len(res) != 6 || res[0] != "arn" || res[1] != "aws" || res[2] != "s3" {
-				continue
+			// AWS IAM treats a bare "*" as "any resource". Normalize it to the
+			// full-wildcard S3 ARN so it flows through the same path as
+			// "arn:aws:s3:::*" instead of being dropped as malformed.
+			var resourcePath string
+			if resource == "*" {
+				resourcePath = "*"
+			} else {
+				res := strings.Split(resource, ":")
+				if len(res) != 6 || res[0] != "arn" || res[1] != "aws" || res[2] != "s3" {
+					continue
+				}
+				resourcePath = res[5]
 			}
 			for _, action := range statement.Action.Strings() {
 				act := strings.Split(action, ":")
@@ -833,7 +842,6 @@ func (e *EmbeddedIamApi) getActions(policy *policy_engine.PolicyDocument) ([]str
 					return nil, fmt.Errorf("not a valid action: '%s'", act[1])
 				}
 
-				resourcePath := res[5]
 				if resourcePath == "*" {
 					// Wildcard - applies to all buckets
 					actions = append(actions, statementAction)

--- a/weed/s3api/s3api_embedded_iam_test.go
+++ b/weed/s3api/s3api_embedded_iam_test.go
@@ -1814,6 +1814,33 @@ func TestEmbeddedIamGetActionsFromPolicy(t *testing.T) {
 	assert.Contains(t, actions, "Write:mybucket")
 }
 
+// TestEmbeddedIamPutUserPolicyAllResourceWildcard reproduces issue #9209:
+// an AWS-style policy using "Action":"s3:*" with a bare "Resource":"*" is
+// valid AWS IAM syntax (meaning "any resource") but was rejected with
+// "no valid actions found in policy document" because the resource parser
+// required a full ARN.
+func TestEmbeddedIamPutUserPolicyAllResourceWildcard(t *testing.T) {
+	api := NewEmbeddedIamApiForTest()
+
+	// From issue #9209: bare "*" resource and bare "s3:*" action.
+	policyDoc := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Sid": "AllowS3Admin",
+			"Effect": "Allow",
+			"Action": "s3:*",
+			"Resource": "*"
+		}]
+	}`
+
+	policy, err := api.GetPolicyDocument(&policyDoc)
+	require.NoError(t, err)
+
+	actions, err := api.getActions(&policy)
+	require.NoError(t, err, "getActions must accept bare \"*\" resource")
+	assert.Contains(t, actions, ACTION_ADMIN, "s3:* should map to admin action")
+}
+
 // TestEmbeddedIamSetUserStatus tests enabling/disabling a user
 func TestEmbeddedIamSetUserStatus(t *testing.T) {
 	api := NewEmbeddedIamApiForTest()


### PR DESCRIPTION
## Summary

Fixes #9209. An AWS-compatible IAM policy with a bare `"*"` resource like

```json
{
  "Version": "2012-10-17",
  "Statement": [
    { "Effect": "Allow", "Action": "s3:*", "Resource": "*" }
  ]
}
```

was rejected by the embedded IAM with `MalformedPolicyDocument: no valid actions found in policy document`. The resource parser in `getActions` (`weed/s3api/s3api_embedded_iam.go`) required a 6-segment S3 ARN and `continue`d past anything else, so every statement with `Resource: "*"` produced zero actions and hit the `len(actions) == 0` guard at the end of the function.

- Short-circuit `resource == "*"` to the same full-wildcard path (`resourcePath = "*"`) that `arn:aws:s3:::*` already takes, matching AWS IAM semantics ("any resource").
- Added `TestEmbeddedIamPutUserPolicyAllResourceWildcard` which feeds the exact policy from #9209 through `getActions` — fails before the change with the same error, passes after.

## Why it regressed

- `len(actions) == 0 → "no valid actions found in policy document"` was introduced by #7740 ("Embed IAM API into S3 server", commit `f41925b6`), which started serving IAM on port 8333 via the new embedded handler in addition to the standalone `weed iam` server.
- The underlying gap — dropping `Resource: "*"` as a malformed ARN — predates the embed and is still present in the standalone path (`weed/iamapi/iamapi_management_handlers.go:GetActions`), but that function returns an empty slice instead of an error, so callers hitting the old `weed iam` server got `PutUserPolicy` silently accepted (with no effective actions). Users who upgraded and started hitting the embedded handler on 8333 now see a hard `MalformedPolicyDocument` error instead of the silent no-op.

## Test plan

- [x] `go test ./weed/s3api/ -run TestEmbeddedIamPutUserPolicyAllResourceWildcard -v` — fails on master, passes on this branch
- [x] `go test ./weed/s3api/...` — full S3 API package suite still green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed IAM policy parsing to correctly handle wildcard (`*`) resources in S3 policies, enabling proper authentication and authorization for policies using AWS-standard wildcard semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->