### PR TITLE
Export REST file_{read,write}_failures metrics on volume servers

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -35,11 +35,13 @@ import (
 const reqIsProxied = "proxied"
 
 func NotFound(w http.ResponseWriter) {
+	stats.VolumeServerFileReadFailures.Inc()
 	stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorGetNotFound).Inc()
 	w.WriteHeader(http.StatusNotFound)
 }
 
 func InternalError(w http.ResponseWriter) {
+	stats.VolumeServerFileReadFailures.Inc()
 	stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorGetInternal).Inc()
 	w.WriteHeader(http.StatusInternalServerError)
 }

--- a/weed/server/volume_server_handlers_write.go
+++ b/weed/server/volume_server_handlers_write.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/topology"
 	"github.com/seaweedfs/seaweedfs/weed/util/buffer_pool"
@@ -28,6 +29,7 @@ func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 	volumeId, ve := needle.NewVolumeId(vid)
 	if ve != nil {
 		glog.V(0).InfolnCtx(ctx, "NewVolumeId error:", ve)
+		stats.VolumeServerFileWriteFailures.Inc()
 		writeJsonError(w, r, http.StatusBadRequest, ve)
 		return
 	}
@@ -42,6 +44,7 @@ func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 
 	reqNeedle, originalSize, contentMd5, ne := needle.CreateNeedleFromRequest(r, vs.FixJpgOrientation, vs.fileSizeLimitBytes, bytesBuffer)
 	if ne != nil {
+		stats.VolumeServerFileWriteFailures.Inc()
 		writeJsonError(w, r, http.StatusBadRequest, ne)
 		return
 	}
@@ -50,6 +53,7 @@ func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 	// use context.WithoutCancel to avoid context cancellation when the client connection is closed
 	isUnchanged, writeError := topology.ReplicatedWrite(context.WithoutCancel(ctx), vs.GetMaster, vs.grpcDialOption, vs.store, volumeId, reqNeedle, r, contentMd5)
 	if writeError != nil {
+		stats.VolumeServerFileWriteFailures.Inc()
 		writeJsonError(w, r, http.StatusInternalServerError, writeError)
 		return
 	}
@@ -117,11 +121,13 @@ func (vs *VolumeServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 	if n.IsChunkedManifest() {
 		chunkManifest, e := operation.LoadChunkManifest(n.Data, n.IsCompressed())
 		if e != nil {
+			stats.VolumeServerFileWriteFailures.Inc()
 			writeJsonError(w, r, http.StatusInternalServerError, fmt.Errorf("Load chunks manifest error: %v", e))
 			return
 		}
 		// make sure all chunks had deleted before delete manifest
 		if e := chunkManifest.DeleteChunks(vs.GetMaster, false, vs.grpcDialOption); e != nil {
+			stats.VolumeServerFileWriteFailures.Inc()
 			writeJsonError(w, r, http.StatusInternalServerError, fmt.Errorf("Delete chunks error: %v", e))
 			return
 		}
@@ -148,6 +154,7 @@ func writeDeleteResult(err error, count int64, w http.ResponseWriter, r *http.Re
 		m["size"] = count
 		writeJsonQuiet(w, r, http.StatusAccepted, m)
 	} else {
+		stats.VolumeServerFileWriteFailures.Inc()
 		writeJsonError(w, r, http.StatusInternalServerError, fmt.Errorf("Deletion Failed: %w", err))
 	}
 }

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -369,6 +369,21 @@ var (
 			Name:      "master_disconnections",
 			Help:      "Number of master server disconnections.",
 		}, []string{"address"})
+	VolumeServerFileReadFailures = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "file_read_failures",
+			Help:      "Counter of overall failed file read requests from clients.",
+		})
+
+	VolumeServerFileWriteFailures = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "file_write_failures",
+			Help:      "Counter of overall failed file write requests from clients.",
+		})
 
 	VolumeServerFileReadFailures = prometheus.NewCounter(
 		prometheus.CounterOpts{

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -369,21 +369,6 @@ var (
 			Name:      "master_disconnections",
 			Help:      "Number of master server disconnections.",
 		}, []string{"address"})
-	VolumeServerFileReadFailures = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: Namespace,
-			Subsystem: "volumeServer",
-			Name:      "file_read_failures",
-			Help:      "Counter of overall failed file read requests from clients.",
-		})
-
-	VolumeServerFileWriteFailures = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: Namespace,
-			Subsystem: "volumeServer",
-			Name:      "file_write_failures",
-			Help:      "Counter of overall failed file write requests from clients.",
-		})
 
 	VolumeServerFileReadFailures = prometheus.NewCounter(
 		prometheus.CounterOpts{


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/8535

# How are we solving the problem?

Update the metrics introduced by https://github.com/seaweedfs/seaweedfs/pull/9177 upon REST read/write request failures, instead of just gRPC.

# How is the PR tested?

Prometheus counter metrics, no tests affected.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error tracking for file operation failures in read and write handlers to provide better visibility into system issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->