### PR TITLE
fix(upload): rewind request body when retrying on connection reset (#9139)

### DIFF
--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -439,7 +439,7 @@ func (uploader *Uploader) upload_content(ctx context.Context, fillBufferFunction
 	if post_err != nil {
 		if strings.Contains(post_err.Error(), "connection reset by peer") ||
 			strings.Contains(post_err.Error(), "use of closed network connection") {
-			glog.V(1).InfofCtx(ctx, "repeat error upload request %s: %v", option.UploadUrl, postErr)
+			glog.V(1).InfofCtx(ctx, "repeat error upload request %s: %v", option.UploadUrl, post_err)
 			stats.FilerHandlerCounter.WithLabelValues(stats.RepeatErrorUploadContent).Inc()
 			// The first attempt already consumed (or partially consumed) the
 			// body, so retrying with the same *http.Request would send 0 bytes

--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -441,6 +441,16 @@ func (uploader *Uploader) upload_content(ctx context.Context, fillBufferFunction
 			strings.Contains(post_err.Error(), "use of closed network connection") {
 			glog.V(1).InfofCtx(ctx, "repeat error upload request %s: %v", option.UploadUrl, postErr)
 			stats.FilerHandlerCounter.WithLabelValues(stats.RepeatErrorUploadContent).Inc()
+			// The first attempt already consumed (or partially consumed) the
+			// body, so retrying with the same *http.Request would send 0 bytes
+			// and Go's transport would surface "ContentLength=N with Body
+			// length 0". http.NewRequestWithContext sets GetBody for
+			// *bytes.Reader bodies; use it to attach a fresh body for retry.
+			if req.GetBody != nil {
+				if newBody, gbErr := req.GetBody(); gbErr == nil {
+					req.Body = newBody
+				}
+			}
 			resp, post_err = uploader.httpClient.Do(req)
 			defer util_http.CloseResponse(resp)
 		}

--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -446,13 +446,21 @@ func (uploader *Uploader) upload_content(ctx context.Context, fillBufferFunction
 			// and Go's transport would surface "ContentLength=N with Body
 			// length 0". http.NewRequestWithContext sets GetBody for
 			// *bytes.Reader bodies; use it to attach a fresh body for retry.
+			// If we can't rewind, skip the inner retry and let the outer
+			// retriedUploadData loop reissue the request with a fresh body —
+			// retrying here with a consumed body would mask the original
+			// "connection reset" error with a misleading "Body length 0".
 			if req.GetBody != nil {
 				if newBody, gbErr := req.GetBody(); gbErr == nil {
 					req.Body = newBody
+					resp, post_err = uploader.httpClient.Do(req)
+					defer util_http.CloseResponse(resp)
+				} else {
+					glog.V(1).InfofCtx(ctx, "skip inner retry for %s: GetBody returned %v", option.UploadUrl, gbErr)
 				}
+			} else {
+				glog.V(1).InfofCtx(ctx, "skip inner retry for %s: req.GetBody is nil", option.UploadUrl)
 			}
-			resp, post_err = uploader.httpClient.Do(req)
-			defer util_http.CloseResponse(resp)
 		}
 	}
 	if post_err != nil {

--- a/weed/operation/upload_content_test.go
+++ b/weed/operation/upload_content_test.go
@@ -1,6 +1,9 @@
 package operation
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -120,5 +123,78 @@ func TestUploadWithRetryDataReassignsOnVolumeSizeExceeded(t *testing.T) {
 	}
 	if httpClient.calls[0] != "http://volume-a/1,first" || httpClient.calls[3] != "http://volume-b/2,second" {
 		t.Fatalf("unexpected upload call sequence: %#v", httpClient.calls)
+	}
+}
+
+// bodyCapturingHTTPClient drains req.Body on every Do, optionally failing the
+// first attempt with a transport error so we can verify upload_content rewinds
+// the body before retrying.
+type bodyCapturingHTTPClient struct {
+	mu          sync.Mutex
+	bodies      [][]byte
+	failFirst   string
+	successJSON string
+}
+
+func (c *bodyCapturingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var captured []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		captured = b
+	}
+	c.bodies = append(c.bodies, captured)
+
+	if len(c.bodies) == 1 && c.failFirst != "" {
+		return nil, errors.New(c.failFirst)
+	}
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(c.successJSON)),
+	}, nil
+}
+
+// TestUploadRewindsBodyOnConnectionReset reproduces issue #9139 follow-up:
+// when the inner Do retry fires on a "connection reset" / "closed network"
+// error, the *bytes.Reader body has already been consumed, so without an
+// explicit rewind the second attempt sends 0 bytes and Go's transport surfaces
+// "ContentLength=N with Body length 0".
+func TestUploadRewindsBodyOnConnectionReset(t *testing.T) {
+	for _, transient := range []string{
+		"connection reset by peer",
+		"use of closed network connection",
+	} {
+		t.Run(transient, func(t *testing.T) {
+			client := &bodyCapturingHTTPClient{
+				failFirst:   transient,
+				successJSON: `{"name":"test.bin","size":42}`,
+			}
+			uploader := newUploader(client)
+
+			payload := bytes.Repeat([]byte("payload-"), 256) // 2048 bytes
+			_, err := uploader.UploadData(context.Background(), payload, &UploadOption{
+				UploadUrl: "http://volume/1,abc",
+				Filename:  "test.bin",
+			})
+			if err != nil {
+				t.Fatalf("upload should succeed after inner retry, got %v", err)
+			}
+			if len(client.bodies) != 2 {
+				t.Fatalf("expected 2 Do attempts, got %d", len(client.bodies))
+			}
+			if len(client.bodies[0]) == 0 {
+				t.Fatalf("first attempt sent an empty body; test setup wrong")
+			}
+			if !bytes.Equal(client.bodies[0], client.bodies[1]) {
+				t.Fatalf("retry body length=%d differs from first attempt length=%d (body was not rewound)",
+					len(client.bodies[1]), len(client.bodies[0]))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Reported via [#9139 (comment)](https://github.com/seaweedfs/seaweedfs/issues/9139#issuecomment-4319740414): mount log shows `Post "...": http: ContentLength=33152 with Body length 0`.
- Inside `upload_content`, when `httpClient.Do(req)` errors with `connection reset by peer` or `use of closed network connection`, we retry with the **same** `*http.Request`. The body is a `*bytes.Reader` the first attempt already drained, so the retry sends 0 bytes and Go's transport surfaces the `Body length 0` error.
- Fix: `http.NewRequestWithContext` populates `req.GetBody` for `*bytes.Reader` bodies. Call it to attach a fresh body before the retry.

## Test plan

- [x] New `TestUploadRewindsBodyOnConnectionReset` (covers both transient errors) reproduces the bug — fails on master, passes with the fix (`retry body length=0 differs from first attempt length=362` without the fix).
- [x] Existing `weed/operation` tests still pass (`go test ./weed/operation/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload reliability: retry logic now recreates and restores request bodies before retrying on transient connection errors; if the body can't be recreated the outer retry is used. Also cleaned up debug logging for clearer error reporting.
* **Tests**
  * Added tests that simulate connection-reset errors and verify two attempts occur and the retried request sends the same body bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->