### PR TITLE
fix(volume): cap leveldb OpenFilesCacheCapacity per index DB (#9139)

### DIFF
--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -199,6 +199,12 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					BlockCacheCapacity:            2 * 1024 * 1024, // default value is 8MiB
 					WriteBuffer:                   1 * 1024 * 1024, // default value is 4MiB
 					CompactionTableSizeMultiplier: 10,              // default value is 1
+					// goleveldb defaults this cache to 500 FDs per DB; with
+					// thousands of volumes per server that ceiling stacks up
+					// and starves WAL rotation (open .../00000N.log: too many
+					// open files). CompactionTableSizeMultiplier=10 already
+					// keeps the SST count low, so a small cache is sufficient.
+					OpenFilesCacheCapacity: 16,
 				}
 				if v.tmpNm != nil {
 					glog.V(0).Infoln("updating leveldb index", v.FileName(".ldb"))
@@ -214,6 +220,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					BlockCacheCapacity:            4 * 1024 * 1024, // default value is 8MiB
 					WriteBuffer:                   2 * 1024 * 1024, // default value is 4MiB
 					CompactionTableSizeMultiplier: 10,              // default value is 1
+					OpenFilesCacheCapacity:        32,              // default 500; bound per-DB FD usage on busy servers
 				}
 				if v.tmpNm != nil {
 					glog.V(0).Infoln("updating leveldb medium index", v.FileName(".ldb"))
@@ -229,6 +236,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					BlockCacheCapacity:            8 * 1024 * 1024, // default value is 8MiB
 					WriteBuffer:                   4 * 1024 * 1024, // default value is 4MiB
 					CompactionTableSizeMultiplier: 10,              // default value is 1
+					OpenFilesCacheCapacity:        64,              // default 500; bound per-DB FD usage on busy servers
 				}
 				if v.tmpNm != nil {
 					glog.V(0).Infoln("updating leveldb large index", v.FileName(".ldb"))

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -16,6 +16,23 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
+// Per-DB caps on goleveldb's open SST file cache. The library default is 500
+// per DB, but a volume server hosts one DB per volume — easily thousands —
+// so the per-DB default sums into FD exhaustion (`open .../00000N.log: too
+// many open files`) even with generous ulimits, especially when leveldb is
+// rotating its WAL.
+//
+// The trade-off: a larger cache lowers re-open overhead on cold reads, a
+// smaller cache bounds total FD usage. CompactionTableSizeMultiplier=10
+// already keeps SST counts low (~10x larger SSTs => ~10x fewer files), so
+// even the small-volume cap is enough to keep the working set hot while
+// leaving headroom for thousands of co-resident DBs.
+const (
+	LevelDbOpenFilesCacheCapacity       = 16
+	LevelDbMediumOpenFilesCacheCapacity = 32
+	LevelDbLargeOpenFilesCacheCapacity  = 64
+)
+
 func loadVolumeWithoutIndex(dirname string, collection string, id needle.VolumeId, needleMapKind NeedleMapKind, ver needle.Version) (v *Volume, err error) {
 	v = &Volume{dir: dirname, Collection: collection, Id: id}
 	v.SuperBlock = super_block.SuperBlock{}
@@ -196,15 +213,10 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 				}
 			case NeedleMapLevelDb:
 				opts := &opt.Options{
-					BlockCacheCapacity:            2 * 1024 * 1024, // default value is 8MiB
-					WriteBuffer:                   1 * 1024 * 1024, // default value is 4MiB
-					CompactionTableSizeMultiplier: 10,              // default value is 1
-					// goleveldb defaults this cache to 500 FDs per DB; with
-					// thousands of volumes per server that ceiling stacks up
-					// and starves WAL rotation (open .../00000N.log: too many
-					// open files). CompactionTableSizeMultiplier=10 already
-					// keeps the SST count low, so a small cache is sufficient.
-					OpenFilesCacheCapacity: 16,
+					BlockCacheCapacity:            2 * 1024 * 1024,               // default value is 8MiB
+					WriteBuffer:                   1 * 1024 * 1024,               // default value is 4MiB
+					CompactionTableSizeMultiplier: 10,                            // default value is 1
+					OpenFilesCacheCapacity:        LevelDbOpenFilesCacheCapacity, // see package-level docs
 				}
 				if v.tmpNm != nil {
 					glog.V(0).Infoln("updating leveldb index", v.FileName(".ldb"))
@@ -217,10 +229,10 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 				}
 			case NeedleMapLevelDbMedium:
 				opts := &opt.Options{
-					BlockCacheCapacity:            4 * 1024 * 1024, // default value is 8MiB
-					WriteBuffer:                   2 * 1024 * 1024, // default value is 4MiB
-					CompactionTableSizeMultiplier: 10,              // default value is 1
-					OpenFilesCacheCapacity:        32,              // default 500; bound per-DB FD usage on busy servers
+					BlockCacheCapacity:            4 * 1024 * 1024,                     // default value is 8MiB
+					WriteBuffer:                   2 * 1024 * 1024,                     // default value is 4MiB
+					CompactionTableSizeMultiplier: 10,                                  // default value is 1
+					OpenFilesCacheCapacity:        LevelDbMediumOpenFilesCacheCapacity, // see package-level docs
 				}
 				if v.tmpNm != nil {
 					glog.V(0).Infoln("updating leveldb medium index", v.FileName(".ldb"))
@@ -233,10 +245,10 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 				}
 			case NeedleMapLevelDbLarge:
 				opts := &opt.Options{
-					BlockCacheCapacity:            8 * 1024 * 1024, // default value is 8MiB
-					WriteBuffer:                   4 * 1024 * 1024, // default value is 4MiB
-					CompactionTableSizeMultiplier: 10,              // default value is 1
-					OpenFilesCacheCapacity:        64,              // default 500; bound per-DB FD usage on busy servers
+					BlockCacheCapacity:            8 * 1024 * 1024,                    // default value is 8MiB
+					WriteBuffer:                   4 * 1024 * 1024,                    // default value is 4MiB
+					CompactionTableSizeMultiplier: 10,                                 // default value is 1
+					OpenFilesCacheCapacity:        LevelDbLargeOpenFilesCacheCapacity, // see package-level docs
 				}
 				if v.tmpNm != nil {
 					glog.V(0).Infoln("updating leveldb large index", v.FileName(".ldb"))


### PR DESCRIPTION
## Summary

- Reported via [#9139 (comment)](https://github.com/seaweedfs/seaweedfs/issues/9139#issuecomment-4319740414): on a busy volume server (3 processes × `-max=3785`), the user's mount log floods with `failed to write leveldb: open .../000006.log: too many open files` — even with a generous ulimit.
- Each leveldb index opens with `opt.Options{...}` that never set `OpenFilesCacheCapacity`, so goleveldb defaults to **500 FDs per DB**. Across thousands of volumes, that ceiling stacks up and starves WAL rotation.
- Fix: cap per-DB `OpenFilesCacheCapacity` at **16 / 32 / 64** for `NeedleMapLevelDb` / `Medium` / `Large`. `CompactionTableSizeMultiplier=10` already keeps SST counts low, so the smaller cache is sufficient and per-DB FD usage is bounded.

## Test plan

- [x] `go build ./weed/storage/...`
- [x] `go test ./weed/storage/` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database performance and resource efficiency through optimized caching behavior across different volume sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->