### PR TITLE
fix(admin): use TLS-aware HTTP client for /dir/status fetch

### DIFF
--- a/weed/admin/dash/cluster_topology.go
+++ b/weed/admin/dash/cluster_topology.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
-var dirStatusClient = &http.Client{
-	Timeout: 5 * time.Second,
-}
+const dirStatusTimeout = 5 * time.Second
 
 // GetClusterTopology returns the current cluster topology with caching
 func (s *AdminServer) GetClusterTopology() (*ClusterTopology, error) {
@@ -50,8 +49,16 @@ func (s *AdminServer) fetchPublicUrlMap() map[string]string {
 		return nil
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), dirStatusTimeout)
+	defer cancel()
+
 	url := fmt.Sprintf("http://%s/dir/status", currentMaster.ToHttpAddress())
-	resp, err := dirStatusClient.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		glog.V(1).Infof("Failed to build /dir/status request for %s: %v", currentMaster, err)
+		return nil
+	}
+	resp, err := util_http.GetGlobalHttpClient().Do(req)
 	if err != nil {
 		glog.V(1).Infof("Failed to fetch /dir/status from %s: %v", currentMaster, err)
 		return nil


### PR DESCRIPTION
# What problem are we solving?

When SeaweedFS is configured with HTTPS-only master via `security.toml [https.master]`, the admin server logs the following NOTICE on master every time the dashboard's cluster topology cache expires:

```
NOTICE: http: TLS handshake error from <admin-ip>:<port>: client sent an HTTP request to an HTTPS server
```

`fetchPublicUrlMap()` in `weed/admin/dash/cluster_topology.go` uses a dedicated `&http.Client{}` (no TLS) and hardcodes `http://` for the URL:

```go
var dirStatusClient = &http.Client{
    Timeout: 5 * time.Second,
}
url := fmt.Sprintf("http://%s/dir/status", currentMaster.ToHttpAddress())
resp, err := dirStatusClient.Get(url)
```

Master rejects the plain-HTTP request, the function falls through to a `glog.V(1)` (verbose-only) error, and the admin UI loses PublicUrl enrichment for data nodes. Functionally cosmetic, but generates log noise on every cache refresh and slightly degrades admin UI in TLS deployments.

## Reproduction

1. Deploy SeaweedFS with `security.toml`:
   ```toml
   [https.client]
   enabled = true
   cert = "/etc/seaweedfs/ssl/client.crt"
   key  = "/etc/seaweedfs/ssl/client.key"
   ca   = "/etc/seaweedfs/ssl/ca.crt"

   [https.master]
   cert = "/etc/seaweedfs/ssl/master.crt"
   key  = "/etc/seaweedfs/ssl/master.key"
   ca   = "/etc/seaweedfs/ssl/ca.crt"
   ```
2. Start `weed master` and `weed admin`.
3. Visit any admin UI page that triggers `GetClusterTopology()` cache refresh.
4. Observe `journalctl -u seaweedfs-master`:
   ```
   NOTICE: http: TLS handshake error from 172.27.0.200:36416: client sent an HTTP request to an HTTPS server
   ```

# How are we solving the problem?

Switch to the existing TLS-aware global HTTP client (`util_http.GetGlobalHttpClient()`). Its `Do()` calls `NormalizeHttpScheme()` which automatically rewrites `http://` → `https://` when `[https.client]` is enabled, and presents the configured client cert.

The 5-second timeout is preserved via `context.WithTimeout()`. The URL string remains unchanged so other configurations (HTTP-only, no TLS) are unaffected — `NormalizeHttpScheme` is a no-op when `expectHttpsScheme` is false.

This follows the same pattern already used by:
- `weed/admin/handlers/file_browser_handlers.go` (reuses TLS transport via `newClientWithTimeout`)
- `weed/server/master_server.go`
- `weed/shell/command_volume_fsck.go`
- `weed/server/filer_server_handlers_proxy.go`

# How is the PR tested?

- Compiled clean: `go build ./weed/admin/dash/` (exit 0); `go vet ./weed/admin/dash/` (exit 0).
- Verified against SeaweedFS 4.21 with HTTPS-only master.
- **Before patch:** master logs `TLS handshake error: client sent an HTTP request to an HTTPS server` on every topology cache miss; `fetchPublicUrlMap()` returns `nil`; admin UI shows internal URLs only.
- **After patch:** no master log noise; `fetchPublicUrlMap()` returns the expected PublicUrl map; admin UI shows PublicUrls.
- Also verified against HTTP-only master (no `[https.master]` in security.toml): behavior unchanged (`NormalizeHttpScheme` no-op, plain HTTP used).

# Checks
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible — single file, +11/-4 lines.
- [ ] I have added unit tests if possible. *(`fetchPublicUrlMap` has no existing test; mocking a TLS-enabled master is non-trivial scaffolding for what is fundamentally a client-construction fix matching established patterns elsewhere in the codebase. Happy to add one if requested.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cluster status endpoint request handling with enhanced error detection and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->