### PR TITLE
 fix(shell): correct volume.list -writable filter unit and comparison

### DIFF
--- a/weed/shell/command_volume_list.go
+++ b/weed/shell/command_volume_list.go
@@ -199,7 +199,7 @@ func (c *commandVolumeList) isNotMatchDiskInfo(readOnly bool, collection string,
 	if *c.readonly && !readOnly {
 		return true
 	}
-	if *c.writable && (readOnly || volumeSize == -1 || c.volumeSizeLimitMb >= uint64(volumeSize)) {
+	if *c.writable && (readOnly || volumeSize == -1 || uint64(volumeSize) >= c.volumeSizeLimitMb*1024*1024) {
 		return true
 	}
 	if *c.collectionPattern != "" {

--- a/weed/shell/command_volume_list.go
+++ b/weed/shell/command_volume_list.go
@@ -199,7 +199,7 @@ func (c *commandVolumeList) isNotMatchDiskInfo(readOnly bool, collection string,
 	if *c.readonly && !readOnly {
 		return true
 	}
-	if *c.writable && (readOnly || volumeSize == -1 || uint64(volumeSize) >= c.volumeSizeLimitMb*1024*1024) {
+	if *c.writable && (readOnly || volumeSize == -1 || (c.volumeSizeLimitMb > 0 && uint64(volumeSize) >= c.volumeSizeLimitMb*util.MiByte)) {
 		return true
 	}
 	if *c.collectionPattern != "" {


### PR DESCRIPTION
## Summary

  - Fix unit mismatch in `volume.list -writable` filter: `volumeSizeLimitMb` (MB) was compared directly against `volumeSize` (bytes)
  without conversion.
  - Fix inverted comparison: a volume is non-writable when `size >= limit`, not `limit >= size`.

  ## Background

  In `weed/shell/command_volume_list.go` the filter was:

  ```go
  if *c.writable && (readOnly || volumeSize == -1 || c.volumeSizeLimitMb >= uint64(volumeSize)) {
      return true
  }

  Other call sites already convert correctly, e.g. command_volume_tier_move.go uses float64(volumeSizeLimitMb)*1024*1024, and
  command_cluster_status.go uses sp.volumeSizeLimitMb*1024*1024.

  Impact

  With the default volumeSizeLimitMb = 30000 (30 GB):

  ┌────────────────────┬──────────────────────┬──────────────┐
  │ Actual volume size │        Before        │    After     │
  ├────────────────────┼──────────────────────┼──────────────┤
  │ 10 KB              │ filtered out (wrong) │ kept         │
  ├────────────────────┼──────────────────────┼──────────────┤
  │ 25 KB              │ filtered out (wrong) │ kept         │
  ├────────────────────┼──────────────────────┼──────────────┤
  │ 1 MB               │ kept                 │ kept         │
  ├────────────────────┼──────────────────────┼──────────────┤
  │ 30 GB (full)       │ kept (wrong)         │ filtered out │
  └────────────────────┴──────────────────────┴──────────────┘

  Any volume whose byte size was numerically smaller than volumeSizeLimitMb (~< 30 KB by default) was wrongly excluded from -writable
  output, and volumes that had actually reached the size limit were not excluded.

  Fix

  if *c.writable && (readOnly || volumeSize == -1 || uint64(volumeSize) >= c.volumeSizeLimitMb*1024*1024) {
      return true
  }


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed writable-volume filtering used by the --writable flag: the size threshold is now interpreted in megabytes and applied correctly (converted to bytes) when deciding eligible volumes, and a zero size limit is treated as “no limit.” This improves which volumes are identified and listed as writable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->