### PR TITLE
fix(seaweed-volume): ceil EC shard slots in maybe_adjust_volume_max

### DIFF
--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -492,7 +492,8 @@ impl Store {
                 let vol_count = loc.volumes_len() as i32;
                 let loc_ec_shards = loc.ec_shard_count();
                 let ec_equivalent = ((loc_ec_shards
-                    + crate::storage::erasure_coding::ec_shard::DATA_SHARDS_COUNT)
+                    + crate::storage::erasure_coding::ec_shard::DATA_SHARDS_COUNT
+                    - 1)
                     / crate::storage::erasure_coding::ec_shard::DATA_SHARDS_COUNT)
                     as i32;
                 let mut max_count = vol_count + ec_equivalent;


### PR DESCRIPTION
## Summary

Mirrors the volume-server side of #9196 in the Rust port. `Store::maybe_adjust_volume_max` was rounding the per-location EC-shard contribution to `max_volume_count` with `(N + D) / D`, which over-counts by one whole-volume slot whenever the location's EC-shard count is `0` or an exact multiple of `DataShardsCount` (10) — the most common case being "no EC shards". Switched to proper ceiling division `(N + D - 1) / D`, matching the Go fix at `weed/storage/store.go:810` and the existing low-disk path in `seaweed-volume/src/server/heartbeat.rs:777-782` (which already used the correct form).

The master-side topology changes from #9196 (`weed/topology/disk.go`, `weed/topology/node.go`, the new `ecShardSlots` helper) have no Rust counterpart, since `seaweed-volume` is volume-server-only. The Rust free-slot calc at `seaweed-volume/src/storage/disk_location.rs:455-467` and `store.rs:135-187` mirrors Go's `FindFreeLocation` formula `((max - volCount) * D - ecCount) / D`, which is already a correct ceiling and needs no change.

## Test plan

- [x] `cargo build` (no new warnings)
- [x] `cargo test --lib maybe_adjust_volume_max` — existing `test_maybe_adjust_volume_max_honors_preallocate_flag` still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed volume capacity calculation for erasure-coded storage configurations to ensure accurate maximum capacity allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->