### PR TITLE
fix(s3api): return 503 + Retry-After when remote object not cached yet

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1000,6 +1000,13 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 				entry = cachedEntry
 				glog.V(1).Infof("streamFromVolumeServers: successfully cached remote object, got %d chunks", len(chunks))
 			} else {
+				// If the client already went away (most common cause of a failed
+				// cache attempt here), surface the context error so the outer
+				// handler treats it as a cancellation instead of writing a 503
+				// the client will never see.
+				if ctxErr := r.Context().Err(); ctxErr != nil {
+					return ctxErr
+				}
 				// Cache attempt did not produce chunks in time. The cache may still
 				// be filling in the background, so return 503 with Retry-After to
 				// let S3 SDKs back off and retry transparently rather than treating

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1000,17 +1000,11 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 				entry = cachedEntry
 				glog.V(1).Infof("streamFromVolumeServers: successfully cached remote object, got %d chunks", len(chunks))
 			} else {
-				// If the client already went away (most common cause of a failed
-				// cache attempt here), surface the context error so the outer
-				// handler treats it as a cancellation instead of writing a 503
-				// the client will never see.
+				// Client disconnected: report cancellation, not 503.
 				if ctxErr := r.Context().Err(); ctxErr != nil {
 					return ctxErr
 				}
-				// Cache attempt did not produce chunks in time. The cache may still
-				// be filling in the background, so return 503 with Retry-After to
-				// let S3 SDKs back off and retry transparently rather than treating
-				// this as a fatal 500 InternalError.
+				// Cache still filling: 503 + Retry-After so SDKs back off and retry.
 				glog.V(1).Infof("streamFromVolumeServers: remote object %s/%s not cached yet, returning 503 for retry", bucket, object)
 				w.Header().Set("Retry-After", "5")
 				s3err.WriteErrorResponse(w, r, s3err.ErrServiceUnavailable)

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1000,10 +1000,14 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 				entry = cachedEntry
 				glog.V(1).Infof("streamFromVolumeServers: successfully cached remote object, got %d chunks", len(chunks))
 			} else {
-				// Caching failed - return error to client
-				glog.Errorf("streamFromVolumeServers: failed to cache remote object for streaming")
-				s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
-				return newStreamErrorWithResponse(fmt.Errorf("failed to cache remote object for streaming"))
+				// Cache attempt did not produce chunks in time. The cache may still
+				// be filling in the background, so return 503 with Retry-After to
+				// let S3 SDKs back off and retry transparently rather than treating
+				// this as a fatal 500 InternalError.
+				glog.V(1).Infof("streamFromVolumeServers: remote object %s/%s not cached yet, returning 503 for retry", bucket, object)
+				w.Header().Set("Retry-After", "5")
+				s3err.WriteErrorResponse(w, r, s3err.ErrServiceUnavailable)
+				return newStreamErrorWithResponse(fmt.Errorf("remote object not cached yet"))
 			}
 		} else if totalSize > 0 && len(entry.Content) == 0 {
 			// Not a remote entry but has size without content - this is a data integrity issue


### PR DESCRIPTION
## Summary
- When a GET hits a remote-only object whose cache fill timed out or was canceled, return `503 ServiceUnavailable` with `Retry-After: 5` instead of `500 InternalError`.
- AWS SDKs (boto3, aws-sdk-go, etc.) already classify 503 as a retryable error and apply exponential backoff transparently, so clients recover without changes; 500 is treated as a fatal server bug and surfaces as `S3DownloadFailedError`.
- Matches AWS S3's "try again later" semantics for transient backpressure.

## Context
From https://github.com/seaweedfs/seaweedfs/discussions/9174 — large remote-only objects sometimes need a second GET to succeed because the first request triggers caching but the SDK times out before the cache fill completes. The cache is still filling in the background; the issue is purely about how the in-flight failure is reported.

Only one site is changed: the `cacheRemoteObjectForStreaming` failure branch in `streamFromVolumeServers`. Genuine streaming/data-integrity errors continue to return 500.

## Test plan
- [ ] `go build ./weed/s3api/...` (passes locally)
- [ ] Manual: configure a remote bucket, GET a large remote-only object whose cache fill exceeds the SDK socket timeout, confirm response is `503` with `Retry-After: 5` and that boto3 retries automatically and succeeds on the next attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for remote object caching. The system now distinguishes between client disconnects and temporary service unavailability, returning a 503 status with retry-after information when remote objects aren't fully cached yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->