### PR TITLE
fix(seaweed-volume): parse host:port.grpcPort in master address

### DIFF
--- a/seaweed-volume/src/server/heartbeat.rs
+++ b/seaweed-volume/src/server/heartbeat.rs
@@ -169,10 +169,20 @@ pub async fn run_heartbeat_with_state(
     }
 }
 
-/// Convert a master address "host:port" to a gRPC host:port target.
-/// The Go master uses port + 10000 for gRPC by default.
+/// Convert a master address to a gRPC `host:port` target.
+///
+/// Mirrors Go's `pb.ServerToGrpcAddress()`:
+/// - `host:port.grpcPort` returns `host:grpcPort` (explicit gRPC port).
+/// - `host:port` returns `host:(port+10000)` (Go's default offset).
+/// - Anything that fails to parse is returned unchanged.
 pub fn to_grpc_address(master_addr: &str) -> String {
     if let Some((host, port_str)) = master_addr.rsplit_once(':') {
+        // "host:port.grpcPort" — the part after the last '.' is the gRPC port.
+        if let Some((_, grpc_port)) = port_str.rsplit_once('.') {
+            if grpc_port.parse::<u16>().is_ok() {
+                return format!("{}:{}", host, grpc_port);
+            }
+        }
         if let Ok(port) = port_str.parse::<u16>() {
             let grpc_port = port + 10000;
             return format!("{}:{}", host, grpc_port);
@@ -1036,6 +1046,26 @@ mod tests {
             cli_white_list: vec![],
             state_file_path: String::new(),
         })
+    }
+
+    #[test]
+    fn test_to_grpc_address_default_offset() {
+        assert_eq!(to_grpc_address("10.0.0.1:9333"), "10.0.0.1:19333");
+        assert_eq!(to_grpc_address("localhost:9333"), "localhost:19333");
+    }
+
+    #[test]
+    fn test_to_grpc_address_explicit_grpc_port() {
+        // host:port.grpcPort form — gRPC port is what's after the dot.
+        assert_eq!(to_grpc_address("10.85.183.6:5300.6300"), "10.85.183.6:6300");
+        assert_eq!(to_grpc_address("master.local:9333.19333"), "master.local:19333");
+    }
+
+    #[test]
+    fn test_to_grpc_address_returns_input_when_unparseable() {
+        assert_eq!(to_grpc_address(""), "");
+        assert_eq!(to_grpc_address("no-port"), "no-port");
+        assert_eq!(to_grpc_address("host:not-a-port"), "host:not-a-port");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes the first bug from #9234: the Rust volume server's heartbeat client did not understand the Go-style `host:port.grpcPort` master address.
- Mirrors `pb.ServerToGrpcAddress()` so explicit gRPC ports are honored; otherwise fall back to the +10000 offset.

## Background
Go encodes a `ServerAddress` as `host:port[.grpcPort]`. When `--master 10.85.183.6:5300.6300` is passed to the Rust volume server, `to_grpc_address()` runs `rsplit_once(':')` and tries to parse `"5300.6300"` as a `u16`, fails, and returns the address unchanged — producing a malformed gRPC target and the `checkWithMaster ... transport error` reported in the issue.

## Test plan
- [x] `cargo test -p weed-volume --lib server::heartbeat`
- [x] New unit tests cover the default offset, explicit `port.grpcPort` form, and unparseable inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * gRPC address configuration now supports explicit port specification using the `host:port.grpcPort` format for more flexible address handling.

* **Tests**
  * Added unit tests verifying default offset conversion, explicit port parsing, and fallback behavior for various address input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->