### PR TITLE
fix(filer): return 503 + Retry-After when remote object not cached yet

### DIFF
--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -47,8 +47,11 @@ var ErrCacheNotReady = errors.New("remote object not cached yet")
 // writePrepareWriteFnErr writes an HTTP response for an error from
 // prepareWriteFn, before any 2xx headers have been written. Client cancels are
 // silent; ErrCacheNotReady becomes 503 + Retry-After; everything else is 500.
+// Clears Content-Length and Content-Range so callers that set them for the
+// success path don't leak stale values into the error response.
 func writePrepareWriteFnErr(w http.ResponseWriter, err error) {
 	w.Header().Del("Content-Length")
+	w.Header().Del("Content-Range")
 	switch {
 	case errors.Is(err, context.Canceled):
 		glog.V(3).Infof("ProcessRangeRequest: client disconnected: %v", err)

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -3,6 +3,7 @@ package weed_server
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,6 +38,28 @@ var startTime = time.Now()
 var writePool = sync.Pool{New: func() interface{} {
 	return bufio.NewWriterSize(nil, 128*1024)
 },
+}
+
+// ErrCacheNotReady signals that a remote-only object's local cache is still
+// filling. Callers should map it to 503 + Retry-After so SDKs back off and retry.
+var ErrCacheNotReady = errors.New("remote object not cached yet")
+
+// writePrepareWriteFnErr writes an HTTP response for an error from
+// prepareWriteFn, before any 2xx headers have been written. Client cancels are
+// silent; ErrCacheNotReady becomes 503 + Retry-After; everything else is 500.
+func writePrepareWriteFnErr(w http.ResponseWriter, err error) {
+	w.Header().Del("Content-Length")
+	switch {
+	case errors.Is(err, context.Canceled):
+		glog.V(3).Infof("ProcessRangeRequest: client disconnected: %v", err)
+	case errors.Is(err, ErrCacheNotReady):
+		glog.V(1).Infof("ProcessRangeRequest: cache not ready, returning 503: %v", err)
+		w.Header().Set("Retry-After", "5")
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+	default:
+		glog.Errorf("ProcessRangeRequest: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func init() {
@@ -290,9 +313,7 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 		w.Header().Set("Content-Length", strconv.FormatInt(totalSize, 10))
 		writeFn, err := prepareWriteFn(0, totalSize)
 		if err != nil {
-			glog.Errorf("ProcessRangeRequest: %v", err)
-			w.Header().Del("Content-Length")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writePrepareWriteFnErr(w, err)
 			return fmt.Errorf("ProcessRangeRequest: %w", err)
 		}
 		if err = writeFn(bufferedWriter); err != nil {
@@ -340,9 +361,7 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 
 		writeFn, err := prepareWriteFn(ra.start, ra.length)
 		if err != nil {
-			glog.Errorf("ProcessRangeRequest range[0]: %+v err: %v", w.Header(), err)
-			w.Header().Del("Content-Length")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writePrepareWriteFnErr(w, err)
 			return fmt.Errorf("ProcessRangeRequest: %w", err)
 		}
 		w.WriteHeader(http.StatusPartialContent)
@@ -365,9 +384,8 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 		}
 		writeFn, err := prepareWriteFn(ra.start, ra.length)
 		if err != nil {
-			glog.Errorf("ProcessRangeRequest range[%d] err: %v", i, err)
-			http.Error(w, "Internal Error", http.StatusInternalServerError)
-			return fmt.Errorf("ProcessRangeRequest range[%d] err: %v", i, err)
+			writePrepareWriteFnErr(w, err)
+			return fmt.Errorf("ProcessRangeRequest range[%d]: %w", i, err)
 		}
 		writeFnByRange[i] = writeFn
 	}

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 )
@@ -46,15 +47,19 @@ var ErrCacheNotReady = errors.New("remote object not cached yet")
 
 // writePrepareWriteFnErr writes an HTTP response for an error from
 // prepareWriteFn, before any 2xx headers have been written. Client cancels are
-// silent; ErrCacheNotReady becomes 503 + Retry-After; everything else is 500.
-// Clears Content-Length and Content-Range so callers that set them for the
-// success path don't leak stale values into the error response.
+// silent; filer_pb.ErrNotFound becomes 404; ErrCacheNotReady becomes 503 +
+// Retry-After; everything else is 500. Strips headers that described the
+// success body (Content-Length / Content-Range / Content-Disposition / ETag /
+// Last-Modified) so they don't get attached to the error response.
 func writePrepareWriteFnErr(w http.ResponseWriter, err error) {
-	w.Header().Del("Content-Length")
-	w.Header().Del("Content-Range")
+	for _, h := range []string{"Content-Length", "Content-Range", "Content-Disposition", "ETag", "Last-Modified"} {
+		w.Header().Del(h)
+	}
 	switch {
 	case errors.Is(err, context.Canceled):
 		glog.V(3).Infof("ProcessRangeRequest: client disconnected: %v", err)
+	case errors.Is(err, filer_pb.ErrNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
 	case errors.Is(err, ErrCacheNotReady):
 		glog.V(1).Infof("ProcessRangeRequest: cache not ready, returning 503: %v", err)
 		w.Header().Set("Retry-After", "5")

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -2,6 +2,7 @@ package weed_server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -214,6 +215,11 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 				// Client disconnected: surface ctx error so caller stays silent.
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					return nil, ctxErr
+				}
+				// Entry vanished mid-cache: forward NotFound so caller maps to 404,
+				// not the 503 retry-loop.
+				if errors.Is(err, filer_pb.ErrNotFound) {
+					return nil, err
 				}
 				// Cache still filling: tag with sentinel so caller maps to 503 + Retry-After.
 				glog.WarningfCtx(ctx, "CacheRemoteObjectToLocalCluster %s: %v", entry.FullPath, err)

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -211,8 +211,13 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 				Name:      name,
 			}); err != nil {
 				stats.FilerHandlerCounter.WithLabelValues(stats.ErrorReadCache).Inc()
-				glog.ErrorfCtx(ctx, "CacheRemoteObjectToLocalCluster %s: %v", entry.FullPath, err)
-				return nil, fmt.Errorf("cache %s: %v", entry.FullPath, err)
+				// Client disconnected: surface ctx error so caller stays silent.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, ctxErr
+				}
+				// Cache still filling: tag with sentinel so caller maps to 503 + Retry-After.
+				glog.WarningfCtx(ctx, "CacheRemoteObjectToLocalCluster %s: %v", entry.FullPath, err)
+				return nil, fmt.Errorf("cache %s: %w", entry.FullPath, ErrCacheNotReady)
 			} else {
 				chunks = resp.Entry.GetChunks()
 			}


### PR DESCRIPTION
## Summary
Mirror #9233 for the native filer HTTP handlers. When `GET /buckets/...` (or any filer HTTP read) hits a remote-only object whose cache fill hasn't completed yet, return `503 ServiceUnavailable` with `Retry-After: 5` instead of `500 InternalError`, and treat client disconnects as silent cancellations rather than logging them as errors.

## Changes
- New `ErrCacheNotReady` sentinel and a small `writePrepareWriteFnErr` helper in `weed/server/common.go`.
- `ProcessRangeRequest` calls the helper at all three pre-`WriteHeader` `prepareWriteFn`-error sites (no-range, single-range, multi-range), so the same classification (cancel / not-ready / other) applies regardless of the request shape.
- `filer_server_handlers_read.go`: when `CacheRemoteObjectToLocalCluster` fails, surface `ctx.Err()` if the client disconnected, else wrap with `ErrCacheNotReady` so the caller maps it to 503.

## Context
Follow-up to #9233 (which fixed the same problem for the S3 API). The filer HTTP path has the same failure mode — see https://github.com/seaweedfs/seaweedfs/discussions/9174#discussioncomment-16670672 for the user's logs (`ProcessRangeRequest: cache /buckets/sdk/dev/3gig.bin: context canceled`).

## Test plan
- [ ] `go build ./weed/server/...` (passes locally)
- [ ] Manual: configure a remote bucket, GET a large remote-only object via the filer HTTP endpoint, confirm response is `503` with `Retry-After: 5` (not `500`) when the cache fill hasn't completed; confirm client disconnects no longer log at Errorf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error responses for remote cache reads: returns 503 with Retry-After when cache not ready and maps missing objects to 404.
  * Suppresses noisy client-facing output for cancelled requests while preserving logs.
  * Ensures success-related headers are removed when an error is returned.
  * Clarified and standardized error messages for multi-range and other failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->