### PR TITLE
fix(seaweed-volume): accept redb aliases for --index

### DIFF
--- a/seaweed-volume/src/config.rs
+++ b/seaweed-volume/src/config.rs
@@ -63,7 +63,9 @@ pub struct Cli {
     #[arg(long = "rack", default_value = "")]
     pub rack: String,
 
-    /// Choose [memory|leveldb|leveldbMedium|leveldbLarge] mode for memory~performance balance.
+    /// Choose [memory|redb|redbMedium|redbLarge] mode for memory~performance balance.
+    /// `leveldb`/`leveldbMedium`/`leveldbLarge` are accepted as aliases for the
+    /// corresponding redb backends (Rust volume server uses redb under the hood).
     #[arg(long = "index", default_value = "memory")]
     pub index: String,
 
@@ -701,14 +703,16 @@ fn resolve_config(cli: Cli) -> VolumeServerConfig {
         ip.clone()
     };
 
-    // Parse index type
+    // Parse index type. Accept both `redb*` (preferred — what the volume server
+    // actually uses) and the legacy `leveldb*` names as aliases.
     let index_type = match cli.index.as_str() {
         "memory" => NeedleMapKind::InMemory,
-        "leveldb" => NeedleMapKind::LevelDb,
-        "leveldbMedium" => NeedleMapKind::LevelDbMedium,
-        "leveldbLarge" => NeedleMapKind::LevelDbLarge,
+        "redb" | "leveldb" => NeedleMapKind::Redb,
+        "redbMedium" | "leveldbMedium" => NeedleMapKind::RedbMedium,
+        "redbLarge" | "leveldbLarge" => NeedleMapKind::RedbLarge,
         other => panic!(
-            "Unknown index type: {}. Use memory|leveldb|leveldbMedium|leveldbLarge",
+            "Unknown index type: {}. Use memory|redb|redbMedium|redbLarge \
+             (leveldb/leveldbMedium/leveldbLarge accepted as aliases)",
             other
         ),
     };
@@ -1372,6 +1376,23 @@ mod tests {
     fn test_resolve_config_defaults_dir_to_platform_temp_dir() {
         let cfg = resolve_config(Cli::parse_from(["bin"]));
         assert_eq!(cfg.folders, vec![default_volume_dir()]);
+    }
+
+    #[test]
+    fn test_resolve_config_index_accepts_redb_and_leveldb_aliases() {
+        let pairs = [
+            ("memory", NeedleMapKind::InMemory),
+            ("redb", NeedleMapKind::Redb),
+            ("leveldb", NeedleMapKind::Redb),
+            ("redbMedium", NeedleMapKind::RedbMedium),
+            ("leveldbMedium", NeedleMapKind::RedbMedium),
+            ("redbLarge", NeedleMapKind::RedbLarge),
+            ("leveldbLarge", NeedleMapKind::RedbLarge),
+        ];
+        for (input, expected) in pairs {
+            let cfg = resolve_config(Cli::parse_from(["bin", "--index", input]));
+            assert_eq!(cfg.index_type, expected, "input={}", input);
+        }
     }
 
     #[test]

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -146,9 +146,9 @@ impl NeedleMapMetric {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NeedleMapKind {
     InMemory,
-    LevelDb,
-    LevelDbMedium,
-    LevelDbLarge,
+    Redb,
+    RedbMedium,
+    RedbLarge,
 }
 
 // ============================================================================

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -776,7 +776,7 @@ impl Volume {
     fn load_index(&mut self) -> Result<(), VolumeError> {
         let use_redb = matches!(
             self.needle_map_kind,
-            NeedleMapKind::LevelDb | NeedleMapKind::LevelDbMedium | NeedleMapKind::LevelDbLarge
+            NeedleMapKind::Redb | NeedleMapKind::RedbMedium | NeedleMapKind::RedbLarge
         );
 
         let idx_path = self.file_name(".idx");


### PR DESCRIPTION
## Summary
- Fixes the second bug from #9234: `--index` rejected `redb` even though the wiki advertises it and the Rust volume server only has a redb-backed disk index (`RedbNeedleMap`).
- `--index` now accepts `memory|redb|redbMedium|redbLarge` as the canonical names, with `leveldb/leveldbMedium/leveldbLarge` kept as aliases for compatibility.
- Renames the internal `NeedleMapKind` variants from `LevelDb*` to `Redb*` so the type names match what the code actually does (the disk backend has always been redb).

## Test plan
- [x] `cargo test -p weed-volume --lib` (244 tests pass)
- [x] New `test_resolve_config_index_accepts_redb_and_leveldb_aliases` covers each accepted spelling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage backend naming from `LevelDb` to `Redb` for consistency
  * Enhanced CLI `--index` option help text to advertise `redb` variants and document `leveldb` as supported aliases
  * Configuration now correctly maps both preferred and legacy storage backend names to appropriate index types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->