### PR TITLE
Export `file_read_invalid_needles` metric for REST read requests on invalid file IDs.

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -57,6 +57,7 @@ func (vs *VolumeServer) proxyReqToTargetServer(w http.ResponseWriter, r *http.Re
 	lookupResult, err := operation.LookupVolumeId(vs.GetMaster, vs.grpcDialOption, volumeId.String())
 	if err != nil || len(lookupResult.Locations) <= 0 {
 		glog.V(0).Infoln("lookup error:", err, r.URL.Path)
+		stats.VolumeServerFileReadInvalidNeedles.Inc()
 		NotFound(w)
 		return
 	}
@@ -65,16 +66,17 @@ func (vs *VolumeServer) proxyReqToTargetServer(w http.ResponseWriter, r *http.Re
 			lookupResult.Locations[i], lookupResult.Locations[j] = lookupResult.Locations[j], lookupResult.Locations[i]
 		})
 	}
-	var tragetUrl *url.URL
+	var targetUrl *url.URL
 	location := fmt.Sprintf("%s:%d", vs.store.Ip, vs.store.Port)
 	for _, loc := range lookupResult.Locations {
 		if !strings.Contains(loc.Url, location) {
 			rawURL, _ := util_http.NormalizeUrl(loc.Url)
-			tragetUrl, _ = url.Parse(rawURL)
+			targetUrl, _ = url.Parse(rawURL)
 			break
 		}
 	}
-	if tragetUrl == nil {
+	if targetUrl == nil {
+		stats.VolumeServerFileReadInvalidNeedles.Inc()
 		stats.VolumeServerHandlerCounter.WithLabelValues(stats.EmptyReadProxyLoc).Inc()
 		glog.Errorf("failed lookup target host is empty locations: %+v, %s", lookupResult.Locations, location)
 		NotFound(w)
@@ -83,8 +85,8 @@ func (vs *VolumeServer) proxyReqToTargetServer(w http.ResponseWriter, r *http.Re
 	if vs.ReadMode == "proxy" {
 		stats.VolumeServerHandlerCounter.WithLabelValues(stats.ReadProxyReq).Inc()
 		// proxy client request to target server
-		r.URL.Host = tragetUrl.Host
-		r.URL.Scheme = tragetUrl.Scheme
+		r.URL.Host = targetUrl.Host
+		r.URL.Scheme = targetUrl.Scheme
 		query := r.URL.Query()
 		query.Set(reqIsProxied, "true")
 		r.URL.RawQuery = query.Encode()
@@ -125,14 +127,14 @@ func (vs *VolumeServer) proxyReqToTargetServer(w http.ResponseWriter, r *http.Re
 	} else {
 		// redirect
 		stats.VolumeServerHandlerCounter.WithLabelValues(stats.ReadRedirectReq).Inc()
-		tragetUrl.Path = fmt.Sprintf("%s/%s,%s", tragetUrl.Path, vid, fid)
+		targetUrl.Path = fmt.Sprintf("%s/%s,%s", targetUrl.Path, vid, fid)
 		arg := url.Values{}
 		if c := r.FormValue("collection"); c != "" {
 			arg.Set("collection", c)
 		}
 		arg.Set(reqIsProxied, "true")
-		tragetUrl.RawQuery = arg.Encode()
-		http.Redirect(w, r, tragetUrl.String(), http.StatusMovedPermanently)
+		targetUrl.RawQuery = arg.Encode()
+		http.Redirect(w, r, targetUrl.String(), http.StatusMovedPermanently)
 		return
 	}
 }
@@ -164,6 +166,7 @@ func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request)
 	_, hasEcVolume := vs.store.FindEcVolume(volumeId)
 	if !hasVolume && !hasEcVolume {
 		if vs.ReadMode == "local" {
+			stats.VolumeServerFileReadInvalidNeedles.Inc()
 			glog.V(0).Infoln("volume is not local:", err, r.URL.Path)
 			NotFound(w)
 			return
@@ -207,7 +210,11 @@ func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request)
 	// glog.V(4).Infoln("read bytes", count, "error", err)
 	if err != nil || count < 0 {
 		glog.V(3).Infof("read %s isNormalVolume %v error: %v", r.URL.Path, hasVolume, err)
-		if err == storage.ErrorNotFound || err == storage.ErrorDeleted || errors.Is(err, erasure_coding.NotFoundError) {
+		invalid_needle := err == storage.ErrorNotFound || errors.Is(err, erasure_coding.NotFoundError)
+		if invalid_needle {
+			stats.VolumeServerFileReadInvalidNeedles.Inc()
+		}
+		if invalid_needle || err == storage.ErrorDeleted {
 			NotFound(w)
 		} else {
 			InternalError(w)

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -378,6 +378,14 @@ var (
 			Help:      "Counter of overall failed file read requests from clients.",
 		})
 
+	VolumeServerFileReadInvalidNeedles = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "file_read_invalid_needles",
+			Help:      "Counter of failed file read requests due to invalid needle IDs from clients.",
+		})
+
 	VolumeServerFileWriteFailures = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -554,6 +562,7 @@ func init() {
 	Gather.MustRegister(VolumeServerInFlightUploadSize)
 	Gather.MustRegister(VolumeServerMasterDisconnections)
 	Gather.MustRegister(VolumeServerFileReadFailures)
+	Gather.MustRegister(VolumeServerFileReadInvalidNeedles)
 	Gather.MustRegister(VolumeServerFileWriteFailures)
 
 	Gather.MustRegister(S3RequestCounter)


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/8535

# How are we solving the problem?

Provides a straightforward metric to count read requests with incorrect file/needle IDs, which can indicate client issues.

Note that the metric does not cover gRPC calls, as the proto API does not support seeking files by ID.

# How is the PR tested?

Prometheus counter metrics, no tests affected.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new metric to track volume-server file read failures caused by invalid needle IDs, improving observability and diagnostics.
* **Bug Fixes**
  * Incremented that metric in additional "not found" read paths (missing lookups, unavailable targets, and read errors classified as not-found) so failure counts more accurately reflect read-not-found conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->