### PR TITLE
chore(weed/topology): prune unused functions

### DIFF
--- a/weed/topology/configuration.go
+++ b/weed/topology/configuration.go
@@ -4,10 +4,6 @@ import (
 	"encoding/xml"
 )
 
-type loc struct {
-	dcName   string
-	rackName string
-}
 type rack struct {
 	Name string   `xml:"name,attr"`
 	Ips  []string `xml:"Ip"`

--- a/weed/topology/volume_growth_reservation_test.go
+++ b/weed/topology/volume_growth_reservation_test.go
@@ -7,20 +7,12 @@ import (
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
-	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 )
 
 // MockGrpcDialOption simulates grpc connection for testing
 type MockGrpcDialOption struct{}
-
-// simulateVolumeAllocation mocks the volume allocation process
-func simulateVolumeAllocation(server *DataNode, vid needle.VolumeId, option *VolumeGrowOption) error {
-	// Simulate some processing time
-	time.Sleep(time.Millisecond * 10)
-	return nil
-}
 
 func TestVolumeGrowth_ReservationBasedAllocation(t *testing.T) {
 	// Create test topology with single server for predictable behavior

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -156,7 +156,7 @@ func NewVolumeLayout(rp *super_block.ReplicaPlacement, ttl *needle.TTL, diskType
 		vacuumedVolumes:  make(map[needle.VolumeId]time.Time),
 		volumeSizeLimit:  volumeSizeLimit,
 		replicationAsMin: replicationAsMin,
-		sizeTracking:    make(map[needle.VolumeId]*volumeSizeTracking),
+		sizeTracking:     make(map[needle.VolumeId]*volumeSizeTracking),
 	}
 }
 
@@ -362,10 +362,6 @@ func (vl *VolumeLayout) isOversized(v *storage.VolumeInfo) bool {
 	return uint64(v.Size) >= vl.volumeSizeLimit
 }
 
-func (vl *VolumeLayout) isCrowdedVolume(v *storage.VolumeInfo) bool {
-	return float64(v.Size) > float64(vl.volumeSizeLimit)*VolumeGrowStrategy.Threshold
-}
-
 // RecordAssign adds the estimated byte size to the volume's tracked effective
 // size and updates the volume's writable state:
 //
@@ -488,7 +484,6 @@ func (vl *VolumeLayout) DrainAndRemoveFromWritable(vid needle.VolumeId) {
 	vl.accessLock.Unlock()
 	vl.waitForPendingDrain(context.Background(), vid)
 }
-
 
 func (vl *VolumeLayout) isEmpty() bool {
 	vl.accessLock.RLock()


### PR DESCRIPTION
This prunes a dead type and unused functions from `weed/topology`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code, helper methods, and testing utilities to improve code maintainability and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->