### PR TITLE
feat(docker): default CMD to `mini -dir=/data` for service-container use

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -89,3 +89,8 @@ WORKDIR /data
 
 # Entrypoint will handle permission fixes and user switching
 ENTRYPOINT ["/entrypoint.sh"]
+# Default to a complete single-process cluster (master+volume+filer+S3+admin)
+# so the image is usable out of the box — including in environments like
+# GitHub Actions service containers that cannot pass arguments to the entrypoint.
+# Override with any other subcommand at `docker run` / compose time.
+CMD ["mini", "-dir=/data"]

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -40,3 +40,8 @@ WORKDIR /data
 
 # Entrypoint will handle permission fixes and user switching
 ENTRYPOINT ["/entrypoint.sh"]
+# Default to a complete single-process cluster (master+volume+filer+S3+admin)
+# so the image is usable out of the box — including in environments like
+# GitHub Actions service containers that cannot pass arguments to the entrypoint.
+# Override with any other subcommand at `docker run` / compose time.
+CMD ["mini", "-dir=/data"]

--- a/docker/Dockerfile.rocksdb_large
+++ b/docker/Dockerfile.rocksdb_large
@@ -68,3 +68,8 @@ WORKDIR /data
 
 # Entrypoint will handle permission fixes and user switching
 ENTRYPOINT ["/entrypoint.sh"]
+# Default to a complete single-process cluster (master+volume+filer+S3+admin)
+# so the image is usable out of the box — including in environments like
+# GitHub Actions service containers that cannot pass arguments to the entrypoint.
+# Override with any other subcommand at `docker run` / compose time.
+CMD ["mini", "-dir=/data"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,17 +37,21 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 isArgPassed() {
+  # Match both `-flag` and `--flag` (and their `=value` forms): the Go fla9
+  # library accepts both, and users may pick either form on the CLI.
   arg="$1"
   argWithEqualSign="$1="
+  argDouble="-$1"
+  argDoubleWithEqualSign="-$1="
   shift
   while [ $# -gt 0 ]; do
     passedArg="$1"
     shift
     case $passedArg in
-    "$arg")
+    "$arg"|"$argDouble")
       return 0
       ;;
-    "$argWithEqualSign"*)
+    "$argWithEqualSign"*|"$argDoubleWithEqualSign"*)
       return 0
       ;;
     esac

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -95,6 +95,15 @@ case "$1" in
   	exec /usr/bin/weed -logtostderr=true server $ARGS $@
   	;;
 
+  'mini')
+  	ARGS="-dir=/data"
+  	if isArgPassed "-dir" "$@"; then
+  	  ARGS=""
+  	fi
+  	shift
+  	exec /usr/bin/weed -logtostderr=true mini $ARGS $@
+  	;;
+
   'filer')
   	ARGS=""
   	shift


### PR DESCRIPTION
## Summary

- Set `CMD ["mini", "-dir=/data"]` on the released Docker images (`Dockerfile.go_build`, `Dockerfile.rocksdb_large`, `Dockerfile.local`) so the image starts a complete single-process cluster out of the box: master + volume + filer + S3 on `:8333` + admin UI.
- Add a `mini` case to `entrypoint.sh` that passes `-logtostderr=true`, mirroring the existing master/volume/server/s3 cases — without it, glog defaults to writing to files instead of the container log stream.
- Backwards compatible: any subcommand passed at `docker run` / `docker compose` time still overrides the default CMD.

## Why

Closes #9247. GitHub Actions' `services:` block exposes `image:`, `env:`, `ports:`, `volumes:`, and `options:`, but does not let you pass arguments to the image entrypoint (see [actions/runner#2139](https://github.com/actions/runner/issues/2139)). With no default CMD, `chrislusf/seaweedfs` exits as soon as it starts in that environment because `weed` requires a subcommand.

`weed mini` is purpose-built for "S3 beginners and small/dev use cases" (see its `Long` doc in `weed/command/mini.go`) — auto-tuned volume sizes, single-master mode, default S3 on :8333. It's the right default for the GHA service-container use case as well as for `docker run chrislusf/seaweedfs` with no args.

## Test plan

- [x] Built locally via `Dockerfile.local`; `docker inspect` shows `Cmd=["mini","-dir=/data"]`, `Entrypoint=["/entrypoint.sh"]`.
- [x] Ran `docker run -d -p 18333:8333 seaweedfs:cmd-test` (no args). `curl http://127.0.0.1:18333/` returned HTTP 200 with a valid `<ListAllMyBucketsResult>`.
- [x] Verified entrypoint dispatch via shell stub: explicit `master`, `volume -max=5`, `s3 -port=8333`, and `mini -dir=/tmp/foo` all route correctly with no double-injection of default flags.
- [ ] CI build of all release variants on tag push (will be exercised by the next release tag via `container_release_unified.yml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Containers now provide a usable default command to start a single-process "mini" cluster out-of-the-box while still allowing overrides.
* **Bug Fixes / Improvements**
  * Startup logic now detects user-provided directory flags (short or long forms) and avoids applying default directory arguments when already specified, preventing duplicate/ignored options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->