### PR TITLE
Export Prometheus metrics for scrubbing operations.

### DIFF
--- a/weed/server/volume_grpc_scrub.go
+++ b/weed/server/volume_grpc_scrub.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 )
@@ -68,6 +71,11 @@ func (vs *VolumeServer) ScrubVolume(ctx context.Context, req *volume_server_pb.S
 			}
 		}
 	}
+
+	scrubLabels := prometheus.Labels{"mode": req.GetMode().String()}
+	stats.VolumeServerScrubLastTimeSeconds.With(scrubLabels).Set(float64(time.Now().Unix()))
+	stats.VolumeServerScrubVolumeFailures.With(scrubLabels).Add(float64(len(brokenVolumes)))
+
 	if len(errs) != 0 {
 		return nil, errors.Join(errs...)
 	}
@@ -128,6 +136,11 @@ func (vs *VolumeServer) ScrubEcVolume(ctx context.Context, req *volume_server_pb
 			}
 		}
 	}
+
+	scrubLabels := prometheus.Labels{"mode": req.GetMode().String()}
+	stats.VolumeServerScrubLastTimeSeconds.With(scrubLabels).Set(float64(time.Now().Unix()))
+	stats.VolumeServerScrubVolumeFailures.With(scrubLabels).Add(float64(len(brokenVolumeIds)))
+	stats.VolumeServerScrubShardFailures.With(scrubLabels).Add(float64(len(brokenShardInfos)))
 
 	res := &volume_server_pb.ScrubEcVolumeResponse{
 		TotalVolumes:     totalVolumes,

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -394,6 +394,30 @@ var (
 			Help:      "Counter of overall failed file write requests from clients.",
 		})
 
+	VolumeServerScrubLastTimeSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "scrub_last_time_seconds",
+			Help:      "Last scrub execution time, as seconds since UNIX epoch.",
+		}, []string{"mode"})
+
+	VolumeServerScrubVolumeFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "scrub_volume_failures",
+			Help:      "Counter of overall volumes with issues detected during scrubbing.",
+		}, []string{"mode"})
+
+	VolumeServerScrubShardFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "scrub_shard_failures",
+			Help:      "Counter of overall EC shards with issues detected during scrubbing.",
+		}, []string{"mode"})
+
 	S3RequestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -564,6 +588,9 @@ func init() {
 	Gather.MustRegister(VolumeServerFileReadFailures)
 	Gather.MustRegister(VolumeServerFileReadInvalidNeedles)
 	Gather.MustRegister(VolumeServerFileWriteFailures)
+	Gather.MustRegister(VolumeServerScrubLastTimeSeconds)
+	Gather.MustRegister(VolumeServerScrubVolumeFailures)
+	Gather.MustRegister(VolumeServerScrubShardFailures)
 
 	Gather.MustRegister(S3RequestCounter)
 	Gather.MustRegister(S3HandlerCounter)


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/8535

# How are we solving the problem?

This PR introduces three new metrics...

  - `scrub_last_time_seconds`
  - `scrub_volume_failures`
  - `scrub_shard_failures`

...capturing overall volume scrub results, and allowing to construct alerts and dashboards to monitor scrubbing progress.

Note that these metrics are aggregated at the volume/EC shard level, and not intended for fine-grained tracking of scrubbing operations.

# How is the PR tested?

Prometheus counter metrics, no tests affected.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for volume scrubbing operations to track last execution time and failure counts for volumes and EC shards, keyed by scrub mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->