### PR TITLE
mount: expose -fuse.maxBackground and -fuse.congestionThreshold flags (closes #9258)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/rdleal/intervalst v1.5.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/schollz/progressbar/v3 v3.19.0
-	github.com/seaweedfs/go-fuse/v2 v2.9.2
+	github.com/seaweedfs/go-fuse/v2 v2.9.3
 	github.com/shirou/gopsutil/v4 v4.26.2
 	github.com/tarantool/go-tarantool/v2 v2.4.2
 	github.com/testcontainers/testcontainers-go v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -1842,6 +1842,8 @@ github.com/seaweedfs/cockroachdb-parser v0.0.0-20260225204133-2f342c5ea564 h1:Tg
 github.com/seaweedfs/cockroachdb-parser v0.0.0-20260225204133-2f342c5ea564/go.mod h1:JSKCh6uCHBz91lQYFYHCyTrSVIPge4SUFVn28iwMNB0=
 github.com/seaweedfs/go-fuse/v2 v2.9.2 h1:IfP/yFjLGO4rALcJY2Gb39PlebHxLnj7dkIiQAjFres=
 github.com/seaweedfs/go-fuse/v2 v2.9.2/go.mod h1:zABdmWEa6A0bwaBeEOBUeUkGIZlxUhcdv+V1Dcc/U/I=
+github.com/seaweedfs/go-fuse/v2 v2.9.3 h1:rJufGrHImTx7yoGUmetUi+To4LrmTQJROJnBHWt92ic=
+github.com/seaweedfs/go-fuse/v2 v2.9.3/go.mod h1:zABdmWEa6A0bwaBeEOBUeUkGIZlxUhcdv+V1Dcc/U/I=
 github.com/seaweedfs/goexif v1.0.3 h1:ve/OjI7dxPW8X9YQsv3JuVMaxEyF9Rvfd04ouL+Bz30=
 github.com/seaweedfs/goexif v1.0.3/go.mod h1:Oni780Z236sXpIQzk1XoJlTwqrJ02smEin9zQeff7Fk=
 github.com/seaweedfs/raft v1.1.7 h1:3mVJZ2p4rdvBtbbrHROPjYKtH+q5qjMBc56G6VRu1kA=

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -68,10 +68,11 @@ type MountOptions struct {
 	posixDirNlink *bool
 
 	// FUSE performance options
-	writebackCache    *bool
-	asyncDio          *bool
-	cacheSymlink      *bool
-	fuseMaxBackground *int
+	writebackCache          *bool
+	asyncDio                *bool
+	cacheSymlink            *bool
+	fuseMaxBackground       *int
+	fuseCongestionThreshold *int
 
 	// macOS-specific FUSE options
 	novncache *bool
@@ -160,7 +161,8 @@ func init() {
 	mountOptions.writebackCache = cmdMount.Flag.Bool("writebackCache", false, "enable FUSE writeback cache for improved write performance (at risk of data loss on crash)")
 	mountOptions.asyncDio = cmdMount.Flag.Bool("asyncDio", false, "enable async direct I/O for better concurrency")
 	mountOptions.cacheSymlink = cmdMount.Flag.Bool("cacheSymlink", false, "enable symlink caching to reduce metadata lookups")
-	mountOptions.fuseMaxBackground = cmdMount.Flag.Int("fuse.maxBackground", 128, "FUSE max_background: maximum in-flight asynchronous requests the kernel will queue. Heavy upload workloads may benefit from higher values (e.g. 2048). Equivalent to writing /sys/fs/fuse/connections/<id>/max_background. The kernel derives congestion_threshold as 3/4 of this value.")
+	mountOptions.fuseMaxBackground = cmdMount.Flag.Int("fuse.maxBackground", 128, "FUSE max_background: maximum in-flight asynchronous requests the kernel will queue. Heavy upload workloads may benefit from higher values (e.g. 2048). Equivalent to writing /sys/fs/fuse/connections/<id>/max_background. If -fuse.congestionThreshold is 0, the kernel derives it as 3/4 of this value.")
+	mountOptions.fuseCongestionThreshold = cmdMount.Flag.Int("fuse.congestionThreshold", 0, "FUSE congestion_threshold: in-flight async request count at which the kernel marks the FUSE bdi as congested and throttles new submissions. 0 means use the default (3/4 of -fuse.maxBackground). Equivalent to writing /sys/fs/fuse/connections/<id>/congestion_threshold. The kernel silently clamps this to -fuse.maxBackground when set higher.")
 
 	// macOS-specific FUSE options
 	mountOptions.novncache = cmdMount.Flag.Bool("sys.novncache", false, "(macOS only) disable vnode name caching to avoid stale data")

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -68,9 +68,10 @@ type MountOptions struct {
 	posixDirNlink *bool
 
 	// FUSE performance options
-	writebackCache *bool
-	asyncDio       *bool
-	cacheSymlink   *bool
+	writebackCache    *bool
+	asyncDio          *bool
+	cacheSymlink      *bool
+	fuseMaxBackground *int
 
 	// macOS-specific FUSE options
 	novncache *bool
@@ -159,6 +160,7 @@ func init() {
 	mountOptions.writebackCache = cmdMount.Flag.Bool("writebackCache", false, "enable FUSE writeback cache for improved write performance (at risk of data loss on crash)")
 	mountOptions.asyncDio = cmdMount.Flag.Bool("asyncDio", false, "enable async direct I/O for better concurrency")
 	mountOptions.cacheSymlink = cmdMount.Flag.Bool("cacheSymlink", false, "enable symlink caching to reduce metadata lookups")
+	mountOptions.fuseMaxBackground = cmdMount.Flag.Int("fuse.maxBackground", 128, "FUSE max_background: maximum in-flight asynchronous requests the kernel will queue. Heavy upload workloads may benefit from higher values (e.g. 2048). Equivalent to writing /sys/fs/fuse/connections/<id>/max_background. The kernel derives congestion_threshold as 3/4 of this value.")
 
 	// macOS-specific FUSE options
 	mountOptions.novncache = cmdMount.Flag.Bool("sys.novncache", false, "(macOS only) disable vnode name caching to avoid stale data")

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -242,11 +242,16 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		fsName = "fuse"
 	}
 
+	maxBackground := 128
+	if option.fuseMaxBackground != nil && *option.fuseMaxBackground > 0 {
+		maxBackground = *option.fuseMaxBackground
+	}
+
 	// mount fuse
 	fuseMountOptions := &fuse.MountOptions{
 		AllowOther:               *option.allowOthers,
 		Options:                  option.extraOptions,
-		MaxBackground:            128,
+		MaxBackground:            maxBackground,
 		MaxWrite:                 1024 * 1024 * 2,
 		MaxReadAhead:             1024 * 1024 * 2,
 		IgnoreSecurityLabels:     false,

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -246,12 +246,17 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	if option.fuseMaxBackground != nil && *option.fuseMaxBackground > 0 {
 		maxBackground = *option.fuseMaxBackground
 	}
+	congestionThreshold := 0
+	if option.fuseCongestionThreshold != nil && *option.fuseCongestionThreshold > 0 {
+		congestionThreshold = *option.fuseCongestionThreshold
+	}
 
 	// mount fuse
 	fuseMountOptions := &fuse.MountOptions{
 		AllowOther:               *option.allowOthers,
 		Options:                  option.extraOptions,
 		MaxBackground:            maxBackground,
+		CongestionThreshold:      congestionThreshold,
 		MaxWrite:                 1024 * 1024 * 2,
 		MaxReadAhead:             1024 * 1024 * 2,
 		IgnoreSecurityLabels:     false,


### PR DESCRIPTION
## Summary

Two CLI flags on `weed mount` to make the kernel FUSE concurrency knobs persistent across remounts/reboots:

- `-fuse.maxBackground` (default `128`, unchanged): kernel cap on async in-flight requests, equivalent to `/sys/fs/fuse/connections/<id>/max_background`.
- `-fuse.congestionThreshold` (default `0` = use kernel default of `3/4 * max_background`): the in-flight count at which the kernel marks the FUSE bdi congested, equivalent to `/sys/fs/fuse/connections/<id>/congestion_threshold`.

Closes #9258.

## Why

The user in #9258 has to do this on every reboot:

```bash
echo 2048 | sudo tee /sys/fs/fuse/connections/<id>/max_background
echo 1536 | sudo tee /sys/fs/fuse/connections/<id>/congestion_threshold
```

…because `/sys/fs/fuse/connections` lives in memory. With these flags:

```bash
weed mount -filer=... -dir=/mnt/sw -fuse.maxBackground=2048
# kernel auto-derives congestion_threshold=1536 (3/4 * 2048) — same as the manual case
```

For non-3/4 ratios, both flags can be set explicitly:

```bash
weed mount ... -fuse.maxBackground=2048 -fuse.congestionThreshold=1900
```

## Dependencies

- Bumps `github.com/seaweedfs/go-fuse/v2` from `v2.9.2` to `v2.9.3`. v2.9.3 adds a `CongestionThreshold` field to `MountOptions` (previously the value was hardcoded to `3/4 * MaxBackground` inside `doInit`). The new field is fully backward-compatible — zero-value semantics match the old hardcoded formula, so no other go-fuse callers need to change.

## Test plan

- [x] `go build ./weed/command/...` passes.
- [x] `go vet ./weed/command/...` produces no new warnings.
- [ ] Manual: `weed mount -dir=/mnt/sw -fuse.maxBackground=2048`, then verify `cat /sys/fs/fuse/connections/<id>/max_background` reports `2048` and `congestion_threshold` reports `1536`.
- [ ] Manual: `weed mount -dir=/mnt/sw -fuse.maxBackground=2048 -fuse.congestionThreshold=1900`, then verify `congestion_threshold` reports `1900`.
- [ ] Default (no flag): `max_background=128`, `congestion_threshold=96`.

## Wiki

`FUSE-Mount.md` on the seaweedfs.wiki has a "Tuning kernel FUSE concurrency" subsection documenting both flags, the 3/4 default, and the kernel's clamp-to-max_background rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-fuse.maxBackground` CLI flag to configure the maximum number of background FUSE requests during mount operations (defaults to 128).
  * Added `-fuse.congestionThreshold` CLI flag to configure FUSE congestion threshold during mounts (defaults to 0).

* **Bug Fixes / Improvements**
  * Mount logic now applies these values to improve FUSE performance tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->