### PR TITLE
test(s3): force-drop collection after deleteBucket in tagging/versioning/cors/copying

### DIFF
--- a/test/s3/copying/s3_copying_test.go
+++ b/test/s3/copying/s3_copying_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	mathrand "math/rand"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -24,30 +25,35 @@ import (
 
 // S3TestConfig holds configuration for S3 tests
 type S3TestConfig struct {
-	Endpoint      string
-	AccessKey     string
-	SecretKey     string
-	Region        string
-	BucketPrefix  string
-	UseSSL        bool
-	SkipVerifySSL bool
+	Endpoint       string
+	MasterEndpoint string
+	AccessKey      string
+	SecretKey      string
+	Region         string
+	BucketPrefix   string
+	UseSSL         bool
+	SkipVerifySSL  bool
 }
 
 // Default test configuration - should match test_config.json
 var defaultConfig = &S3TestConfig{
-	Endpoint:      "http://127.0.0.1:8000", // Use explicit IPv4 address
-	AccessKey:     "some_access_key1",
-	SecretKey:     "some_secret_key1",
-	Region:        "us-east-1",
-	BucketPrefix:  "test-copying-",
-	UseSSL:        false,
-	SkipVerifySSL: true,
+	Endpoint:       "http://127.0.0.1:8000", // Use explicit IPv4 address
+	MasterEndpoint: "http://127.0.0.1:9333", // Default SeaweedFS master HTTP port
+	AccessKey:      "some_access_key1",
+	SecretKey:      "some_secret_key1",
+	Region:         "us-east-1",
+	BucketPrefix:   "test-copying-",
+	UseSSL:         false,
+	SkipVerifySSL:  true,
 }
 
 func init() {
 	mathrand.Seed(time.Now().UnixNano())
 	if endpoint := os.Getenv("S3_ENDPOINT"); endpoint != "" {
 		defaultConfig.Endpoint = endpoint
+	}
+	if masterEndpoint := os.Getenv("MASTER_ENDPOINT"); masterEndpoint != "" {
+		defaultConfig.MasterEndpoint = masterEndpoint
 	}
 }
 
@@ -128,8 +134,16 @@ func createBucket(t *testing.T, client *s3.Client, bucketName string) {
 	require.NoError(t, err)
 }
 
-// deleteBucket deletes a bucket and all its contents
+// deleteBucket deletes a bucket and all its contents.
+// Always force-drops the underlying collection at the master afterwards: the S3
+// DeleteBucket can race with concurrent `volume_grow` requests (the warm-create
+// batch keeps registering volumes after the master's collection-delete sweep has
+// already snapshotted the layout), so 1-3 volumes per bucket can leak. Without
+// this, running enough tests on a single `weed mini` server exhausts the data
+// node's volume slots and every subsequent PutObject 500s with "Not enough data
+// nodes found".
 func deleteBucket(t *testing.T, client *s3.Client, bucketName string) {
+	defer forceDeleteCollection(t, bucketName)
 	// First, delete all objects
 	deleteAllObjects(t, client, bucketName)
 
@@ -142,6 +156,39 @@ func deleteBucket(t *testing.T, client *s3.Client, bucketName string) {
 		if !strings.Contains(err.Error(), "NoSuchBucket") {
 			t.Logf("Warning: failed to delete bucket %s: %v", bucketName, err)
 		}
+	}
+}
+
+// forceDeleteCollection drops the SeaweedFS collection backing a test bucket via the master's
+// /col/delete admin endpoint. The S3 layer normally drops the collection on DeleteBucket, but
+// in-flight `volume_grow` requests can register volumes after the master's first sweep, leaking
+// them. Best-effort: a 400 from the master means the collection was already gone, which is the
+// success path and not an error.
+func forceDeleteCollection(t *testing.T, bucketName string) {
+	if defaultConfig.MasterEndpoint == "" {
+		return
+	}
+	endpoint := strings.TrimRight(defaultConfig.MasterEndpoint, "/") + "/col/delete?collection=" + url.QueryEscape(bucketName)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Logf("Note: building collection delete request for %s failed: %v", bucketName, err)
+		return
+	}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logf("Note: force-delete collection %s failed: %v", bucketName, err)
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		t.Logf("Force-deleted collection %s", bucketName)
+	case http.StatusBadRequest:
+		// Collection already gone - normal path when DeleteBucket succeeded.
+	default:
+		t.Logf("Note: force-delete collection %s returned HTTP %d", bucketName, resp.StatusCode)
 	}
 }
 

--- a/test/s3/copying/s3_copying_test.go
+++ b/test/s3/copying/s3_copying_test.go
@@ -104,6 +104,12 @@ func getNewBucketName() string {
 	return fmt.Sprintf("%s%d-%d", defaultConfig.BucketPrefix, timestamp, randomSuffix)
 }
 
+// testRunStart marks when this test process started; cleanupTestBuckets only
+// sweeps buckets created before this point so a concurrent `go test` run against
+// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
+// gives clock skew between test host and master room.
+var testRunStart = time.Now().Add(-time.Minute)
+
 // cleanupTestBuckets removes any leftover test buckets from previous runs
 func cleanupTestBuckets(t *testing.T, client *s3.Client) {
 	resp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
@@ -114,6 +120,10 @@ func cleanupTestBuckets(t *testing.T, client *s3.Client) {
 
 	for _, bucket := range resp.Buckets {
 		bucketName := *bucket.Name
+		// Skip buckets newer than this process — they belong to a concurrent run.
+		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
+			continue
+		}
 		// Only delete buckets that match our test prefix
 		if strings.HasPrefix(bucketName, defaultConfig.BucketPrefix) {
 			t.Logf("Cleaning up leftover test bucket: %s", bucketName)

--- a/test/s3/copying/s3_copying_test.go
+++ b/test/s3/copying/s3_copying_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -101,16 +102,20 @@ func getNewBucketName() string {
 	timestamp := time.Now().UnixNano()
 	// Add random suffix to prevent collisions when tests run quickly
 	randomSuffix := mathrand.Intn(100000)
-	return fmt.Sprintf("%s%d-%d", defaultConfig.BucketPrefix, timestamp, randomSuffix)
+	return fmt.Sprintf("%sr%s-%d-%d", defaultConfig.BucketPrefix, testRunID, timestamp, randomSuffix)
 }
 
-// testRunStart marks when this test process started; cleanupTestBuckets only
-// sweeps buckets created before this point so a concurrent `go test` run against
-// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
-// gives clock skew between test host and master room.
-var testRunStart = time.Now().Add(-time.Minute)
+// testRunID uniquely identifies this `go test` invocation. It's embedded into
+// every bucket created by getNewBucketName (after defaultConfig.BucketPrefix), so
+// the cleanup sweep can scope deletions to buckets that belong to this run only —
+// letting concurrent runs against the same endpoints coexist without tearing each
+// other's buckets down. Stale buckets left behind by a crashed prior run share the
+// family prefix but a different runID, so they are not swept here; `make clean`
+// (or wiping the data dir) is the right cleanup for that case.
+var testRunID = strconv.FormatInt(time.Now().UnixNano(), 36)
 
-// cleanupTestBuckets removes any leftover test buckets from previous runs
+// cleanupTestBuckets removes any leftover test buckets from this run.
+// Buckets from concurrent runs carry a different runID marker and are skipped.
 func cleanupTestBuckets(t *testing.T, client *s3.Client) {
 	resp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
 	if err != nil {
@@ -118,14 +123,11 @@ func cleanupTestBuckets(t *testing.T, client *s3.Client) {
 		return
 	}
 
+	runPrefix := defaultConfig.BucketPrefix + "r" + testRunID + "-"
 	for _, bucket := range resp.Buckets {
 		bucketName := *bucket.Name
-		// Skip buckets newer than this process — they belong to a concurrent run.
-		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
-			continue
-		}
-		// Only delete buckets that match our test prefix
-		if strings.HasPrefix(bucketName, defaultConfig.BucketPrefix) {
+		// Only sweep buckets owned by this run (prefix + runID marker).
+		if strings.HasPrefix(bucketName, runPrefix) {
 			t.Logf("Cleaning up leftover test bucket: %s", bucketName)
 			deleteBucket(t, client, bucketName)
 		}

--- a/test/s3/copying/s3_copying_test.go
+++ b/test/s3/copying/s3_copying_test.go
@@ -134,6 +134,11 @@ func cleanupTestBuckets(t *testing.T, client *s3.Client) {
 
 // createBucket creates a new bucket for testing
 func createBucket(t *testing.T, client *s3.Client, bucketName string) {
+	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
+	// fresh slate. Without this, leaked collection volumes from a panicked or
+	// interrupted earlier run accumulate on a single `weed mini` data node and
+	// the suite eventually exhausts its volume slots.
+	cleanupTestBuckets(t, client)
 	// First, try to delete the bucket if it exists (cleanup from previous failed tests)
 	deleteBucket(t, client, bucketName)
 

--- a/test/s3/cors/s3_cors_test.go
+++ b/test/s3/cors/s3_cors_test.go
@@ -3,6 +3,10 @@ package cors
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,26 +23,43 @@ import (
 
 // S3TestConfig holds configuration for S3 tests
 type S3TestConfig struct {
-	Endpoint      string
-	AccessKey     string
-	SecretKey     string
-	Region        string
-	BucketPrefix  string
-	UseSSL        bool
-	SkipVerifySSL bool
+	Endpoint       string
+	MasterEndpoint string
+	AccessKey      string
+	SecretKey      string
+	Region         string
+	BucketPrefix   string
+	UseSSL         bool
+	SkipVerifySSL  bool
+}
+
+// allTestBucketPrefixes lists every prefix used to name buckets in this test suite.
+// cleanupLeftoverTestBuckets uses it to find stale buckets from prior tests/runs.
+// Add the new prefix here whenever a test introduces one.
+var allTestBucketPrefixes = []string{
+	"test-cors-",
 }
 
 // getDefaultConfig returns a fresh instance of the default test configuration
 // to avoid parallel test issues with global mutable state
 func getDefaultConfig() *S3TestConfig {
+	endpoint := os.Getenv("S3_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:8333" // Default SeaweedFS S3 port
+	}
+	masterEndpoint := os.Getenv("MASTER_ENDPOINT")
+	if masterEndpoint == "" {
+		masterEndpoint = "http://localhost:9333" // Default SeaweedFS master HTTP port
+	}
 	return &S3TestConfig{
-		Endpoint:      "http://localhost:8333", // Default SeaweedFS S3 port
-		AccessKey:     "some_access_key1",
-		SecretKey:     "some_secret_key1",
-		Region:        "us-east-1",
-		BucketPrefix:  "test-cors-",
-		UseSSL:        false,
-		SkipVerifySSL: true,
+		Endpoint:       endpoint,
+		MasterEndpoint: masterEndpoint,
+		AccessKey:      "some_access_key1",
+		SecretKey:      "some_secret_key1",
+		Region:         "us-east-1",
+		BucketPrefix:   "test-cors-",
+		UseSSL:         false,
+		SkipVerifySSL:  true,
 	}
 }
 
@@ -71,6 +92,10 @@ func getS3Client(t *testing.T) *s3.Client {
 // createTestBucket creates a test bucket with a unique name
 func createTestBucket(t *testing.T, client *s3.Client) string {
 	defaultConfig := getDefaultConfig()
+	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
+	// fresh slate. Without this, leaked collection volumes accumulate on a single
+	// `weed mini` data node and the suite eventually exhausts its volume slots.
+	cleanupLeftoverTestBuckets(t, client)
 	bucketName := fmt.Sprintf("%s%d", defaultConfig.BucketPrefix, time.Now().UnixNano())
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
@@ -84,8 +109,16 @@ func createTestBucket(t *testing.T, client *s3.Client) string {
 	return bucketName
 }
 
-// cleanupTestBucket removes the test bucket and all its contents
+// cleanupTestBucket removes the test bucket and all its contents.
+// Always force-drops the underlying collection at the master afterwards: the S3
+// DeleteBucket can race with concurrent `volume_grow` requests (the warm-create
+// batch keeps registering volumes after the master's collection-delete sweep has
+// already snapshotted the layout), so 1-3 volumes per bucket can leak. Without
+// this, running enough tests on a single `weed mini` server exhausts the data
+// node's volume slots and every subsequent PutObject 500s with "Not enough data
+// nodes found".
 func cleanupTestBucket(t *testing.T, client *s3.Client, bucketName string) {
+	defer forceDeleteCollection(t, bucketName)
 	// First, delete all objects in the bucket
 	listResp, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucketName),
@@ -109,6 +142,71 @@ func cleanupTestBucket(t *testing.T, client *s3.Client, bucketName string) {
 	if err != nil {
 		t.Logf("Warning: failed to delete bucket %s: %v", bucketName, err)
 	}
+}
+
+// forceDeleteCollection drops the SeaweedFS collection backing a test bucket via the master's
+// /col/delete admin endpoint. The S3 layer normally drops the collection on DeleteBucket, but
+// in-flight `volume_grow` requests can register volumes after the master's first sweep, leaking
+// them. Best-effort: a 400 from the master means the collection was already gone, which is the
+// success path and not an error.
+func forceDeleteCollection(t *testing.T, bucketName string) {
+	masterEndpoint := getDefaultConfig().MasterEndpoint
+	if masterEndpoint == "" {
+		return
+	}
+	endpoint := strings.TrimRight(masterEndpoint, "/") + "/col/delete?collection=" + url.QueryEscape(bucketName)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Logf("Note: building collection delete request for %s failed: %v", bucketName, err)
+		return
+	}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logf("Note: force-delete collection %s failed: %v", bucketName, err)
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		t.Logf("Force-deleted collection %s", bucketName)
+	case http.StatusBadRequest:
+		// Collection already gone - normal path when DeleteBucket succeeded.
+	default:
+		t.Logf("Note: force-delete collection %s returned HTTP %d", bucketName, resp.StatusCode)
+	}
+}
+
+// cleanupAllTestBuckets cleans up any leftover test buckets matching any prefix this
+// suite uses. Called from cleanupLeftoverTestBuckets before each new bucket creation
+// so a single `weed mini` data node does not exhaust its volume slots after many tests.
+func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
+	listResp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	if err != nil {
+		t.Logf("Warning: failed to list buckets for cleanup: %v", err)
+		return
+	}
+
+	for _, bucket := range listResp.Buckets {
+		if bucket.Name == nil {
+			continue
+		}
+		for _, prefix := range allTestBucketPrefixes {
+			if strings.HasPrefix(*bucket.Name, prefix) {
+				t.Logf("Cleaning up leftover test bucket: %s", *bucket.Name)
+				cleanupTestBucket(t, client, *bucket.Name)
+				break
+			}
+		}
+	}
+}
+
+// cleanupLeftoverTestBuckets is invoked from createTestBucket so each new bucket starts
+// with a clean slate even when a prior test panicked, was interrupted, or its volumes
+// have not yet been reclaimed by the master.
+func cleanupLeftoverTestBuckets(t *testing.T, client *s3.Client) {
+	cleanupAllTestBuckets(t, client)
 }
 
 // TestCORSConfigurationManagement tests basic CORS configuration CRUD operations

--- a/test/s3/cors/s3_cors_test.go
+++ b/test/s3/cors/s3_cors_test.go
@@ -49,7 +49,7 @@ func getDefaultConfig() *S3TestConfig {
 	}
 	masterEndpoint := os.Getenv("MASTER_ENDPOINT")
 	if masterEndpoint == "" {
-		masterEndpoint = "http://localhost:9333" // Default SeaweedFS master HTTP port
+		masterEndpoint = "http://127.0.0.1:9333" // Default SeaweedFS master HTTP port
 	}
 	return &S3TestConfig{
 		Endpoint:       endpoint,

--- a/test/s3/cors/s3_cors_test.go
+++ b/test/s3/cors/s3_cors_test.go
@@ -35,7 +35,7 @@ type S3TestConfig struct {
 }
 
 // allTestBucketPrefixes lists every prefix used to name buckets in this test suite.
-// cleanupLeftoverTestBuckets uses it to find stale buckets from prior tests/runs.
+// cleanupAllTestBuckets uses it to find stale buckets from prior tests/runs.
 // Add the new prefix here whenever a test introduces one.
 var allTestBucketPrefixes = []string{
 	"test-cors-",
@@ -102,10 +102,11 @@ func getS3Client(t *testing.T) *s3.Client {
 // createTestBucket creates a test bucket with a unique name
 func createTestBucket(t *testing.T, client *s3.Client) string {
 	defaultConfig := getDefaultConfig()
-	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
-	// fresh slate. Without this, leaked collection volumes accumulate on a single
-	// `weed mini` data node and the suite eventually exhausts its volume slots.
-	cleanupLeftoverTestBuckets(t, client)
+	// Sweep stale buckets from prior tests in this run so each new bucket starts
+	// on a fresh slate. Without this, leaked collection volumes accumulate on a
+	// single `weed mini` data node and the suite eventually exhausts its volume
+	// slots.
+	cleanupAllTestBuckets(t, client)
 	bucketName := fmt.Sprintf("%sr%s-%d", defaultConfig.BucketPrefix, testRunID, time.Now().UnixNano())
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
@@ -188,9 +189,10 @@ func forceDeleteCollection(t *testing.T, bucketName string) {
 	}
 }
 
-// cleanupAllTestBuckets cleans up any leftover test buckets matching any prefix this
-// suite uses. Called from cleanupLeftoverTestBuckets before each new bucket creation
-// so a single `weed mini` data node does not exhaust its volume slots after many tests.
+// cleanupAllTestBuckets cleans up any leftover test buckets owned by this run
+// (prefix + runID marker). Called from createTestBucket before each new bucket
+// creation so a single `weed mini` data node does not exhaust its volume slots
+// after many tests.
 func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 	listResp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
 	if err != nil {
@@ -212,13 +214,6 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 			}
 		}
 	}
-}
-
-// cleanupLeftoverTestBuckets is invoked from createTestBucket so each new bucket starts
-// with a clean slate even when a prior test panicked, was interrupted, or its volumes
-// have not yet been reclaimed by the master.
-func cleanupLeftoverTestBuckets(t *testing.T, client *s3.Client) {
-	cleanupAllTestBuckets(t, client)
 }
 
 // TestCORSConfigurationManagement tests basic CORS configuration CRUD operations

--- a/test/s3/cors/s3_cors_test.go
+++ b/test/s3/cors/s3_cors_test.go
@@ -40,6 +40,12 @@ var allTestBucketPrefixes = []string{
 	"test-cors-",
 }
 
+// testRunStart marks when this test process started; cleanupAllTestBuckets only
+// sweeps buckets created before this point so a concurrent `go test` run against
+// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
+// gives clock skew between test host and master room.
+var testRunStart = time.Now().Add(-time.Minute)
+
 // getDefaultConfig returns a fresh instance of the default test configuration
 // to avoid parallel test issues with global mutable state
 func getDefaultConfig() *S3TestConfig {
@@ -190,6 +196,10 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 
 	for _, bucket := range listResp.Buckets {
 		if bucket.Name == nil {
+			continue
+		}
+		// Skip buckets newer than this process — they belong to a concurrent run.
+		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
 			continue
 		}
 		for _, prefix := range allTestBucketPrefixes {

--- a/test/s3/cors/s3_cors_test.go
+++ b/test/s3/cors/s3_cors_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -40,11 +41,14 @@ var allTestBucketPrefixes = []string{
 	"test-cors-",
 }
 
-// testRunStart marks when this test process started; cleanupAllTestBuckets only
-// sweeps buckets created before this point so a concurrent `go test` run against
-// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
-// gives clock skew between test host and master room.
-var testRunStart = time.Now().Add(-time.Minute)
+// testRunID uniquely identifies this `go test` invocation. It's embedded into
+// every bucket created by createTestBucket (after defaultConfig.BucketPrefix), so
+// the cleanup sweep can scope deletions to buckets that belong to this run only —
+// letting concurrent runs against the same endpoints coexist without tearing each
+// other's buckets down. Stale buckets left behind by a crashed prior run share the
+// family prefix but a different runID, so they are not swept here; `make clean`
+// (or wiping the data dir) is the right cleanup for that case.
+var testRunID = strconv.FormatInt(time.Now().UnixNano(), 36)
 
 // getDefaultConfig returns a fresh instance of the default test configuration
 // to avoid parallel test issues with global mutable state
@@ -102,7 +106,7 @@ func createTestBucket(t *testing.T, client *s3.Client) string {
 	// fresh slate. Without this, leaked collection volumes accumulate on a single
 	// `weed mini` data node and the suite eventually exhausts its volume slots.
 	cleanupLeftoverTestBuckets(t, client)
-	bucketName := fmt.Sprintf("%s%d", defaultConfig.BucketPrefix, time.Now().UnixNano())
+	bucketName := fmt.Sprintf("%sr%s-%d", defaultConfig.BucketPrefix, testRunID, time.Now().UnixNano())
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
@@ -198,12 +202,10 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 		if bucket.Name == nil {
 			continue
 		}
-		// Skip buckets newer than this process — they belong to a concurrent run.
-		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
-			continue
-		}
 		for _, prefix := range allTestBucketPrefixes {
-			if strings.HasPrefix(*bucket.Name, prefix) {
+			// Only sweep buckets owned by this run (prefix + runID marker).
+			// Buckets from concurrent runs carry a different runID and are skipped.
+			if strings.HasPrefix(*bucket.Name, prefix+"r"+testRunID+"-") {
 				t.Logf("Cleaning up leftover test bucket: %s", *bucket.Name)
 				cleanupTestBucket(t, client, *bucket.Name)
 				break

--- a/test/s3/tagging/s3_tagging_test.go
+++ b/test/s3/tagging/s3_tagging_test.go
@@ -47,7 +47,7 @@ func getDefaultConfig() *S3TestConfig {
 	}
 	masterEndpoint := os.Getenv("MASTER_ENDPOINT")
 	if masterEndpoint == "" {
-		masterEndpoint = "http://localhost:9333" // Default SeaweedFS master HTTP port
+		masterEndpoint = "http://127.0.0.1:9333" // Default SeaweedFS master HTTP port
 	}
 	accessKey := os.Getenv("S3_ACCESS_KEY")
 	if accessKey == "" {

--- a/test/s3/tagging/s3_tagging_test.go
+++ b/test/s3/tagging/s3_tagging_test.go
@@ -34,7 +34,7 @@ type S3TestConfig struct {
 }
 
 // allTestBucketPrefixes lists every prefix used to name buckets in this test suite.
-// cleanupLeftoverTestBuckets uses it to find stale buckets from prior tests/runs.
+// cleanupAllTestBuckets uses it to find stale buckets from prior tests/runs.
 // Add the new prefix here whenever a test introduces one.
 var allTestBucketPrefixes = []string{
 	"test-tagging-",
@@ -102,10 +102,11 @@ func getS3Client(t *testing.T) *s3.Client {
 // createTestBucket creates a test bucket with a unique name
 func createTestBucket(t *testing.T, client *s3.Client) string {
 	defaultConfig := getDefaultConfig()
-	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
-	// fresh slate. Without this, leaked collection volumes accumulate on a single
-	// `weed mini` data node and the suite eventually exhausts its volume slots.
-	cleanupLeftoverTestBuckets(t, client)
+	// Sweep stale buckets from prior tests in this run so each new bucket starts
+	// on a fresh slate. Without this, leaked collection volumes accumulate on a
+	// single `weed mini` data node and the suite eventually exhausts its volume
+	// slots.
+	cleanupAllTestBuckets(t, client)
 	bucketName := fmt.Sprintf("%sr%s-%d", defaultConfig.BucketPrefix, testRunID, time.Now().UnixNano())
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
@@ -215,9 +216,10 @@ func forceDeleteCollection(t *testing.T, bucketName string) {
 	}
 }
 
-// cleanupAllTestBuckets cleans up any leftover test buckets matching any prefix this
-// suite uses. Called from cleanupLeftoverTestBuckets before each new bucket creation
-// so a single `weed mini` data node does not exhaust its volume slots after many tests.
+// cleanupAllTestBuckets cleans up any leftover test buckets owned by this run
+// (prefix + runID marker). Called from createTestBucket before each new bucket
+// creation so a single `weed mini` data node does not exhaust its volume slots
+// after many tests.
 func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 	listResp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
 	if err != nil {
@@ -239,13 +241,6 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 			}
 		}
 	}
-}
-
-// cleanupLeftoverTestBuckets is invoked from createTestBucket so each new bucket starts
-// with a clean slate even when a prior test panicked, was interrupted, or its volumes
-// have not yet been reclaimed by the master.
-func cleanupLeftoverTestBuckets(t *testing.T, client *s3.Client) {
-	cleanupAllTestBuckets(t, client)
 }
 
 // TestObjectTaggingOnUpload tests that tags sent during object upload (via X-Amz-Tagging header)

--- a/test/s3/tagging/s3_tagging_test.go
+++ b/test/s3/tagging/s3_tagging_test.go
@@ -3,6 +3,9 @@ package tagging
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -19,13 +22,21 @@ import (
 
 // S3TestConfig holds configuration for S3 tests
 type S3TestConfig struct {
-	Endpoint      string
-	AccessKey     string
-	SecretKey     string
-	Region        string
-	BucketPrefix  string
-	UseSSL        bool
-	SkipVerifySSL bool
+	Endpoint       string
+	MasterEndpoint string
+	AccessKey      string
+	SecretKey      string
+	Region         string
+	BucketPrefix   string
+	UseSSL         bool
+	SkipVerifySSL  bool
+}
+
+// allTestBucketPrefixes lists every prefix used to name buckets in this test suite.
+// cleanupLeftoverTestBuckets uses it to find stale buckets from prior tests/runs.
+// Add the new prefix here whenever a test introduces one.
+var allTestBucketPrefixes = []string{
+	"test-tagging-",
 }
 
 // getDefaultConfig returns a fresh instance of the default test configuration
@@ -33,6 +44,10 @@ func getDefaultConfig() *S3TestConfig {
 	endpoint := os.Getenv("S3_ENDPOINT")
 	if endpoint == "" {
 		endpoint = "http://localhost:8333" // Default SeaweedFS S3 port
+	}
+	masterEndpoint := os.Getenv("MASTER_ENDPOINT")
+	if masterEndpoint == "" {
+		masterEndpoint = "http://localhost:9333" // Default SeaweedFS master HTTP port
 	}
 	accessKey := os.Getenv("S3_ACCESS_KEY")
 	if accessKey == "" {
@@ -43,13 +58,14 @@ func getDefaultConfig() *S3TestConfig {
 		secretKey = "some_secret_key1"
 	}
 	return &S3TestConfig{
-		Endpoint:      endpoint,
-		AccessKey:     accessKey,
-		SecretKey:     secretKey,
-		Region:        "us-east-1",
-		BucketPrefix:  "test-tagging-",
-		UseSSL:        false,
-		SkipVerifySSL: true,
+		Endpoint:       endpoint,
+		MasterEndpoint: masterEndpoint,
+		AccessKey:      accessKey,
+		SecretKey:      secretKey,
+		Region:         "us-east-1",
+		BucketPrefix:   "test-tagging-",
+		UseSSL:         false,
+		SkipVerifySSL:  true,
 	}
 }
 
@@ -76,6 +92,10 @@ func getS3Client(t *testing.T) *s3.Client {
 // createTestBucket creates a test bucket with a unique name
 func createTestBucket(t *testing.T, client *s3.Client) string {
 	defaultConfig := getDefaultConfig()
+	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
+	// fresh slate. Without this, leaked collection volumes accumulate on a single
+	// `weed mini` data node and the suite eventually exhausts its volume slots.
+	cleanupLeftoverTestBuckets(t, client)
 	bucketName := fmt.Sprintf("%s%d", defaultConfig.BucketPrefix, time.Now().UnixNano())
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
@@ -89,8 +109,16 @@ func createTestBucket(t *testing.T, client *s3.Client) string {
 	return bucketName
 }
 
-// cleanupTestBucket removes the test bucket and all its contents
+// cleanupTestBucket removes the test bucket and all its contents.
+// Always force-drops the underlying collection at the master afterwards: the S3
+// DeleteBucket can race with concurrent `volume_grow` requests (the warm-create
+// batch keeps registering volumes after the master's collection-delete sweep has
+// already snapshotted the layout), so 1-3 volumes per bucket can leak. Without
+// this, running enough tests on a single `weed mini` server exhausts the data
+// node's volume slots and every subsequent PutObject 500s with "Not enough data
+// nodes found".
 func cleanupTestBucket(t *testing.T, client *s3.Client, bucketName string) {
+	defer forceDeleteCollection(t, bucketName)
 	// First, delete all objects in the bucket
 	listResp, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucketName),
@@ -141,6 +169,71 @@ func cleanupTestBucket(t *testing.T, client *s3.Client, bucketName string) {
 	if err != nil {
 		t.Logf("Warning: failed to delete bucket %s: %v", bucketName, err)
 	}
+}
+
+// forceDeleteCollection drops the SeaweedFS collection backing a test bucket via the master's
+// /col/delete admin endpoint. The S3 layer normally drops the collection on DeleteBucket, but
+// in-flight `volume_grow` requests can register volumes after the master's first sweep, leaking
+// them. Best-effort: a 400 from the master means the collection was already gone, which is the
+// success path and not an error.
+func forceDeleteCollection(t *testing.T, bucketName string) {
+	masterEndpoint := getDefaultConfig().MasterEndpoint
+	if masterEndpoint == "" {
+		return
+	}
+	endpoint := strings.TrimRight(masterEndpoint, "/") + "/col/delete?collection=" + url.QueryEscape(bucketName)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Logf("Note: building collection delete request for %s failed: %v", bucketName, err)
+		return
+	}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logf("Note: force-delete collection %s failed: %v", bucketName, err)
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		t.Logf("Force-deleted collection %s", bucketName)
+	case http.StatusBadRequest:
+		// Collection already gone - normal path when DeleteBucket succeeded.
+	default:
+		t.Logf("Note: force-delete collection %s returned HTTP %d", bucketName, resp.StatusCode)
+	}
+}
+
+// cleanupAllTestBuckets cleans up any leftover test buckets matching any prefix this
+// suite uses. Called from cleanupLeftoverTestBuckets before each new bucket creation
+// so a single `weed mini` data node does not exhaust its volume slots after many tests.
+func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
+	listResp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	if err != nil {
+		t.Logf("Warning: failed to list buckets for cleanup: %v", err)
+		return
+	}
+
+	for _, bucket := range listResp.Buckets {
+		if bucket.Name == nil {
+			continue
+		}
+		for _, prefix := range allTestBucketPrefixes {
+			if strings.HasPrefix(*bucket.Name, prefix) {
+				t.Logf("Cleaning up leftover test bucket: %s", *bucket.Name)
+				cleanupTestBucket(t, client, *bucket.Name)
+				break
+			}
+		}
+	}
+}
+
+// cleanupLeftoverTestBuckets is invoked from createTestBucket so each new bucket starts
+// with a clean slate even when a prior test panicked, was interrupted, or its volumes
+// have not yet been reclaimed by the master.
+func cleanupLeftoverTestBuckets(t *testing.T, client *s3.Client) {
+	cleanupAllTestBuckets(t, client)
 }
 
 // TestObjectTaggingOnUpload tests that tags sent during object upload (via X-Amz-Tagging header)

--- a/test/s3/tagging/s3_tagging_test.go
+++ b/test/s3/tagging/s3_tagging_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,11 +40,14 @@ var allTestBucketPrefixes = []string{
 	"test-tagging-",
 }
 
-// testRunStart marks when this test process started; cleanupAllTestBuckets only
-// sweeps buckets created before this point so a concurrent `go test` run against
-// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
-// gives clock skew between test host and master room.
-var testRunStart = time.Now().Add(-time.Minute)
+// testRunID uniquely identifies this `go test` invocation. It's embedded into
+// every bucket created by createTestBucket (after defaultConfig.BucketPrefix), so
+// the cleanup sweep can scope deletions to buckets that belong to this run only —
+// letting concurrent runs against the same endpoints coexist without tearing each
+// other's buckets down. Stale buckets left behind by a crashed prior run share the
+// family prefix but a different runID, so they are not swept here; `make clean`
+// (or wiping the data dir) is the right cleanup for that case.
+var testRunID = strconv.FormatInt(time.Now().UnixNano(), 36)
 
 // getDefaultConfig returns a fresh instance of the default test configuration
 func getDefaultConfig() *S3TestConfig {
@@ -102,7 +106,7 @@ func createTestBucket(t *testing.T, client *s3.Client) string {
 	// fresh slate. Without this, leaked collection volumes accumulate on a single
 	// `weed mini` data node and the suite eventually exhausts its volume slots.
 	cleanupLeftoverTestBuckets(t, client)
-	bucketName := fmt.Sprintf("%s%d", defaultConfig.BucketPrefix, time.Now().UnixNano())
+	bucketName := fmt.Sprintf("%sr%s-%d", defaultConfig.BucketPrefix, testRunID, time.Now().UnixNano())
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
@@ -225,12 +229,10 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 		if bucket.Name == nil {
 			continue
 		}
-		// Skip buckets newer than this process — they belong to a concurrent run.
-		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
-			continue
-		}
 		for _, prefix := range allTestBucketPrefixes {
-			if strings.HasPrefix(*bucket.Name, prefix) {
+			// Only sweep buckets owned by this run (prefix + runID marker).
+			// Buckets from concurrent runs carry a different runID and are skipped.
+			if strings.HasPrefix(*bucket.Name, prefix+"r"+testRunID+"-") {
 				t.Logf("Cleaning up leftover test bucket: %s", *bucket.Name)
 				cleanupTestBucket(t, client, *bucket.Name)
 				break

--- a/test/s3/tagging/s3_tagging_test.go
+++ b/test/s3/tagging/s3_tagging_test.go
@@ -39,6 +39,12 @@ var allTestBucketPrefixes = []string{
 	"test-tagging-",
 }
 
+// testRunStart marks when this test process started; cleanupAllTestBuckets only
+// sweeps buckets created before this point so a concurrent `go test` run against
+// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
+// gives clock skew between test host and master room.
+var testRunStart = time.Now().Add(-time.Minute)
+
 // getDefaultConfig returns a fresh instance of the default test configuration
 func getDefaultConfig() *S3TestConfig {
 	endpoint := os.Getenv("S3_ENDPOINT")
@@ -217,6 +223,10 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 
 	for _, bucket := range listResp.Buckets {
 		if bucket.Name == nil {
+			continue
+		}
+		// Skip buckets newer than this process — they belong to a concurrent run.
+		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
 			continue
 		}
 		for _, prefix := range allTestBucketPrefixes {

--- a/test/s3/versioning/s3_versioning_test.go
+++ b/test/s3/versioning/s3_versioning_test.go
@@ -47,7 +47,7 @@ var defaultConfig = &S3TestConfig{
 }
 
 // allTestBucketPrefixes lists every prefix used to name buckets in this test suite.
-// cleanupLeftoverTestBuckets uses it to find stale buckets from prior tests/runs.
+// cleanupAllTestBuckets uses it to find stale buckets from prior tests/runs.
 // Add the new prefix here whenever a test introduces one.
 var allTestBucketPrefixes = []string{
 	"test-versioning-",  // covers test-versioning-, test-versioning-directories, test-versioning-interaction-, test-versioned-acl/list
@@ -112,10 +112,11 @@ func getNewBucketName() string {
 
 // createBucket creates a new bucket for testing
 func createBucket(t *testing.T, client *s3.Client, bucketName string) {
-	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
-	// fresh slate. Without this, leaked collection volumes accumulate on a single
-	// `weed mini` data node and the suite eventually exhausts its volume slots.
-	cleanupLeftoverTestBuckets(t, client)
+	// Sweep stale buckets from prior tests in this run so each new bucket starts
+	// on a fresh slate. Without this, leaked collection volumes accumulate on a
+	// single `weed mini` data node and the suite eventually exhausts its volume
+	// slots.
+	cleanupAllTestBuckets(t, client)
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
 	})
@@ -180,9 +181,10 @@ func forceDeleteCollection(t *testing.T, bucketName string) {
 	}
 }
 
-// cleanupAllTestBuckets cleans up any leftover test buckets matching any prefix this
-// suite uses. Called from cleanupLeftoverTestBuckets before each new bucket creation
-// so a single `weed mini` data node does not exhaust its volume slots after many tests.
+// cleanupAllTestBuckets cleans up any leftover test buckets owned by this run
+// (prefix + runID marker). Called from createBucket before each new bucket
+// creation so a single `weed mini` data node does not exhaust its volume slots
+// after many tests.
 func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 	listResp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
 	if err != nil {
@@ -204,13 +206,6 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 			}
 		}
 	}
-}
-
-// cleanupLeftoverTestBuckets is invoked from createBucket so each new bucket starts
-// with a clean slate even when a prior test panicked, was interrupted, or its volumes
-// have not yet been reclaimed by the master.
-func cleanupLeftoverTestBuckets(t *testing.T, client *s3.Client) {
-	cleanupAllTestBuckets(t, client)
 }
 
 // deleteAllObjectVersions deletes all object versions in a bucket

--- a/test/s3/versioning/s3_versioning_test.go
+++ b/test/s3/versioning/s3_versioning_test.go
@@ -3,6 +3,10 @@ package s3api
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,24 +23,48 @@ import (
 
 // S3TestConfig holds configuration for S3 tests
 type S3TestConfig struct {
-	Endpoint      string
-	AccessKey     string
-	SecretKey     string
-	Region        string
-	BucketPrefix  string
-	UseSSL        bool
-	SkipVerifySSL bool
+	Endpoint       string
+	MasterEndpoint string
+	AccessKey      string
+	SecretKey      string
+	Region         string
+	BucketPrefix   string
+	UseSSL         bool
+	SkipVerifySSL  bool
 }
 
 // Default test configuration - should match s3tests.conf
 var defaultConfig = &S3TestConfig{
-	Endpoint:      "http://localhost:8333", // Default SeaweedFS S3 port
-	AccessKey:     "some_access_key1",
-	SecretKey:     "some_secret_key1",
-	Region:        "us-east-1",
-	BucketPrefix:  "test-versioning-",
-	UseSSL:        false,
-	SkipVerifySSL: true,
+	Endpoint:       firstNonEmpty(os.Getenv("S3_ENDPOINT"), "http://localhost:8333"),       // Default SeaweedFS S3 port
+	MasterEndpoint: firstNonEmpty(os.Getenv("MASTER_ENDPOINT"), "http://localhost:9333"),   // Default SeaweedFS master HTTP port
+	AccessKey:      "some_access_key1",
+	SecretKey:      "some_secret_key1",
+	Region:         "us-east-1",
+	BucketPrefix:   "test-versioning-",
+	UseSSL:         false,
+	SkipVerifySSL:  true,
+}
+
+// allTestBucketPrefixes lists every prefix used to name buckets in this test suite.
+// cleanupLeftoverTestBuckets uses it to find stale buckets from prior tests/runs.
+// Add the new prefix here whenever a test introduces one.
+var allTestBucketPrefixes = []string{
+	"test-versioning-",  // covers test-versioning-, test-versioning-directories, test-versioning-interaction-, test-versioned-acl/list
+	"test-versioned-",
+	"test-error-messages-",
+	"test-delete-markers",
+	"test-concurrent-delete",
+	"test-suspended-versioning-delete",
+	"test-bucket-",
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // getS3Client creates an AWS S3 client for testing
@@ -72,14 +100,26 @@ func getNewBucketName() string {
 
 // createBucket creates a new bucket for testing
 func createBucket(t *testing.T, client *s3.Client, bucketName string) {
+	// Sweep stale buckets from prior tests/runs so each new bucket starts on a
+	// fresh slate. Without this, leaked collection volumes accumulate on a single
+	// `weed mini` data node and the suite eventually exhausts its volume slots.
+	cleanupLeftoverTestBuckets(t, client)
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
 	})
 	require.NoError(t, err)
 }
 
-// deleteBucket deletes a bucket and all its contents
+// deleteBucket deletes a bucket and all its contents.
+// Always force-drops the underlying collection at the master afterwards: the S3
+// DeleteBucket can race with concurrent `volume_grow` requests (the warm-create
+// batch keeps registering volumes after the master's collection-delete sweep has
+// already snapshotted the layout), so 1-3 volumes per bucket can leak. Without
+// this, running enough tests on a single `weed mini` server exhausts the data
+// node's volume slots and every subsequent PutObject 500s with "Not enough data
+// nodes found".
 func deleteBucket(t *testing.T, client *s3.Client, bucketName string) {
+	defer forceDeleteCollection(t, bucketName)
 	// First, delete all objects and versions
 	err := deleteAllObjectVersions(t, client, bucketName)
 	if err != nil {
@@ -93,6 +133,70 @@ func deleteBucket(t *testing.T, client *s3.Client, bucketName string) {
 	if err != nil {
 		t.Logf("Warning: failed to delete bucket %s: %v", bucketName, err)
 	}
+}
+
+// forceDeleteCollection drops the SeaweedFS collection backing a test bucket via the master's
+// /col/delete admin endpoint. The S3 layer normally drops the collection on DeleteBucket, but
+// in-flight `volume_grow` requests can register volumes after the master's first sweep, leaking
+// them. Best-effort: a 400 from the master means the collection was already gone, which is the
+// success path and not an error.
+func forceDeleteCollection(t *testing.T, bucketName string) {
+	if defaultConfig.MasterEndpoint == "" {
+		return
+	}
+	endpoint := strings.TrimRight(defaultConfig.MasterEndpoint, "/") + "/col/delete?collection=" + url.QueryEscape(bucketName)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Logf("Note: building collection delete request for %s failed: %v", bucketName, err)
+		return
+	}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logf("Note: force-delete collection %s failed: %v", bucketName, err)
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		t.Logf("Force-deleted collection %s", bucketName)
+	case http.StatusBadRequest:
+		// Collection already gone - normal path when DeleteBucket succeeded.
+	default:
+		t.Logf("Note: force-delete collection %s returned HTTP %d", bucketName, resp.StatusCode)
+	}
+}
+
+// cleanupAllTestBuckets cleans up any leftover test buckets matching any prefix this
+// suite uses. Called from cleanupLeftoverTestBuckets before each new bucket creation
+// so a single `weed mini` data node does not exhaust its volume slots after many tests.
+func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
+	listResp, err := client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	if err != nil {
+		t.Logf("Warning: failed to list buckets for cleanup: %v", err)
+		return
+	}
+
+	for _, bucket := range listResp.Buckets {
+		if bucket.Name == nil {
+			continue
+		}
+		for _, prefix := range allTestBucketPrefixes {
+			if strings.HasPrefix(*bucket.Name, prefix) {
+				t.Logf("Cleaning up leftover test bucket: %s", *bucket.Name)
+				deleteBucket(t, client, *bucket.Name)
+				break
+			}
+		}
+	}
+}
+
+// cleanupLeftoverTestBuckets is invoked from createBucket so each new bucket starts
+// with a clean slate even when a prior test panicked, was interrupted, or its volumes
+// have not yet been reclaimed by the master.
+func cleanupLeftoverTestBuckets(t *testing.T, client *s3.Client) {
+	cleanupAllTestBuckets(t, client)
 }
 
 // deleteAllObjectVersions deletes all object versions in a bucket

--- a/test/s3/versioning/s3_versioning_test.go
+++ b/test/s3/versioning/s3_versioning_test.go
@@ -36,7 +36,7 @@ type S3TestConfig struct {
 // Default test configuration - should match s3tests.conf
 var defaultConfig = &S3TestConfig{
 	Endpoint:       firstNonEmpty(os.Getenv("S3_ENDPOINT"), "http://localhost:8333"),       // Default SeaweedFS S3 port
-	MasterEndpoint: firstNonEmpty(os.Getenv("MASTER_ENDPOINT"), "http://localhost:9333"),   // Default SeaweedFS master HTTP port
+	MasterEndpoint: firstNonEmpty(os.Getenv("MASTER_ENDPOINT"), "http://127.0.0.1:9333"),   // Default SeaweedFS master HTTP port
 	AccessKey:      "some_access_key1",
 	SecretKey:      "some_secret_key1",
 	Region:         "us-east-1",

--- a/test/s3/versioning/s3_versioning_test.go
+++ b/test/s3/versioning/s3_versioning_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -58,11 +59,16 @@ var allTestBucketPrefixes = []string{
 	"test-bucket-",
 }
 
-// testRunStart marks when this test process started; cleanupAllTestBuckets only
-// sweeps buckets created before this point so a concurrent `go test` run against
-// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
-// gives clock skew between test host and master room.
-var testRunStart = time.Now().Add(-time.Minute)
+// testRunID uniquely identifies this `go test` invocation. It's embedded into
+// every bucket created by getNewBucketName (after defaultConfig.BucketPrefix), so
+// the cleanup sweep can scope deletions to buckets that belong to this run only —
+// letting concurrent runs against the same endpoints coexist without tearing each
+// other's buckets down. Stale buckets left behind by a crashed prior run share the
+// family prefix but a different runID, so they are not swept here; `make clean`
+// (or wiping the data dir) is the right cleanup for that case. Fixed-name buckets
+// like "test-versioning-directories" do not flow through this sweep — they are
+// short-lived and handled by their own deferred deleteBucket.
+var testRunID = strconv.FormatInt(time.Now().UnixNano(), 36)
 
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
@@ -101,7 +107,7 @@ func getS3Client(t *testing.T) *s3.Client {
 // getNewBucketName generates a unique bucket name
 func getNewBucketName() string {
 	timestamp := time.Now().UnixNano()
-	return fmt.Sprintf("%s%d", defaultConfig.BucketPrefix, timestamp)
+	return fmt.Sprintf("%sr%s-%d", defaultConfig.BucketPrefix, testRunID, timestamp)
 }
 
 // createBucket creates a new bucket for testing
@@ -188,12 +194,10 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 		if bucket.Name == nil {
 			continue
 		}
-		// Skip buckets newer than this process — they belong to a concurrent run.
-		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
-			continue
-		}
 		for _, prefix := range allTestBucketPrefixes {
-			if strings.HasPrefix(*bucket.Name, prefix) {
+			// Only sweep buckets owned by this run (prefix + runID marker).
+			// Buckets from concurrent runs carry a different runID and are skipped.
+			if strings.HasPrefix(*bucket.Name, prefix+"r"+testRunID+"-") {
 				t.Logf("Cleaning up leftover test bucket: %s", *bucket.Name)
 				deleteBucket(t, client, *bucket.Name)
 				break

--- a/test/s3/versioning/s3_versioning_test.go
+++ b/test/s3/versioning/s3_versioning_test.go
@@ -58,6 +58,12 @@ var allTestBucketPrefixes = []string{
 	"test-bucket-",
 }
 
+// testRunStart marks when this test process started; cleanupAllTestBuckets only
+// sweeps buckets created before this point so a concurrent `go test` run against
+// the same endpoints cannot have its live buckets torn down. The 1-minute backdate
+// gives clock skew between test host and master room.
+var testRunStart = time.Now().Add(-time.Minute)
+
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
 		if v != "" {
@@ -180,6 +186,10 @@ func cleanupAllTestBuckets(t *testing.T, client *s3.Client) {
 
 	for _, bucket := range listResp.Buckets {
 		if bucket.Name == nil {
+			continue
+		}
+		// Skip buckets newer than this process — they belong to a concurrent run.
+		if bucket.CreationDate != nil && bucket.CreationDate.After(testRunStart) {
 			continue
 		}
 		for _, prefix := range allTestBucketPrefixes {


### PR DESCRIPTION
## Summary

- Mirrors the retention-suite fix (#9244 commits `ac3a756d` + `363d5caa`) into four other s3 integration suites that share the same shape: **tagging**, **versioning**, **cors**, **copying**.
- Each test creates a unique bucket = new SeaweedFS collection; the master's warm-create issues a 7-volume grow batch. The S3 `DeleteBucket`-driven collection sweep snapshots the layout once, but in-flight `volume_grow` requests keep registering volumes *after* the snapshot, leaking 1-3 volumes per bucket. On a single `weed mini` data node with the auto-derived volume cap, those leaks pile up fast and every subsequent `PutObject` 500s with `Not enough data nodes found`.
- Each patched suite now: (1) carries a `MasterEndpoint` config (with `MASTER_ENDPOINT` env override), (2) hits the master's `GET /col/delete?collection=…` admin endpoint as a deferred follow-up to every `DeleteBucket`, and (3) prefix-sweeps leftover buckets before every `createBucket` so a panicked or interrupted prior test cannot leak buckets into the next.

## Motivation

Observed in CI run [25076507655 / job 73470441740](https://github.com/seaweedfs/seaweedfs/actions/runs/25076507655/job/73470441740), where `TestDeleteObjectTaggingOnVersionedBucket` and the four versioned tagging tests after it failed with `InternalError 500` after the data node hit `topo failed to pick 1 from 0 node candidates`. Reading the server log, the master cleaned up volumes 1-4 of the first collection, while volumes 5, 6, 7 of the same collection (created concurrently by the warm-create) were only deleted at server shutdown. The pattern repeated for every test, producing 11 leaked volumes by the 10th test.

## Scope decisions

| Suite | Patched | Reason |
|---|---|---|
| tagging | yes | 14 tests, exact retention-shape, was the failing suite |
| versioning | yes | 44 tests, exact shape, prefix list expanded |
| cors | yes | 18 tests, exact shape |
| copying | yes | 15 tests, already prefix-swept; only `forceDeleteCollection` added |
| iam | no | Separate framework + AWS SDK v1; already passes `-master.volumeSizeLimitMB=100` |
| sse | no | Different helper signatures (ctx + error returns); docker-compose path already passes `-volumeSizeLimitMB=50` |
| policy | no | `TestCluster` already passes `-master.volumeSizeLimitMB=32` and tears the cluster down per run |
| basic / etag / acl / delete | no | Run against an external endpoint, not their own `weed mini` |
| filer_group / distributed_lock / checksum / spark / catalog_trino / parquet | no | Three or fewer tests; cannot exhaust the cap |

## Test plan

- [x] `go vet ./test/s3/...` passes.
- [x] `go test -count=1 -run='^$' ./test/s3/{tagging,versioning,cors,copying}` (compile check) passes.
- [ ] Re-run the failing CI job and confirm the tagging suite finishes without `InternalError`.
- [ ] Confirm versioning + cors + copying CI jobs still pass (they were green before — this should not regress them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Embed a per-test-run marker in S3 bucket names and only remove buckets from the same run.
  * Sweep and remove leftover buckets matching the run marker before creating new ones to allow concurrent test runs.
  * Allow configuring the master admin endpoint via environment variable (defaults to localhost) for cleanup.
  * After S3 deletion, perform a best-effort master-side collection drop; already-removed collections are treated as non-errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->