### PR TITLE
fix(s3api): fix uint16 overflow in doListFilerEntries Limit calculation

### DIFF
--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -588,7 +588,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 	request := &filer_pb.ListEntriesRequest{
 		Directory:          dir,
 		Prefix:             prefix,
-		Limit:              uint32(cursor.maxKeys + 2), // bucket root directory needs to skip additional s3_constants.MultipartUploadsFolder folder
+		Limit:              uint32(cursor.maxKeys) + 2, // bucket root directory needs to skip additional s3_constants.MultipartUploadsFolder folder
 		StartFromFileName:  marker,
 		InclusiveStartFrom: inclusiveStartFrom,
 	}


### PR DESCRIPTION
## Problem

In `doListFilerEntries` (`weed/s3api/s3api_object_handlers_list.go`), the filer request `Limit` is computed as:

```go
Limit: uint32(cursor.maxKeys + 2),
```

`cursor.maxKeys` is `uint16`. The addition `cursor.maxKeys + 2` is evaluated in **uint16 arithmetic** before the cast to `uint32`, so:

| `cursor.maxKeys` | uint16 result of `+2` | `Limit` sent to filer | Observed behaviour |
|---|---|---|---|
| 65534 | 0 (overflow) | 0 | Listing returns **empty** |
| 65535 | 1 (overflow) | 1 | Listing returns **only 1 entry** |

Although the S3 spec caps `max-keys` at 1000, the V2 list-objects parser uses `ParseUint(..., 10, 16)`, which silently accepts any value up to 65535 without error. A client that sends `max-keys=65534` will receive an empty listing even when the bucket is non-empty.

## Root Cause

```go
// weed/s3api/s3api_object_handlers_list.go
Limit: uint32(cursor.maxKeys + 2),   // ← addition happens in uint16 space
```

## Fix

Cast `cursor.maxKeys` to `uint32` **before** adding 2:

```go
Limit: uint32(cursor.maxKeys) + 2,   // ← safe: addition in uint32 space
```

## Testing

Verified with a minimal Go program that `uint32(uint16(65534) + 2) == 0` while `uint32(uint16(65534)) + 2 == 65536`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected limit calculation in list operations to ensure proper handling of large values and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->