### PR TITLE
fix(s3api): clean up multipart upload parts on ErrInvalidPart

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -452,7 +452,9 @@ func (s3a *S3ApiServer) prepareMultipartCompletionState(r *http.Request, input *
 		if !ok {
 			glog.Errorf("part %d has no entry", partNumber)
 			stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedPartNotFound).Inc()
-			return nil, nil, s3err.ErrInvalidPart
+			return &multipartCompletionState{
+				deleteEntries: deleteEntries,
+			}, nil, s3err.ErrInvalidPart
 		}
 		found := false
 


### PR DESCRIPTION
## Problem

When `CompleteMultipartUpload` is called with a part number that does not exist in the upload directory, `prepareMultipartCompletionState` returns `(nil, nil, ErrInvalidPart)`.

The caller (`completeMultipartUpload`) only cleans up the upload directory when `completionState` is **non-nil**:

```go
if completionState != nil {
    for _, deleteEntry := range completionState.deleteEntries {
        // delete part files and upload directory
    }
}
```

Because `completionState` is `nil` on the `ErrInvalidPart` path, all already-uploaded part files are left in the filer under the upload directory and are **never garbage-collected**, causing a permanent storage leak.

## Root Cause

```go
// weed/s3api/filer_multipart.go – prepareMultipartCompletionState
if !ok {
    glog.Errorf("part %d has no entry", partNumber)
    stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedPartNotFound).Inc()
    return nil, nil, s3err.ErrInvalidPart   // completionState is nil; cleanup skipped
}
```

## Fix

Return a `*multipartCompletionState` that carries the `deleteEntries` slice collected so far. The caller's existing cleanup loop then removes the orphaned part files and the upload directory even when the overall `CompleteMultipartUpload` fails:

```go
return &multipartCompletionState{
    deleteEntries: deleteEntries,
}, nil, s3err.ErrInvalidPart
```

## Impact

Any `CompleteMultipartUpload` request that references a non-existent part number will silently leak storage. The leaked files can only be removed by calling `AbortMultipartUpload` or by manual filer cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 multipart upload completion to ensure temporary files are properly cleaned up even when encountering missing parts during the completion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->