### PR TITLE
fix(storage): fix verifyDeletedNeedleIntegrity using wrong offset

### DIFF
--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -155,7 +155,7 @@ func doCheckAndFixVolumeData(v *Volume, indexFile *os.File, indexOffset int64) (
 	}
 	if size < 0 {
 		// read the deletion entry
-		if lastAppendAtNs, err = verifyDeletedNeedleIntegrity(v.DataBackend, v.Version(), key); err != nil {
+		if lastAppendAtNs, err = verifyDeletedNeedleIntegrity(v.DataBackend, v.Version(), offset.ToActualOffset(), key); err != nil {
 			return lastAppendAtNs, fmt.Errorf("verifyNeedleIntegrity %s failed: %v", indexFile.Name(), err)
 		}
 	} else {
@@ -241,16 +241,11 @@ func verifyNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version,
 	return n.AppendAtNs, err
 }
 
-func verifyDeletedNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version, key types.NeedleId) (lastAppendAtNs uint64, err error) {
+func verifyDeletedNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version, offset int64, key types.NeedleId) (lastAppendAtNs uint64, err error) {
 	n := new(needle.Needle)
-	size := n.DiskSize(v)
-	var fileSize int64
-	fileSize, _, err = datFile.GetStat()
-	if err != nil {
-		return 0, fmt.Errorf("GetStat: %w", err)
-	}
-	if err = n.ReadData(datFile, fileSize-size, types.Size(0), v); err != nil {
-		return n.AppendAtNs, fmt.Errorf("read data [%d,%d) : %v", fileSize-size, size, err)
+	size := types.TombstoneFileSize
+	if err = n.ReadData(datFile, offset, size, v); err != nil {
+		return n.AppendAtNs, fmt.Errorf("read data [%d,%d) : %v", offset, offset+needle.GetActualSize(size, v), err)
 	}
 	if n.Id != key {
 		return n.AppendAtNs, fmt.Errorf("index key %v does not match needle's Id %v", key, n.Id)

--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -156,7 +156,7 @@ func doCheckAndFixVolumeData(v *Volume, indexFile *os.File, indexOffset int64) (
 	if size < 0 {
 		// read the deletion entry
 		if lastAppendAtNs, err = verifyDeletedNeedleIntegrity(v.DataBackend, v.Version(), offset.ToActualOffset(), key); err != nil {
-			return lastAppendAtNs, fmt.Errorf("verifyNeedleIntegrity %s failed: %v", indexFile.Name(), err)
+			return lastAppendAtNs, fmt.Errorf("verifyDeletedNeedleIntegrity %s failed: %v", indexFile.Name(), err)
 		}
 	} else {
 		if lastAppendAtNs, err = verifyNeedleIntegrity(v.DataBackend, v.Version(), offset.ToActualOffset(), key, size); err != nil {


### PR DESCRIPTION
## Problem

`verifyDeletedNeedleIntegrity` in `weed/storage/volume_checking.go` is supposed to verify that a deletion tombstone recorded in the index file is consistent with the data file. However, it **ignores the offset** from the index and instead always reads from `fileSize - DiskSize(0)`:

```go
func verifyDeletedNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version, key types.NeedleId) (lastAppendAtNs uint64, err error) {
    n := new(needle.Needle)
    size := n.DiskSize(v)          // DiskSize when n.Size==0, not TombstoneFileSize
    var fileSize int64
    fileSize, _, err = datFile.GetStat()
    ...
    if err = n.ReadData(datFile, fileSize-size, types.Size(0), v); err != nil {
        // reads from end of file, not from the index offset
    }
    ...
}
```

This is only correct when the deleted needle is the **very last entry** in the `.dat` file. If a deletion tombstone was written in the middle of the volume (e.g. followed by subsequent writes), the function reads the wrong bytes, causing:

1. **False negative**: the key-mismatch check passes silently because the bytes at the end of the file happen to look like a valid needle with the same ID.
2. **False positive**: a spurious integrity error is reported for a perfectly valid volume.

Additionally, `n.DiskSize(v)` is computed with `n.Size == 0` (a freshly allocated needle), which gives a different size than the actual tombstone (`types.TombstoneFileSize = -1`).

## Root Cause

The function signature does not accept an `offset` parameter, so it cannot seek to the correct position. The companion function `verifyNeedleIntegrity` correctly accepts and uses an `offset` parameter.

## Fix

Pass the actual offset from the index entry to `verifyDeletedNeedleIntegrity` and use `types.TombstoneFileSize` as the read size, mirroring `verifyNeedleIntegrity`:

```go
// caller: doCheckAndFixVolumeData
if size < 0 {
    if lastAppendAtNs, err = verifyDeletedNeedleIntegrity(v.DataBackend, v.Version(), offset.ToActualOffset(), key); err != nil {
        ...
    }
}

// callee
func verifyDeletedNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version, offset int64, key types.NeedleId) (lastAppendAtNs uint64, err error) {
    n := new(needle.Needle)
    size := types.TombstoneFileSize
    if err = n.ReadData(datFile, offset, size, v); err != nil {
        return n.AppendAtNs, fmt.Errorf("read data [%d,%d) : %v", offset, offset+needle.GetActualSize(size, v), err)
    }
    if n.Id != key {
        return n.AppendAtNs, fmt.Errorf("index key %v does not match needle's Id %v", key, n.Id)
    }
    return n.AppendAtNs, err
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integrity checks for deleted items by reading tombstone data from explicit data-file offsets, reducing incorrect verification results.
  * Error reporting for deleted-data reads now reports exact byte ranges, making failures clearer and easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->