### PR TITLE
fix(mount): copy xattr value bytes to avoid FUSE buffer aliasing

### DIFF
--- a/weed/mount/weedfs_xattr.go
+++ b/weed/mount/weedfs_xattr.go
@@ -131,7 +131,10 @@ func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr st
 	case sys.XATTR_REPLACE:
 		fallthrough
 	default:
-		entry.Extended[XATTR_PREFIX+attr] = data
+		// data aliases the FUSE request's pooled input buffer, which is
+		// recycled once this handler returns. Copy before storing so a
+		// later request reusing the buffer cannot corrupt the value.
+		entry.Extended[XATTR_PREFIX+attr] = append([]byte(nil), data...)
 	}
 
 	if fh != nil {

--- a/weed/mount/weedfs_xattr_test.go
+++ b/weed/mount/weedfs_xattr_test.go
@@ -1,0 +1,62 @@
+//go:build !freebsd
+
+package mount
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/go-fuse/v2/fuse"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// TestSetXAttrCopiesValueBuffer reproduces the bug from
+// https://github.com/seaweedfs/seaweedfs/discussions/9275 where `cp -a`
+// of a file with an extended attribute leaves the destination with a
+// corrupted value. The root cause is that go-fuse hands SetXAttr a
+// `data` slice that aliases the per-request input buffer; when the
+// buffer is returned to the pool and reused for another FUSE request,
+// any reference still held by entry.Extended sees garbage.
+//
+// The bug only manifested when the file was open during setxattr (the
+// open-fh path defers persistence to flush). We simulate that by
+// mutating the caller-supplied buffer after SetXAttr returns.
+func TestSetXAttrCopiesValueBuffer(t *testing.T) {
+	wfs := newCopyRangeTestWFS()
+
+	path := util.FullPath("/aaa.txt")
+	inode := wfs.inodeToPath.Lookup(path, 1, false, false, 0, true)
+	fh := wfs.fhMap.AcquireFileHandle(wfs, inode, &filer_pb.Entry{
+		Name: "aaa.txt",
+		Attributes: &filer_pb.FuseAttributes{
+			FileMode: 0100644,
+			Inode:    inode,
+		},
+	})
+	fh.RememberPath(path)
+
+	// Caller buffer aliases a pool that the kernel will overwrite on
+	// the very next request. SetXAttr must defensively copy.
+	buf := []byte("test,in")
+	status := wfs.SetXAttr(make(chan struct{}), &fuse.SetXAttrIn{
+		InHeader: fuse.InHeader{NodeId: inode},
+	}, "user.xtags", buf)
+	if status != fuse.OK {
+		t.Fatalf("SetXAttr status = %v, want OK", status)
+	}
+
+	// Simulate the request buffer being recycled and reused for an
+	// unrelated payload.
+	for i := range buf {
+		buf[i] = 0xff
+	}
+
+	dest := make([]byte, 64)
+	n, status := wfs.GetXAttr(make(chan struct{}), &fuse.InHeader{NodeId: inode}, "user.xtags", dest)
+	if status != fuse.OK {
+		t.Fatalf("GetXAttr status = %v, want OK", status)
+	}
+	if got := string(dest[:n]); got != "test,in" {
+		t.Fatalf("GetXAttr value = %q, want %q (buffer aliasing leaked into stored xattr)", got, "test,in")
+	}
+}


### PR DESCRIPTION
## Summary
- Fix [discussion #9275](https://github.com/seaweedfs/seaweedfs/discussions/9275): `cp -a` of a file with an extended attribute leaves the destination with a corrupted (random binary) value.
- Root cause: `SetXAttr` stored the caller-supplied `data` slice directly in `entry.Extended`. That slice aliases go-fuse's per-request input buffer, which is returned to a pool the moment the handler returns. When the file is open during `setxattr` (open-fh path defers persistence to flush), the next FUSE request recycles the buffer and silently overwrites the stored bytes; `flushMetadataToFiler` then ships garbage to the filer. The path-based `setfattr` worked only because it saves synchronously inside the same handler, before the buffer can be reused.
- Defensively copy the bytes on the way into the map, and add a unit test that mutates the caller buffer after `SetXAttr` returns to lock in the invariant. The test fails on `master` and passes with this change.

## Test plan
- [x] `go test ./weed/mount/ -count=1`
- [x] `go build ./...`
- [x] New `TestSetXAttrCopiesValueBuffer` fails when the fix is reverted (verified locally) and passes with the fix.
- [ ] Manual `cp -a` reproducer in the discussion (`touch a; setfattr -n user.xtags -v test,in a; cp -a a b; getfattr -d a b`) shows identical xattr values on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extended file attribute (xattr) value corruption when persisting file system attributes, ensuring attribute data remains intact during storage.

* **Tests**
  * Added test to verify extended file attribute values are correctly preserved and not corrupted during storage and retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->