### PR TITLE
feat(filer.sync): add -verifySync mode to filer.sync for cross-cluster file comparison

### DIFF
--- a/weed/command/command.go
+++ b/weed/command/command.go
@@ -27,6 +27,7 @@ var Commands = []*Command{
 	cmdFilerRemoteSynchronize,
 	cmdFilerReplicate,
 	cmdFilerSynchronize,
+	cmdFilerSyncVerify,
 	cmdFix,
 	cmdFuse,
 	cmdIam,

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -200,7 +200,7 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 			grpcDialOptionA, grpcDialOptionB)
 		if err != nil {
 			glog.Errorf("verify sync error: %v", err)
-			return true
+			return false
 		}
 		return true
 	}

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -61,6 +61,8 @@ type SyncOptions struct {
 	clientEpoch      atomic.Int32
 	debug            *bool
 	debugPort        *int
+	verifySync       *bool
+	modifyTimeAgo    *time.Duration
 }
 
 const (
@@ -121,6 +123,8 @@ func init() {
 	syncOptions.bSecurity = cmdFilerSynchronize.Flag.String("b.security", "", "security.toml file for filer B when clusters use different certificates")
 	syncOptions.debug = cmdFilerSynchronize.Flag.Bool("debug", false, "serves runtime profiling data via pprof on the port specified by -debug.port")
 	syncOptions.debugPort = cmdFilerSynchronize.Flag.Int("debug.port", 6060, "http port for debugging")
+	syncOptions.verifySync = cmdFilerSynchronize.Flag.Bool("verifySync", false, "verify sync by comparing entries between filer A and B, then exit")
+	syncOptions.modifyTimeAgo = cmdFilerSynchronize.Flag.Duration("modifyTimeAgo", 0, "in verifySync mode, only verify files modified before this duration ago (e.g. 1h)")
 	syncOptions.clientId = util.RandomInt32()
 }
 
@@ -185,6 +189,18 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 
 	filerA := pb.ServerAddress(*syncOptions.filerA)
 	filerB := pb.ServerAddress(*syncOptions.filerB)
+
+	// verifySync mode: compare entries and exit
+	if *syncOptions.verifySync {
+		err := runVerifySync(filerA, filerB, *syncOptions.aPath, *syncOptions.bPath,
+			*syncOptions.isActivePassive, *syncOptions.modifyTimeAgo,
+			grpcDialOptionA, grpcDialOptionB)
+		if err != nil {
+			glog.Errorf("verify sync error: %v", err)
+			return true
+		}
+		return true
+	}
 
 	// start filer.sync metrics server
 	go statsCollect.StartMetricsServer(*syncOptions.metricsHttpIp, *syncOptions.metricsHttpPort)

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -63,6 +63,7 @@ type SyncOptions struct {
 	debugPort        *int
 	verifySync       *bool
 	modifyTimeAgo    *time.Duration
+	verifyJsonOutput *bool
 }
 
 const (
@@ -125,6 +126,7 @@ func init() {
 	syncOptions.debugPort = cmdFilerSynchronize.Flag.Int("debug.port", 6060, "http port for debugging")
 	syncOptions.verifySync = cmdFilerSynchronize.Flag.Bool("verifySync", false, "verify sync by comparing entries between filer A and B, then exit")
 	syncOptions.modifyTimeAgo = cmdFilerSynchronize.Flag.Duration("modifyTimeAgo", 0, "in verifySync mode, only verify files modified before this duration ago (e.g. 1h)")
+	syncOptions.verifyJsonOutput = cmdFilerSynchronize.Flag.Bool("verifyJsonOutput", false, "in verifySync mode, emit NDJSON output (one JSON object per line) for external tooling")
 	syncOptions.clientId = util.RandomInt32()
 }
 
@@ -194,6 +196,7 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 	if *syncOptions.verifySync {
 		err := runVerifySync(filerA, filerB, *syncOptions.aPath, *syncOptions.bPath,
 			*syncOptions.isActivePassive, *syncOptions.modifyTimeAgo,
+			*syncOptions.verifyJsonOutput,
 			grpcDialOptionA, grpcDialOptionB)
 		if err != nil {
 			glog.Errorf("verify sync error: %v", err)

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -200,7 +200,7 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 			grpcDialOptionA, grpcDialOptionB)
 		if err != nil {
 			glog.Errorf("verify sync error: %v", err)
-			return false
+			os.Exit(2)
 		}
 		return true
 	}

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -61,9 +61,6 @@ type SyncOptions struct {
 	clientEpoch      atomic.Int32
 	debug            *bool
 	debugPort        *int
-	verifySync       *bool
-	modifyTimeAgo    *time.Duration
-	verifyJsonOutput *bool
 }
 
 const (
@@ -124,9 +121,6 @@ func init() {
 	syncOptions.bSecurity = cmdFilerSynchronize.Flag.String("b.security", "", "security.toml file for filer B when clusters use different certificates")
 	syncOptions.debug = cmdFilerSynchronize.Flag.Bool("debug", false, "serves runtime profiling data via pprof on the port specified by -debug.port")
 	syncOptions.debugPort = cmdFilerSynchronize.Flag.Int("debug.port", 6060, "http port for debugging")
-	syncOptions.verifySync = cmdFilerSynchronize.Flag.Bool("verifySync", false, "verify sync by comparing entries between filer A and B, then exit")
-	syncOptions.modifyTimeAgo = cmdFilerSynchronize.Flag.Duration("modifyTimeAgo", 0, "in verifySync mode, only verify files modified before this duration ago (e.g. 1h)")
-	syncOptions.verifyJsonOutput = cmdFilerSynchronize.Flag.Bool("verifyJsonOutput", false, "in verifySync mode, emit NDJSON output (one JSON object per line) for external tooling")
 	syncOptions.clientId = util.RandomInt32()
 }
 
@@ -191,19 +185,6 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 
 	filerA := pb.ServerAddress(*syncOptions.filerA)
 	filerB := pb.ServerAddress(*syncOptions.filerB)
-
-	// verifySync mode: compare entries and exit
-	if *syncOptions.verifySync {
-		err := runVerifySync(filerA, filerB, *syncOptions.aPath, *syncOptions.bPath,
-			*syncOptions.isActivePassive, *syncOptions.modifyTimeAgo,
-			*syncOptions.verifyJsonOutput,
-			grpcDialOptionA, grpcDialOptionB)
-		if err != nil {
-			glog.Errorf("verify sync error: %v", err)
-			os.Exit(2)
-		}
-		return true
-	}
 
 	// start filer.sync metrics server
 	go statsCollect.StartMetricsServer(*syncOptions.metricsHttpIp, *syncOptions.metricsHttpPort)

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -108,6 +108,12 @@ func runFilerSyncVerify(cmd *Command, args []string) bool {
 // children to acquire slots.
 const verifySyncConcurrency = 5
 
+// isTooRecent reports whether entry's mtime is past cutoff (sync-lag tolerance).
+// Returns false when cutoff is zero or attributes are missing.
+func isTooRecent(entry *filer_pb.Entry, cutoff time.Time) bool {
+	return !cutoff.IsZero() && entry != nil && entry.Attributes != nil && entry.Attributes.Mtime > cutoff.Unix()
+}
+
 type VerifyResult struct {
 	dirCount      atomic.Int64
 	fileCount     atomic.Int64
@@ -352,21 +358,24 @@ func compareDirectory(ctx context.Context,
 		case eA != nil && (eB == nil || eA.Name < eB.Name):
 			// entry only in A
 			entryA := streamA.advance()
-			if !cutoffTime.IsZero() && entryA.Attributes != nil && entryA.Attributes.Mtime > cutoffTime.Unix() {
+			if entryA.IsDirectory {
+				// Always recurse for missing-in-B directories: a recent
+				// child write can bump the parent's mtime even though
+				// older missing files exist underneath. The cutoff is
+				// applied per-file inside countMissingRecursive.
+				reportDiff(diffMissing, dirA, entryA, nil, result)
+				countMissingRecursive(ctx, clientA, path.Join(dirA, entryA.Name), cutoffTime, result)
+			} else if isTooRecent(entryA, cutoffTime) {
 				result.skippedRecent.Add(1)
 			} else {
 				reportDiff(diffMissing, dirA, entryA, nil, result)
-				if entryA.IsDirectory {
-					// directory missing in B: count all files under it as missing
-					countMissingRecursive(ctx, clientA, path.Join(dirA, entryA.Name), cutoffTime, result)
-				}
 			}
 
 		case eB != nil && (eA == nil || eB.Name < eA.Name):
 			// entry only in B
 			entryB := streamB.advance()
 			if !isActivePassive {
-				if !cutoffTime.IsZero() && entryB.Attributes != nil && entryB.Attributes.Mtime > cutoffTime.Unix() {
+				if isTooRecent(entryB, cutoffTime) {
 					result.skippedRecent.Add(1)
 				} else {
 					reportDiff(diffOnlyInB, dirB, entryB, nil, result)
@@ -384,8 +393,8 @@ func compareDirectory(ctx context.Context,
 					b: path.Join(dirB, entryB.Name),
 				})
 			} else if !entryA.IsDirectory && !entryB.IsDirectory {
-				// skip recently modified files
-				if !cutoffTime.IsZero() && entryA.Attributes != nil && entryA.Attributes.Mtime > cutoffTime.Unix() {
+				// Skip if either side was modified recently (sync-lag tolerance).
+				if isTooRecent(entryA, cutoffTime) || isTooRecent(entryB, cutoffTime) {
 					result.skippedRecent.Add(1)
 				} else {
 					compareEntries(dirA, entryA, entryB, result)
@@ -414,25 +423,40 @@ func compareDirectory(ctx context.Context,
 	releaseSlot()
 
 	if len(subDirs) > 0 {
-		var wg sync.WaitGroup
-		errCh := make(chan error, len(subDirs))
-
-		for _, pair := range subDirs {
-			wg.Add(1)
-			go func(a, b string) {
-				defer wg.Done()
-				if err := compareDirectory(ctx, clientA, clientB, a, b, isActivePassive, cutoffTime, sem, result); err != nil {
-					errCh <- err
-				}
-			}(pair.a, pair.b)
+		// Bounded worker pool: cap goroutines per directory level instead
+		// of spawning one per child. A directory with thousands of subdirs
+		// would otherwise park ~2KB per waiting goroutine even though
+		// only `verifySyncConcurrency` can do I/O at once.
+		workers := verifySyncConcurrency
+		if len(subDirs) < workers {
+			workers = len(subDirs)
 		}
+		jobs := make(chan dirPair, len(subDirs))
+		errCh := make(chan error, 1) // first error wins; others dropped
+		var wg sync.WaitGroup
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for pair := range jobs {
+					if err := compareDirectory(ctx, clientA, clientB, pair.a, pair.b, isActivePassive, cutoffTime, sem, result); err != nil {
+						select {
+						case errCh <- err:
+						default:
+						}
+					}
+				}
+			}()
+		}
+		for _, pair := range subDirs {
+			jobs <- pair
+		}
+		close(jobs)
 		wg.Wait()
 		close(errCh)
-
-		for err := range errCh {
-			if err != nil {
-				return err
-			}
+		if err := <-errCh; err != nil {
+			return err
 		}
 	}
 

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -132,7 +133,9 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	ctx := context.Background()
 	sem := make(chan struct{}, verifySyncConcurrency)
 
-	err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, sem, result)
+	if err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, sem, result); err != nil {
+		return err
+	}
 
 	totalErrors := result.missingCount.Load() + result.sizeMismatch.Load() + result.etagMismatch.Load()
 	if !isActivePassive {
@@ -168,9 +171,6 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 		fmt.Fprintf(os.Stdout, "  Total errors:         %d\n", totalErrors)
 	}
 
-	if err != nil {
-		return err
-	}
 	if totalErrors > 0 {
 		return fmt.Errorf("found %d differences", totalErrors)
 	}
@@ -282,7 +282,7 @@ func compareDirectory(ctx context.Context,
 				reportDiff(diffMissing, dirA, entryA, nil, result)
 				if entryA.IsDirectory {
 					// directory missing in B: count all files under it as missing
-					countMissingRecursive(ctx, clientA, fmt.Sprintf("%s/%s", dirA, entryA.Name), cutoffTime, result)
+					countMissingRecursive(ctx, clientA, path.Join(dirA, entryA.Name), cutoffTime, result)
 				}
 			}
 
@@ -290,7 +290,11 @@ func compareDirectory(ctx context.Context,
 			// entry only in B
 			entryB := streamB.advance()
 			if !isActivePassive {
-				reportDiff(diffOnlyInB, dirB, entryB, nil, result)
+				if !cutoffTime.IsZero() && entryB.Attributes != nil && entryB.Attributes.Mtime > cutoffTime.Unix() {
+					result.skippedRecent.Add(1)
+				} else {
+					reportDiff(diffOnlyInB, dirB, entryB, nil, result)
+				}
 			}
 
 		default:
@@ -300,8 +304,8 @@ func compareDirectory(ctx context.Context,
 
 			if entryA.IsDirectory && entryB.IsDirectory {
 				subDirs = append(subDirs, dirPair{
-					a: fmt.Sprintf("%s/%s", dirA, entryA.Name),
-					b: fmt.Sprintf("%s/%s", dirB, entryB.Name),
+					a: path.Join(dirA, entryA.Name),
+					b: path.Join(dirB, entryB.Name),
 				})
 			} else if !entryA.IsDirectory && !entryB.IsDirectory {
 				// skip recently modified files
@@ -444,7 +448,7 @@ func reportDiff(diffType verifyDiffType, dir string, entryA, entryB *filer_pb.En
 }
 
 func writeTextDiff(result *VerifyResult, diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry) {
-	path := fmt.Sprintf("%s/%s", dir, entryA.Name)
+	entryPath := path.Join(dir, entryA.Name)
 
 	result.outputMu.Lock()
 	defer result.outputMu.Unlock()
@@ -452,21 +456,21 @@ func writeTextDiff(result *VerifyResult, diffType verifyDiffType, dir string, en
 	switch diffType {
 	case diffMissing:
 		if entryA.IsDirectory {
-			fmt.Fprintf(os.Stdout, "[MISSING]       %s/ (directory)\n", path)
+			fmt.Fprintf(os.Stdout, "[MISSING]       %s/ (directory)\n", entryPath)
 		} else {
 			fmt.Fprintf(os.Stdout, "[MISSING]       %s (size=%d, etag=%s)\n",
-				path, filer.FileSize(entryA), filer.ETag(entryA))
+				entryPath, filer.FileSize(entryA), filer.ETag(entryA))
 		}
 	case diffOnlyInB:
-		fmt.Fprintf(os.Stdout, "[ONLY_IN_B]     %s\n", path)
+		fmt.Fprintf(os.Stdout, "[ONLY_IN_B]     %s\n", entryPath)
 	case diffSizeMismatch:
 		ann := annotation(entryA, entryB)
 		fmt.Fprintf(os.Stdout, "[SIZE_MISMATCH] %s (a=%d, b=%d%s)\n",
-			path, filer.FileSize(entryA), filer.FileSize(entryB), ann)
+			entryPath, filer.FileSize(entryA), filer.FileSize(entryB), ann)
 	case diffETagMismatch:
 		ann := annotation(entryA, entryB)
 		fmt.Fprintf(os.Stdout, "[ETAG_MISMATCH] %s (a=%s, b=%s%s)\n",
-			path, filer.ETag(entryA), filer.ETag(entryB), ann)
+			entryPath, filer.ETag(entryA), filer.ETag(entryB), ann)
 	}
 }
 
@@ -489,8 +493,7 @@ func annotation(entryA, entryB *filer_pb.Entry) string {
 }
 
 func writeJSONDiff(result *VerifyResult, diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry) {
-	path := fmt.Sprintf("%s/%s", dir, entryA.Name)
-	rec := diffRecord{Path: path}
+	rec := diffRecord{Path: path.Join(dir, entryA.Name)}
 
 	switch diffType {
 	case diffMissing:
@@ -555,7 +558,7 @@ func countMissingRecursive(ctx context.Context, client filer_pb.FilerClient, dir
 	err := filer_pb.ReadDirAllEntries(ctx, client, util.FullPath(dir), "",
 		func(entry *filer_pb.Entry, isLast bool) error {
 			if entry.IsDirectory {
-				countMissingRecursive(ctx, client, fmt.Sprintf("%s/%s", dir, entry.Name), cutoffTime, result)
+				countMissingRecursive(ctx, client, path.Join(dir, entry.Name), cutoffTime, result)
 				return nil
 			}
 			if !cutoffTime.IsZero() && entry.Attributes != nil && entry.Attributes.Mtime > cutoffTime.Unix() {

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sync"
@@ -24,6 +25,11 @@ type VerifyResult struct {
 	etagMismatch  atomic.Int64
 	onlyInB       atomic.Int64
 	skippedRecent atomic.Int64
+
+	// outputMu serializes writes to stdout. Multiple goroutines call
+	// reportDiff concurrently from compareDirectory worker pool.
+	outputMu   sync.Mutex
+	jsonOutput bool
 }
 
 type verifyDiffType int
@@ -34,6 +40,36 @@ const (
 	diffSizeMismatch                       // size differs
 	diffETagMismatch                       // etag differs
 )
+
+// diffRecord is the JSON Lines schema for a single diff entry.
+type diffRecord struct {
+	Type          string       `json:"type"`
+	Path          string       `json:"path"`
+	IsDirectory   bool         `json:"isDirectory,omitempty"`
+	A             *entryRecord `json:"a,omitempty"`
+	B             *entryRecord `json:"b,omitempty"`
+	MtimeRelation string       `json:"mtimeRelation,omitempty"` // EQUAL | A_NEWER | B_NEWER
+	MtimeDelta    string       `json:"mtimeDelta,omitempty"`    // human-readable, e.g. "5d", "12h"
+	Hint          string       `json:"hint,omitempty"`          // late_updates_skip_likely | sync_lag_or_event_miss
+}
+
+type entryRecord struct {
+	Size  uint64 `json:"size"`
+	Mtime int64  `json:"mtime"`
+	ETag  string `json:"etag,omitempty"`
+}
+
+type summaryRecord struct {
+	Type          string `json:"type"`
+	Directories   int64  `json:"directories"`
+	Files         int64  `json:"files"`
+	SkippedRecent int64  `json:"skippedRecent"`
+	Missing       int64  `json:"missing"`
+	SizeMismatch  int64  `json:"sizeMismatch"`
+	ETagMismatch  int64  `json:"etagMismatch"`
+	OnlyInB       int64  `json:"onlyInB"`
+	TotalErrors   int64  `json:"totalErrors"`
+}
 
 // simpleFilerClient implements filer_pb.FilerClient for gRPC connections
 type simpleFilerClient struct {
@@ -58,6 +94,7 @@ func (c *simpleFilerClient) GetDataCenter() string {
 
 func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	isActivePassive bool, modifyTimeAgo time.Duration,
+	jsonOutput bool,
 	grpcDialOptionA, grpcDialOptionB grpc.DialOption) error {
 
 	clientA := &simpleFilerClient{grpcAddress: filerA, grpcDialOption: grpcDialOptionA}
@@ -66,36 +103,55 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	var cutoffTime time.Time
 	if modifyTimeAgo > 0 {
 		cutoffTime = time.Now().Add(-modifyTimeAgo)
-		fmt.Fprintf(os.Stdout, "Verifying files modified before %v (modifyTimeAgo=%v)\n", cutoffTime.Format(time.RFC3339), modifyTimeAgo)
 	}
 
-	fmt.Fprintf(os.Stdout, "Comparing %s%s => %s%s (isActivePassive=%v)\n\n",
-		filerA, aPath, filerB, bPath, isActivePassive)
+	if !jsonOutput {
+		if !cutoffTime.IsZero() {
+			fmt.Fprintf(os.Stdout, "Verifying files modified before %v (modifyTimeAgo=%v)\n",
+				cutoffTime.Format(time.RFC3339), modifyTimeAgo)
+		}
+		fmt.Fprintf(os.Stdout, "Comparing %s%s => %s%s (isActivePassive=%v)\n\n",
+			filerA, aPath, filerB, bPath, isActivePassive)
+	}
 
-	result := &VerifyResult{}
+	result := &VerifyResult{jsonOutput: jsonOutput}
 	ctx := context.Background()
 
 	err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, result)
-
-	// print summary
-	fmt.Fprintf(os.Stdout, "\nSummary:\n")
-	fmt.Fprintf(os.Stdout, "  Directories compared: %d\n", result.dirCount.Load())
-	fmt.Fprintf(os.Stdout, "  Files verified:       %d\n", result.fileCount.Load())
-	if result.skippedRecent.Load() > 0 {
-		fmt.Fprintf(os.Stdout, "  Skipped (too recent): %d\n", result.skippedRecent.Load())
-	}
-	fmt.Fprintf(os.Stdout, "  Missing in B:         %d\n", result.missingCount.Load())
-	fmt.Fprintf(os.Stdout, "  Size mismatch:        %d\n", result.sizeMismatch.Load())
-	fmt.Fprintf(os.Stdout, "  ETag mismatch:        %d\n", result.etagMismatch.Load())
-	if !isActivePassive {
-		fmt.Fprintf(os.Stdout, "  Only in B:            %d\n", result.onlyInB.Load())
-	}
 
 	totalErrors := result.missingCount.Load() + result.sizeMismatch.Load() + result.etagMismatch.Load()
 	if !isActivePassive {
 		totalErrors += result.onlyInB.Load()
 	}
-	fmt.Fprintf(os.Stdout, "  Total errors:         %d\n", totalErrors)
+
+	if jsonOutput {
+		summary := summaryRecord{
+			Type:          "SUMMARY",
+			Directories:   result.dirCount.Load(),
+			Files:         result.fileCount.Load(),
+			SkippedRecent: result.skippedRecent.Load(),
+			Missing:       result.missingCount.Load(),
+			SizeMismatch:  result.sizeMismatch.Load(),
+			ETagMismatch:  result.etagMismatch.Load(),
+			OnlyInB:       result.onlyInB.Load(),
+			TotalErrors:   totalErrors,
+		}
+		writeJSONLine(result, summary)
+	} else {
+		fmt.Fprintf(os.Stdout, "\nSummary:\n")
+		fmt.Fprintf(os.Stdout, "  Directories compared: %d\n", result.dirCount.Load())
+		fmt.Fprintf(os.Stdout, "  Files verified:       %d\n", result.fileCount.Load())
+		if result.skippedRecent.Load() > 0 {
+			fmt.Fprintf(os.Stdout, "  Skipped (too recent): %d\n", result.skippedRecent.Load())
+		}
+		fmt.Fprintf(os.Stdout, "  Missing in B:         %d\n", result.missingCount.Load())
+		fmt.Fprintf(os.Stdout, "  Size mismatch:        %d\n", result.sizeMismatch.Load())
+		fmt.Fprintf(os.Stdout, "  ETag mismatch:        %d\n", result.etagMismatch.Load())
+		if !isActivePassive {
+			fmt.Fprintf(os.Stdout, "  Only in B:            %d\n", result.onlyInB.Load())
+		}
+		fmt.Fprintf(os.Stdout, "  Total errors:         %d\n", totalErrors)
+	}
 
 	if err != nil {
 		return err
@@ -246,12 +302,79 @@ func compareEntries(dir string, entryA, entryB *filer_pb.Entry, result *VerifyRe
 	}
 }
 
-func reportDiff(diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry, result *VerifyResult) {
-	path := fmt.Sprintf("%s/%s", dir, entryA.Name)
+// mtimeRelation classifies B.mtime vs A.mtime. Both entries must be non-nil.
+// Returns relation, absolute delta in seconds, and human-readable string.
+func mtimeRelation(entryA, entryB *filer_pb.Entry) (relation, deltaStr string, deltaSec int64) {
+	if entryA == nil || entryB == nil || entryA.Attributes == nil || entryB.Attributes == nil {
+		return "", "", 0
+	}
+	delta := entryB.Attributes.Mtime - entryA.Attributes.Mtime
+	abs := delta
+	if abs < 0 {
+		abs = -abs
+	}
+	switch {
+	case delta == 0:
+		return "EQUAL", "0s", 0
+	case delta > 0:
+		return "B_NEWER", formatSeconds(abs), abs
+	default:
+		return "A_NEWER", formatSeconds(abs), abs
+	}
+}
 
+func formatSeconds(s int64) string {
+	switch {
+	case s < 60:
+		return fmt.Sprintf("%ds", s)
+	case s < 3600:
+		return fmt.Sprintf("%dm", s/60)
+	case s < 86400:
+		return fmt.Sprintf("%dh", s/3600)
+	default:
+		return fmt.Sprintf("%dd", s/86400)
+	}
+}
+
+// hintFor returns an automatic interpretation hint based on mtime relation.
+// Only emitted for SIZE_MISMATCH and ETAG_MISMATCH where both entries exist.
+func hintFor(relation string) string {
+	switch relation {
+	case "B_NEWER":
+		return "late_updates_skip_likely"
+	case "A_NEWER":
+		return "sync_lag_or_event_miss"
+	}
+	return ""
+}
+
+func reportDiff(diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry, result *VerifyResult) {
 	switch diffType {
 	case diffMissing:
 		result.missingCount.Add(1)
+	case diffOnlyInB:
+		result.onlyInB.Add(1)
+	case diffSizeMismatch:
+		result.sizeMismatch.Add(1)
+	case diffETagMismatch:
+		result.etagMismatch.Add(1)
+	}
+
+	if result.jsonOutput {
+		writeJSONDiff(result, diffType, dir, entryA, entryB)
+	} else {
+		writeTextDiff(result, diffType, dir, entryA, entryB)
+	}
+}
+
+func writeTextDiff(result *VerifyResult, diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry) {
+	path := fmt.Sprintf("%s/%s", dir, entryA.Name)
+
+	result.outputMu.Lock()
+	defer result.outputMu.Unlock()
+
+	switch diffType {
+	case diffMissing:
 		if entryA.IsDirectory {
 			fmt.Fprintf(os.Stdout, "[MISSING]       %s/ (directory)\n", path)
 		} else {
@@ -259,17 +382,97 @@ func reportDiff(diffType verifyDiffType, dir string, entryA, entryB *filer_pb.En
 				path, filer.FileSize(entryA), filer.ETag(entryA))
 		}
 	case diffOnlyInB:
-		result.onlyInB.Add(1)
-		fmt.Fprintf(os.Stdout, "[ONLY_IN_B]     %s\n", fmt.Sprintf("%s/%s", dir, entryA.Name))
+		fmt.Fprintf(os.Stdout, "[ONLY_IN_B]     %s\n", path)
 	case diffSizeMismatch:
-		result.sizeMismatch.Add(1)
-		fmt.Fprintf(os.Stdout, "[SIZE_MISMATCH] %s (a=%d, b=%d)\n",
-			path, filer.FileSize(entryA), filer.FileSize(entryB))
+		ann := annotation(entryA, entryB)
+		fmt.Fprintf(os.Stdout, "[SIZE_MISMATCH] %s (a=%d, b=%d%s)\n",
+			path, filer.FileSize(entryA), filer.FileSize(entryB), ann)
 	case diffETagMismatch:
-		result.etagMismatch.Add(1)
-		fmt.Fprintf(os.Stdout, "[ETAG_MISMATCH] %s (a=%s, b=%s)\n",
-			path, filer.ETag(entryA), filer.ETag(entryB))
+		ann := annotation(entryA, entryB)
+		fmt.Fprintf(os.Stdout, "[ETAG_MISMATCH] %s (a=%s, b=%s%s)\n",
+			path, filer.ETag(entryA), filer.ETag(entryB), ann)
 	}
+}
+
+// annotation builds the trailing ", mtime: ... [hint]" segment for text output.
+// Returns empty string if entries are unavailable.
+func annotation(entryA, entryB *filer_pb.Entry) string {
+	relation, delta, _ := mtimeRelation(entryA, entryB)
+	if relation == "" {
+		return ""
+	}
+	switch relation {
+	case "EQUAL":
+		return ", mtime equal [chunk-level issue]"
+	case "B_NEWER":
+		return fmt.Sprintf(", B newer +%s [late-updates skip likely]", delta)
+	case "A_NEWER":
+		return fmt.Sprintf(", A newer +%s [sync lag or event miss]", delta)
+	}
+	return ""
+}
+
+func writeJSONDiff(result *VerifyResult, diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry) {
+	path := fmt.Sprintf("%s/%s", dir, entryA.Name)
+	rec := diffRecord{Path: path}
+
+	switch diffType {
+	case diffMissing:
+		rec.Type = "MISSING"
+		rec.IsDirectory = entryA.IsDirectory
+		rec.A = toEntryRecord(entryA)
+	case diffOnlyInB:
+		rec.Type = "ONLY_IN_B"
+		// for diffOnlyInB the existing convention passes the entry as entryA
+		rec.IsDirectory = entryA.IsDirectory
+		rec.B = toEntryRecord(entryA)
+	case diffSizeMismatch:
+		rec.Type = "SIZE_MISMATCH"
+		rec.A = toEntryRecord(entryA)
+		rec.B = toEntryRecord(entryB)
+		relation, delta, _ := mtimeRelation(entryA, entryB)
+		rec.MtimeRelation = relation
+		rec.MtimeDelta = delta
+		rec.Hint = hintFor(relation)
+	case diffETagMismatch:
+		rec.Type = "ETAG_MISMATCH"
+		rec.A = toEntryRecord(entryA)
+		rec.B = toEntryRecord(entryB)
+		relation, delta, _ := mtimeRelation(entryA, entryB)
+		rec.MtimeRelation = relation
+		rec.MtimeDelta = delta
+		rec.Hint = hintFor(relation)
+	}
+
+	writeJSONLine(result, rec)
+}
+
+func toEntryRecord(entry *filer_pb.Entry) *entryRecord {
+	if entry == nil {
+		return nil
+	}
+	r := &entryRecord{
+		Size: filer.FileSize(entry),
+		ETag: filer.ETag(entry),
+	}
+	if entry.Attributes != nil {
+		r.Mtime = entry.Attributes.Mtime
+	}
+	return r
+}
+
+// writeJSONLine emits a single JSON object followed by newline. Holds outputMu
+// across marshal+write so concurrent goroutines never interleave.
+func writeJSONLine(result *VerifyResult, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		glog.Warningf("marshal verify record: %v", err)
+		return
+	}
+	result.outputMu.Lock()
+	defer result.outputMu.Unlock()
+	os.Stdout.Write(data)
+	os.Stdout.Write([]byte{'\n'})
 }
 
 func countMissingRecursive(ctx context.Context, client filer_pb.FilerClient, dir string, cutoffTime time.Time, result *VerifyResult) {
@@ -286,9 +489,7 @@ func countMissingRecursive(ctx context.Context, client filer_pb.FilerClient, dir
 				result.skippedRecent.Add(1)
 				continue
 			}
-			result.missingCount.Add(1)
-			fmt.Fprintf(os.Stdout, "[MISSING]       %s/%s (size=%d, etag=%s)\n",
-				dir, entry.Name, filer.FileSize(entry), filer.ETag(entry))
+			reportDiff(diffMissing, dir, entry, nil, result)
 		}
 	}
 }

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -177,6 +177,62 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	return nil
 }
 
+// entryStream is a sorted, streaming view of a single directory's entries.
+// A background goroutine pages through the directory via ReadDirAllEntries
+// and forwards each entry to a buffered channel; the caller consumes entries
+// one at a time through peek/advance. Memory usage is O(channel buffer) —
+// independent of directory size — rather than O(total entries).
+type entryStream struct {
+	ch   <-chan *filer_pb.Entry
+	head *filer_pb.Entry
+	done bool
+	err  error // written before ch is closed; safe to read once done==true
+}
+
+// newEntryStream starts the background goroutine. It exits when listing
+// completes, an error occurs, or ctx is cancelled; the channel is always
+// closed before exit so consumers do not block indefinitely.
+func newEntryStream(ctx context.Context, client filer_pb.FilerClient, dir string) *entryStream {
+	ch := make(chan *filer_pb.Entry, 64)
+	s := &entryStream{ch: ch}
+	go func() {
+		defer close(ch)
+		s.err = filer_pb.ReadDirAllEntries(ctx, client, util.FullPath(dir), "",
+			func(entry *filer_pb.Entry, isLast bool) error {
+				select {
+				case ch <- entry:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			})
+	}()
+	return s
+}
+
+// peek returns the next entry without consuming it, or nil at end-of-stream.
+func (s *entryStream) peek() *filer_pb.Entry {
+	if s.done {
+		return nil
+	}
+	if s.head == nil {
+		e, ok := <-s.ch
+		if !ok {
+			s.done = true
+			return nil
+		}
+		s.head = e
+	}
+	return s.head
+}
+
+// advance consumes and returns the next entry.
+func (s *entryStream) advance() *filer_pb.Entry {
+	e := s.peek()
+	s.head = nil
+	return e
+}
+
 func compareDirectory(ctx context.Context,
 	clientA, clientB filer_pb.FilerClient,
 	dirA, dirB string,
@@ -200,33 +256,26 @@ func compareDirectory(ctx context.Context,
 
 	result.dirCount.Add(1)
 
-	entriesA, errA := listEntries(ctx, clientA, dirA)
-	if errA != nil {
-		return fmt.Errorf("list %s on filer A: %v", dirA, errA)
-	}
-	entriesB, errB := listEntries(ctx, clientB, dirB)
-	if errB != nil {
-		return fmt.Errorf("list %s on filer B: %v", dirB, errB)
-	}
+	// A child context ensures that stream goroutines are cancelled and their
+	// channels are closed if compareDirectory returns early (e.g. on error).
+	mergeCtx, cancelMerge := context.WithCancel(ctx)
+	defer cancelMerge()
+
+	streamA := newEntryStream(mergeCtx, clientA, dirA)
+	streamB := newEntryStream(mergeCtx, clientB, dirB)
 
 	// collect subdirectories for recursive comparison
 	type dirPair struct{ a, b string }
 	var subDirs []dirPair
 
-	i, j := 0, 0
-	for i < len(entriesA) || j < len(entriesB) {
-		var nameA, nameB string
-		if i < len(entriesA) {
-			nameA = entriesA[i].Name
-		}
-		if j < len(entriesB) {
-			nameB = entriesB[j].Name
-		}
+	for streamA.peek() != nil || streamB.peek() != nil {
+		eA := streamA.peek()
+		eB := streamB.peek()
 
 		switch {
-		case i < len(entriesA) && (j >= len(entriesB) || nameA < nameB):
+		case eA != nil && (eB == nil || eA.Name < eB.Name):
 			// entry only in A
-			entryA := entriesA[i]
+			entryA := streamA.advance()
 			if !cutoffTime.IsZero() && entryA.Attributes != nil && entryA.Attributes.Mtime > cutoffTime.Unix() {
 				result.skippedRecent.Add(1)
 			} else {
@@ -236,19 +285,18 @@ func compareDirectory(ctx context.Context,
 					countMissingRecursive(ctx, clientA, fmt.Sprintf("%s/%s", dirA, entryA.Name), cutoffTime, result)
 				}
 			}
-			i++
 
-		case j < len(entriesB) && (i >= len(entriesA) || nameB < nameA):
+		case eB != nil && (eA == nil || eB.Name < eA.Name):
 			// entry only in B
+			entryB := streamB.advance()
 			if !isActivePassive {
-				reportDiff(diffOnlyInB, dirB, entriesB[j], nil, result)
+				reportDiff(diffOnlyInB, dirB, entryB, nil, result)
 			}
-			j++
 
 		default:
 			// same name in both
-			entryA := entriesA[i]
-			entryB := entriesB[j]
+			entryA := streamA.advance()
+			entryB := streamB.advance()
 
 			if entryA.IsDirectory && entryB.IsDirectory {
 				subDirs = append(subDirs, dirPair{
@@ -269,9 +317,16 @@ func compareDirectory(ctx context.Context,
 					reportDiff(diffOnlyInB, dirB, entryB, nil, result)
 				}
 			}
-			i++
-			j++
 		}
+	}
+
+	// Both channels are closed: close happens-before the receive of the zero
+	// value, so stream.err is visible here without additional synchronisation.
+	if err := streamA.err; err != nil && err != context.Canceled {
+		return fmt.Errorf("list %s on filer A: %v", dirA, err)
+	}
+	if err := streamB.err; err != nil && err != context.Canceled {
+		return fmt.Errorf("list %s on filer B: %v", dirB, err)
 	}
 
 	// Release our slot before recursing so children can acquire it. Holding
@@ -304,14 +359,6 @@ func compareDirectory(ctx context.Context,
 	return nil
 }
 
-func listEntries(ctx context.Context, client filer_pb.FilerClient, dir string) ([]*filer_pb.Entry, error) {
-	var entries []*filer_pb.Entry
-	err := filer_pb.ReadDirAllEntries(ctx, client, util.FullPath(dir), "", func(entry *filer_pb.Entry, isLast bool) error {
-		entries = append(entries, entry)
-		return nil
-	})
-	return entries, err
-}
 
 func compareEntries(dir string, entryA, entryB *filer_pb.Entry, result *VerifyResult) {
 	result.fileCount.Add(1)
@@ -505,20 +552,20 @@ func writeJSONLine(result *VerifyResult, v any) {
 }
 
 func countMissingRecursive(ctx context.Context, client filer_pb.FilerClient, dir string, cutoffTime time.Time, result *VerifyResult) {
-	entries, err := listEntries(ctx, client, dir)
-	if err != nil {
-		glog.Warningf("list missing directory %s: %v", dir, err)
-		return
-	}
-	for _, entry := range entries {
-		if entry.IsDirectory {
-			countMissingRecursive(ctx, client, fmt.Sprintf("%s/%s", dir, entry.Name), cutoffTime, result)
-		} else {
+	err := filer_pb.ReadDirAllEntries(ctx, client, util.FullPath(dir), "",
+		func(entry *filer_pb.Entry, isLast bool) error {
+			if entry.IsDirectory {
+				countMissingRecursive(ctx, client, fmt.Sprintf("%s/%s", dir, entry.Name), cutoffTime, result)
+				return nil
+			}
 			if !cutoffTime.IsZero() && entry.Attributes != nil && entry.Attributes.Mtime > cutoffTime.Unix() {
 				result.skippedRecent.Add(1)
-				continue
+				return nil
 			}
 			reportDiff(diffMissing, dir, entry, nil, result)
-		}
+			return nil
+		})
+	if err != nil {
+		glog.Warningf("list missing directory %s: %v", dir, err)
 	}
 }

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -17,6 +17,20 @@ import (
 	"google.golang.org/grpc"
 )
 
+// verifySyncConcurrency caps concurrent directory I/O across the entire
+// recursive walk. A single shared semaphore is created in runVerifySync and
+// passed down so the limit applies globally — a per-call semaphore would only
+// cap concurrency per directory level, allowing fanout to grow as
+// verifySyncConcurrency^depth on deep trees.
+//
+// Trade-off: higher values reduce wall time on wide trees by parallelizing
+// listEntries RPCs, at the cost of more concurrent load on both filers and
+// more memory from queued goroutines (each waiting goroutine ~2KB stack).
+// Each compareDirectory holds a slot only for its own listing+compare phase
+// and releases before recursing, so a parent never blocks waiting for
+// children to acquire slots.
+const verifySyncConcurrency = 5
+
 type VerifyResult struct {
 	dirCount      atomic.Int64
 	fileCount     atomic.Int64
@@ -116,8 +130,9 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 
 	result := &VerifyResult{jsonOutput: jsonOutput}
 	ctx := context.Background()
+	sem := make(chan struct{}, verifySyncConcurrency)
 
-	err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, result)
+	err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, sem, result)
 
 	totalErrors := result.missingCount.Load() + result.sizeMismatch.Load() + result.etagMismatch.Load()
 	if !isActivePassive {
@@ -167,7 +182,21 @@ func compareDirectory(ctx context.Context,
 	dirA, dirB string,
 	isActivePassive bool,
 	cutoffTime time.Time,
+	sem chan struct{},
 	result *VerifyResult) error {
+
+	// Hold a slot only for this directory's I/O phase (listings + merge).
+	// Released before recursing so parents never block waiting for children
+	// to acquire slots — see verifySyncConcurrency for the rationale.
+	sem <- struct{}{}
+	released := false
+	releaseSlot := func() {
+		if !released {
+			released = true
+			<-sem
+		}
+	}
+	defer releaseSlot()
 
 	result.dirCount.Add(1)
 
@@ -245,19 +274,19 @@ func compareDirectory(ctx context.Context,
 		}
 	}
 
-	// recurse into subdirectories with concurrency
+	// Release our slot before recursing so children can acquire it. Holding
+	// it across wg.Wait would deadlock once depth exceeds verifySyncConcurrency.
+	releaseSlot()
+
 	if len(subDirs) > 0 {
 		var wg sync.WaitGroup
 		errCh := make(chan error, len(subDirs))
-		sem := make(chan struct{}, 5) // concurrency limit
 
 		for _, pair := range subDirs {
 			wg.Add(1)
 			go func(a, b string) {
 				defer wg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
-				if err := compareDirectory(ctx, clientA, clientB, a, b, isActivePassive, cutoffTime, result); err != nil {
+				if err := compareDirectory(ctx, clientA, clientB, a, b, isActivePassive, cutoffTime, sem, result); err != nil {
 					errCh <- err
 				}
 			}(pair.a, pair.b)

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -14,9 +14,85 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"google.golang.org/grpc"
 )
+
+type SyncVerifyOptions struct {
+	filerA          *string
+	filerB          *string
+	aPath           *string
+	bPath           *string
+	aSecurity       *string
+	bSecurity       *string
+	isActivePassive *bool
+	modifiedTimeAgo *time.Duration
+	jsonOutput      *bool
+}
+
+var syncVerifyOptions SyncVerifyOptions
+
+func init() {
+	cmdFilerSyncVerify.Run = runFilerSyncVerify // break init cycle
+	syncVerifyOptions.filerA = cmdFilerSyncVerify.Flag.String("a", "", "filer A in one SeaweedFS cluster")
+	syncVerifyOptions.filerB = cmdFilerSyncVerify.Flag.String("b", "", "filer B in the other SeaweedFS cluster")
+	syncVerifyOptions.aPath = cmdFilerSyncVerify.Flag.String("a.path", "/", "directory to verify on filer A")
+	syncVerifyOptions.bPath = cmdFilerSyncVerify.Flag.String("b.path", "/", "directory to verify on filer B")
+	syncVerifyOptions.aSecurity = cmdFilerSyncVerify.Flag.String("a.security", "", "security.toml file for filer A when clusters use different certificates")
+	syncVerifyOptions.bSecurity = cmdFilerSyncVerify.Flag.String("b.security", "", "security.toml file for filer B when clusters use different certificates")
+	syncVerifyOptions.isActivePassive = cmdFilerSyncVerify.Flag.Bool("isActivePassive", false, "one directional comparison from A to B; entries only in B are not reported")
+	syncVerifyOptions.modifiedTimeAgo = cmdFilerSyncVerify.Flag.Duration("modifiedTimeAgo", 0, "only verify files modified before this duration ago (e.g. 1h) for sync-lag tolerance")
+	syncVerifyOptions.jsonOutput = cmdFilerSyncVerify.Flag.Bool("jsonOutput", false, "emit NDJSON output (one JSON object per line) for external tooling")
+}
+
+var cmdFilerSyncVerify = &Command{
+	UsageLine: "filer.sync.verify -a=<oneFilerHost>:<oneFilerPort> -b=<otherFilerHost>:<otherFilerPort>",
+	Short:     "compare entries between two filers and report differences",
+	Long: `compare entries between two filers and report differences, then exit.
+
+	Useful for validating active/passive sync targets agree with the source.
+	Reports MISSING (in A but not in B), ONLY_IN_B (in B but not in A; suppressed
+	in active-passive mode), SIZE_MISMATCH, and ETAG_MISMATCH. Honors
+	-modifiedTimeAgo to skip recently-modified files (sync-lag tolerance) and
+	-isActivePassive for unidirectional comparison.
+
+	Exits with code 0 on agreement, 2 on differences or operational errors.
+
+`,
+}
+
+func runFilerSyncVerify(cmd *Command, args []string) bool {
+	util.LoadSecurityConfiguration()
+	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
+
+	grpcDialOptionA := grpcDialOption
+	grpcDialOptionB := grpcDialOption
+	if *syncVerifyOptions.aSecurity != "" {
+		var err error
+		if grpcDialOptionA, err = security.LoadClientTLSFromFile(*syncVerifyOptions.aSecurity, "grpc.client"); err != nil {
+			glog.Fatalf("load security config for filer A: %v", err)
+		}
+	}
+	if *syncVerifyOptions.bSecurity != "" {
+		var err error
+		if grpcDialOptionB, err = security.LoadClientTLSFromFile(*syncVerifyOptions.bSecurity, "grpc.client"); err != nil {
+			glog.Fatalf("load security config for filer B: %v", err)
+		}
+	}
+
+	filerA := pb.ServerAddress(*syncVerifyOptions.filerA)
+	filerB := pb.ServerAddress(*syncVerifyOptions.filerB)
+
+	if err := runVerifySync(filerA, filerB, *syncVerifyOptions.aPath, *syncVerifyOptions.bPath,
+		*syncVerifyOptions.isActivePassive, *syncVerifyOptions.modifiedTimeAgo,
+		*syncVerifyOptions.jsonOutput,
+		grpcDialOptionA, grpcDialOptionB); err != nil {
+		glog.Errorf("verify sync: %v", err)
+		os.Exit(2)
+	}
+	return true
+}
 
 // verifySyncConcurrency caps concurrent directory I/O across the entire
 // recursive walk. A single shared semaphore is created in runVerifySync and
@@ -108,7 +184,7 @@ func (c *simpleFilerClient) GetDataCenter() string {
 }
 
 func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
-	isActivePassive bool, modifyTimeAgo time.Duration,
+	isActivePassive bool, modifiedTimeAgo time.Duration,
 	jsonOutput bool,
 	grpcDialOptionA, grpcDialOptionB grpc.DialOption) error {
 
@@ -116,14 +192,14 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	clientB := &simpleFilerClient{grpcAddress: filerB, grpcDialOption: grpcDialOptionB}
 
 	var cutoffTime time.Time
-	if modifyTimeAgo > 0 {
-		cutoffTime = time.Now().Add(-modifyTimeAgo)
+	if modifiedTimeAgo > 0 {
+		cutoffTime = time.Now().Add(-modifiedTimeAgo)
 	}
 
 	if !jsonOutput {
 		if !cutoffTime.IsZero() {
-			fmt.Fprintf(os.Stdout, "Verifying files modified before %v (modifyTimeAgo=%v)\n",
-				cutoffTime.Format(time.RFC3339), modifyTimeAgo)
+			fmt.Fprintf(os.Stdout, "Verifying files modified before %v (modifiedTimeAgo=%v)\n",
+				cutoffTime.Format(time.RFC3339), modifiedTimeAgo)
 		}
 		fmt.Fprintf(os.Stdout, "Comparing %s%s => %s%s (isActivePassive=%v)\n\n",
 			filerA, aPath, filerB, bPath, isActivePassive)

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -1,0 +1,294 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"google.golang.org/grpc"
+)
+
+type VerifyResult struct {
+	dirCount      atomic.Int64
+	fileCount     atomic.Int64
+	missingCount  atomic.Int64
+	sizeMismatch  atomic.Int64
+	etagMismatch  atomic.Int64
+	onlyInB       atomic.Int64
+	skippedRecent atomic.Int64
+}
+
+type verifyDiffType int
+
+const (
+	diffMissing      verifyDiffType = iota // in A but not in B
+	diffOnlyInB                            // in B but not in A
+	diffSizeMismatch                       // size differs
+	diffETagMismatch                       // etag differs
+)
+
+// simpleFilerClient implements filer_pb.FilerClient for gRPC connections
+type simpleFilerClient struct {
+	grpcAddress    pb.ServerAddress
+	grpcDialOption grpc.DialOption
+}
+
+func (c *simpleFilerClient) WithFilerClient(streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+	return pb.WithGrpcClient(streamingMode, 0, func(grpcConnection *grpc.ClientConn) error {
+		client := filer_pb.NewSeaweedFilerClient(grpcConnection)
+		return fn(client)
+	}, c.grpcAddress.ToGrpcAddress(), false, c.grpcDialOption)
+}
+
+func (c *simpleFilerClient) AdjustedUrl(location *filer_pb.Location) string {
+	return location.Url
+}
+
+func (c *simpleFilerClient) GetDataCenter() string {
+	return ""
+}
+
+func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
+	isActivePassive bool, modifyTimeAgo time.Duration,
+	grpcDialOptionA, grpcDialOptionB grpc.DialOption) error {
+
+	clientA := &simpleFilerClient{grpcAddress: filerA, grpcDialOption: grpcDialOptionA}
+	clientB := &simpleFilerClient{grpcAddress: filerB, grpcDialOption: grpcDialOptionB}
+
+	var cutoffTime time.Time
+	if modifyTimeAgo > 0 {
+		cutoffTime = time.Now().Add(-modifyTimeAgo)
+		fmt.Fprintf(os.Stdout, "Verifying files modified before %v (modifyTimeAgo=%v)\n", cutoffTime.Format(time.RFC3339), modifyTimeAgo)
+	}
+
+	fmt.Fprintf(os.Stdout, "Comparing %s%s => %s%s (isActivePassive=%v)\n\n",
+		filerA, aPath, filerB, bPath, isActivePassive)
+
+	result := &VerifyResult{}
+	ctx := context.Background()
+
+	err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, result)
+
+	// print summary
+	fmt.Fprintf(os.Stdout, "\nSummary:\n")
+	fmt.Fprintf(os.Stdout, "  Directories compared: %d\n", result.dirCount.Load())
+	fmt.Fprintf(os.Stdout, "  Files verified:       %d\n", result.fileCount.Load())
+	if result.skippedRecent.Load() > 0 {
+		fmt.Fprintf(os.Stdout, "  Skipped (too recent): %d\n", result.skippedRecent.Load())
+	}
+	fmt.Fprintf(os.Stdout, "  Missing in B:         %d\n", result.missingCount.Load())
+	fmt.Fprintf(os.Stdout, "  Size mismatch:        %d\n", result.sizeMismatch.Load())
+	fmt.Fprintf(os.Stdout, "  ETag mismatch:        %d\n", result.etagMismatch.Load())
+	if !isActivePassive {
+		fmt.Fprintf(os.Stdout, "  Only in B:            %d\n", result.onlyInB.Load())
+	}
+
+	totalErrors := result.missingCount.Load() + result.sizeMismatch.Load() + result.etagMismatch.Load()
+	if !isActivePassive {
+		totalErrors += result.onlyInB.Load()
+	}
+	fmt.Fprintf(os.Stdout, "  Total errors:         %d\n", totalErrors)
+
+	if err != nil {
+		return err
+	}
+	if totalErrors > 0 {
+		return fmt.Errorf("found %d differences", totalErrors)
+	}
+	return nil
+}
+
+func compareDirectory(ctx context.Context,
+	clientA, clientB filer_pb.FilerClient,
+	dirA, dirB string,
+	isActivePassive bool,
+	cutoffTime time.Time,
+	result *VerifyResult) error {
+
+	result.dirCount.Add(1)
+
+	entriesA, errA := listEntries(ctx, clientA, dirA)
+	if errA != nil {
+		return fmt.Errorf("list %s on filer A: %v", dirA, errA)
+	}
+	entriesB, errB := listEntries(ctx, clientB, dirB)
+	if errB != nil {
+		return fmt.Errorf("list %s on filer B: %v", dirB, errB)
+	}
+
+	// collect subdirectories for recursive comparison
+	type dirPair struct{ a, b string }
+	var subDirs []dirPair
+
+	i, j := 0, 0
+	for i < len(entriesA) || j < len(entriesB) {
+		var nameA, nameB string
+		if i < len(entriesA) {
+			nameA = entriesA[i].Name
+		}
+		if j < len(entriesB) {
+			nameB = entriesB[j].Name
+		}
+
+		switch {
+		case i < len(entriesA) && (j >= len(entriesB) || nameA < nameB):
+			// entry only in A
+			entryA := entriesA[i]
+			if !cutoffTime.IsZero() && entryA.Attributes != nil && entryA.Attributes.Mtime > cutoffTime.Unix() {
+				result.skippedRecent.Add(1)
+			} else {
+				reportDiff(diffMissing, dirA, entryA, nil, result)
+				if entryA.IsDirectory {
+					// directory missing in B: count all files under it as missing
+					countMissingRecursive(ctx, clientA, fmt.Sprintf("%s/%s", dirA, entryA.Name), cutoffTime, result)
+				}
+			}
+			i++
+
+		case j < len(entriesB) && (i >= len(entriesA) || nameB < nameA):
+			// entry only in B
+			if !isActivePassive {
+				reportDiff(diffOnlyInB, dirB, entriesB[j], nil, result)
+			}
+			j++
+
+		default:
+			// same name in both
+			entryA := entriesA[i]
+			entryB := entriesB[j]
+
+			if entryA.IsDirectory && entryB.IsDirectory {
+				subDirs = append(subDirs, dirPair{
+					a: fmt.Sprintf("%s/%s", dirA, entryA.Name),
+					b: fmt.Sprintf("%s/%s", dirB, entryB.Name),
+				})
+			} else if !entryA.IsDirectory && !entryB.IsDirectory {
+				// skip recently modified files
+				if !cutoffTime.IsZero() && entryA.Attributes != nil && entryA.Attributes.Mtime > cutoffTime.Unix() {
+					result.skippedRecent.Add(1)
+				} else {
+					compareEntries(dirA, entryA, entryB, result)
+				}
+			} else {
+				// type mismatch: one is dir, other is file
+				reportDiff(diffMissing, dirA, entryA, nil, result)
+				if !isActivePassive {
+					reportDiff(diffOnlyInB, dirB, entryB, nil, result)
+				}
+			}
+			i++
+			j++
+		}
+	}
+
+	// recurse into subdirectories with concurrency
+	if len(subDirs) > 0 {
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(subDirs))
+		sem := make(chan struct{}, 5) // concurrency limit
+
+		for _, pair := range subDirs {
+			wg.Add(1)
+			go func(a, b string) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				if err := compareDirectory(ctx, clientA, clientB, a, b, isActivePassive, cutoffTime, result); err != nil {
+					errCh <- err
+				}
+			}(pair.a, pair.b)
+		}
+		wg.Wait()
+		close(errCh)
+
+		for err := range errCh {
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func listEntries(ctx context.Context, client filer_pb.FilerClient, dir string) ([]*filer_pb.Entry, error) {
+	var entries []*filer_pb.Entry
+	err := filer_pb.ReadDirAllEntries(ctx, client, util.FullPath(dir), "", func(entry *filer_pb.Entry, isLast bool) error {
+		entries = append(entries, entry)
+		return nil
+	})
+	return entries, err
+}
+
+func compareEntries(dir string, entryA, entryB *filer_pb.Entry, result *VerifyResult) {
+	result.fileCount.Add(1)
+
+	sizeA := filer.FileSize(entryA)
+	sizeB := filer.FileSize(entryB)
+	if sizeA != sizeB {
+		reportDiff(diffSizeMismatch, dir, entryA, entryB, result)
+		return
+	}
+
+	etagA := filer.ETag(entryA)
+	etagB := filer.ETag(entryB)
+	if etagA != etagB {
+		reportDiff(diffETagMismatch, dir, entryA, entryB, result)
+		return
+	}
+}
+
+func reportDiff(diffType verifyDiffType, dir string, entryA, entryB *filer_pb.Entry, result *VerifyResult) {
+	path := fmt.Sprintf("%s/%s", dir, entryA.Name)
+
+	switch diffType {
+	case diffMissing:
+		result.missingCount.Add(1)
+		if entryA.IsDirectory {
+			fmt.Fprintf(os.Stdout, "[MISSING]       %s/ (directory)\n", path)
+		} else {
+			fmt.Fprintf(os.Stdout, "[MISSING]       %s (size=%d, etag=%s)\n",
+				path, filer.FileSize(entryA), filer.ETag(entryA))
+		}
+	case diffOnlyInB:
+		result.onlyInB.Add(1)
+		fmt.Fprintf(os.Stdout, "[ONLY_IN_B]     %s\n", fmt.Sprintf("%s/%s", dir, entryA.Name))
+	case diffSizeMismatch:
+		result.sizeMismatch.Add(1)
+		fmt.Fprintf(os.Stdout, "[SIZE_MISMATCH] %s (a=%d, b=%d)\n",
+			path, filer.FileSize(entryA), filer.FileSize(entryB))
+	case diffETagMismatch:
+		result.etagMismatch.Add(1)
+		fmt.Fprintf(os.Stdout, "[ETAG_MISMATCH] %s (a=%s, b=%s)\n",
+			path, filer.ETag(entryA), filer.ETag(entryB))
+	}
+}
+
+func countMissingRecursive(ctx context.Context, client filer_pb.FilerClient, dir string, cutoffTime time.Time, result *VerifyResult) {
+	entries, err := listEntries(ctx, client, dir)
+	if err != nil {
+		glog.Warningf("list missing directory %s: %v", dir, err)
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDirectory {
+			countMissingRecursive(ctx, client, fmt.Sprintf("%s/%s", dir, entry.Name), cutoffTime, result)
+		} else {
+			if !cutoffTime.IsZero() && entry.Attributes != nil && entry.Attributes.Mtime > cutoffTime.Unix() {
+				result.skippedRecent.Add(1)
+				continue
+			}
+			result.missingCount.Add(1)
+			fmt.Fprintf(os.Stdout, "[MISSING]       %s/%s (size=%d, etag=%s)\n",
+				dir, entry.Name, filer.FileSize(entry), filer.ETag(entry))
+		}
+	}
+}

--- a/weed/command/filer_sync_verify_test.go
+++ b/weed/command/filer_sync_verify_test.go
@@ -229,6 +229,178 @@ func TestVerifySyncConcurrencyBound(t *testing.T) {
 	}
 }
 
+// TestVerifySyncETagMismatch confirms that two files with the same size but
+// different Md5 checksums are counted as an ETag mismatch, not a size mismatch.
+func TestVerifySyncETagMismatch(t *testing.T) {
+	newEntry := func(name string, md5 []byte) *filer_pb.Entry {
+		return &filer_pb.Entry{
+			Name: name,
+			Attributes: &filer_pb.FuseAttributes{
+				FileSize: 100,
+				Md5:      md5,
+			},
+		}
+	}
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {newEntry("data.bin", []byte{0x11, 0x22, 0x33})},
+		},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {newEntry("data.bin", []byte{0x44, 0x55, 0x66})},
+		},
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	if err := compareDirectory(context.Background(), clientA, clientB,
+		"/root", "/root", false, time.Time{}, sem, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := result.etagMismatch.Load(); got != 1 {
+		t.Errorf("etagMismatch = %d, want 1", got)
+	}
+	if got := result.sizeMismatch.Load(); got != 0 {
+		t.Errorf("sizeMismatch = %d, want 0 (same size should not trigger size mismatch)", got)
+	}
+}
+
+// TestVerifySyncCutoffTime verifies that entries newer than cutoffTime are
+// skipped in both the A-only (MISSING) and B-only (ONLY_IN_B) branches.
+func TestVerifySyncCutoffTime(t *testing.T) {
+	cutoff := time.Unix(1000, 0)
+
+	recentEntry := func(name string) *filer_pb.Entry {
+		return &filer_pb.Entry{
+			Name:       name,
+			Attributes: &filer_pb.FuseAttributes{FileSize: 10, Mtime: 2000}, // > cutoff
+		}
+	}
+	oldEntry := func(name string) *filer_pb.Entry {
+		return &filer_pb.Entry{
+			Name:       name,
+			Attributes: &filer_pb.FuseAttributes{FileSize: 10, Mtime: 500}, // < cutoff
+		}
+	}
+
+	t.Run("A-only recent file is skipped, not reported missing", func(t *testing.T) {
+		clientA := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {recentEntry("new.txt")}},
+		}
+		clientB := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {}},
+		}
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/", "/", false, cutoff, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.skippedRecent.Load(); got != 1 {
+			t.Errorf("skippedRecent = %d, want 1", got)
+		}
+		if got := result.missingCount.Load(); got != 0 {
+			t.Errorf("missingCount = %d, want 0 (recent file should be skipped)", got)
+		}
+	})
+
+	t.Run("A-only old file is reported missing", func(t *testing.T) {
+		clientA := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {oldEntry("old.txt")}},
+		}
+		clientB := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {}},
+		}
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/", "/", false, cutoff, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.missingCount.Load(); got != 1 {
+			t.Errorf("missingCount = %d, want 1", got)
+		}
+	})
+
+	t.Run("B-only recent file is skipped, not reported as ONLY_IN_B", func(t *testing.T) {
+		clientA := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {}},
+		}
+		clientB := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {recentEntry("new.txt")}},
+		}
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/", "/", false, cutoff, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.skippedRecent.Load(); got != 1 {
+			t.Errorf("skippedRecent = %d, want 1", got)
+		}
+		if got := result.onlyInB.Load(); got != 0 {
+			t.Errorf("onlyInB = %d, want 0 (recent B-only file should be skipped)", got)
+		}
+	})
+
+	t.Run("B-only old file is reported as ONLY_IN_B", func(t *testing.T) {
+		clientA := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {}},
+		}
+		clientB := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/": {oldEntry("old.txt")}},
+		}
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/", "/", false, cutoff, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.onlyInB.Load(); got != 1 {
+			t.Errorf("onlyInB = %d, want 1", got)
+		}
+	})
+}
+
+// TestVerifySyncRootPath is a regression test for the path.Join fix.
+// fmt.Sprintf("%s/%s", "/", name) produced "//name"; path.Join produces "/name".
+// This test walks from "/" and verifies the child directory is found and
+// compared correctly (not silently skipped due to a malformed path).
+func TestVerifySyncRootPath(t *testing.T) {
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/":      {verifyDirEntry("data")},
+			"/data":  {verifyFileEntry("file.txt", 42)},
+		},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/":      {verifyDirEntry("data")},
+			"/data":  {verifyFileEntry("file.txt", 42)},
+		},
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	if err := compareDirectory(context.Background(), clientA, clientB,
+		"/", "/", false, time.Time{}, sem, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.missingCount.Load() != 0 || result.sizeMismatch.Load() != 0 {
+		t.Errorf("identical trees from root should have no diffs: missing=%d size=%d",
+			result.missingCount.Load(), result.sizeMismatch.Load())
+	}
+	// 2 directories traversed: "/" and "/data"
+	if got := result.dirCount.Load(); got != 2 {
+		t.Errorf("dirCount = %d, want 2 (root + /data)", got)
+	}
+	// 1 file compared: /data/file.txt
+	if got := result.fileCount.Load(); got != 1 {
+		t.Errorf("fileCount = %d, want 1", got)
+	}
+}
+
 // TestVerifySyncNoDeadlockDeepTree ensures that a tree deeper than
 // verifySyncConcurrency completes without deadlocking. With a per-call
 // semaphore the walk would still complete (just with unbounded goroutines);

--- a/weed/command/filer_sync_verify_test.go
+++ b/weed/command/filer_sync_verify_test.go
@@ -1,0 +1,277 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// --- stream / inner-client / outer-client mocks ---
+
+type verifyTestStream struct {
+	entries []*filer_pb.Entry
+	idx     int
+}
+
+func (s *verifyTestStream) Recv() (*filer_pb.ListEntriesResponse, error) {
+	if s.idx >= len(s.entries) {
+		return nil, io.EOF
+	}
+	resp := &filer_pb.ListEntriesResponse{Entry: s.entries[s.idx]}
+	s.idx++
+	return resp, nil
+}
+
+func (s *verifyTestStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *verifyTestStream) Trailer() metadata.MD         { return metadata.MD{} }
+func (s *verifyTestStream) CloseSend() error             { return nil }
+func (s *verifyTestStream) Context() context.Context     { return context.Background() }
+func (s *verifyTestStream) SendMsg(_ any) error          { return nil }
+func (s *verifyTestStream) RecvMsg(_ any) error          { return nil }
+
+// verifyTestInnerClient is the SeaweedFilerClient passed to fn inside WithFilerClient.
+type verifyTestInnerClient struct {
+	filer_pb.SeaweedFilerClient // embed for unimplemented RPCs
+	entriesByDir map[string][]*filer_pb.Entry
+}
+
+func (c *verifyTestInnerClient) ListEntries(_ context.Context, in *filer_pb.ListEntriesRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[filer_pb.ListEntriesResponse], error) {
+	return &verifyTestStream{entries: c.entriesByDir[in.Directory]}, nil
+}
+
+// verifyTestFilerClient implements filer_pb.FilerClient and tracks concurrent
+// WithFilerClient invocations to let tests verify the global concurrency bound.
+type verifyTestFilerClient struct {
+	entriesByDir map[string][]*filer_pb.Entry
+	inFlight     int64 // accessed via atomic
+	peakFlight   int64 // accessed via atomic
+	delay        time.Duration
+}
+
+func (c *verifyTestFilerClient) WithFilerClient(_ bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+	// track peak concurrent in-flight listings
+	n := atomic.AddInt64(&c.inFlight, 1)
+	defer atomic.AddInt64(&c.inFlight, -1)
+	for {
+		peak := atomic.LoadInt64(&c.peakFlight)
+		if n <= peak || atomic.CompareAndSwapInt64(&c.peakFlight, peak, n) {
+			break
+		}
+	}
+	if c.delay > 0 {
+		time.Sleep(c.delay)
+	}
+	return fn(&verifyTestInnerClient{entriesByDir: c.entriesByDir})
+}
+
+func (c *verifyTestFilerClient) AdjustedUrl(_ *filer_pb.Location) string { return "" }
+func (c *verifyTestFilerClient) GetDataCenter() string                   { return "" }
+
+// --- entry helpers ---
+
+func verifyFileEntry(name string, size uint64) *filer_pb.Entry {
+	return &filer_pb.Entry{
+		Name:       name,
+		Attributes: &filer_pb.FuseAttributes{FileSize: size},
+	}
+}
+
+func verifyDirEntry(name string) *filer_pb.Entry {
+	return &filer_pb.Entry{Name: name, IsDirectory: true}
+}
+
+// --- tests ---
+
+// TestVerifySyncMissingFile confirms that a file present in A but absent in B
+// is counted as missing.
+func TestVerifySyncMissingFile(t *testing.T) {
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {verifyFileEntry("file.txt", 100)},
+		},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {},
+		},
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	err := compareDirectory(context.Background(), clientA, clientB,
+		"/root", "/root", false, time.Time{}, sem, result)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := result.missingCount.Load(); got != 1 {
+		t.Errorf("missingCount = %d, want 1", got)
+	}
+	if got := result.sizeMismatch.Load(); got != 0 {
+		t.Errorf("sizeMismatch = %d, want 0", got)
+	}
+}
+
+// TestVerifySyncOnlyInB confirms that a file present only in B is counted
+// (non-active-passive mode) or ignored (active-passive mode).
+func TestVerifySyncOnlyInB(t *testing.T) {
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{"/root": {}},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {verifyFileEntry("extra.txt", 50)},
+		},
+	}
+
+	t.Run("bidirectional", func(t *testing.T) {
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/root", "/root", false, time.Time{}, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.onlyInB.Load(); got != 1 {
+			t.Errorf("onlyInB = %d, want 1", got)
+		}
+	})
+
+	t.Run("active-passive ignores onlyInB", func(t *testing.T) {
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/root", "/root", true, time.Time{}, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.onlyInB.Load(); got != 0 {
+			t.Errorf("onlyInB = %d, want 0 in active-passive mode", got)
+		}
+	})
+}
+
+// TestVerifySyncSizeMismatch confirms that a file with differing sizes is
+// counted as a size mismatch and not as missing.
+func TestVerifySyncSizeMismatch(t *testing.T) {
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {verifyFileEntry("data.bin", 1024)},
+		},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/root": {verifyFileEntry("data.bin", 512)},
+		},
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	err := compareDirectory(context.Background(), clientA, clientB,
+		"/root", "/root", false, time.Time{}, sem, result)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := result.sizeMismatch.Load(); got != 1 {
+		t.Errorf("sizeMismatch = %d, want 1", got)
+	}
+	if got := result.missingCount.Load(); got != 0 {
+		t.Errorf("missingCount = %d, want 0", got)
+	}
+}
+
+// TestVerifySyncConcurrencyBound verifies that the shared semaphore keeps peak
+// concurrent filer listings at or below verifySyncConcurrency at all times.
+// A 5ms delay per WithFilerClient call makes the concurrency overlap observable.
+func TestVerifySyncConcurrencyBound(t *testing.T) {
+	// Wide, shallow tree: root with 20 identical subdirectories.
+	const fanout = 20
+	entriesA := make(map[string][]*filer_pb.Entry)
+	entriesB := make(map[string][]*filer_pb.Entry)
+
+	rootDirs := make([]*filer_pb.Entry, fanout)
+	for i := range fanout {
+		name := fmt.Sprintf("sub%02d", i)
+		rootDirs[i] = verifyDirEntry(name)
+		entriesA["/root/"+name] = []*filer_pb.Entry{verifyFileEntry("f.txt", 10)}
+		entriesB["/root/"+name] = []*filer_pb.Entry{verifyFileEntry("f.txt", 10)}
+	}
+	entriesA["/root"] = rootDirs
+	entriesB["/root"] = rootDirs
+
+	clientA := &verifyTestFilerClient{entriesByDir: entriesA, delay: 5 * time.Millisecond}
+	clientB := &verifyTestFilerClient{entriesByDir: entriesB, delay: 5 * time.Millisecond}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	if err := compareDirectory(context.Background(), clientA, clientB,
+		"/root", "/root", false, time.Time{}, sem, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.missingCount.Load() != 0 || result.sizeMismatch.Load() != 0 {
+		t.Errorf("unexpected diffs in identical tree")
+	}
+
+	if peak := atomic.LoadInt64(&clientA.peakFlight); peak > verifySyncConcurrency {
+		t.Errorf("clientA peak concurrent listings = %d, want ≤ %d (verifySyncConcurrency)",
+			peak, verifySyncConcurrency)
+	}
+	if peak := atomic.LoadInt64(&clientB.peakFlight); peak > verifySyncConcurrency {
+		t.Errorf("clientB peak concurrent listings = %d, want ≤ %d (verifySyncConcurrency)",
+			peak, verifySyncConcurrency)
+	}
+}
+
+// TestVerifySyncNoDeadlockDeepTree ensures that a tree deeper than
+// verifySyncConcurrency completes without deadlocking. With a per-call
+// semaphore the walk would still complete (just with unbounded goroutines);
+// this test mainly guards that the shared-semaphore release-before-recurse
+// invariant holds — i.e. the walk finishes within the timeout.
+func TestVerifySyncNoDeadlockDeepTree(t *testing.T) {
+	// Build a binary tree of depth 10 (well past verifySyncConcurrency=5).
+	const depth = 10
+	entriesA := make(map[string][]*filer_pb.Entry)
+	entriesB := make(map[string][]*filer_pb.Entry)
+
+	var buildTree func(path string, d int)
+	buildTree = func(path string, d int) {
+		if d == 0 {
+			entriesA[path] = []*filer_pb.Entry{verifyFileEntry("leaf.txt", 1)}
+			entriesB[path] = []*filer_pb.Entry{verifyFileEntry("leaf.txt", 1)}
+			return
+		}
+		children := []*filer_pb.Entry{verifyDirEntry("left"), verifyDirEntry("right")}
+		entriesA[path] = children
+		entriesB[path] = children
+		buildTree(path+"/left", d-1)
+		buildTree(path+"/right", d-1)
+	}
+	buildTree("/root", depth)
+
+	clientA := &verifyTestFilerClient{entriesByDir: entriesA}
+	clientB := &verifyTestFilerClient{entriesByDir: entriesB}
+
+	done := make(chan error, 1)
+	go func() {
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		done <- compareDirectory(context.Background(), clientA, clientB,
+			"/root", "/root", false, time.Time{}, sem, result)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("compareDirectory did not complete within 10s — possible deadlock")
+	}
+}

--- a/weed/command/filer_sync_verify_test.go
+++ b/weed/command/filer_sync_verify_test.go
@@ -363,6 +363,86 @@ func TestVerifySyncCutoffTime(t *testing.T) {
 	})
 }
 
+// TestVerifySyncCutoffMatchedFileBSideRecent verifies that when matched-name
+// files differ but only the B side is recently modified, the comparison is
+// skipped (sync-lag tolerance) rather than reporting a spurious mismatch.
+func TestVerifySyncCutoffMatchedFileBSideRecent(t *testing.T) {
+	cutoff := time.Unix(1000, 0)
+
+	entry := func(size uint64, mtime int64) *filer_pb.Entry {
+		return &filer_pb.Entry{
+			Name:       "data.bin",
+			Attributes: &filer_pb.FuseAttributes{FileSize: size, Mtime: mtime},
+		}
+	}
+
+	// A is old (size 100), B is recently rewritten with a different size.
+	// Without the B-side cutoff check this would surface as SIZE_MISMATCH.
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{"/": {entry(100, 500)}},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{"/": {entry(200, 2000)}},
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	if err := compareDirectory(context.Background(), clientA, clientB,
+		"/", "/", false, cutoff, sem, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := result.skippedRecent.Load(); got != 1 {
+		t.Errorf("skippedRecent = %d, want 1 (B-side recent should skip)", got)
+	}
+	if got := result.sizeMismatch.Load(); got != 0 {
+		t.Errorf("sizeMismatch = %d, want 0 (recent B should not surface as mismatch)", got)
+	}
+}
+
+// TestVerifySyncMissingDirRecursesEvenWithRecentMtime verifies that a
+// directory missing in B with a recent mtime still has its subtree walked,
+// so older missing files inside are reported. A recent child write can bump
+// the parent mtime even though older missing files exist underneath.
+func TestVerifySyncMissingDirRecursesEvenWithRecentMtime(t *testing.T) {
+	cutoff := time.Unix(1000, 0)
+
+	recentDir := &filer_pb.Entry{
+		Name:        "subdir",
+		IsDirectory: true,
+		Attributes:  &filer_pb.FuseAttributes{Mtime: 2000}, // > cutoff
+	}
+	oldChild := &filer_pb.Entry{
+		Name:       "old.txt",
+		Attributes: &filer_pb.FuseAttributes{FileSize: 10, Mtime: 500}, // < cutoff
+	}
+
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/":        {recentDir},
+			"/subdir":  {oldChild},
+		},
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/": {},
+		},
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	if err := compareDirectory(context.Background(), clientA, clientB,
+		"/", "/", false, cutoff, sem, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect: directory MISSING + recursed-old-file MISSING = 2 missing.
+	if got := result.missingCount.Load(); got != 2 {
+		t.Errorf("missingCount = %d, want 2 (recent dir + old child inside)", got)
+	}
+	if got := result.skippedRecent.Load(); got != 0 {
+		t.Errorf("skippedRecent = %d, want 0 (dir mtime should not gate recursion)", got)
+	}
+}
+
 // TestVerifySyncRootPath is a regression test for the path.Join fix.
 // fmt.Sprintf("%s/%s", "/", name) produced "//name"; path.Join produces "/name".
 // This test walks from "/" and verifies the child directory is found and


### PR DESCRIPTION
# What problem are we solving?

## Summary

**Adds a verification mode to `weed filer.sync` that compares entries between two filers** without performing synchronization, for validating that an active/passive sync target agrees with the source.

## Why

We operate two clusters in a blue/green configuration for the purpose of SeaweedFS version updates and data backup/recovery. The clusters are kept in **sync via filer.sync in an Active-Passive setup from blue to green.**

* blue: production service (no orphan cleanup or any other maintenance is performed, to avoid chunk loss)
* green: backup cluster + SeaweedFS version updates + various experiments

**In order to replace blue with green, we need to guarantee that green is a superset of blue.** We'd like to verify whether this actually holds, in an efficient manner. 

# How are we solving the problem?

## `-verifySync`

- New flag on `filer.sync`. When set, the command compares filer A and filer B then exits.
- Uses directory-level sorted-merge of `ListEntries` results (alphabetical order is guaranteed by the API), giving O(N) comparison with O(entries-per-directory) memory.
- Concurrent worker pool for subdirectory recursion (concurrency=5).
- Compares `Size` and `ETag`. Reports `MISSING`, `SIZE_MISMATCH`, `ETAG_MISMATCH`, `ONLY_IN_B`.
- Honours `-isActivePassive` for unidirectional comparison and `-modifyTimeAgo` to skip recently-modified files (sync-lag tolerance).


```mermaid
flowchart TD
    A["Source Entry<br/>chunks: [c1, c2, c3]<br/>ETag: abc123"] -->|filer.sync| B["replicateChunks()"]
    B --> C["fetchAndWrite(c1) → new FID"]
    B --> D["fetchAndWrite(c2) → new FID"]
    B --> E["fetchAndWrite(c3) → new FID"]
    C --> F["Target Entry<br/>chunks: [new1, new2, new3]<br/>ETag: abc123 (preserved!)"]
    D --> F
    E --> F
    style A fill:#4a9eff,color:#fff
    style F fill:#2ecc71,color:#fff
```

## Comparison Algorithm: Per-Directory Sorted Merge

Since `ListEntries` guarantees name-sorted output, we can perform an O(n) comparison using a two-pointer sorted merge.

```mermaid
flowchart TD
    Start["compareDirectory(dirA, dirB)"] --> ListA["ListEntries(filerA, dir)"]
    Start --> ListB["ListEntries(filerB, dir)"]
    ListA --> Merge["Two-pointer Sorted Merge"]
    ListB --> Merge

    Merge --> CaseA{"nameA < nameB?"}
    CaseA -->|Yes| Missing["MISSING in B"]

    Merge --> CaseB{"nameA > nameB?"}
    CaseB -->|Yes| OnlyB["ONLY_IN_B<br/>(skip if activePassive)"]

    Merge --> CaseC{"nameA == nameB?"}
    CaseC -->|Yes| Compare["Compare Size + ETag"]
    Compare --> SizeDiff{"Size differs?"}
    SizeDiff -->|Yes| SizeMismatch["SIZE_MISMATCH"]
    SizeDiff -->|No| EtagDiff{"ETag differs?"}
    EtagDiff -->|Yes| EtagMismatch["ETAG_MISMATCH"]
    EtagDiff -->|No| OK["OK ✓"]

    CaseC -->|"Both dirs"| Recurse["Recurse into subdirectory<br/>(worker pool, concurrency=5)"]
    style Missing fill:#e74c3c,color:#fff
    style SizeMismatch fill:#e67e22,color:#fff
    style EtagMismatch fill:#f39c12,color:#fff
    style OnlyB fill:#95a5a6,color:#fff
    style OK fill:#2ecc71,color:#fff
```

**Memory efficiency:** O(entries per directory) — no need to load the entire file list into memory.


### `-verifyJsonOutput`

- Emits NDJSON (one JSON object per line) for every diff and a final `SUMMARY` record.
- Schema: `{type, path, isDirectory?, a:{size, mtime, etag}, b:{...}, mtimeRelation, mtimeDelta, hint}`.
- Designed to be piped into external diagnostic and recovery scripts.

### Mtime annotation

For every `SIZE_MISMATCH` and `ETAG_MISMATCH` the diff line/record carries an automatic interpretation hint based on the mtime relation between A and B:

| Relation | Hint | Common cause |
|---|---|---|
| `B_NEWER` | `late_updates_skip_likely` | Target has a stub or older direct write; sync's `existingEntry.Mtime > newEntry.Mtime` guard permanently skips. |
| `A_NEWER` | `sync_lag_or_event_miss` | Sync subscriber dropped events or is far behind. |
| `EQUAL` | *(none)* | Likely chunk-level corruption, not a metadata problem. |

The hint is a strong diagnostic signal. In our deployment it directly surfaced bootstrap-induced stub entries that had been silently blocking sync for weeks.


## Usage

```bash
# Basic active/passive verification
weed filer.sync \
  -a=filerA:8888 -b=filerB:8888 \
  -isActivePassive \
  -verifySync \
  -modifyTimeAgo=1h

# NDJSON for tooling
weed filer.sync \
  -a=filerA:8888 -b=filerB:8888 \
  -isActivePassive -verifySync -modifyTimeAgo=1h \
  -verifyJsonOutput | jq 'select(.type=="ETAG_MISMATCH")'
```

# How is the PR tested?
There are no notable failure logs, so the root cause of the sync failure will need to be investigated separately. That said, the newly added verify mode already turned up 2 missing directories, 10 files with size mismatches, and 1 file with matching size but a differing ETag.

```
Verifying files modified before 2026-04-28T13:53:36+09:00 (modifyTimeAgo=1h0m0s)
Comparing node0047.nfra.io:8888/buckets => node0044:8888/buckets (isActivePassive=true)

[MISSING]       /buckets/dfs/.uploads/ (directory)
[MISSING]       /buckets/dfs/monitoring/ray-prod-260327/metrics/tmp/searchResults/ (directory)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/n/srch1-3b-instruct/config.json (a=996, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/n/srch1-3b-instruct/config.json.origin (a=1383, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/n/srch1-3b-instruct/tokenizer_config.json (a=11875, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/n/srch1-3b-instruct/trainer_state.json (a=39638, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/n/srch1-3b-instruct/training_args.bin (a=7544, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/n/srch1-3b-instruct/vocab.json (a=1858019, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/qwen/qwen3.5-9b/model.safetensors-00004-of-00004.safetensors (a=3325995712, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/qwen/qwen3.5-9b/model.safetensors.index.json (a=79657, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/qwen/qwen3.5-9b/preprocessor_config.json (a=390, b=0)
[SIZE_MISMATCH] /buckets/dfs/models/fine-tuning/qwen/qwen3.5-9b/tokenizer.json (a=12807982, b=0)
[ETAG_MISMATCH] /buckets/dfs/fine-tuning/sk-Z06qoZq3L54_Ef40MUsgDw/ftjob-3e50c560ab45426a88fe7ff9/trainer_log.jsonl (a=d41d8cd98f00b204e9800998ecf8427e-29, b=d41d8cd98f00b204e9800998ecf8427e-28)

Summary:
  Directories compared: 2997
  Files verified:       24107
  Skipped (too recent): 188
  Missing in B:         2
  Size mismatch:        10
  ETag mismatch:        1
  Total errors:         13
```



# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI command to compare two directory trees, reporting MISSING, ONLY_IN_B, SIZE_MISMATCH, and ETAG_MISMATCH.
  * Options: active-passive mode, modification-time cutoff to skip recent items, JSON (NDJSON) or human-readable output, and configurable concurrency for traversal.
  * Returns non-zero exit code when differences are found.

* **Tests**
  * Comprehensive tests covering mismatch types, time-based skips, concurrency limits, and deep recursive traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->