### PR TITLE
chore(weed/mq/kafka/protocol): prune no-op test

### DIFF
--- a/weed/mq/kafka/protocol/offset_fetch_pattern_test.go
+++ b/weed/mq/kafka/protocol/offset_fetch_pattern_test.go
@@ -204,33 +204,6 @@ func TestOffsetCommitConsistency(t *testing.T) {
 	})
 }
 
-// TestFetchEmptyPartitionHandling tests what happens when fetching
-// from a partition with no more messages
-func TestFetchEmptyPartitionHandling(t *testing.T) {
-	t.Skip("Integration test - requires mock broker setup")
-
-	t.Run("EmptyPartitionBehavior", func(t *testing.T) {
-		const (
-			topic      = "test-topic"
-			partition  = int32(0)
-			lastOffset = int64(999) // Messages 0-999 exist
-		)
-
-		// Test 1: Fetch at HWM should return empty
-		// Expected: Fetch(1000, HWM=1000) returns empty (not error)
-		// This is normal, consumer should retry
-
-		// Test 2: Fetch beyond HWM should return error or empty
-		// Expected: Fetch(1000, HWM=1000) + wait for new messages
-		// Consumer should NOT give up
-
-		// Test 3: After new message arrives, fetch should succeed
-		// Expected: Fetch(1000, HWM=1001) returns 1 message
-
-		t.Logf("✅ Empty partition handling verified")
-	})
-}
-
 // TestLongPollWithOffsetCommit verifies long-poll semantics work correctly
 // with offset commits (no throttling confusion)
 func TestLongPollWithOffsetCommit(t *testing.T) {


### PR DESCRIPTION
This removes `TestFetchEmptyPartitionHandling()`, a no-op test in `weed/mq/kafka/protocol` that set some constants and had some comments but otherwise did nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test coverage for empty partition handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->