### PR TITLE
fix(master): bump seaweedfs/raft to v1.1.8 for Windows syncDir fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/seaweedfs/goexif v1.0.3
-	github.com/seaweedfs/raft v1.1.7
+	github.com/seaweedfs/raft v1.1.8
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1844,8 +1844,8 @@ github.com/seaweedfs/go-fuse/v2 v2.9.3 h1:rJufGrHImTx7yoGUmetUi+To4LrmTQJROJnBHW
 github.com/seaweedfs/go-fuse/v2 v2.9.3/go.mod h1:zABdmWEa6A0bwaBeEOBUeUkGIZlxUhcdv+V1Dcc/U/I=
 github.com/seaweedfs/goexif v1.0.3 h1:ve/OjI7dxPW8X9YQsv3JuVMaxEyF9Rvfd04ouL+Bz30=
 github.com/seaweedfs/goexif v1.0.3/go.mod h1:Oni780Z236sXpIQzk1XoJlTwqrJ02smEin9zQeff7Fk=
-github.com/seaweedfs/raft v1.1.7 h1:3mVJZ2p4rdvBtbbrHROPjYKtH+q5qjMBc56G6VRu1kA=
-github.com/seaweedfs/raft v1.1.7/go.mod h1:fgs/rAVEzjQ7e04XMzG3eJhwZZRmBW+2uRtjakeCGeU=
+github.com/seaweedfs/raft v1.1.8 h1:a5f+wSnriRjINLqLqMY7DDNNfU1+kv6TKBuOZa0KDwU=
+github.com/seaweedfs/raft v1.1.8/go.mod h1:fgs/rAVEzjQ7e04XMzG3eJhwZZRmBW+2uRtjakeCGeU=
 github.com/secure-systems-lab/go-securesystemslib v0.6.0 h1:T65atpAVCJQK14UA57LMdZGpHi4QYSH/9FZyNGqMYIA=
 github.com/secure-systems-lab/go-securesystemslib v0.6.0/go.mod h1:8Mtpo9JKks/qhPG4HGZ2LGMvrPbzuxwfz/f/zLfEWkk=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
## Summary

- Fixes #9292: `weed mini` (and any master) on Windows panics with `raft: failed to sync state dir: sync m9333: Zugriff verweigert` on every term-persisting write.
- Root cause is in `seaweedfs/raft` v1.1.7: `writeState` ends with an fsync of the state directory via `os.Open(dir)` + `f.Sync()`. On Windows the `Sync` syscall maps to `FlushFileBuffers`, which requires `GENERIC_WRITE`, but `os.Open` opens read-only — so the call always returns `ERROR_ACCESS_DENIED`.
- Fixed upstream in seaweedfs/raft#10 (released as v1.1.8): split `syncDir` into build-tagged files. Unix keeps the durability fsync; Windows is a no-op because NTFS journals rename metadata and there is no portable equivalent of `fsync(dir_fd)`.
- This PR is just the version bump.

## Test plan

- [x] `go build ./weed/...` (host)
- [x] `GOOS=windows GOARCH=amd64 go build ./weed` (the `weed` binary, which is what ships on Windows)
- [x] `go test ./weed/server/... -run 'Raft|Master'`
- [ ] A Windows reporter on #9292 confirms `weed mini` can be Ctrl-C'd and restarted cleanly without wiping `m9333/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go module dependencies to latest compatible versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->