### PR TITLE
refactor(weed/storage): log volume file removal failures

### DIFF
--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -89,20 +89,26 @@ func (v *Volume) Destroy(onlyEmpty bool) (err error) {
 
 func removeVolumeFiles(filename string) {
 	// basic
-	os.Remove(filename + ".dat")
-	os.Remove(filename + ".idx")
-	os.Remove(filename + ".vif")
+	deleteAndLog := func(ext string) {
+		fullFilename := filename + "." + ext
+		if err := os.RemoveAll(fullFilename); err != nil {
+			glog.V(0).Infof("failed to remove volume file %s: %s", fullFilename, err)
+		}
+	}
+	deleteAndLog("dat")
+	deleteAndLog("idx")
+	deleteAndLog("vif")
 	// sorted index file
-	os.Remove(filename + ".sdx")
+	deleteAndLog("sdx")
 	// compaction
-	os.Remove(filename + ".cpd")
-	os.Remove(filename + ".cpx")
+	deleteAndLog("cpd")
+	deleteAndLog("cpx")
 	// level db index file
-	os.RemoveAll(filename + ".ldb")
+	deleteAndLog("ldb")
 	// redb index file (Rust volume server)
-	os.Remove(filename + ".rdb")
+	deleteAndLog("rdb")
 	// marker for damaged or incomplete volume
-	os.Remove(filename + ".note")
+	deleteAndLog("note")
 }
 
 func (v *Volume) asyncRequestAppend(request *needle.AsyncRequest) {


### PR DESCRIPTION
As currently constructed, the `removeVolumeFiles()` function in `weed/storage` blindly attempts to delete volume files without checking if the operations were successful.

Instead of changing the function signature to add an error return, I added messages to the logs to notify an operator that volume file deletion is failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage volume file cleanup with enhanced error handling and logging. All associated file variants are now consistently removed through a unified deletion process, and any failures are properly logged for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->