### PR TITLE
fix(mount): keep async flush when LockOwner has no POSIX locks

### DIFF
--- a/weed/mount/posix_file_lock.go
+++ b/weed/mount/posix_file_lock.go
@@ -234,6 +234,31 @@ func (plt *PosixLockTable) releaseMatching(inode uint64, matches func(lockRange)
 	plt.maybeCleanupInode(inode, il)
 }
 
+// HasPosixOwner reports whether owner currently holds any POSIX byte-range
+// locks on inode. FUSE may provide a non-zero FlushIn.LockOwner even when no
+// locks were taken, so callers should consult the lock table before treating a
+// flush as lock-sensitive.
+func (plt *PosixLockTable) HasPosixOwner(inode uint64, owner uint64) bool {
+	if owner == 0 {
+		return false
+	}
+	il := plt.getInodeLocks(inode)
+	if il == nil {
+		return false
+	}
+	il.mu.Lock()
+	defer il.mu.Unlock()
+	if il.dead {
+		return false
+	}
+	for _, lk := range il.locks {
+		if !lk.IsFlock && lk.Owner == owner {
+			return true
+		}
+	}
+	return false
+}
+
 // releaseWakeRef drops the temporary reference that keeps inodeLocks live while
 // a woken waiter retries its SetLkw acquisition.
 func releaseWakeRef(il *inodeLocks, waiter *lockWaiter) {

--- a/weed/mount/posix_file_lock_test.go
+++ b/weed/mount/posix_file_lock_test.go
@@ -274,6 +274,32 @@ func TestReleasePosixOwnerDoesNotReleaseFlockLocks(t *testing.T) {
 	}
 }
 
+func TestHasPosixOwnerIgnoresMissingOwnerAndFlock(t *testing.T) {
+	plt := NewPosixLockTable()
+	inode := uint64(1)
+
+	if plt.HasPosixOwner(inode, 1) {
+		t.Fatal("missing owner should not be reported as holding POSIX locks")
+	}
+
+	if s := plt.SetLk(inode, lockRange{Start: 0, End: math.MaxUint64, Typ: syscall.F_WRLCK, Owner: 1, Pid: 10, IsFlock: true}); s != fuse.OK {
+		t.Fatalf("set flock: %v", s)
+	}
+	if plt.HasPosixOwner(inode, 1) {
+		t.Fatal("flock owner should not be reported as a POSIX lock owner")
+	}
+
+	if s := plt.SetLk(inode, lockRange{Start: 0, End: 99, Typ: syscall.F_WRLCK, Owner: 2, Pid: 20}); s != fuse.OK {
+		t.Fatalf("set POSIX lock: %v", s)
+	}
+	if !plt.HasPosixOwner(inode, 2) {
+		t.Fatal("POSIX lock owner was not reported")
+	}
+	if plt.HasPosixOwner(inode, 0) {
+		t.Fatal("zero owner should not be reported")
+	}
+}
+
 func TestWakeEligibleWaitersKeepsInodeUntilWakeRefReleased(t *testing.T) {
 	plt := NewPosixLockTable()
 	inode := uint64(1)

--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -65,9 +65,12 @@ func (wfs *WFS) Flush(cancel <-chan struct{}, in *fuse.FlushIn) fuse.Status {
 		return fuse.OK
 	}
 
-	// When a closing lock owner is present, flush synchronously before waking any
-	// blocked POSIX lock waiters so write-serialized callers cannot overtake each other.
-	allowAsync := in.LockOwner == 0
+	// FlushIn.LockOwner is populated by some FUSE kernels even when the process
+	// did not hold byte-range locks. Only force the synchronous close path when
+	// this owner actually has POSIX locks to release; otherwise writebackCache
+	// would silently degrade to a blocking flush for ordinary close().
+	hasPosixLocks := wfs.posixLocks.HasPosixOwner(in.NodeId, in.LockOwner)
+	allowAsync := !hasPosixLocks
 	status := wfs.doFlush(fh, in.Uid, in.Gid, allowAsync)
 	if in.LockOwner != 0 {
 		wfs.posixLocks.ReleasePosixOwner(in.NodeId, in.LockOwner)


### PR DESCRIPTION
# What problem are we solving?

`Flush` was forcing a synchronous flush whenever `FlushIn.LockOwner != 0`, on the assumption that a non-zero owner meant a closing POSIX lock holder. In practice, the FUSE kernel populates `FlushIn.LockOwner` for any file descriptor that *might* have participated in locking, not only when locks were actually taken. The result: the writebackCache async-flush path added in #8727 was silently disabled for most ordinary `close()` calls, costing the per-file network round-trip benefit it was meant to provide for workloads like `rsync` and `cp -r` of many small files (see #8695).

# How are we solving the problem?

Consult the POSIX lock table before treating `LockOwner` as lock-sensitive:

- New `PosixLockTable.HasPosixOwner(inode, owner)` returns true only if the owner holds a non-flock byte-range lock on the inode.
- `Flush` now derives `allowAsync` from `!HasPosixOwner(...)`. Owners that actually hold a POSIX lock still take the synchronous path so blocked `SetLkw` waiters observe post-flush state when `ReleasePosixOwner` wakes them. Everyone else goes async as intended.

The `flock` namespace is excluded — flock cleanup runs in `Release` (via `FUSE_RELEASE_FLOCK_UNLOCK`), not `Flush`.

Related: #8695

# How is the PR tested?

- New unit test `TestHasPosixOwnerIgnoresMissingOwnerAndFlock` covers the four corners of the helper: missing inode entry, flock-only ownership, POSIX-locked owner, and `owner == 0`.
- Existing locking tests (`TestReleasePosixOwner*`, `TestSetLkw*`, the flock churn stress test) still pass; they cover the sync-flush + wake-waiters ordering this change preserves.
- `go build ./weed/mount/` clean, `go test ./weed/mount/` passes.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.