### PR TITLE
feat(mini): add -bucket flag to pre-create an S3 bucket on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ This single command starts a complete SeaweedFS setup with:
 - **WebDAV**: http://localhost:7333
 - **Admin UI**: http://localhost:23646
 
-To start an object store with a pre-created bucket, pass `-bucket=<name>` (the bucket is created on first start if it does not already exist; the flag is a no-op when empty):
+To start an object store with a pre-created bucket, pass `-bucket=<name>` or set the `S3_BUCKET` env var (the bucket is created on first start if it does not already exist; the flag is a no-op when empty):
 
 ```bash
 ./weed mini -dir=/data -bucket=my-bucket
+# or
+S3_BUCKET=my-bucket ./weed mini -dir=/data
 ```
 
 Perfect for development, testing, learning SeaweedFS, and single node deployments!

--- a/README.md
+++ b/README.md
@@ -80,36 +80,29 @@ Table of Contents
 
 
 ## Quick Start with weed mini ##
-The easiest way to get started with SeaweedFS for development and testing:
 
-* Download the latest binary from https://github.com/seaweedfs/seaweedfs/releases and unzip a single binary file `weed` or `weed.exe`.
-
-Example:
+Download the latest binary from https://github.com/seaweedfs/seaweedfs/releases and unzip the single `weed` (or `weed.exe`) file. Then start a ready-to-use S3 object store with credentials and a pre-created bucket in one command:
 
 ```bash
-# remove quarantine on macOS
-# xattr -d com.apple.quarantine  ./weed
-
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
 ./weed mini -dir=/data
 ```
 
-This single command starts a complete SeaweedFS setup with:
+That's it — the S3 endpoint is at http://localhost:8333, `my-bucket` already exists, and `admin`/`secret` are valid credentials. Drop any of the env vars to skip that piece (no `S3_BUCKET` → no bucket created; no AWS keys → S3 runs in unauthenticated "Allow All" mode for development).
+
+The same command starts everything else too:
+- **S3 Endpoint**: http://localhost:8333
 - **Master UI**: http://localhost:9333
 - **Volume Server**: http://localhost:9340
 - **Filer UI**: http://localhost:8888
-- **S3 Endpoint**: http://localhost:8333
 - **WebDAV**: http://localhost:7333
 - **Admin UI**: http://localhost:23646
 
-To start an object store with a pre-created bucket, pass `-bucket=<name>` or set the `S3_BUCKET` env var (the bucket is created on first start if it does not already exist; the flag is a no-op when empty):
+> macOS: if the binary is quarantined, run `xattr -d com.apple.quarantine ./weed` first.
 
-```bash
-./weed mini -dir=/data -bucket=my-bucket
-# or
-S3_BUCKET=my-bucket ./weed mini -dir=/data
-```
-
-Perfect for development, testing, learning SeaweedFS, and single node deployments!
+Perfect for development, testing, learning SeaweedFS, and single-node deployments.
 
 ## Quick Start for S3 API on Docker ##
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ This single command starts a complete SeaweedFS setup with:
 - **WebDAV**: http://localhost:7333
 - **Admin UI**: http://localhost:23646
 
+To start an object store with a pre-created bucket, pass `-bucket=<name>` (the bucket is created on first start if it does not already exist; the flag is a no-op when empty):
+
+```bash
+./weed mini -dir=/data -bucket=my-bucket
+```
+
 Perfect for development, testing, learning SeaweedFS, and single node deployments!
 
 ## Quick Start for S3 API on Docker ##

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ S3_BUCKET=my-bucket \
 ./weed mini -dir=/data
 ```
 
-That's it — the S3 endpoint is at http://localhost:8333, `my-bucket` already exists, and `admin`/`secret` are valid credentials. Drop any of the env vars to skip that piece (no `S3_BUCKET` → no bucket created; no AWS keys → S3 runs in unauthenticated "Allow All" mode for development).
+That's it — the S3 endpoint is at http://localhost:8333, `my-bucket` already exists, and `admin`/`secret` are valid credentials. `S3_BUCKET` accepts a comma-separated list (e.g. `raw,processed`); use `S3_TABLE_BUCKET` for S3 Tables (Iceberg) buckets. Drop any of the env vars to skip that piece (no AWS keys → S3 runs in unauthenticated "Allow All" mode for development).
 
 The same command starts everything else too:
 - **S3 Endpoint**: http://localhost:8333

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -214,7 +214,8 @@ Example Usage:
 	weed mini                   # Use current directory
 	weed mini -dir=/data        # Custom data directory
 	weed mini -dir=/data -master.port=9444  # Custom master port
-	weed mini -dir=/data -bucket=my-bucket  # Pre-create an S3 bucket on startup
+	weed mini -dir=/data -bucket=my-bucket          # Pre-create an S3 bucket on startup
+	weed mini -dir=/data -bucket=bucket1,bucket2    # Pre-create multiple S3 buckets
 
 After starting, you can access:
 - Master UI:       http://localhost:9333
@@ -247,7 +248,7 @@ var (
 	miniS3Config                    = cmdMini.Flag.String("s3.config", "", "path to the S3 config file")
 	miniIamConfig                   = cmdMini.Flag.String("s3.iam.config", "", "path to the advanced IAM config file for S3")
 	miniS3AllowDeleteBucketNotEmpty = cmdMini.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
-	miniBucket                      = cmdMini.Flag.String("bucket", "", "create this S3 bucket on startup if it does not already exist; leave empty to skip. Falls back to S3_BUCKET env var.")
+	miniBucket                      = cmdMini.Flag.String("bucket", "", "comma-separated S3 bucket names to create on startup if they do not already exist; leave empty to skip. Falls back to S3_BUCKET env var.")
 )
 
 // getBindIp determines the bind IP address based on miniIp and miniBindIp flags
@@ -1024,13 +1025,13 @@ func runMini(cmd *Command, args []string) bool {
 		triggerMiniClientsShutdown(10 * time.Second)
 	})
 
-	// Create the requested bucket (if any) before announcing readiness.
-	bucketName := *miniBucket
-	if bucketName == "" {
-		bucketName = os.Getenv("S3_BUCKET")
+	// Create the requested bucket(s) (if any) before announcing readiness.
+	bucketSpec := *miniBucket
+	if bucketSpec == "" {
+		bucketSpec = os.Getenv("S3_BUCKET")
 	}
-	if err := ensureMiniBucket(bucketName); err != nil {
-		glog.Warningf("failed to create bucket %q: %v", bucketName, err)
+	if err := ensureMiniBuckets(bucketSpec); err != nil {
+		glog.Warningf("failed to ensure buckets %q: %v", bucketSpec, err)
 	}
 
 	// Print welcome message after all services are running
@@ -1498,15 +1499,15 @@ func printWelcomeMessage() {
 	fmt.Println("")
 }
 
-// ensureMiniBucket creates the named bucket on the embedded filer if it does
-// not already exist. Empty bucketName is a no-op so users who do not pass
-// -bucket pay nothing.
-func ensureMiniBucket(bucketName string) error {
-	if bucketName == "" {
+// ensureMiniBuckets creates each named bucket on the embedded filer if it does
+// not already exist. bucketSpec is a comma-separated list (whitespace around
+// each name is trimmed); empty entries and an empty spec are no-ops so callers
+// who do not pass -bucket pay nothing. Per-bucket failures are logged and the
+// loop continues so a single bad name does not block creating the rest.
+func ensureMiniBuckets(bucketSpec string) error {
+	names := parseBucketList(bucketSpec)
+	if len(names) == 0 {
 		return nil
-	}
-	if err := s3bucket.VerifyS3BucketName(bucketName); err != nil {
-		return fmt.Errorf("invalid bucket name %q: %w", bucketName, err)
 	}
 
 	filerAddress := pb.NewServerAddress(*miniIp, *miniFilerOptions.port, *miniFilerOptions.portGrpc)
@@ -1514,26 +1515,56 @@ func ensureMiniBucket(bucketName string) error {
 
 	const bucketsPath = "/buckets"
 	// Derive from miniClientsCtx so Ctrl+C cancels the bucket RPCs, and bound
-	// with a short timeout so a stalled filer cannot block the welcome message
-	// indefinitely.
-	ctx, cancel := context.WithTimeout(miniClientsCtx(), 5*time.Second)
-	defer cancel()
+	// with a short timeout (per bucket) so a stalled filer cannot block the
+	// welcome message indefinitely.
 	return pb.WithGrpcFilerClient(false, 0, filerAddress, grpcDialOption, func(client filer_pb.SeaweedFilerClient) error {
-		_, err := filer_pb.LookupEntry(ctx, client, &filer_pb.LookupDirectoryEntryRequest{
-			Directory: bucketsPath,
-			Name:      bucketName,
-		})
-		if err == nil {
-			glog.V(0).Infof("bucket %s already exists", bucketName)
-			return nil
+		for _, name := range names {
+			if err := s3bucket.VerifyS3BucketName(name); err != nil {
+				glog.Warningf("invalid bucket name %q: %v", name, err)
+				continue
+			}
+			ctx, cancel := context.WithTimeout(miniClientsCtx(), 5*time.Second)
+			_, err := filer_pb.LookupEntry(ctx, client, &filer_pb.LookupDirectoryEntryRequest{
+				Directory: bucketsPath,
+				Name:      name,
+			})
+			if err == nil {
+				glog.V(0).Infof("bucket %s already exists", name)
+				cancel()
+				continue
+			}
+			if err != filer_pb.ErrNotFound {
+				glog.Warningf("lookup bucket %s: %v", name, err)
+				cancel()
+				continue
+			}
+			if err := filer_pb.DoMkdir(ctx, client, bucketsPath, name, nil); err != nil {
+				glog.Warningf("create bucket %s: %v", name, err)
+				cancel()
+				continue
+			}
+			cancel()
+			glog.V(0).Infof("created bucket %s", name)
 		}
-		if err != filer_pb.ErrNotFound {
-			return fmt.Errorf("lookup bucket %s: %w", bucketName, err)
-		}
-		if err := filer_pb.DoMkdir(ctx, client, bucketsPath, bucketName, nil); err != nil {
-			return fmt.Errorf("create bucket %s: %w", bucketName, err)
-		}
-		glog.V(0).Infof("created bucket %s", bucketName)
 		return nil
 	})
+}
+
+// parseBucketList splits a comma-separated bucket spec into a deduplicated list
+// of trimmed, non-empty names, preserving the order they were given.
+func parseBucketList(spec string) []string {
+	if spec == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var names []string
+	for _, raw := range strings.Split(spec, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
 }

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1544,7 +1544,7 @@ func ensureMiniBuckets(bucketSpec string) error {
 				cancel()
 				continue
 			}
-			if err != filer_pb.ErrNotFound {
+			if !errors.Is(err, filer_pb.ErrNotFound) {
 				glog.Warningf("lookup bucket %s: %v", name, err)
 				cancel()
 				continue

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1509,8 +1509,12 @@ func ensureMiniBucket(bucketName string) error {
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 
 	const bucketsPath = "/buckets"
+	// Derive from miniClientsCtx so Ctrl+C cancels the bucket RPCs, and bound
+	// with a short timeout so a stalled filer cannot block the welcome message
+	// indefinitely.
+	ctx, cancel := context.WithTimeout(miniClientsCtx(), 5*time.Second)
+	defer cancel()
 	return pb.WithGrpcFilerClient(false, 0, filerAddress, grpcDialOption, func(client filer_pb.SeaweedFilerClient) error {
-		ctx := context.Background()
 		_, err := filer_pb.LookupEntry(ctx, client, &filer_pb.LookupDirectoryEntryRequest{
 			Directory: bucketsPath,
 			Name:      bucketName,
@@ -1523,7 +1527,7 @@ func ensureMiniBucket(bucketName string) error {
 			return fmt.Errorf("lookup bucket %s: %w", bucketName, err)
 		}
 		if err := filer_pb.DoMkdir(ctx, client, bucketsPath, bucketName, nil); err != nil {
-			return err
+			return fmt.Errorf("create bucket %s: %w", bucketName, err)
 		}
 		glog.V(0).Infof("created bucket %s", bucketName)
 		return nil

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/bits"
 	"net"
@@ -17,6 +18,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	pluginworker "github.com/seaweedfs/seaweedfs/weed/plugin/worker"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3bucket"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3tables"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -214,8 +216,9 @@ Example Usage:
 	weed mini                   # Use current directory
 	weed mini -dir=/data        # Custom data directory
 	weed mini -dir=/data -master.port=9444  # Custom master port
-	weed mini -dir=/data -bucket=my-bucket          # Pre-create an S3 bucket on startup
-	weed mini -dir=/data -bucket=bucket1,bucket2    # Pre-create multiple S3 buckets
+	weed mini -dir=/data -bucket=my-bucket             # Pre-create an S3 bucket on startup
+	weed mini -dir=/data -bucket=bucket1,bucket2       # Pre-create multiple S3 buckets
+	weed mini -dir=/data -tableBucket=iceberg-tables   # Pre-create an S3 Tables bucket
 
 After starting, you can access:
 - Master UI:       http://localhost:9333
@@ -249,6 +252,7 @@ var (
 	miniIamConfig                   = cmdMini.Flag.String("s3.iam.config", "", "path to the advanced IAM config file for S3")
 	miniS3AllowDeleteBucketNotEmpty = cmdMini.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
 	miniBucket                      = cmdMini.Flag.String("bucket", "", "comma-separated S3 bucket names to create on startup if they do not already exist; leave empty to skip. Falls back to S3_BUCKET env var.")
+	miniTableBucket                 = cmdMini.Flag.String("tableBucket", "", "comma-separated S3 Tables bucket names to create on startup if they do not already exist; leave empty to skip. Falls back to S3_TABLE_BUCKET env var.")
 )
 
 // getBindIp determines the bind IP address based on miniIp and miniBindIp flags
@@ -1033,6 +1037,13 @@ func runMini(cmd *Command, args []string) bool {
 	if err := ensureMiniBuckets(bucketSpec); err != nil {
 		glog.Warningf("failed to ensure buckets %q: %v", bucketSpec, err)
 	}
+	tableBucketSpec := *miniTableBucket
+	if tableBucketSpec == "" {
+		tableBucketSpec = os.Getenv("S3_TABLE_BUCKET")
+	}
+	if err := ensureMiniTableBuckets(tableBucketSpec); err != nil {
+		glog.Warningf("failed to ensure table buckets %q: %v", tableBucketSpec, err)
+	}
 
 	// Print welcome message after all services are running
 	printWelcomeMessage()
@@ -1545,6 +1556,44 @@ func ensureMiniBuckets(bucketSpec string) error {
 			}
 			cancel()
 			glog.V(0).Infof("created bucket %s", name)
+		}
+		return nil
+	})
+}
+
+// ensureMiniTableBuckets creates each named S3 Tables bucket on the embedded
+// filer if it does not already exist. bucketSpec is comma-separated; whitespace
+// is trimmed and duplicates are dropped. Per-bucket failures are logged so one
+// bad name does not block the rest. Buckets are owned by s3tables.DefaultAccountID
+// since mini does not yet model multi-account ownership.
+func ensureMiniTableBuckets(bucketSpec string) error {
+	names := parseBucketList(bucketSpec)
+	if len(names) == 0 {
+		return nil
+	}
+
+	filerAddress := pb.NewServerAddress(*miniIp, *miniFilerOptions.port, *miniFilerOptions.portGrpc)
+	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
+
+	return pb.WithGrpcFilerClient(false, 0, filerAddress, grpcDialOption, func(client filer_pb.SeaweedFilerClient) error {
+		manager := s3tables.NewManager()
+		mgrClient := s3tables.NewManagerClient(client)
+		for _, name := range names {
+			ctx, cancel := context.WithTimeout(miniClientsCtx(), 5*time.Second)
+			req := &s3tables.CreateTableBucketRequest{Name: name}
+			var resp s3tables.CreateTableBucketResponse
+			err := manager.Execute(ctx, mgrClient, "CreateTableBucket", req, &resp, s3tables.DefaultAccountID)
+			cancel()
+			if err == nil {
+				glog.V(0).Infof("created table bucket %s", name)
+				continue
+			}
+			var s3Err *s3tables.S3TablesError
+			if errors.As(err, &s3Err) && s3Err.Type == s3tables.ErrCodeBucketAlreadyExists {
+				glog.V(0).Infof("table bucket %s already exists", name)
+				continue
+			}
+			glog.Warningf("create table bucket %s: %v", name, err)
 		}
 		return nil
 	})

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	pluginworker "github.com/seaweedfs/seaweedfs/weed/plugin/worker"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3bucket"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -212,6 +214,7 @@ Example Usage:
 	weed mini                   # Use current directory
 	weed mini -dir=/data        # Custom data directory
 	weed mini -dir=/data -master.port=9444  # Custom master port
+	weed mini -dir=/data -bucket=my-bucket  # Pre-create an S3 bucket on startup
 
 After starting, you can access:
 - Master UI:       http://localhost:9333
@@ -244,6 +247,7 @@ var (
 	miniS3Config                    = cmdMini.Flag.String("s3.config", "", "path to the S3 config file")
 	miniIamConfig                   = cmdMini.Flag.String("s3.iam.config", "", "path to the advanced IAM config file for S3")
 	miniS3AllowDeleteBucketNotEmpty = cmdMini.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
+	miniBucket                      = cmdMini.Flag.String("bucket", "", "create this S3 bucket on startup if it does not already exist; leave empty to skip")
 )
 
 // getBindIp determines the bind IP address based on miniIp and miniBindIp flags
@@ -1020,6 +1024,11 @@ func runMini(cmd *Command, args []string) bool {
 		triggerMiniClientsShutdown(10 * time.Second)
 	})
 
+	// Create the requested bucket (if any) before announcing readiness.
+	if err := ensureMiniBucket(*miniBucket); err != nil {
+		glog.Warningf("failed to create bucket %q: %v", *miniBucket, err)
+	}
+
 	// Print welcome message after all services are running
 	printWelcomeMessage()
 
@@ -1483,4 +1492,40 @@ func printWelcomeMessage() {
 
 	fmt.Print(sb.String())
 	fmt.Println("")
+}
+
+// ensureMiniBucket creates the named bucket on the embedded filer if it does
+// not already exist. Empty bucketName is a no-op so users who do not pass
+// -bucket pay nothing.
+func ensureMiniBucket(bucketName string) error {
+	if bucketName == "" {
+		return nil
+	}
+	if err := s3bucket.VerifyS3BucketName(bucketName); err != nil {
+		return fmt.Errorf("invalid bucket name %q: %w", bucketName, err)
+	}
+
+	filerAddress := pb.NewServerAddress(*miniIp, *miniFilerOptions.port, *miniFilerOptions.portGrpc)
+	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
+
+	const bucketsPath = "/buckets"
+	return pb.WithGrpcFilerClient(false, 0, filerAddress, grpcDialOption, func(client filer_pb.SeaweedFilerClient) error {
+		ctx := context.Background()
+		_, err := filer_pb.LookupEntry(ctx, client, &filer_pb.LookupDirectoryEntryRequest{
+			Directory: bucketsPath,
+			Name:      bucketName,
+		})
+		if err == nil {
+			glog.V(0).Infof("bucket %s already exists", bucketName)
+			return nil
+		}
+		if err != filer_pb.ErrNotFound {
+			return fmt.Errorf("lookup bucket %s: %w", bucketName, err)
+		}
+		if err := filer_pb.DoMkdir(ctx, client, bucketsPath, bucketName, nil); err != nil {
+			return err
+		}
+		glog.V(0).Infof("created bucket %s", bucketName)
+		return nil
+	})
 }

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -247,7 +247,7 @@ var (
 	miniS3Config                    = cmdMini.Flag.String("s3.config", "", "path to the S3 config file")
 	miniIamConfig                   = cmdMini.Flag.String("s3.iam.config", "", "path to the advanced IAM config file for S3")
 	miniS3AllowDeleteBucketNotEmpty = cmdMini.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
-	miniBucket                      = cmdMini.Flag.String("bucket", "", "create this S3 bucket on startup if it does not already exist; leave empty to skip")
+	miniBucket                      = cmdMini.Flag.String("bucket", "", "create this S3 bucket on startup if it does not already exist; leave empty to skip. Falls back to S3_BUCKET env var.")
 )
 
 // getBindIp determines the bind IP address based on miniIp and miniBindIp flags
@@ -1025,8 +1025,12 @@ func runMini(cmd *Command, args []string) bool {
 	})
 
 	// Create the requested bucket (if any) before announcing readiness.
-	if err := ensureMiniBucket(*miniBucket); err != nil {
-		glog.Warningf("failed to create bucket %q: %v", *miniBucket, err)
+	bucketName := *miniBucket
+	if bucketName == "" {
+		bucketName = os.Getenv("S3_BUCKET")
+	}
+	if err := ensureMiniBucket(bucketName); err != nil {
+		glog.Warningf("failed to create bucket %q: %v", bucketName, err)
 	}
 
 	// Print welcome message after all services are running

--- a/weed/command/mini_bucket_test.go
+++ b/weed/command/mini_bucket_test.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBucketList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "one", []string{"one"}},
+		{"multi", "one,two,three", []string{"one", "two", "three"}},
+		{"trims whitespace", " one , two , three ", []string{"one", "two", "three"}},
+		{"drops empty entries", "one,,two,", []string{"one", "two"}},
+		{"dedupes preserving order", "one,two,one,three,two", []string{"one", "two", "three"}},
+		{"only commas", ",,,", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseBucketList(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseBucketList(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `-bucket` flag to `weed mini` that creates the named S3 bucket on the embedded filer at startup if it does not already exist.
- Empty value (the default) is a no-op, so existing usage is unaffected.
- Idempotent: re-running with the same `-bucket` value just logs that the bucket already exists.

This makes it easy to launch the all-in-one binary as a ready-to-use object store with a known bucket already provisioned, without a separate `weed shell s3.bucket.create` step. Particularly useful for container/CI startups.

Bucket name is validated with the same `s3bucket.VerifyS3BucketName` rules used by the S3 API, and creation goes through the filer gRPC just like the S3 auto-create path (`/buckets/<bucket>` directory).

README and the `Quick-Start-with-weed-mini` wiki page were updated alongside.

## Test plan
- [x] `go build ./weed/...` succeeds
- [x] `go test ./weed/command/ -run TestMini` passes
- [x] Manual: `weed mini -dir=/tmp/x -bucket=my-test-bucket` creates the bucket; `weed shell` `fs.ls /buckets` confirms it
- [x] Manual: re-running with the same `-bucket` value logs `bucket my-test-bucket already exists` and does not error
- [x] Manual: starting without `-bucket` behaves identically to before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support to pre-create named S3 buckets and S3 Tables buckets at startup via new options (env var fallbacks); failures are logged as warnings and do not stop startup.

* **Documentation**
  * Quick Start shows a one-command example that sets AWS env vars and starts the service, clarifies local S3 endpoint and bucket behavior, explains unauthenticated dev mode when keys are omitted, lists service endpoints, and adds a macOS quarantine note.

* **Tests**
  * Added unit test covering parsing/deduplication of comma‑separated bucket lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->