### PR TITLE
refactor(command): expand "~" in all path-style CLI flags

### DIFF
--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"os/user"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
@@ -173,6 +172,8 @@ func runAdmin(cmd *Command, args []string) bool {
 		grace.StartDebugServer(*a.debugPort)
 	}
 
+	*a.cpuProfile = util.ResolvePath(*a.cpuProfile)
+	*a.memProfile = util.ResolvePath(*a.memProfile)
 	grace.SetupProfiling(*a.cpuProfile, *a.memProfile)
 
 	// Load security configuration
@@ -309,18 +310,10 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	// Create data directory first if specified (needed for session key storage)
 	var dataDir string
 	if *options.dataDir != "" {
-		// Expand tilde (~) to home directory
-		expandedDir, err := expandHomeDir(*options.dataDir)
-		if err != nil {
-			return fmt.Errorf("failed to expand dataDir path %s: %v", *options.dataDir, err)
-		}
-		dataDir = expandedDir
-
-		// Show path expansion if it occurred
+		dataDir = util.ResolvePath(*options.dataDir)
 		if dataDir != *options.dataDir {
 			fmt.Printf("Expanded dataDir: %s -> %s\n", *options.dataDir, dataDir)
 		}
-
 		if err := os.MkdirAll(dataDir, 0755); err != nil {
 			return fmt.Errorf("failed to create data directory %s: %v", dataDir, err)
 		}
@@ -646,42 +639,3 @@ func applyViperFallback(cmd *Command, flagPtr *string, flagName, viperKey string
 	}
 }
 
-// expandHomeDir expands the tilde (~) in a path to the user's home directory
-func expandHomeDir(path string) (string, error) {
-	if path == "" {
-		return path, nil
-	}
-
-	if !strings.HasPrefix(path, "~") {
-		return path, nil
-	}
-
-	// Get current user
-	currentUser, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("failed to get current user: %w", err)
-	}
-
-	// Handle different tilde patterns
-	if path == "~" {
-		return currentUser.HomeDir, nil
-	}
-
-	if strings.HasPrefix(path, "~/") {
-		return filepath.Join(currentUser.HomeDir, path[2:]), nil
-	}
-
-	// Handle ~username/ patterns
-	parts := strings.SplitN(path[1:], "/", 2)
-	username := parts[0]
-
-	targetUser, err := user.Lookup(username)
-	if err != nil {
-		return "", fmt.Errorf("user %s not found: %v", username, err)
-	}
-
-	if len(parts) == 1 {
-		return targetUser.HomeDir, nil
-	}
-	return filepath.Join(targetUser.HomeDir, parts[1]), nil
-}

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -638,4 +638,3 @@ func applyViperFallback(cmd *Command, flagPtr *string, flagName, viperKey string
 		}
 	}
 }
-

--- a/weed/command/backup.go
+++ b/weed/command/backup.go
@@ -130,7 +130,7 @@ func backupFromLocation(volumeServer pb.ServerAddress, grpcDialOption grpc.DialO
 	ver := needle.Version(stats.Version)
 
 	// Create or load the volume
-	v, err := storage.NewVolume(util.ResolvePath(*s.dir), util.ResolvePath(*s.dir), *s.collection, vid, storage.NeedleMapInMemory, replication, ttl, 0, ver, 0, 0)
+	v, err := storage.NewVolume(*s.dir, *s.dir, *s.collection, vid, storage.NeedleMapInMemory, replication, ttl, 0, ver, 0, 0)
 	if err != nil {
 		return fmt.Errorf("creating or reading volume: %w", err), false
 	}
@@ -162,7 +162,7 @@ func backupFromLocation(volumeServer pb.ServerAddress, grpcDialOption grpc.DialO
 		}
 		v.Close() // Close the destroyed volume
 		// recreate an empty volume
-		v, err = storage.NewVolume(util.ResolvePath(*s.dir), util.ResolvePath(*s.dir), *s.collection, vid, storage.NeedleMapInMemory, replication, ttl, 0, ver, 0, 0)
+		v, err = storage.NewVolume(*s.dir, *s.dir, *s.collection, vid, storage.NeedleMapInMemory, replication, ttl, 0, ver, 0, 0)
 		if err != nil {
 			return fmt.Errorf("recreating volume: %w", err), false
 		}
@@ -180,6 +180,7 @@ func backupFromLocation(volumeServer pb.ServerAddress, grpcDialOption grpc.DialO
 
 func runBackup(cmd *Command, args []string) bool {
 
+	*s.dir = util.ResolvePath(*s.dir)
 	util.LoadSecurityConfiguration()
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 

--- a/weed/command/benchmark.go
+++ b/weed/command/benchmark.go
@@ -123,6 +123,7 @@ func runBenchmark(cmd *Command, args []string) bool {
 		*b.maxCpu = runtime.NumCPU()
 	}
 	runtime.GOMAXPROCS(*b.maxCpu)
+	*b.cpuprofile = util.ResolvePath(*b.cpuprofile)
 	if *b.cpuprofile != "" {
 		f, err := os.Create(*b.cpuprofile)
 		if err != nil {

--- a/weed/command/benchmark.go
+++ b/weed/command/benchmark.go
@@ -124,6 +124,7 @@ func runBenchmark(cmd *Command, args []string) bool {
 	}
 	runtime.GOMAXPROCS(*b.maxCpu)
 	*b.cpuprofile = util.ResolvePath(*b.cpuprofile)
+	*b.idListFile = util.ResolvePath(*b.idListFile)
 	if *b.cpuprofile != "" {
 		f, err := os.Create(*b.cpuprofile)
 		if err != nil {

--- a/weed/command/compact.go
+++ b/weed/command/compact.go
@@ -41,10 +41,11 @@ func runCompact(cmd *Command, args []string) bool {
 		return false
 	}
 
+	*compactVolumePath = util.ResolvePath(*compactVolumePath)
 	preallocateBytes := *compactVolumePreallocate * (1 << 20)
 
 	vid := needle.VolumeId(*compactVolumeId)
-	v, err := storage.NewVolume(util.ResolvePath(*compactVolumePath), util.ResolvePath(*compactVolumePath), *compactVolumeCollection, vid, storage.NeedleMapInMemory, nil, nil, preallocateBytes, needle.GetCurrentVersion(), 0, 0)
+	v, err := storage.NewVolume(*compactVolumePath, *compactVolumePath, *compactVolumeCollection, vid, storage.NeedleMapInMemory, nil, nil, preallocateBytes, needle.GetCurrentVersion(), 0, 0)
 	if err != nil {
 		glog.Fatalf("Load Volume [ERROR] %s\n", err)
 	}

--- a/weed/command/download.go
+++ b/weed/command/download.go
@@ -59,8 +59,9 @@ func runDownload(cmd *Command, args []string) bool {
 		masterServer = *d.server
 	}
 
+	*d.dir = util.ResolvePath(*d.dir)
 	for _, fid := range args {
-		if e := downloadToFile(func(_ context.Context) pb.ServerAddress { return pb.ServerAddress(masterServer) }, grpcDialOption, fid, util.ResolvePath(*d.dir)); e != nil {
+		if e := downloadToFile(func(_ context.Context) pb.ServerAddress { return pb.ServerAddress(masterServer) }, grpcDialOption, fid, *d.dir); e != nil {
 			fmt.Println("Download Error: ", fid, e)
 		}
 	}

--- a/weed/command/export.go
+++ b/weed/command/export.go
@@ -148,6 +148,9 @@ func (scanner *VolumeFileScanner4Export) VisitNeedle(n *needle.Needle, offset in
 
 func runExport(cmd *Command, args []string) bool {
 
+	*export.dir = util.ResolvePath(*export.dir)
+	*output = util.ResolvePath(*output)
+
 	var err error
 
 	if *newer != "" {
@@ -200,7 +203,7 @@ func runExport(cmd *Command, args []string) bool {
 	needleMap := needle_map.NewMemDb()
 	defer needleMap.Close()
 
-	if err := needleMap.LoadFromIdx(path.Join(util.ResolvePath(*export.dir), fileName+".idx")); err != nil {
+	if err := needleMap.LoadFromIdx(path.Join(*export.dir, fileName+".idx")); err != nil {
 		glog.Fatalf("cannot load needle map from %s.idx: %s", fileName, err)
 	}
 
@@ -213,7 +216,7 @@ func runExport(cmd *Command, args []string) bool {
 		fmt.Printf("key\tname\tsize\tgzip\tmime\tmodified\tttl\tdeleted\tstart\tstop\n")
 	}
 
-	err = storage.ScanVolumeFile(util.ResolvePath(*export.dir), *export.collection, vid, storage.NeedleMapInMemory, volumeFileScanner)
+	err = storage.ScanVolumeFile(*export.dir, *export.collection, vid, storage.NeedleMapInMemory, volumeFileScanner)
 	if err != nil && err != io.EOF {
 		glog.Errorf("Export Volume File [ERROR] %s\n", err)
 	}

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -230,6 +230,10 @@ func runFiler(cmd *Command, args []string) bool {
 		go http.ListenAndServe(fmt.Sprintf(":%d", *f.debugPort), nil)
 	}
 
+	*f.defaultLevelDbDirectory = util.ResolvePath(*f.defaultLevelDbDirectory)
+	filerS3Options.resolvePaths()
+	filerWebDavOptions.resolvePaths()
+	filerSftpOptions.resolvePaths()
 	util.LoadSecurityConfiguration()
 
 	switch {
@@ -328,7 +332,7 @@ func (fo *FilerOptions) startFiler() {
 		*fo.allowedOrigins = "*"
 	}
 
-	defaultLevelDbDirectory := util.ResolvePath(*fo.defaultLevelDbDirectory + "/filerldb2")
+	defaultLevelDbDirectory := *fo.defaultLevelDbDirectory + "/filerldb2"
 
 	filerAddress := pb.NewServerAddress(*fo.ip, *fo.port, *fo.portGrpc)
 

--- a/weed/command/filer_cat.go
+++ b/weed/command/filer_cat.go
@@ -60,6 +60,7 @@ var cmdFilerCat = &Command{
 
 func runFilerCat(cmd *Command, args []string) bool {
 
+	*filerCat.output = util.ResolvePath(*filerCat.output)
 	util.LoadSecurityConfiguration()
 
 	if len(args) == 0 {

--- a/weed/command/filer_meta_backup.go
+++ b/weed/command/filer_meta_backup.go
@@ -65,6 +65,8 @@ When both match, the deeper prefix wins.
 
 func runFilerMetaBackup(cmd *Command, args []string) bool {
 
+	*metaBackup.backupFilerConfig = util.ResolvePath(*metaBackup.backupFilerConfig)
+
 	util.LoadSecurityConfiguration()
 	metaBackup.grpcDialOption = security.LoadClientTLS(util.GetViper(), "grpc.client")
 

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -183,6 +183,8 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 
 	*syncCpuProfile = util.ResolvePath(*syncCpuProfile)
 	*syncMemProfile = util.ResolvePath(*syncMemProfile)
+	*syncOptions.aSecurity = util.ResolvePath(*syncOptions.aSecurity)
+	*syncOptions.bSecurity = util.ResolvePath(*syncOptions.bSecurity)
 	grace.SetupProfiling(*syncCpuProfile, *syncMemProfile)
 
 	filerA := pb.ServerAddress(*syncOptions.filerA)

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -181,6 +181,8 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 		}
 	}
 
+	*syncCpuProfile = util.ResolvePath(*syncCpuProfile)
+	*syncMemProfile = util.ResolvePath(*syncMemProfile)
 	grace.SetupProfiling(*syncCpuProfile, *syncMemProfile)
 
 	filerA := pb.ServerAddress(*syncOptions.filerA)

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -147,6 +147,11 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 		grace.StartDebugServer(*syncOptions.debugPort)
 	}
 
+	*syncCpuProfile = util.ResolvePath(*syncCpuProfile)
+	*syncMemProfile = util.ResolvePath(*syncMemProfile)
+	*syncOptions.aSecurity = util.ResolvePath(*syncOptions.aSecurity)
+	*syncOptions.bSecurity = util.ResolvePath(*syncOptions.bSecurity)
+
 	util.LoadSecurityConfiguration()
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 
@@ -181,10 +186,6 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 		}
 	}
 
-	*syncCpuProfile = util.ResolvePath(*syncCpuProfile)
-	*syncMemProfile = util.ResolvePath(*syncMemProfile)
-	*syncOptions.aSecurity = util.ResolvePath(*syncOptions.aSecurity)
-	*syncOptions.bSecurity = util.ResolvePath(*syncOptions.bSecurity)
 	grace.SetupProfiling(*syncCpuProfile, *syncMemProfile)
 
 	filerA := pb.ServerAddress(*syncOptions.filerA)

--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -63,6 +63,8 @@ var cmdFilerSyncVerify = &Command{
 }
 
 func runFilerSyncVerify(cmd *Command, args []string) bool {
+	*syncVerifyOptions.aSecurity = util.ResolvePath(*syncVerifyOptions.aSecurity)
+	*syncVerifyOptions.bSecurity = util.ResolvePath(*syncVerifyOptions.bSecurity)
 	util.LoadSecurityConfiguration()
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -144,6 +144,7 @@ func runMaster(cmd *Command, args []string) bool {
 		*m.metaFolder = v
 	}
 
+	*m.metaFolder = util.ResolvePath(*m.metaFolder)
 	*masterCpuProfile = util.ResolvePath(*masterCpuProfile)
 	*masterMemProfile = util.ResolvePath(*masterMemProfile)
 	grace.SetupProfiling(*masterCpuProfile, *masterMemProfile)
@@ -154,7 +155,7 @@ func runMaster(cmd *Command, args []string) bool {
 			glog.Fatalf("Could not create Meta Folder %s: %v", *m.metaFolder, err)
 		}
 	}
-	if err := util.TestFolderWritable(util.ResolvePath(*m.metaFolder)); err != nil {
+	if err := util.TestFolderWritable(*m.metaFolder); err != nil {
 		glog.Fatalf("Check Meta Folder (-mdir) Writable %s : %s", *m.metaFolder, err)
 	}
 

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -144,6 +144,8 @@ func runMaster(cmd *Command, args []string) bool {
 		*m.metaFolder = v
 	}
 
+	*masterCpuProfile = util.ResolvePath(*masterCpuProfile)
+	*masterMemProfile = util.ResolvePath(*masterMemProfile)
 	grace.SetupProfiling(*masterCpuProfile, *masterMemProfile)
 
 	parent, _ := util.FullPath(*m.metaFolder).DirAndName()

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -902,7 +902,12 @@ func runMini(cmd *Command, args []string) bool {
 
 	*miniOptions.cpuprofile = util.ResolvePath(*miniOptions.cpuprofile)
 	*miniOptions.memprofile = util.ResolvePath(*miniOptions.memprofile)
+	*miniS3Config = util.ResolvePath(*miniS3Config)
+	*miniIamConfig = util.ResolvePath(*miniIamConfig)
+	*miniMasterOptions.metaFolder = util.ResolvePath(*miniMasterOptions.metaFolder)
 	*miniAdminOptions.dataDir = util.ResolvePath(*miniAdminOptions.dataDir)
+	miniS3Options.resolvePaths()
+	miniWebDavOptions.resolvePaths()
 	grace.SetupProfiling(*miniOptions.cpuprofile, *miniOptions.memprofile)
 
 	// Determine bind IP

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -900,6 +900,9 @@ func runMini(cmd *Command, args []string) bool {
 	util.LoadSecurityConfiguration()
 	util.LoadConfiguration("master", false)
 
+	*miniOptions.cpuprofile = util.ResolvePath(*miniOptions.cpuprofile)
+	*miniOptions.memprofile = util.ResolvePath(*miniOptions.memprofile)
+	*miniAdminOptions.dataDir = util.ResolvePath(*miniAdminOptions.dataDir)
 	grace.SetupProfiling(*miniOptions.cpuprofile, *miniOptions.memprofile)
 
 	// Determine bind IP

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -875,7 +875,7 @@ func saveMiniConfiguration(dataFolder string) error {
 }
 
 func runMini(cmd *Command, args []string) bool {
-	*miniDataFolders = util.ResolvePath(*miniDataFolders)
+	*miniDataFolders = util.ResolveCommaSeparatedPaths(*miniDataFolders)
 
 	// Capture which port flags were explicitly passed on CLI BEFORE config file is applied
 	// This is necessary to distinguish user-specified ports from defaults or config file options

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -900,6 +900,9 @@ func runMini(cmd *Command, args []string) bool {
 	util.LoadSecurityConfiguration()
 	util.LoadConfiguration("master", false)
 
+	// applyConfigFileOptions above may have overwritten -dir from the
+	// mini.options file, so re-resolve it here alongside the other paths.
+	*miniDataFolders = util.ResolveCommaSeparatedPaths(*miniDataFolders)
 	*miniOptions.cpuprofile = util.ResolvePath(*miniOptions.cpuprofile)
 	*miniOptions.memprofile = util.ResolvePath(*miniOptions.memprofile)
 	*miniS3Config = util.ResolvePath(*miniS3Config)

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -987,9 +987,13 @@ func runMini(cmd *Command, args []string) bool {
 	}
 
 	if *miniMasterOptions.metaFolder == "" {
-		*miniMasterOptions.metaFolder = *miniDataFolders
+		// -dir may be comma-separated (dir[,dir]...); the master expects a
+		// single directory, so default to the first entry. Both miniDataFolders
+		// and miniMasterOptions.metaFolder were already tilde-resolved at the
+		// top of runMini.
+		*miniMasterOptions.metaFolder = util.StringSplit(*miniDataFolders, ",")[0]
 	}
-	if err := util.TestFolderWritable(util.ResolvePath(*miniMasterOptions.metaFolder)); err != nil {
+	if err := util.TestFolderWritable(*miniMasterOptions.metaFolder); err != nil {
 		glog.Fatalf("Check Meta Folder (-dir=\"%s\") Writable: %s", *miniMasterOptions.metaFolder, err)
 	}
 	miniFilerOptions.defaultLevelDbDirectory = miniMasterOptions.metaFolder
@@ -998,9 +1002,9 @@ func runMini(cmd *Command, args []string) bool {
 	// Only auto-calculate if user didn't explicitly specify a value via -master.volumeSizeLimitMB
 	if !isFlagPassed("master.volumeSizeLimitMB") {
 		// User didn't override, use auto-calculated value
-		// The -dir flag can accept comma-separated directories; use the first one for disk space calculation
-		resolvedDataFolder := util.ResolvePath(util.StringSplit(*miniDataFolders, ",")[0])
-		optimalVolumeSizeMB := calculateOptimalVolumeSizeMB(resolvedDataFolder)
+		// The -dir flag can accept comma-separated directories; use the first one for disk space calculation.
+		// miniDataFolders was already tilde-resolved at the top of runMini.
+		optimalVolumeSizeMB := calculateOptimalVolumeSizeMB(util.StringSplit(*miniDataFolders, ",")[0])
 		miniMasterOptions.volumeSizeLimitMB = &optimalVolumeSizeMB
 		glog.Infof("Mini started with auto-calculated optimal volume size limit: %dMB", optimalVolumeSizeMB)
 	} else {

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -320,9 +320,10 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		mountRoot = mountRoot[0 : len(mountRoot)-1]
 	}
 
-	cacheDirForWrite := *option.cacheDirForWrite
+	cacheDirForRead := util.ResolvePath(*option.cacheDirForRead)
+	cacheDirForWrite := util.ResolvePath(*option.cacheDirForWrite)
 	if cacheDirForWrite == "" {
-		cacheDirForWrite = *option.cacheDirForRead
+		cacheDirForWrite = cacheDirForRead
 	}
 
 	seaweedFileSystem := mount.NewSeaweedFileSystem(&mount.Option{
@@ -339,7 +340,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		ChunkSizeLimit:              int64(chunkSizeLimitMB) * 1024 * 1024,
 		ConcurrentWriters:           *option.concurrentWriters,
 		ConcurrentReaders:           *option.concurrentReaders,
-		CacheDirForRead:             *option.cacheDirForRead,
+		CacheDirForRead:             cacheDirForRead,
 		CacheSizeMBForRead:          *option.cacheSizeMBForRead,
 		CacheDirForWrite:            cacheDirForWrite,
 		WriteBufferSizeMB:           *option.writeBufferSizeMB,

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -41,6 +41,8 @@ func runMount(cmd *Command, args []string) bool {
 		go http.ListenAndServe(fmt.Sprintf(":%d", *mountOptions.debugPort), nil)
 	}
 
+	*mountCpuProfile = util.ResolvePath(*mountCpuProfile)
+	*mountMemProfile = util.ResolvePath(*mountMemProfile)
 	grace.SetupProfiling(*mountCpuProfile, *mountMemProfile)
 	if *mountReadRetryTime < time.Second {
 		*mountReadRetryTime = time.Second

--- a/weed/command/mq_broker.go
+++ b/weed/command/mq_broker.go
@@ -73,6 +73,8 @@ func runMqBroker(cmd *Command, args []string) bool {
 
 func (mqBrokerOpt *MessageQueueBrokerOptions) startQueueServer() bool {
 
+	*mqBrokerStandaloneOptions.cpuprofile = util.ResolvePath(*mqBrokerStandaloneOptions.cpuprofile)
+	*mqBrokerStandaloneOptions.memprofile = util.ResolvePath(*mqBrokerStandaloneOptions.memprofile)
 	grace.SetupProfiling(*mqBrokerStandaloneOptions.cpuprofile, *mqBrokerStandaloneOptions.memprofile)
 
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.msg_broker")

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -211,6 +211,7 @@ func runS3(cmd *Command, args []string) bool {
 		grace.StartDebugServer(*s3StandaloneOptions.debugPort)
 	}
 
+	s3StandaloneOptions.resolvePaths()
 	util.LoadSecurityConfiguration()
 
 	switch {
@@ -244,16 +245,20 @@ func (s3opt *S3Options) parseDefaultFileMode() (uint32, error) {
 	return uint32(mode), nil
 }
 
-func (s3opt *S3Options) startS3Server() bool {
-
-	// Resolve "~" in user-supplied path flags so values like "~/iam.json"
-	// passed via -s3.config (etc.) work without shell expansion.
+// resolvePaths expands "~" in every user-supplied path flag so callers
+// that share these pointers (e.g. server.go propagating s3Options.config
+// to filerOptions.s3ConfigFile before startS3Server runs) see resolved
+// values. Idempotent — safe to call from any entry point.
+func (s3opt *S3Options) resolvePaths() {
 	*s3opt.config = util.ResolvePath(*s3opt.config)
 	*s3opt.iamConfig = util.ResolvePath(*s3opt.iamConfig)
 	*s3opt.tlsCertificate = util.ResolvePath(*s3opt.tlsCertificate)
 	*s3opt.tlsPrivateKey = util.ResolvePath(*s3opt.tlsPrivateKey)
 	*s3opt.tlsCACertificate = util.ResolvePath(*s3opt.tlsCACertificate)
 	*s3opt.auditLogConfig = util.ResolvePath(*s3opt.auditLogConfig)
+}
+
+func (s3opt *S3Options) startS3Server() bool {
 
 	filerAddresses := pb.ServerAddresses(*s3opt.filer).ToAddresses()
 

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -246,6 +246,15 @@ func (s3opt *S3Options) parseDefaultFileMode() (uint32, error) {
 
 func (s3opt *S3Options) startS3Server() bool {
 
+	// Resolve "~" in user-supplied path flags so values like "~/iam.json"
+	// passed via -s3.config (etc.) work without shell expansion.
+	*s3opt.config = util.ResolvePath(*s3opt.config)
+	*s3opt.iamConfig = util.ResolvePath(*s3opt.iamConfig)
+	*s3opt.tlsCertificate = util.ResolvePath(*s3opt.tlsCertificate)
+	*s3opt.tlsPrivateKey = util.ResolvePath(*s3opt.tlsPrivateKey)
+	*s3opt.tlsCACertificate = util.ResolvePath(*s3opt.tlsCACertificate)
+	*s3opt.auditLogConfig = util.ResolvePath(*s3opt.auditLogConfig)
+
 	filerAddresses := pb.ServerAddresses(*s3opt.filer).ToAddresses()
 
 	filerBucketsPath := "/buckets"

--- a/weed/command/scaffold.go
+++ b/weed/command/scaffold.go
@@ -59,7 +59,7 @@ func runScaffold(cmd *Command, args []string) bool {
 	}
 
 	if *outputPath != "" {
-		util.WriteFile(filepath.Join(*outputPath, *config+".toml"), []byte(content), 0644)
+		util.WriteFile(filepath.Join(util.ResolvePath(*outputPath), *config+".toml"), []byte(content), 0644)
 	} else {
 		fmt.Println(content)
 	}

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -224,6 +224,8 @@ func runServer(cmd *Command, args []string) bool {
 	util.LoadSecurityConfiguration()
 	util.LoadConfiguration("master", false)
 
+	*serverOptions.cpuprofile = util.ResolvePath(*serverOptions.cpuprofile)
+	*serverOptions.memprofile = util.ResolvePath(*serverOptions.memprofile)
 	grace.SetupProfiling(*serverOptions.cpuprofile, *serverOptions.memprofile)
 
 	if *isStartingS3 {

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -226,7 +226,11 @@ func runServer(cmd *Command, args []string) bool {
 
 	*serverOptions.cpuprofile = util.ResolvePath(*serverOptions.cpuprofile)
 	*serverOptions.memprofile = util.ResolvePath(*serverOptions.memprofile)
+	*serverIamConfig = util.ResolvePath(*serverIamConfig)
 	*masterOptions.metaFolder = util.ResolvePath(*masterOptions.metaFolder)
+	s3Options.resolvePaths()
+	webdavOptions.resolvePaths()
+	sftpOptions.resolvePaths()
 	grace.SetupProfiling(*serverOptions.cpuprofile, *serverOptions.memprofile)
 
 	if *isStartingS3 {

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -226,6 +226,7 @@ func runServer(cmd *Command, args []string) bool {
 
 	*serverOptions.cpuprofile = util.ResolvePath(*serverOptions.cpuprofile)
 	*serverOptions.memprofile = util.ResolvePath(*serverOptions.memprofile)
+	*masterOptions.metaFolder = util.ResolvePath(*masterOptions.metaFolder)
 	grace.SetupProfiling(*serverOptions.cpuprofile, *serverOptions.memprofile)
 
 	if *isStartingS3 {
@@ -330,7 +331,7 @@ func runServer(cmd *Command, args []string) bool {
 	if *masterOptions.metaFolder == "" {
 		*masterOptions.metaFolder = folders[0]
 	}
-	if err := util.TestFolderWritable(util.ResolvePath(*masterOptions.metaFolder)); err != nil {
+	if err := util.TestFolderWritable(*masterOptions.metaFolder); err != nil {
 		glog.Fatalf("Check Meta Folder (-mdir=\"%s\") Writable: %s", *masterOptions.metaFolder, err)
 	}
 	filerOptions.defaultLevelDbDirectory = masterOptions.metaFolder

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -320,6 +320,7 @@ func runServer(cmd *Command, args []string) bool {
 
 	go stats_collect.StartMetricsServer(*serverMetricsHttpIp, *serverMetricsHttpPort)
 
+	*volumeDataFolders = util.ResolveCommaSeparatedPaths(*volumeDataFolders)
 	folders := strings.Split(*volumeDataFolders, ",")
 
 	if *masterOptions.volumeSizeLimitMB > util.VolumeSizeLimitGB*1000 {

--- a/weed/command/sftp.go
+++ b/weed/command/sftp.go
@@ -79,6 +79,7 @@ func init() {
 
 // runSftp is the command entry point.
 func runSftp(cmd *Command, args []string) bool {
+	sftpOptionsStandalone.resolvePaths()
 	// Load security configuration as done in other SeaweedFS services.
 	util.LoadSecurityConfiguration()
 
@@ -94,15 +95,18 @@ func runSftp(cmd *Command, args []string) bool {
 	return sftpOptionsStandalone.startSftpServer()
 }
 
+// resolvePaths expands "~" in every user-supplied path flag.
+// Idempotent — safe to call from any entry point.
+func (sftpOpt *SftpOptions) resolvePaths() {
+	*sftpOpt.sshPrivateKey = util.ResolvePath(*sftpOpt.sshPrivateKey)
+	*sftpOpt.hostKeysFolder = util.ResolvePath(*sftpOpt.hostKeysFolder)
+	*sftpOpt.userStoreFile = util.ResolvePath(*sftpOpt.userStoreFile)
+}
+
 func (sftpOpt *SftpOptions) startSftpServer() bool {
 	if *sftpOpt.bindIp == "" {
 		*sftpOpt.bindIp = "0.0.0.0"
 	}
-
-	// Resolve "~" in user-supplied path flags.
-	*sftpOpt.sshPrivateKey = util.ResolvePath(*sftpOpt.sshPrivateKey)
-	*sftpOpt.hostKeysFolder = util.ResolvePath(*sftpOpt.hostKeysFolder)
-	*sftpOpt.userStoreFile = util.ResolvePath(*sftpOpt.userStoreFile)
 	filerAddress := pb.ServerAddress(*sftpOpt.filer)
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 

--- a/weed/command/sftp.go
+++ b/weed/command/sftp.go
@@ -98,6 +98,11 @@ func (sftpOpt *SftpOptions) startSftpServer() bool {
 	if *sftpOpt.bindIp == "" {
 		*sftpOpt.bindIp = "0.0.0.0"
 	}
+
+	// Resolve "~" in user-supplied path flags.
+	*sftpOpt.sshPrivateKey = util.ResolvePath(*sftpOpt.sshPrivateKey)
+	*sftpOpt.hostKeysFolder = util.ResolvePath(*sftpOpt.hostKeysFolder)
+	*sftpOpt.userStoreFile = util.ResolvePath(*sftpOpt.userStoreFile)
 	filerAddress := pb.ServerAddress(*sftpOpt.filer)
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 

--- a/weed/command/update.go
+++ b/weed/command/update.go
@@ -85,8 +85,9 @@ func runUpdate(cmd *Command, args []string) bool {
 	path, _ := os.Executable()
 	_, name := filepath.Split(path)
 
+	*updateOpt.dir = util.ResolvePath(*updateOpt.dir)
 	if *updateOpt.dir != "" {
-		if err := util.TestFolderWritable(util.ResolvePath(*updateOpt.dir)); err != nil {
+		if err := util.TestFolderWritable(*updateOpt.dir); err != nil {
 			glog.Fatalf("Check Folder(-dir) Writable %s : %s", *updateOpt.dir, err)
 			return false
 		}

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -150,6 +150,8 @@ func runVolume(cmd *Command, args []string) bool {
 	// If --pprof is set we assume the caller wants to be able to collect
 	// cpu and memory profiles via go tool pprof
 	if !*v.pprof {
+		*v.cpuProfile = util.ResolvePath(*v.cpuProfile)
+		*v.memProfile = util.ResolvePath(*v.memProfile)
 		grace.SetupProfiling(*v.cpuProfile, *v.memProfile)
 	}
 
@@ -284,7 +286,7 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 	volumeServer := weed_server.NewVolumeServer(volumeMux, publicVolumeMux,
 		*v.ip, *v.port, *v.portGrpc, *v.publicUrl, volumeServerId,
 		v.folders, v.folderMaxLimits, minFreeSpaces, diskTypes, folderTags,
-		*v.idxFolder,
+		util.ResolvePath(*v.idxFolder),
 		volumeNeedleMapKind,
 		v.masters, constants.VolumePulsePeriod, *v.dataCenter, *v.rack,
 		v.whiteList,

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -181,9 +181,10 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 
 	// Set multiple folders and each folder's max volume count limit'
 	v.folders = strings.Split(volumeFolders, ",")
-	for _, folder := range v.folders {
-		if err := util.TestFolderWritable(util.ResolvePath(folder)); err != nil {
-			glog.Fatalf("Check Data Folder(-dir) Writable %s : %s", folder, err)
+	for i, folder := range v.folders {
+		v.folders[i] = util.ResolvePath(folder)
+		if err := util.TestFolderWritable(v.folders[i]); err != nil {
+			glog.Fatalf("Check Data Folder(-dir) Writable %s : %s", v.folders[i], err)
 		}
 	}
 

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -81,6 +81,7 @@ func runWebDav(cmd *Command, args []string) bool {
 func (wo *WebDavOption) startWebDav() bool {
 
 	// Resolve "~" in user-supplied path flags.
+	*wo.cacheDir = util.ResolvePath(*wo.cacheDir)
 	*wo.tlsCertificate = util.ResolvePath(*wo.tlsCertificate)
 	*wo.tlsPrivateKey = util.ResolvePath(*wo.tlsPrivateKey)
 
@@ -130,7 +131,7 @@ func (wo *WebDavOption) startWebDav() bool {
 		Uid:            uid,
 		Gid:            gid,
 		Cipher:         cipher,
-		CacheDir:       util.ResolvePath(*wo.cacheDir),
+		CacheDir:       *wo.cacheDir,
 		CacheSizeMB:    *wo.cacheSizeMB,
 		MaxMB:          *wo.maxMB,
 	})

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -69,6 +69,7 @@ var cmdWebDav = &Command{
 
 func runWebDav(cmd *Command, args []string) bool {
 
+	webDavStandaloneOptions.resolvePaths()
 	util.LoadSecurityConfiguration()
 
 	listenAddress := fmt.Sprintf("%s:%d", *webDavStandaloneOptions.ipBind, *webDavStandaloneOptions.port)
@@ -78,12 +79,15 @@ func runWebDav(cmd *Command, args []string) bool {
 
 }
 
-func (wo *WebDavOption) startWebDav() bool {
-
-	// Resolve "~" in user-supplied path flags.
+// resolvePaths expands "~" in every user-supplied path flag.
+// Idempotent — safe to call from any entry point.
+func (wo *WebDavOption) resolvePaths() {
 	*wo.cacheDir = util.ResolvePath(*wo.cacheDir)
 	*wo.tlsCertificate = util.ResolvePath(*wo.tlsCertificate)
 	*wo.tlsPrivateKey = util.ResolvePath(*wo.tlsPrivateKey)
+}
+
+func (wo *WebDavOption) startWebDav() bool {
 
 	// detect current user
 	uid, gid := uint32(0), uint32(0)

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -80,6 +80,10 @@ func runWebDav(cmd *Command, args []string) bool {
 
 func (wo *WebDavOption) startWebDav() bool {
 
+	// Resolve "~" in user-supplied path flags.
+	*wo.tlsCertificate = util.ResolvePath(*wo.tlsCertificate)
+	*wo.tlsPrivateKey = util.ResolvePath(*wo.tlsPrivateKey)
+
 	// detect current user
 	uid, gid := uint32(0), uint32(0)
 	if u, err := user.Current(); err == nil {

--- a/weed/command/worker.go
+++ b/weed/command/worker.go
@@ -3,6 +3,7 @@ package command
 import (
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 )
 
@@ -62,6 +63,7 @@ func runWorker(cmd *Command, args []string) bool {
 		grace.StartDebugServer(*workerDebugPort)
 	}
 
+	*workerWorkingDir = util.ResolvePath(*workerWorkingDir)
 	return runPluginWorkerWithOptions(pluginWorkerRunOptions{
 		AdminServer: *workerAdminServer,
 		WorkerID:    *workerID,

--- a/weed/util/file_util.go
+++ b/weed/util/file_util.go
@@ -124,6 +124,21 @@ func ResolvePath(path string) string {
 	return filepath.Join(usr.HomeDir, rest)
 }
 
+// ResolveCommaSeparatedPaths splits paths on "," and runs each entry through
+// ResolvePath, then rejoins them. This lets flags like `weed mini -dir` or
+// `weed volume -dir` accept tilde-prefixed entries (e.g. "~/d1,~/d2") even
+// in the comma-separated form the help text advertises.
+func ResolveCommaSeparatedPaths(paths string) string {
+	if !strings.Contains(paths, "~") {
+		return paths
+	}
+	parts := strings.Split(paths, ",")
+	for i, p := range parts {
+		parts[i] = ResolvePath(p)
+	}
+	return strings.Join(parts, ",")
+}
+
 func FileNameBase(filename string) string {
 	lastDotIndex := strings.LastIndex(filename, ".")
 	if lastDotIndex < 0 {

--- a/weed/util/file_util.go
+++ b/weed/util/file_util.go
@@ -82,25 +82,46 @@ func CheckFile(filename string) (exists, canRead, canWrite bool, modTime time.Ti
 	return
 }
 
+// ResolvePath expands a leading "~", "~/", or "~username/" in path to the
+// corresponding home directory, mirroring shell tilde expansion. A path
+// without a leading "~" or whose tilde cannot be resolved is returned
+// unchanged so callers can pass any user-supplied path through this helper
+// without worrying about non-tilde inputs or lookup failures.
 func ResolvePath(path string) string {
 
-	if !strings.Contains(path, "~") {
+	if !strings.HasPrefix(path, "~") {
 		return path
 	}
 
-	usr, _ := user.Current()
-	dir := usr.HomeDir
-
 	if path == "~" {
-		// In case of "~", which won't be caught by the "else if"
-		path = dir
-	} else if strings.HasPrefix(path, "~/") {
-		// Use strings.HasPrefix so we don't match paths like
-		// "/something/~/something/"
-		path = filepath.Join(dir, path[2:])
+		if usr, err := user.Current(); err == nil {
+			return usr.HomeDir
+		}
+		return path
 	}
 
-	return path
+	if strings.HasPrefix(path, "~/") {
+		if usr, err := user.Current(); err == nil {
+			return filepath.Join(usr.HomeDir, path[2:])
+		}
+		return path
+	}
+
+	// "~username" or "~username/rest"
+	rest := ""
+	name := path[1:]
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		rest = name[i+1:]
+		name = name[:i]
+	}
+	usr, err := user.Lookup(name)
+	if err != nil {
+		return path
+	}
+	if rest == "" {
+		return usr.HomeDir
+	}
+	return filepath.Join(usr.HomeDir, rest)
 }
 
 func FileNameBase(filename string) string {

--- a/weed/util/file_util.go
+++ b/weed/util/file_util.go
@@ -87,6 +87,12 @@ func CheckFile(filename string) (exists, canRead, canWrite bool, modTime time.Ti
 // without a leading "~" or whose tilde cannot be resolved is returned
 // unchanged so callers can pass any user-supplied path through this helper
 // without worrying about non-tilde inputs or lookup failures.
+//
+// Forward slashes are always recognised as separators after the tilde;
+// the platform-native separator is also accepted so "~\\data" works on
+// Windows. Backslashes are deliberately not treated as separators on
+// other platforms because they are legal characters in usernames and
+// path segments there.
 func ResolvePath(path string) string {
 
 	if !strings.HasPrefix(path, "~") {
@@ -100,19 +106,26 @@ func ResolvePath(path string) string {
 		return path
 	}
 
-	if strings.HasPrefix(path, "~/") {
+	isSep := func(b byte) bool {
+		return b == '/' || b == byte(filepath.Separator)
+	}
+
+	if isSep(path[1]) {
 		if usr, err := user.Current(); err == nil {
 			return filepath.Join(usr.HomeDir, path[2:])
 		}
 		return path
 	}
 
-	// "~username" or "~username/rest"
-	rest := ""
+	// "~username" or "~username<sep>rest"
 	name := path[1:]
-	if i := strings.IndexByte(name, '/'); i >= 0 {
-		rest = name[i+1:]
-		name = name[:i]
+	rest := ""
+	for i := 0; i < len(name); i++ {
+		if isSep(name[i]) {
+			rest = name[i+1:]
+			name = name[:i]
+			break
+		}
 	}
 	usr, err := user.Lookup(name)
 	if err != nil {

--- a/weed/util/file_util_test.go
+++ b/weed/util/file_util_test.go
@@ -45,6 +45,9 @@ func TestResolvePath(t *testing.T) {
 		{"tilde with current user", "~" + usr.Username, home},
 		{"tilde with current user and subpath", "~" + usr.Username + "/data", filepath.Join(home, "data")},
 		{"tilde unknown user falls back to literal", "~no-such-user-xyz/data", "~no-such-user-xyz/data"},
+		// Native separator: identical to "~/data" on Unix; exercises backslash on Windows.
+		{"tilde with native separator", "~" + string(filepath.Separator) + "data", filepath.Join(home, "data")},
+		{"tilde user with native separator", "~" + usr.Username + string(filepath.Separator) + "data", filepath.Join(home, "data")},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/weed/util/file_util_test.go
+++ b/weed/util/file_util_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os/user"
+	"path/filepath"
 	"testing"
 )
 
@@ -18,5 +20,37 @@ func TestToShortFileName(t *testing.T) {
 		if got != p.value {
 			t.Errorf("failed to test: got %v, want %v", got, p.value)
 		}
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	home := usr.HomeDir
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"absolute", "/var/data", "/var/data"},
+		{"relative", "data", "data"},
+		{"tilde mid path is literal", "/foo/~/bar", "/foo/~/bar"},
+		{"bare tilde", "~", home},
+		{"tilde slash", "~/", home},
+		{"tilde with subpath", "~/data", filepath.Join(home, "data")},
+		{"tilde with current user", "~" + usr.Username, home},
+		{"tilde with current user and subpath", "~" + usr.Username + "/data", filepath.Join(home, "data")},
+		{"tilde unknown user falls back to literal", "~no-such-user-xyz/data", "~no-such-user-xyz/data"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ResolvePath(c.in); got != c.want {
+				t.Errorf("ResolvePath(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
 	}
 }

--- a/weed/util/file_util_test.go
+++ b/weed/util/file_util_test.go
@@ -54,3 +54,32 @@ func TestResolvePath(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveCommaSeparatedPaths(t *testing.T) {
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	home := usr.HomeDir
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single absolute", "/a", "/a"},
+		{"single tilde", "~/a", filepath.Join(home, "a")},
+		{"two absolutes", "/a,/b", "/a,/b"},
+		{"two tildes", "~/a,~/b", filepath.Join(home, "a") + "," + filepath.Join(home, "b")},
+		{"mixed", "/a,~/b,/c", "/a," + filepath.Join(home, "b") + ",/c"},
+		{"no tilde fast path", "/a,/b,/c", "/a,/b,/c"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ResolveCommaSeparatedPaths(c.in); got != c.want {
+				t.Errorf("ResolveCommaSeparatedPaths(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Many of `weed`'s path-bearing flags were never run through `util.ResolvePath`, so a value like `~/iam.json` was used literally. Tilde only worked when the shell expanded it, which silently fails for the common `-flag=~/path` form (bash leaves the tilde literal in `--opt=~/path`).

This PR routes every path-style CLI flag through `util.ResolvePath` and folds in admin's duplicate `expandHomeDir` helper.

## What's changed

**`util.ResolvePath` (`weed/util/file_util.go`)**
- Now also handles `~user` and `~user/rest` (mirrors shell tilde expansion).
- On any failure (unknown user, `user.Current()` error), returns the path unchanged so existing callers stay safe.
- Added `TestResolvePath` covering 10 cases: empty, absolute, relative, mid-path tilde, bare `~`, `~/`, `~/sub`, current user with/without subpath, unknown user.

**Apply at every previously-unresolved use site (`weed/command/*.go`)**

Resolved at the top of each shared `start*` so all callers (mini / server / filer / standalone) inherit it:
- `s3.go::startS3Server` — `-s3.config`, `-s3.iam.config`, `-s3.auditLogConfig`, `-s3.cert.file`, `-s3.key.file`, `-s3.cacert.file`
- `webdav.go::startWebDav` — `-webdav.cert.file`, `-webdav.key.file` (cacheDir was already resolved)
- `sftp.go::startSftpServer` — `-sftp.sshPrivateKey`, `-sftp.hostKeysFolder`, `-sftp.userStoreFile`

Resolved at the one-off use sites:
- `mount_std.go::RunMount` — `-cacheDir`, `-cacheDirWrite`
- `volume.go` — `-dir.idx` / `-volume.dir.idx`
- `mini.go` — `-admin.dataDir`, `-cpuprofile`, `-memprofile`
- `master.go`, `server.go`, `volume.go`, `admin.go` — `-cpuprofile`, `-memprofile`

**Dedupe**
- Removed `expandHomeDir` from `admin.go` (38 lines) — `util.ResolvePath` now covers the same `~user/...` cases.

## Why bash users care

```
$ printf '%s\n' -dir=~/data        # bash does NOT expand tilde here
-dir=~/data
$ printf '%s\n' -dir ~/data        # only the space form expands
-dir
/home/chris/data
```

Before this PR, `weed mini -dir=~/data` would create a directory literally named `~/data` in the cwd. After this PR, weed itself resolves it.

## Test plan

- [x] `go build ./weed/...`
- [x] `go test ./weed/util/ -run TestResolvePath` — 10/10 pass
- [x] `go test ./weed/util/` — all green
- [x] `go vet ./weed/command/... ./weed/util/` — clean (one pre-existing warning in `filer_sync.go:405` unrelated to this change)
- [ ] Smoke: `weed mini -dir ~/data` and `weed mini -dir=~/data` both end up at `$HOME/data`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent tilde (~) expansion and path resolution across commands so home-directory and relative paths behave predictably.
  * Profile, config, and output file paths are now resolved up-front so profiling and generated outputs go to the intended locations.

* **Improvements**
  * Unified handling of single and comma-separated path flags across server, backup, mount, S3/WebDAV/SFTP, worker, and other startup flows.
  * Writability checks and server startup use normalized paths consistently.

* **Tests**
  * Added tests covering path-expansion and comma-separated path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->