### PR TITLE
feat(iam): account-scoped OIDC providers (Phase 3c)

### DIFF
--- a/weed/iam/integration/account_scope_test.go
+++ b/weed/iam/integration/account_scope_test.go
@@ -1,0 +1,72 @@
+package integration
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetProviderByIssuerAndAccount(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryOIDCProviderStore()
+
+	// Two providers for the same issuer, scoped to different accounts.
+	must := func(rec *OIDCProviderRecord) {
+		if err := store.StoreProvider(ctx, "", rec); err != nil {
+			t.Fatalf("store: %v", err)
+		}
+	}
+	must(&OIDCProviderRecord{
+		AccountID: "111",
+		ARN:       "arn:aws:iam::111:oidc-provider/idp.example",
+		URL:       "https://idp.example",
+		ClientIDs: []string{"a"},
+	})
+	must(&OIDCProviderRecord{
+		AccountID: "222",
+		ARN:       "arn:aws:iam::222:oidc-provider/idp.example",
+		URL:       "https://idp.example",
+		ClientIDs: []string{"b"},
+	})
+
+	t.Run("matching account returns scoped record", func(t *testing.T) {
+		rec, err := store.GetProviderByIssuerAndAccount(ctx, "", "https://idp.example", "111")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if rec.AccountID != "111" {
+			t.Fatalf("unexpected record: %+v", rec)
+		}
+	})
+
+	t.Run("unknown account is rejected", func(t *testing.T) {
+		if _, err := store.GetProviderByIssuerAndAccount(ctx, "", "https://idp.example", "999"); err == nil {
+			t.Fatal("expected error for cross-account use")
+		}
+	})
+
+	t.Run("global provider satisfies any account", func(t *testing.T) {
+		must(&OIDCProviderRecord{
+			AccountID: "",
+			ARN:       "arn:aws:iam:::oidc-provider/global.example",
+			URL:       "https://global.example",
+			ClientIDs: []string{"x"},
+		})
+		rec, err := store.GetProviderByIssuerAndAccount(ctx, "", "https://global.example", "anything")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if rec.AccountID != "" {
+			t.Fatalf("expected global record, got AccountID=%q", rec.AccountID)
+		}
+	})
+
+	t.Run("empty caller account accepts any record", func(t *testing.T) {
+		rec, err := store.GetProviderByIssuerAndAccount(ctx, "", "https://idp.example", "")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if rec == nil {
+			t.Fatal("expected a record")
+		}
+	})
+}

--- a/weed/iam/integration/iam_manager.go
+++ b/weed/iam/integration/iam_manager.go
@@ -802,14 +802,22 @@ func (m *IAMManager) enforceProviderAccountScope(ctx context.Context, request *s
 	if err != nil {
 		return nil // signature validation will reject, no need to fail twice
 	}
-	rec, err := m.oidcProviderStore.GetProviderByIssuer(ctx, m.getFilerAddress(), issuer)
-	if err != nil {
-		return nil // unknown issuer; STS layer will reject
-	}
-	if rec.AccountID == "" || rec.AccountID == roleAccount {
+	// Look for a provider that is either global or scoped to the role's
+	// account. Multiple providers may share an issuer (e.g. one global plus
+	// one per tenant), and GetProviderByIssuer returns the first match
+	// arbitrarily — using it here would falsely reject a valid request
+	// whenever the wrong record happens to come back first.
+	if _, err := m.oidcProviderStore.GetProviderByIssuerAndAccount(ctx, m.getFilerAddress(), issuer, roleAccount); err == nil {
 		return nil
 	}
-	return fmt.Errorf("OIDC provider for issuer %s is registered in account %s; cannot be used to assume a role in account %s", issuer, rec.AccountID, roleAccount)
+	// No allowed match. Distinguish "issuer entirely unknown" (let the STS
+	// layer reject with the existing not-registered error) from "issuer is
+	// registered but only in a different account" (surface a precise error
+	// so the operator knows the call was cross-account).
+	if other, err := m.oidcProviderStore.GetProviderByIssuer(ctx, m.getFilerAddress(), issuer); err == nil {
+		return fmt.Errorf("OIDC provider for issuer %s is registered in account %s; cannot be used to assume a role in account %s", issuer, other.AccountID, roleAccount)
+	}
+	return nil
 }
 
 // extractIssuerFromJWT returns the iss claim of a JWT without verifying its

--- a/weed/iam/integration/iam_manager.go
+++ b/weed/iam/integration/iam_manager.go
@@ -744,6 +744,14 @@ func (m *IAMManager) AssumeRoleWithWebIdentity(ctx context.Context, request *sts
 		return nil, fmt.Errorf("IAM manager not initialized")
 	}
 
+	// Claim-based mode bypasses role lookup and trust policy entirely; the
+	// STS service handles the policy resolution from the JWT itself. Account
+	// scoping still applies but at the provider-resolution layer in Phase 3c
+	// (we'll plug that in once a multi-account assume path lands).
+	if sts.IsClaimBasedPolicyRoleArn(request.RoleArn) {
+		return m.stsService.AssumeRoleWithWebIdentity(ctx, request)
+	}
+
 	// Extract role name from ARN
 	roleName := utils.ExtractRoleNameFromArn(request.RoleArn)
 
@@ -751,6 +759,14 @@ func (m *IAMManager) AssumeRoleWithWebIdentity(ctx context.Context, request *sts
 	roleDef, err := m.roleStore.GetRole(ctx, m.getFilerAddress(), roleName)
 	if err != nil {
 		return nil, fmt.Errorf("role not found: %s", roleName)
+	}
+
+	// Account scoping: when the role lives in account A, the OIDC provider
+	// validating the token must be either global (AccountID="") or also live
+	// in account A. Skip when we can't resolve account context; fall through
+	// to the existing trust-policy enforcement.
+	if err := m.enforceProviderAccountScope(ctx, request); err != nil {
+		return nil, err
 	}
 
 	// Validate trust policy before allowing STS to assume the role
@@ -765,6 +781,55 @@ func (m *IAMManager) AssumeRoleWithWebIdentity(ctx context.Context, request *sts
 
 	// Use STS service to assume the role
 	return m.stsService.AssumeRoleWithWebIdentity(ctx, request)
+}
+
+// enforceProviderAccountScope checks that the OIDC provider matching the
+// token's issuer is registered in either the role's account or as a global
+// (account-less) provider. Returns nil when no provider store is configured
+// (preserves the static-config-only path) or when the issuer is not known to
+// the store (the existing STS-layer issuer→provider map handles that case
+// during validation).
+func (m *IAMManager) enforceProviderAccountScope(ctx context.Context, request *sts.AssumeRoleWithWebIdentityRequest) error {
+	if m.oidcProviderStore == nil {
+		return nil
+	}
+	roleAccount := utils.ParseRoleARN(request.RoleArn).AccountID
+	if roleAccount == "" {
+		// Legacy ARN form (no account): nothing to enforce.
+		return nil
+	}
+	issuer, err := extractIssuerFromJWT(request.WebIdentityToken)
+	if err != nil {
+		return nil // signature validation will reject, no need to fail twice
+	}
+	rec, err := m.oidcProviderStore.GetProviderByIssuer(ctx, m.getFilerAddress(), issuer)
+	if err != nil {
+		return nil // unknown issuer; STS layer will reject
+	}
+	if rec.AccountID == "" || rec.AccountID == roleAccount {
+		return nil
+	}
+	return fmt.Errorf("OIDC provider for issuer %s is registered in account %s; cannot be used to assume a role in account %s", issuer, rec.AccountID, roleAccount)
+}
+
+// extractIssuerFromJWT returns the iss claim of a JWT without verifying its
+// signature. Safe here because the caller still goes through full signature
+// + issuer validation in the STS service; this is purely for routing.
+func extractIssuerFromJWT(token string) (string, error) {
+	parser := new(jwt.Parser)
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return "", err
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", fmt.Errorf("invalid claims")
+	}
+	iss, _ := claims["iss"].(string)
+	if iss == "" {
+		return "", fmt.Errorf("token has no iss claim")
+	}
+	return iss, nil
 }
 
 // capDurationByRole returns the requested duration clamped to the role's

--- a/weed/iam/integration/oidc_provider_store.go
+++ b/weed/iam/integration/oidc_provider_store.go
@@ -81,6 +81,7 @@ type OIDCProviderStore interface {
 	StoreProvider(ctx context.Context, filerAddress string, record *OIDCProviderRecord) error
 	GetProviderByARN(ctx context.Context, filerAddress string, arn string) (*OIDCProviderRecord, error)
 	GetProviderByIssuer(ctx context.Context, filerAddress string, issuer string) (*OIDCProviderRecord, error)
+	GetProviderByIssuerAndAccount(ctx context.Context, filerAddress string, issuer, accountID string) (*OIDCProviderRecord, error)
 	ListProviders(ctx context.Context, filerAddress string) ([]*OIDCProviderRecord, error)
 	DeleteProvider(ctx context.Context, filerAddress string, arn string) error
 }
@@ -135,6 +136,29 @@ func (m *MemoryOIDCProviderStore) GetProviderByIssuer(ctx context.Context, _ str
 		}
 	}
 	return nil, fmt.Errorf("no OIDC provider registered for issuer: %s", issuer)
+}
+
+// GetProviderByIssuerAndAccount returns the record matching `issuer` whose
+// AccountID is empty (global) or equals `accountID`. AWS-style account
+// scoping: cross-account references must go through a shared/global
+// provider, which is why an empty AccountID is treated as a wildcard.
+//
+// `accountID` may itself be empty when the caller has no specific account
+// context (e.g. claim-based mode); in that case any registered provider
+// matching the issuer is acceptable.
+func (m *MemoryOIDCProviderStore) GetProviderByIssuerAndAccount(ctx context.Context, _ string, issuer, accountID string) (*OIDCProviderRecord, error) {
+	want := normalizeIssuer(issuer)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, rec := range m.providers {
+		if normalizeIssuer(rec.URL) != want {
+			continue
+		}
+		if rec.AccountID == "" || accountID == "" || rec.AccountID == accountID {
+			return copyOIDCProviderRecord(rec), nil
+		}
+	}
+	return nil, fmt.Errorf("no OIDC provider registered for issuer %s in account %s", issuer, accountID)
 }
 
 // ListProviders returns every record sorted by ARN for stable output.
@@ -281,6 +305,25 @@ func (f *FilerOIDCProviderStore) GetProviderByIssuer(ctx context.Context, filerA
 		}
 	}
 	return nil, fmt.Errorf("no OIDC provider registered for issuer: %s", issuer)
+}
+
+// GetProviderByIssuerAndAccount filters by AccountID on top of the issuer scan.
+// See the MemoryOIDCProviderStore equivalent for semantics.
+func (f *FilerOIDCProviderStore) GetProviderByIssuerAndAccount(ctx context.Context, filerAddress string, issuer, accountID string) (*OIDCProviderRecord, error) {
+	records, err := f.ListProviders(ctx, filerAddress)
+	if err != nil {
+		return nil, err
+	}
+	want := normalizeIssuer(issuer)
+	for _, rec := range records {
+		if normalizeIssuer(rec.URL) != want {
+			continue
+		}
+		if rec.AccountID == "" || accountID == "" || rec.AccountID == accountID {
+			return rec, nil
+		}
+	}
+	return nil, fmt.Errorf("no OIDC provider registered for issuer %s in account %s", issuer, accountID)
 }
 
 // ListProviders enumerates every record in the directory.

--- a/weed/iam/oidc/oidc_provider.go
+++ b/weed/iam/oidc/oidc_provider.go
@@ -132,9 +132,15 @@ func extractClaimPolicies(claims map[string]interface{}, claimName string) []str
 	case []interface{}:
 		out := make([]string, 0, len(v))
 		for _, e := range v {
-			if s, ok := e.(string); ok && s != "" {
-				out = append(out, s)
+			s, ok := e.(string)
+			if !ok {
+				continue
 			}
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			out = append(out, s)
 		}
 		if len(out) == 0 {
 			return nil

--- a/weed/iam/oidc/oidc_provider.go
+++ b/weed/iam/oidc/oidc_provider.go
@@ -92,6 +92,14 @@ type OIDCConfig struct {
 	// allowlist (e.g. ["team", "env"]) to opt specific keys in.
 	AllowedPrincipalTagKeys []string `json:"allowedPrincipalTagKeys,omitempty"`
 
+	// PolicyClaim names a JWT claim whose value carries the effective policy
+	// list for the session. When non-empty and the assume request opts into
+	// claim-based policy mode via the ClaimBasedPolicyRoleArn sentinel, the
+	// policies are pulled from this claim rather than from a server-side
+	// role mapping. Accepted shapes: string (single policy), comma-separated
+	// string, or string array.
+	PolicyClaim string `json:"policyClaim,omitempty"`
+
 	// TLSCACert is the path to the CA certificate file for custom/self-signed certificates
 	TLSCACert string `json:"tlsCaCert,omitempty"`
 
@@ -105,6 +113,55 @@ type OIDCConfig struct {
 // an object whose top-level keys are tag names. AWS uses the same string;
 // see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html.
 const PrincipalTagsClaim = "https://aws.amazon.com/tags/principal_tags"
+
+// extractClaimPolicies reads policy names from the configured JWT claim.
+// Accepts three shapes: a single string ("readonly"), a comma-separated
+// string ("readonly,billing"), or a string array. Returns nil when the
+// provider isn't in claim-based mode or the claim is absent/empty.
+func extractClaimPolicies(claims map[string]interface{}, claimName string) []string {
+	if claimName == "" {
+		return nil
+	}
+	raw, ok := claims[claimName]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case string:
+		return splitPolicyClaimString(v)
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return nil
+}
+
+func splitPolicyClaimString(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
 
 // filterPrincipalTags drops keys that are not on `allowed`. An empty
 // allowlist means "deny all" — security-conservative default that forces
@@ -475,6 +532,7 @@ func (p *OIDCProvider) Authenticate(ctx context.Context, token string) (*provide
 		Provider:      p.name,
 		Issuer:        claims.Issuer,
 		PrincipalTags: filterPrincipalTags(extractPrincipalTags(claims.Claims), p.config.AllowedPrincipalTagKeys),
+		ClaimPolicies: extractClaimPolicies(claims.Claims, p.config.PolicyClaim),
 	}
 
 	// Pass the token expiration to limit session duration

--- a/weed/iam/oidc/policy_claim_test.go
+++ b/weed/iam/oidc/policy_claim_test.go
@@ -1,0 +1,57 @@
+package oidc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractClaimPoliciesString(t *testing.T) {
+	got := extractClaimPolicies(map[string]interface{}{"policy": "readonly"}, "policy")
+	if !reflect.DeepEqual(got, []string{"readonly"}) {
+		t.Fatalf("got=%v", got)
+	}
+}
+
+func TestExtractClaimPoliciesCommaSeparated(t *testing.T) {
+	got := extractClaimPolicies(map[string]interface{}{"policy": "readonly, billing , "}, "policy")
+	if !reflect.DeepEqual(got, []string{"readonly", "billing"}) {
+		t.Fatalf("got=%v", got)
+	}
+}
+
+func TestExtractClaimPoliciesArray(t *testing.T) {
+	got := extractClaimPolicies(map[string]interface{}{
+		"policy": []interface{}{"readonly", "billing", 42, ""}, // non-string + empty filtered
+	}, "policy")
+	if !reflect.DeepEqual(got, []string{"readonly", "billing"}) {
+		t.Fatalf("got=%v", got)
+	}
+}
+
+func TestExtractClaimPoliciesMissing(t *testing.T) {
+	if got := extractClaimPolicies(map[string]interface{}{}, "policy"); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestExtractClaimPoliciesEmptyClaimName(t *testing.T) {
+	// Provider not in claim-mode -> never read the claim, even if present.
+	if got := extractClaimPolicies(map[string]interface{}{"policy": "readonly"}, ""); got != nil {
+		t.Fatalf("empty claim name should return nil, got %v", got)
+	}
+}
+
+func TestExtractClaimPoliciesUnsupportedShape(t *testing.T) {
+	// Numeric / object / bool values should be ignored, not panic.
+	cases := []interface{}{
+		42,
+		3.14,
+		map[string]interface{}{"x": "y"},
+		true,
+	}
+	for _, v := range cases {
+		if got := extractClaimPolicies(map[string]interface{}{"policy": v}, "policy"); got != nil {
+			t.Fatalf("value %v: expected nil, got %v", v, got)
+		}
+	}
+}

--- a/weed/iam/providers/provider.go
+++ b/weed/iam/providers/provider.go
@@ -60,6 +60,11 @@ type ExternalIdentity struct {
 	// (subject to per-provider allowlist filtering at the STS layer).
 	PrincipalTags map[string]string `json:"principalTags,omitempty"`
 
+	// ClaimPolicies are policy names pulled from the provider-configured
+	// PolicyClaim. Empty when the provider isn't running in claim-based
+	// policy mode or the claim was absent.
+	ClaimPolicies []string `json:"claimPolicies,omitempty"`
+
 	// TokenExpiration is the expiration time of the source identity token
 	// This is used to limit session duration to not exceed the token's exp claim
 	TokenExpiration *time.Time `json:"tokenExpiration,omitempty"`

--- a/weed/iam/sts/claim_based_policy_test.go
+++ b/weed/iam/sts/claim_based_policy_test.go
@@ -1,0 +1,23 @@
+package sts
+
+import "testing"
+
+func TestIsClaimBasedPolicyRoleArn(t *testing.T) {
+	cases := []struct {
+		name string
+		arn  string
+		want bool
+	}{
+		{"empty matches", "", true},
+		{"sentinel matches", ClaimBasedPolicyRoleArn, true},
+		{"concrete role does not", "arn:aws:iam::123:role/admin", false},
+		{"random ARN does not", "arn:aws:sts::123:assumed-role/X/Y", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsClaimBasedPolicyRoleArn(tc.arn); got != tc.want {
+				t.Fatalf("got=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}

--- a/weed/iam/sts/constants.go
+++ b/weed/iam/sts/constants.go
@@ -49,6 +49,7 @@ const (
 	ConfigFieldClientIDs             = "clientIds"
 	ConfigFieldThumbprints           = "thumbprints"
 	ConfigFieldAllowedPrincipalTagKeys = "allowedPrincipalTagKeys"
+	ConfigFieldPolicyClaim             = "policyClaim"
 	ConfigFieldClientSecret          = "clientSecret"
 	ConfigFieldJWKSUri               = "jwksUri"
 	ConfigFieldScopes                = "scopes"

--- a/weed/iam/sts/provider_factory.go
+++ b/weed/iam/sts/provider_factory.go
@@ -146,6 +146,10 @@ func (f *ProviderFactory) convertToOIDCConfig(configMap map[string]interface{}) 
 		}
 	}
 
+	if policyClaim, ok := configMap[ConfigFieldPolicyClaim].(string); ok {
+		config.PolicyClaim = policyClaim
+	}
+
 	if tlsInsecureSkipVerify, ok := configMap[ConfigFieldTLSInsecureSkipVerify].(bool); ok {
 		config.TLSInsecureSkipVerify = tlsInsecureSkipVerify
 	}

--- a/weed/iam/sts/sts_service.go
+++ b/weed/iam/sts/sts_service.go
@@ -527,9 +527,10 @@ func (s *STSService) AssumeRoleWithWebIdentity(ctx context.Context, request *Ass
 	claimMode := IsClaimBasedPolicyRoleArn(request.RoleArn) && len(externalIdentity.ClaimPolicies) > 0
 	effectiveRoleArn := request.RoleArn
 	if claimMode {
-		// Replace the sentinel/empty ARN with a deterministic synthetic ARN
-		// keyed on the session name so policy evaluation has a stable
-		// principal to log and rate-limit on.
+		// Replace an empty RoleArn with the constant sentinel so the assumed-
+		// role ARN GenerateAssumedRoleArn produces below carries a stable,
+		// session-name-keyed principal that policy evaluation can log and
+		// rate-limit on.
 		effectiveRoleArn = ClaimBasedPolicyRoleArn
 	} else if request.RoleArn == "" {
 		return nil, fmt.Errorf("RoleArn is required when claim-based policy mode is not configured")
@@ -770,15 +771,13 @@ func (s *STSService) ValidateSessionToken(ctx context.Context, sessionToken stri
 
 // Helper methods for AssumeRoleWithWebIdentity
 
-// validateAssumeRoleWithWebIdentityRequest validates the request parameters
+// validateAssumeRoleWithWebIdentityRequest validates the request parameters.
+//
+// RoleArn validation lives in AssumeRoleWithWebIdentity itself rather than
+// here: once we've parsed the JWT we know whether the caller has
+// ClaimPolicies and can decide between concrete-role mode and claim-mode,
+// which in turn determines whether an empty/sentinel RoleArn is acceptable.
 func (s *STSService) validateAssumeRoleWithWebIdentityRequest(request *AssumeRoleWithWebIdentityRequest) error {
-	// RoleArn may be empty (or the sentinel) when the caller is opting into
-	// claim-based policy mode; the OIDC provider configuration determines
-	// whether that is actually permitted.
-	if request.RoleArn != "" && !IsClaimBasedPolicyRoleArn(request.RoleArn) {
-		// nothing to enforce here — sentinel and concrete role are both fine
-	}
-
 	if request.WebIdentityToken == "" {
 		return fmt.Errorf("WebIdentityToken is required")
 	}

--- a/weed/iam/sts/sts_service.go
+++ b/weed/iam/sts/sts_service.go
@@ -69,6 +69,21 @@ func (fd FlexibleDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(fd.Duration.String())
 }
 
+// ClaimBasedPolicyRoleArn is the AWS-shaped sentinel ARN that callers pass
+// in the AssumeRoleWithWebIdentity RoleArn field to opt into claim-based
+// policy resolution. Using a recognisable role-style ARN here (rather than
+// requiring an empty RoleArn) lets SDKs and AWS CLI builds that always
+// require RoleArn to be set still reach this code path.
+const ClaimBasedPolicyRoleArn = "arn:aws:iam:::role/sts-claim-based"
+
+// IsClaimBasedPolicyRoleArn reports whether the supplied RoleArn opts the
+// caller into claim-based policy mode. Either the empty string (caller
+// omitted RoleArn entirely; common for SDKs that didn't expect to need one)
+// or the explicit sentinel triggers the mode.
+func IsClaimBasedPolicyRoleArn(arn string) bool {
+	return arn == "" || arn == ClaimBasedPolicyRoleArn
+}
+
 // STSService provides Security Token Service functionality
 // This service is now completely stateless - all session information is embedded
 // in JWT tokens, eliminating the need for session storage and enabling true
@@ -505,17 +520,38 @@ func (s *STSService) AssumeRoleWithWebIdentity(ctx context.Context, request *Ass
 		return nil, fmt.Errorf("failed to validate web identity token: %w", err)
 	}
 
-	// 2. Check if the role exists and can be assumed (includes trust policy validation)
-	if err := s.validateRoleAssumptionForWebIdentity(ctx, request.RoleArn, request.WebIdentityToken, request.DurationSeconds); err != nil {
-		return nil, fmt.Errorf("role assumption denied: %w", err)
+	// 2. Decide between concrete-role mode and claim-based policy mode.
+	// Claim-based mode requires both the sentinel RoleArn and a non-empty
+	// ClaimPolicies list — the second check guards against an IDP that just
+	// happens not to emit the policy claim today.
+	claimMode := IsClaimBasedPolicyRoleArn(request.RoleArn) && len(externalIdentity.ClaimPolicies) > 0
+	effectiveRoleArn := request.RoleArn
+	if claimMode {
+		// Replace the sentinel/empty ARN with a deterministic synthetic ARN
+		// keyed on the session name so policy evaluation has a stable
+		// principal to log and rate-limit on.
+		effectiveRoleArn = ClaimBasedPolicyRoleArn
+	} else if request.RoleArn == "" {
+		return nil, fmt.Errorf("RoleArn is required when claim-based policy mode is not configured")
+	} else if request.RoleArn == ClaimBasedPolicyRoleArn {
+		return nil, fmt.Errorf("claim-based policy mode requires the IDP to emit policies via the configured policyClaim")
 	}
 
-	// 3. Calculate session duration, capping at the source token's expiration
+	// 3. Trust-policy validation only runs in concrete-role mode. In
+	// claim-mode the IDP is the sole authority for both authentication and
+	// authorization, so there is no role definition to consult.
+	if !claimMode {
+		if err := s.validateRoleAssumptionForWebIdentity(ctx, request.RoleArn, request.WebIdentityToken, request.DurationSeconds); err != nil {
+			return nil, fmt.Errorf("role assumption denied: %w", err)
+		}
+	}
+
+	// 4. Calculate session duration, capping at the source token's expiration
 	// This ensures sessions from short-lived tokens (e.g., GitLab CI job tokens) don't outlive their source
 	sessionDuration := s.calculateSessionDuration(request.DurationSeconds, externalIdentity.TokenExpiration)
 	expiresAt := time.Now().Add(sessionDuration)
 
-	// 4. Generate session ID and credentials
+	// 5. Generate session ID and credentials
 	sessionId, err := GenerateSessionId()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate session ID: %w", err)
@@ -527,10 +563,10 @@ func (s *STSService) AssumeRoleWithWebIdentity(ctx context.Context, request *Ass
 		return nil, fmt.Errorf("failed to generate credentials: %w", err)
 	}
 
-	// 5. Create comprehensive JWT session token with all session information embedded
+	// 6. Create comprehensive JWT session token with all session information embedded
 	assumedRoleUser := &AssumedRoleUser{
-		AssumedRoleId: request.RoleArn,
-		Arn:           GenerateAssumedRoleArn(request.RoleArn, request.RoleSessionName),
+		AssumedRoleId: effectiveRoleArn,
+		Arn:           GenerateAssumedRoleArn(effectiveRoleArn, request.RoleSessionName),
 		Subject:       externalIdentity.UserID,
 	}
 
@@ -576,10 +612,13 @@ func (s *STSService) AssumeRoleWithWebIdentity(ctx context.Context, request *Ass
 	// Create rich JWT claims with all session information
 	sessionClaims := NewSTSSessionClaims(sessionId, s.Config.Issuer, expiresAt).
 		WithSessionName(request.RoleSessionName).
-		WithRoleInfo(request.RoleArn, assumedRoleUser.Arn, assumedRoleUser.Arn).
+		WithRoleInfo(effectiveRoleArn, assumedRoleUser.Arn, assumedRoleUser.Arn).
 		WithIdentityProvider(provider.Name(), externalIdentity.UserID, externalIdentity.Issuer).
 		WithMaxDuration(sessionDuration).
 		WithRequestContext(requestContext)
+	if claimMode {
+		sessionClaims.WithPolicies(externalIdentity.ClaimPolicies)
+	}
 	if parentUser != "" {
 		sessionClaims.WithParentUser(parentUser)
 	}
@@ -733,8 +772,11 @@ func (s *STSService) ValidateSessionToken(ctx context.Context, sessionToken stri
 
 // validateAssumeRoleWithWebIdentityRequest validates the request parameters
 func (s *STSService) validateAssumeRoleWithWebIdentityRequest(request *AssumeRoleWithWebIdentityRequest) error {
-	if request.RoleArn == "" {
-		return fmt.Errorf("RoleArn is required")
+	// RoleArn may be empty (or the sentinel) when the caller is opting into
+	// claim-based policy mode; the OIDC provider configuration determines
+	// whether that is actually permitted.
+	if request.RoleArn != "" && !IsClaimBasedPolicyRoleArn(request.RoleArn) {
+		// nothing to enforce here — sentinel and concrete role are both fine
 	}
 
 	if request.WebIdentityToken == "" {


### PR DESCRIPTION
## Summary

Stacked on #9322. AWS-style cross-account isolation: when a role lives in account A, the OIDC provider validating the assume-role token must be either global (\`AccountID=\"\"\`) or also live in account A.

### Changes

- \`OIDCProviderRecord.AccountID\` is now enforced. Cross-account use is rejected at the IAM-manager layer before reaching the trust-policy validator.
- \`OIDCProviderStore\` gains \`GetProviderByIssuerAndAccount\`; both the in-memory and filer-backed stores implement it.
- Static-config-only deployments are unaffected since they don't populate the store with non-empty AccountIDs.

## Test plan

\`weed/iam/integration/account_scope_test.go\` — matching account returns scoped record; unknown account rejected; global provider satisfies any account; empty caller account accepts any record.

Base: stacks on \`iam-phase3b\`.