### PR TITLE
fix(iam): reject empty issuer in ComputeParentUser

### DIFF
--- a/weed/iam/sts/parent_user_test.go
+++ b/weed/iam/sts/parent_user_test.go
@@ -43,6 +43,14 @@ func TestComputeParentUserEmptySub(t *testing.T) {
 	}
 }
 
+func TestComputeParentUserEmptyIss(t *testing.T) {
+	// Without an issuer, two different IDPs that both name a user "alice"
+	// would collide on the same parent_user. Refuse rather than hash.
+	if got := ComputeParentUser("alice", ""); got != "" {
+		t.Fatalf("empty iss should produce empty parent user, got %q", got)
+	}
+}
+
 func TestComputeParentUserEncoding(t *testing.T) {
 	got := ComputeParentUser("alice", "https://idp.example/")
 	// Base64 RawURL has no padding and uses URL-safe alphabet — important

--- a/weed/iam/sts/session_claims.go
+++ b/weed/iam/sts/session_claims.go
@@ -17,7 +17,7 @@ import (
 // id. The hash is base64-rawurl-encoded SHA-256 over "openid:<sub>:<iss>" so
 // it stays filesystem-safe and bounded in length for storage in audit paths.
 func ComputeParentUser(sub, iss string) string {
-	if sub == "" {
+	if sub == "" || iss == "" {
 		return ""
 	}
 	h := sha256.Sum256([]byte("openid:" + sub + ":" + iss))


### PR DESCRIPTION
## Summary

Follow-up to #9318. `ComputeParentUser(sub, iss)` short-circuited only on empty `sub`, but the same `sub` from two different IDPs would still collapse onto the same hash if `iss` was empty. Reject empty `iss` symmetrically so callers get an empty parent_user instead of a colliding one.

Addresses coderabbit review on #9318.

## Test plan

- `weed/iam/sts/parent_user_test.go` — added `TestComputeParentUserEmptyIss`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty identity inputs (subject or issuer) now consistently yield an empty parent-user value instead of producing a derived identifier.

* **Tests**
  * Added unit test coverage for the empty-input edge case to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->