### PR TITLE
fix(mini): raise admin readiness timeout to 2 minutes

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1275,7 +1275,12 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 // waitForAdminServerReady pings the admin server HTTP endpoint to check if it's ready
 func waitForAdminServerReady(adminAddr string) error {
 	healthAddr := getHealthCheckAddr(fmt.Sprintf("%s/health", adminAddr))
-	maxAttempts := 60 // 60 * 500ms = 30 seconds max wait
+	// 240 * 500ms = 120 seconds max wait. The previous 30-second ceiling was
+	// too tight on busy CI runners where master + filer + volume + admin all
+	// initialise on a shared worker — the S3 Policy Shell Integration Tests
+	// flaked regularly even though the admin server still came up within a
+	// minute or two. Two minutes leaves headroom without being absurd locally.
+	maxAttempts := 240
 	attempt := 0
 	client := &http.Client{
 		Timeout: 1 * time.Second,


### PR DESCRIPTION
## Summary

\`weed/command/mini.go\`'s \`waitForAdminServerReady\` capped startup polling at 30 seconds (60 × 500 ms). On busy GitHub Actions runners, master + filer + volume + admin all initialise concurrently on a shared worker and the admin HTTP \`/health\` endpoint regularly takes longer than 30 s to respond, even though the server eventually comes up fine within a minute or two.

This has been flaking the **S3 Policy Shell Integration Tests** job across multiple PRs (every PR in the IAM stack hit it during one CI sweep). Bump the ceiling to 2 minutes (240 attempts) so runner contention doesn't fatal the readiness check; happy-path local runs still return on the first poll.

## Test plan

- \`go build ./...\` clean.
- Watching CI on the IAM stack which has been hitting this flake will confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server initialization resilience by extending the startup timeout window to provide better reliability during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->