### PR TITLE
fix(mount): skip pressure-eviction of gappy page chunks (#9330)

### DIFF
--- a/weed/mount/page_writer/chunk_interval_list.go
+++ b/weed/mount/page_writer/chunk_interval_list.go
@@ -86,6 +86,28 @@ func (list *ChunkWrittenIntervalList) WrittenSize() (writtenByteCount int64) {
 	return
 }
 
+// IsContiguouslyWritten reports whether every written interval is adjacent
+// to the next, i.e. the chunk's covered bytes form one unbroken run from
+// the first interval's StartOffset to the last interval's stopOffset.
+// An empty list is reported as contiguous.
+//
+// SaveContent emits one volume chunk per maximal adjacent run, so a list
+// with internal gaps produces multiple volume chunks with no chunk
+// covering the gap; reads then silently zero-fill the gap range
+// (filer/stream.go:177-186). This is correct for genuinely sparse writes
+// finalized at flush, but incorrect when an in-progress chunk is sealed
+// by buffer-pressure eviction while FUSE writeback still has writes in
+// flight for the gap range. The eviction policy checks this so that
+// only gap-free chunks are sealed under pressure (issue #9330).
+func (list *ChunkWrittenIntervalList) IsContiguouslyWritten() bool {
+	for t := list.head.next; t != list.tail && t.next != list.tail; t = t.next {
+		if t.stopOffset != t.next.StartOffset {
+			return false
+		}
+	}
+	return true
+}
+
 func (list *ChunkWrittenIntervalList) addInterval(interval *ChunkWrittenInterval) {
 
 	//t := list.head

--- a/weed/mount/page_writer/chunk_interval_list.go
+++ b/weed/mount/page_writer/chunk_interval_list.go
@@ -86,35 +86,19 @@ func (list *ChunkWrittenIntervalList) WrittenSize() (writtenByteCount int64) {
 	return
 }
 
-// IsContiguouslyWritten reports whether the chunk's written bytes form
-// one unbroken run starting at offset 0. Returns false for an empty list
-// (nothing to seal yet) and for any list whose first interval does not
-// start at 0 or whose intervals have an internal gap.
-//
-// SaveContent emits one volume chunk per maximal adjacent run, so a list
-// with a gap (leading or internal) produces multiple volume chunks with
-// no chunk covering the gap; reads then silently zero-fill the gap range
-// (filer/stream.go:177-186). This is correct for genuinely sparse writes
-// finalized at flush, but incorrect when an in-progress chunk is sealed
-// by buffer-pressure eviction while FUSE writeback still has writes in
-// flight for the gap range. The eviction policy checks this so that
-// only gap-free chunks are sealed under pressure (issue #9330).
-//
-// The "starts at 0" check applies the same logic to a leading hole that
-// the adjacency check applies to an internal hole — pressure-driven
-// sealing should not race FUSE writeback on either, and at flush both
-// are sealed unconditionally via FlushAll for sparse-file semantics.
+// IsContiguouslyWritten reports whether the written bytes form one
+// unbroken run starting at offset 0. Pressure-driven sealing uses this
+// to avoid racing in-flight FUSE writeback on a gap range — sealing a
+// gappy chunk would emit volume chunks with no coverage for the gap and
+// reads would silently zero-fill it (issue #9330).
 func (list *ChunkWrittenIntervalList) IsContiguouslyWritten() bool {
 	first := list.head.next
-	if first == list.tail {
-		return false // empty: nothing to seal
-	}
-	if first.StartOffset != 0 {
-		return false // leading gap before offset 0
+	if first == list.tail || first.StartOffset != 0 {
+		return false
 	}
 	for t := first; t.next != list.tail; t = t.next {
 		if t.stopOffset != t.next.StartOffset {
-			return false // internal gap
+			return false
 		}
 	}
 	return true

--- a/weed/mount/page_writer/chunk_interval_list.go
+++ b/weed/mount/page_writer/chunk_interval_list.go
@@ -86,23 +86,35 @@ func (list *ChunkWrittenIntervalList) WrittenSize() (writtenByteCount int64) {
 	return
 }
 
-// IsContiguouslyWritten reports whether every written interval is adjacent
-// to the next, i.e. the chunk's covered bytes form one unbroken run from
-// the first interval's StartOffset to the last interval's stopOffset.
-// An empty list is reported as contiguous.
+// IsContiguouslyWritten reports whether the chunk's written bytes form
+// one unbroken run starting at offset 0. Returns false for an empty list
+// (nothing to seal yet) and for any list whose first interval does not
+// start at 0 or whose intervals have an internal gap.
 //
 // SaveContent emits one volume chunk per maximal adjacent run, so a list
-// with internal gaps produces multiple volume chunks with no chunk
-// covering the gap; reads then silently zero-fill the gap range
+// with a gap (leading or internal) produces multiple volume chunks with
+// no chunk covering the gap; reads then silently zero-fill the gap range
 // (filer/stream.go:177-186). This is correct for genuinely sparse writes
 // finalized at flush, but incorrect when an in-progress chunk is sealed
 // by buffer-pressure eviction while FUSE writeback still has writes in
 // flight for the gap range. The eviction policy checks this so that
 // only gap-free chunks are sealed under pressure (issue #9330).
+//
+// The "starts at 0" check applies the same logic to a leading hole that
+// the adjacency check applies to an internal hole — pressure-driven
+// sealing should not race FUSE writeback on either, and at flush both
+// are sealed unconditionally via FlushAll for sparse-file semantics.
 func (list *ChunkWrittenIntervalList) IsContiguouslyWritten() bool {
-	for t := list.head.next; t != list.tail && t.next != list.tail; t = t.next {
+	first := list.head.next
+	if first == list.tail {
+		return false // empty: nothing to seal
+	}
+	if first.StartOffset != 0 {
+		return false // leading gap before offset 0
+	}
+	for t := first; t.next != list.tail; t = t.next {
 		if t.stopOffset != t.next.StartOffset {
-			return false
+			return false // internal gap
 		}
 	}
 	return true

--- a/weed/mount/page_writer/chunk_interval_list_test.go
+++ b/weed/mount/page_writer/chunk_interval_list_test.go
@@ -81,6 +81,36 @@ func hasData(usage *ChunkWrittenIntervalList, chunkStartOffset, x int64) bool {
 	return false
 }
 
+func TestIsContiguouslyWritten(t *testing.T) {
+	const chunkSize int64 = 2 * 1024 * 1024
+	cases := []struct {
+		name     string
+		writes   [][2]int64
+		expected bool
+	}{
+		{name: "empty", writes: nil, expected: true},
+		{name: "single full", writes: [][2]int64{{0, chunkSize}}, expected: true},
+		{name: "single partial at start", writes: [][2]int64{{0, chunkSize / 4}}, expected: true},
+		{name: "single partial in middle", writes: [][2]int64{{chunkSize / 4, chunkSize / 2}}, expected: true},
+		{name: "two adjacent halves in order", writes: [][2]int64{{0, chunkSize / 2}, {chunkSize / 2, chunkSize}}, expected: true},
+		{name: "two adjacent halves out of order", writes: [][2]int64{{chunkSize / 2, chunkSize}, {0, chunkSize / 2}}, expected: true},
+		{name: "gap in middle", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 2, chunkSize}}, expected: false},
+		{name: "two intervals with 1-byte gap", writes: [][2]int64{{0, 100}, {101, 200}}, expected: false},
+		{name: "overlapping covers everything", writes: [][2]int64{{0, chunkSize*3/4 + 1}, {chunkSize / 2, chunkSize}}, expected: true},
+		{name: "three adjacent thirds", writes: [][2]int64{{0, chunkSize / 3}, {chunkSize / 3, 2 * chunkSize / 3}, {2 * chunkSize / 3, chunkSize}}, expected: true},
+		{name: "three intervals with middle gap", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 3, chunkSize / 2}, {chunkSize / 2, chunkSize}}, expected: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			list := newChunkWrittenIntervalList()
+			for i, w := range tc.writes {
+				list.MarkWritten(w[0], w[1], int64(i+1))
+			}
+			assert.Equal(t, tc.expected, list.IsContiguouslyWritten(), "IsContiguouslyWritten mismatch")
+		})
+	}
+}
+
 func TestIsComplete_AdjacentIntervals(t *testing.T) {
 	// Linux FUSE delivers writes up to FUSE_MAX_PAGES_PER_REQ
 	// (typically 1 MiB) per op, so a 2 MiB chunk filled by sequential

--- a/weed/mount/page_writer/chunk_interval_list_test.go
+++ b/weed/mount/page_writer/chunk_interval_list_test.go
@@ -88,16 +88,22 @@ func TestIsContiguouslyWritten(t *testing.T) {
 		writes   [][2]int64
 		expected bool
 	}{
-		{name: "empty", writes: nil, expected: true},
+		// nothing written yet: not eligible — still waiting for first byte.
+		{name: "empty", writes: nil, expected: false},
+		// one unbroken run starting at 0 — the only eviction-eligible shapes.
 		{name: "single full", writes: [][2]int64{{0, chunkSize}}, expected: true},
 		{name: "single partial at start", writes: [][2]int64{{0, chunkSize / 4}}, expected: true},
-		{name: "single partial in middle", writes: [][2]int64{{chunkSize / 4, chunkSize / 2}}, expected: true},
 		{name: "two adjacent halves in order", writes: [][2]int64{{0, chunkSize / 2}, {chunkSize / 2, chunkSize}}, expected: true},
 		{name: "two adjacent halves out of order", writes: [][2]int64{{chunkSize / 2, chunkSize}, {0, chunkSize / 2}}, expected: true},
-		{name: "gap in middle", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 2, chunkSize}}, expected: false},
-		{name: "two intervals with 1-byte gap", writes: [][2]int64{{0, 100}, {101, 200}}, expected: false},
 		{name: "overlapping covers everything", writes: [][2]int64{{0, chunkSize*3/4 + 1}, {chunkSize / 2, chunkSize}}, expected: true},
 		{name: "three adjacent thirds", writes: [][2]int64{{0, chunkSize / 3}, {chunkSize / 3, 2 * chunkSize / 3}, {2 * chunkSize / 3, chunkSize}}, expected: true},
+		// leading gap (no byte 0..start) — sealing now would race in-flight
+		// FUSE writeback for the leading range.
+		{name: "single partial in middle", writes: [][2]int64{{chunkSize / 4, chunkSize / 2}}, expected: false},
+		{name: "first byte missing", writes: [][2]int64{{1, chunkSize}}, expected: false},
+		// internal gap — same race for the gap range.
+		{name: "gap in middle", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 2, chunkSize}}, expected: false},
+		{name: "two intervals with 1-byte gap", writes: [][2]int64{{0, 100}, {101, 200}}, expected: false},
 		{name: "three intervals with middle gap", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 3, chunkSize / 2}, {chunkSize / 2, chunkSize}}, expected: false},
 	}
 	for _, tc := range cases {

--- a/weed/mount/page_writer/chunk_interval_list_test.go
+++ b/weed/mount/page_writer/chunk_interval_list_test.go
@@ -88,20 +88,15 @@ func TestIsContiguouslyWritten(t *testing.T) {
 		writes   [][2]int64
 		expected bool
 	}{
-		// nothing written yet: not eligible — still waiting for first byte.
 		{name: "empty", writes: nil, expected: false},
-		// one unbroken run starting at 0 — the only eviction-eligible shapes.
 		{name: "single full", writes: [][2]int64{{0, chunkSize}}, expected: true},
 		{name: "single partial at start", writes: [][2]int64{{0, chunkSize / 4}}, expected: true},
 		{name: "two adjacent halves in order", writes: [][2]int64{{0, chunkSize / 2}, {chunkSize / 2, chunkSize}}, expected: true},
 		{name: "two adjacent halves out of order", writes: [][2]int64{{chunkSize / 2, chunkSize}, {0, chunkSize / 2}}, expected: true},
 		{name: "overlapping covers everything", writes: [][2]int64{{0, chunkSize*3/4 + 1}, {chunkSize / 2, chunkSize}}, expected: true},
 		{name: "three adjacent thirds", writes: [][2]int64{{0, chunkSize / 3}, {chunkSize / 3, 2 * chunkSize / 3}, {2 * chunkSize / 3, chunkSize}}, expected: true},
-		// leading gap (no byte 0..start) — sealing now would race in-flight
-		// FUSE writeback for the leading range.
 		{name: "single partial in middle", writes: [][2]int64{{chunkSize / 4, chunkSize / 2}}, expected: false},
 		{name: "first byte missing", writes: [][2]int64{{1, chunkSize}}, expected: false},
-		// internal gap — same race for the gap range.
 		{name: "gap in middle", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 2, chunkSize}}, expected: false},
 		{name: "two intervals with 1-byte gap", writes: [][2]int64{{0, 100}, {101, 200}}, expected: false},
 		{name: "three intervals with middle gap", writes: [][2]int64{{0, chunkSize / 4}, {chunkSize / 3, chunkSize / 2}, {chunkSize / 2, chunkSize}}, expected: false},

--- a/weed/mount/page_writer/page_chunk.go
+++ b/weed/mount/page_writer/page_chunk.go
@@ -11,6 +11,7 @@ type PageChunk interface {
 	WriteDataAt(src []byte, offset int64, tsNs int64) (n int)
 	ReadDataAt(p []byte, off int64, tsNs int64) (maxStop int64)
 	IsComplete() bool
+	IsContiguouslyWritten() bool
 	ActivityScore() int64
 	WrittenSize() int64
 	LastWriteTsNs() int64

--- a/weed/mount/page_writer/page_chunk_mem.go
+++ b/weed/mount/page_writer/page_chunk_mem.go
@@ -81,6 +81,13 @@ func (mc *MemChunk) IsComplete() bool {
 	return mc.usage.IsComplete(mc.chunkSize)
 }
 
+func (mc *MemChunk) IsContiguouslyWritten() bool {
+	mc.RLock()
+	defer mc.RUnlock()
+
+	return mc.usage.IsContiguouslyWritten()
+}
+
 func (mc *MemChunk) ActivityScore() int64 {
 	return mc.activityScore.ActivityScore()
 }

--- a/weed/mount/page_writer/page_chunk_swapfile.go
+++ b/weed/mount/page_writer/page_chunk_swapfile.go
@@ -172,6 +172,12 @@ func (sc *SwapFileChunk) IsComplete() bool {
 	return sc.usage.IsComplete(sc.swapfile.chunkSize)
 }
 
+func (sc *SwapFileChunk) IsContiguouslyWritten() bool {
+	sc.RLock()
+	defer sc.RUnlock()
+	return sc.usage.IsContiguouslyWritten()
+}
+
 func (sc *SwapFileChunk) ActivityScore() int64 {
 	return sc.activityScore.ActivityScore()
 }

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -118,34 +118,40 @@ func (up *UploadPipeline) SaveDataAt(p []byte, off int64, isSequential bool, tsN
 	}
 	if !found {
 		if len(up.writableChunks) > up.writableChunkLimit {
-			// if current file chunks is over the per file buffer count limit
+			// Pressure-driven eviction: pick the fullest writable chunk
+			// whose written intervals form one unbroken run, and seal it.
+			//
+			// Skipping chunks with internal gaps prevents issue #9330: a
+			// chunk with gaps would be uploaded as multiple volume chunks
+			// with no chunk covering the gap range, and reads
+			// (filer/stream.go:177-186) silently zero-fill that range.
+			// Under FUSE writeback caching, partially-arrived writes for
+			// a single page chunk routinely look like a gappy interval
+			// list mid-flight, and pressure-evicting one of those bakes
+			// the in-flight gap into volume storage permanently.
+			//
+			// Genuinely sparse writes that never get filled are still
+			// sealed at flush via FlushAll; only pressure-driven
+			// eviction is restricted here. If no writable chunk is
+			// gap-free, fall through without evicting — the new chunk
+			// is still added (the per-pipeline limit is a soft cap; the
+			// memChunkCounter ceiling below redirects to swap if memory
+			// is tight) and natural completion via maybeMoveToSealed
+			// drains the pipeline.
 			candidateChunkIndex, fullness := LogicChunkIndex(-1), int64(0)
 			for lci, mc := range up.writableChunks {
+				if !mc.IsContiguouslyWritten() {
+					continue
+				}
 				chunkFullness := mc.WrittenSize()
 				if fullness < chunkFullness {
 					candidateChunkIndex = lci
 					fullness = chunkFullness
 				}
 			}
-			/*  // this algo generates too many chunks
-			candidateChunkIndex, lowestActivityScore := LogicChunkIndex(-1), int64(math.MaxInt64)
-			for wci, wc := range up.writableChunks {
-				activityScore := wc.ActivityScore()
-				if lowestActivityScore >= activityScore {
-					if lowestActivityScore == activityScore {
-						chunkFullness := wc.WrittenSize()
-						if fullness < chunkFullness {
-							candidateChunkIndex = lci
-							fullness = chunkFullness
-						}
-					}
-					candidateChunkIndex = wci
-					lowestActivityScore = activityScore
-				}
+			if candidateChunkIndex >= 0 {
+				up.moveToSealed(up.writableChunks[candidateChunkIndex], candidateChunkIndex)
 			}
-			*/
-			up.moveToSealed(up.writableChunks[candidateChunkIndex], candidateChunkIndex)
-			// fmt.Printf("flush chunk %d with %d bytes written\n", logicChunkIndex, fullness)
 		}
 		// fmt.Printf("isSequential:%v len(up.writableChunks):%v memChunkCounter:%v", isSequential, len(up.writableChunks), memChunkCounter)
 		if isSequential &&
@@ -270,28 +276,30 @@ func (up *UploadPipeline) moveToSealed(memChunk PageChunk, logicChunkIndex Logic
 	up.chunksLock.Lock()
 }
 
-// EvictOneWritableChunk force-seals the fullest writable chunk in this
-// pipeline, submitting it for async upload. Called by the accountant's
-// evictor when Reserve would block. Returns true if a chunk was sealed.
-// The fullest-chunk heuristic matches the over-limit path in SaveDataAt:
-// sealing the chunk closest to full maximizes the upload's usefulness
-// and avoids thrashing on repeatedly re-creating the same half-empty
-// chunk. Callers must not hold up.chunksLock.
+// EvictOneWritableChunk force-seals the fullest gap-free writable chunk
+// in this pipeline, submitting it for async upload. Called by the
+// accountant's evictor when Reserve would block. Returns true if a chunk
+// was sealed. Skips chunks with internal gaps to avoid baking in-flight
+// FUSE writes into split volume chunks (issue #9330) — see SaveDataAt
+// for the same filter and rationale. Callers must not hold up.chunksLock.
 func (up *UploadPipeline) EvictOneWritableChunk() bool {
 	up.chunksLock.Lock()
 	defer up.chunksLock.Unlock()
 	if len(up.writableChunks) == 0 {
 		return false
 	}
-	var bestIndex LogicChunkIndex
+	bestIndex := LogicChunkIndex(-1)
 	var bestBytes int64 = -1
 	for lci, wc := range up.writableChunks {
+		if !wc.IsContiguouslyWritten() {
+			continue
+		}
 		if b := wc.WrittenSize(); b > bestBytes {
 			bestIndex = lci
 			bestBytes = b
 		}
 	}
-	if bestBytes < 0 {
+	if bestIndex < 0 {
 		return false
 	}
 	up.moveToSealed(up.writableChunks[bestIndex], bestIndex)
@@ -328,6 +336,16 @@ func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, max
 		}
 		age := nowNs - lastWrite
 		if age < idleThresholdNs {
+			continue
+		}
+		// Same gap-free guard as SaveDataAt's pressure path: never seal a
+		// chunk whose written intervals have an internal hole, because
+		// SaveContent would split it into multiple volume chunks with no
+		// chunk covering the hole and reads would silently zero-fill it
+		// (issue #9330). Idle chunks past idleThresholdNs are usually
+		// done, but FUSE writeback can dispatch out of order, and the
+		// proactive flusher should not race FUSE on partial chunks.
+		if !chunk.IsContiguouslyWritten() {
 			continue
 		}
 		written := chunk.WrittenSize()

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -2,6 +2,7 @@ package page_writer
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 
@@ -276,23 +277,43 @@ func (up *UploadPipeline) moveToSealed(memChunk PageChunk, logicChunkIndex Logic
 	up.chunksLock.Lock()
 }
 
-// EvictOneWritableChunk force-seals the fullest gap-free writable chunk
-// in this pipeline, submitting it for async upload. Called by the
-// accountant's evictor when Reserve would block. Returns true if a chunk
-// was sealed. Skips chunks with internal gaps to avoid baking in-flight
-// FUSE writes into split volume chunks (issue #9330) — see SaveDataAt
-// for the same filter and rationale. Callers must not hold up.chunksLock.
+// EvictOneWritableChunk force-seals one writable chunk in this pipeline
+// and submits it for async upload, so the accountant's Reserve loop can
+// make progress. Returns true if a chunk was sealed. Callers must not
+// hold up.chunksLock.
+//
+// Two-pass selection:
+//
+//  1. Strict pass: prefer the fullest chunk whose written intervals form
+//     one unbroken run starting at offset 0. This is the safe candidate
+//     for sequential cp through FUSE writeback — no in-flight pages get
+//     baked into split volume chunks (issue #9330).
+//
+//  2. Fallback: if every dirty chunk is gappy (genuinely sparse workload,
+//     or a sequential cp where every chunk is mid-flight), pick the
+//     oldest writer instead. Returning false here would deadlock the
+//     accountant's Reserve loop — `cond.Wait` only wakes on Release, and
+//     Release only fires when an upload completes, so refusing every
+//     gappy chunk means no upload starts, no Release fires, and the
+//     blocked writer never reaches FlushAll. The oldest-LastWriteTsNs
+//     heuristic narrows the FUSE-race window: a chunk untouched the
+//     longest is the most likely to have received its final pages
+//     already.
+//
+// SaveContent emits one volume chunk per maximal adjacent run, so a
+// gappy chunk sealed by the fallback uploads only the bytes it has;
+// any pages that arrive later land in a fresh MemChunk for the same
+// logicChunkIndex and are sealed in turn (auto on IsComplete, by a
+// later evict, or by FlushAll on close). The full coverage is
+// reconstructed at read time by readResolvedChunks.
 func (up *UploadPipeline) EvictOneWritableChunk() bool {
 	up.chunksLock.Lock()
 	defer up.chunksLock.Unlock()
 	if len(up.writableChunks) == 0 {
 		return false
 	}
-	// bestBytes starts at 0 (not -1) so that an empty chunk — which is
-	// trivially "contiguous" by the previous interval-list semantics
-	// but is now reported false by IsContiguouslyWritten — is still
-	// not picked here even if that semantic ever loosens. Matches the
-	// fullness initialization in SaveDataAt's pressure path.
+
+	// Strict pass: fullest contiguous-from-0 chunk.
 	bestIndex := LogicChunkIndex(-1)
 	var bestBytes int64
 	for lci, wc := range up.writableChunks {
@@ -304,6 +325,29 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 			bestBytes = b
 		}
 	}
+
+	// Fallback: oldest non-empty chunk. Tie-break on WrittenSize so we
+	// pick the most upload-worthy among equally-old candidates.
+	if bestIndex < 0 {
+		oldestTsNs := int64(math.MaxInt64)
+		var fallbackBytes int64
+		for lci, wc := range up.writableChunks {
+			b := wc.WrittenSize()
+			if b == 0 {
+				continue
+			}
+			ts := wc.LastWriteTsNs()
+			if ts == 0 {
+				continue // chunk is freshly created; nothing meaningful to seal
+			}
+			if ts < oldestTsNs || (ts == oldestTsNs && b > fallbackBytes) {
+				bestIndex = lci
+				oldestTsNs = ts
+				fallbackBytes = b
+			}
+		}
+	}
+
 	if bestIndex < 0 {
 		return false
 	}

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -288,8 +288,13 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 	if len(up.writableChunks) == 0 {
 		return false
 	}
+	// bestBytes starts at 0 (not -1) so that an empty chunk — which is
+	// trivially "contiguous" by the previous interval-list semantics
+	// but is now reported false by IsContiguouslyWritten — is still
+	// not picked here even if that semantic ever loosens. Matches the
+	// fullness initialization in SaveDataAt's pressure path.
 	bestIndex := LogicChunkIndex(-1)
-	var bestBytes int64 = -1
+	var bestBytes int64
 	for lci, wc := range up.writableChunks {
 		if !wc.IsContiguouslyWritten() {
 			continue

--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -119,35 +119,18 @@ func (up *UploadPipeline) SaveDataAt(p []byte, off int64, isSequential bool, tsN
 	}
 	if !found {
 		if len(up.writableChunks) > up.writableChunkLimit {
-			// Pressure-driven eviction: pick the fullest writable chunk
-			// whose written intervals form one unbroken run, and seal it.
-			//
-			// Skipping chunks with internal gaps prevents issue #9330: a
-			// chunk with gaps would be uploaded as multiple volume chunks
-			// with no chunk covering the gap range, and reads
-			// (filer/stream.go:177-186) silently zero-fill that range.
-			// Under FUSE writeback caching, partially-arrived writes for
-			// a single page chunk routinely look like a gappy interval
-			// list mid-flight, and pressure-evicting one of those bakes
-			// the in-flight gap into volume storage permanently.
-			//
-			// Genuinely sparse writes that never get filled are still
-			// sealed at flush via FlushAll; only pressure-driven
-			// eviction is restricted here. If no writable chunk is
-			// gap-free, fall through without evicting — the new chunk
-			// is still added (the per-pipeline limit is a soft cap; the
-			// memChunkCounter ceiling below redirects to swap if memory
-			// is tight) and natural completion via maybeMoveToSealed
-			// drains the pipeline.
+			// Per-pipeline soft cap. Seal the fullest gap-free chunk;
+			// gappy chunks must wait so in-flight FUSE writeback can fill
+			// the gap (issue #9330). If none qualifies, fall through —
+			// the memChunkCounter ceiling below redirects to swap.
 			candidateChunkIndex, fullness := LogicChunkIndex(-1), int64(0)
 			for lci, mc := range up.writableChunks {
 				if !mc.IsContiguouslyWritten() {
 					continue
 				}
-				chunkFullness := mc.WrittenSize()
-				if fullness < chunkFullness {
+				if b := mc.WrittenSize(); b > fullness {
 					candidateChunkIndex = lci
-					fullness = chunkFullness
+					fullness = b
 				}
 			}
 			if candidateChunkIndex >= 0 {
@@ -277,35 +260,12 @@ func (up *UploadPipeline) moveToSealed(memChunk PageChunk, logicChunkIndex Logic
 	up.chunksLock.Lock()
 }
 
-// EvictOneWritableChunk force-seals one writable chunk in this pipeline
-// and submits it for async upload, so the accountant's Reserve loop can
-// make progress. Returns true if a chunk was sealed. Callers must not
+// EvictOneWritableChunk force-seals one writable chunk so the accountant's
+// Reserve loop can make progress. Strict pass picks the fullest gap-free
+// chunk (issue #9330). Fallback picks the oldest non-empty writer when
+// nothing is gap-free; without it Reserve deadlocks (cond.Wait only wakes
+// on Release, Release only fires on upload completion). Callers must not
 // hold up.chunksLock.
-//
-// Two-pass selection:
-//
-//  1. Strict pass: prefer the fullest chunk whose written intervals form
-//     one unbroken run starting at offset 0. This is the safe candidate
-//     for sequential cp through FUSE writeback — no in-flight pages get
-//     baked into split volume chunks (issue #9330).
-//
-//  2. Fallback: if every dirty chunk is gappy (genuinely sparse workload,
-//     or a sequential cp where every chunk is mid-flight), pick the
-//     oldest writer instead. Returning false here would deadlock the
-//     accountant's Reserve loop — `cond.Wait` only wakes on Release, and
-//     Release only fires when an upload completes, so refusing every
-//     gappy chunk means no upload starts, no Release fires, and the
-//     blocked writer never reaches FlushAll. The oldest-LastWriteTsNs
-//     heuristic narrows the FUSE-race window: a chunk untouched the
-//     longest is the most likely to have received its final pages
-//     already.
-//
-// SaveContent emits one volume chunk per maximal adjacent run, so a
-// gappy chunk sealed by the fallback uploads only the bytes it has;
-// any pages that arrive later land in a fresh MemChunk for the same
-// logicChunkIndex and are sealed in turn (auto on IsComplete, by a
-// later evict, or by FlushAll on close). The full coverage is
-// reconstructed at read time by readResolvedChunks.
 func (up *UploadPipeline) EvictOneWritableChunk() bool {
 	up.chunksLock.Lock()
 	defer up.chunksLock.Unlock()
@@ -313,7 +273,6 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 		return false
 	}
 
-	// Strict pass: fullest contiguous-from-0 chunk.
 	bestIndex := LogicChunkIndex(-1)
 	var bestBytes int64
 	for lci, wc := range up.writableChunks {
@@ -326,8 +285,6 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 		}
 	}
 
-	// Fallback: oldest non-empty chunk. Tie-break on WrittenSize so we
-	// pick the most upload-worthy among equally-old candidates.
 	if bestIndex < 0 {
 		oldestTsNs := int64(math.MaxInt64)
 		var fallbackBytes int64
@@ -338,7 +295,7 @@ func (up *UploadPipeline) EvictOneWritableChunk() bool {
 			}
 			ts := wc.LastWriteTsNs()
 			if ts == 0 {
-				continue // chunk is freshly created; nothing meaningful to seal
+				continue
 			}
 			if ts < oldestTsNs || (ts == oldestTsNs && b > fallbackBytes) {
 				bestIndex = lci
@@ -387,13 +344,10 @@ func (up *UploadPipeline) ProactiveFlush(nowNs int64, idleThresholdNs int64, max
 		if age < idleThresholdNs {
 			continue
 		}
-		// Same gap-free guard as SaveDataAt's pressure path: never seal a
-		// chunk whose written intervals have an internal hole, because
-		// SaveContent would split it into multiple volume chunks with no
-		// chunk covering the hole and reads would silently zero-fill it
-		// (issue #9330). Idle chunks past idleThresholdNs are usually
-		// done, but FUSE writeback can dispatch out of order, and the
-		// proactive flusher should not race FUSE on partial chunks.
+		// Skip gappy chunks; FUSE writeback may still be in flight for the
+		// hole and SaveContent would bake it into split volume chunks
+		// (issue #9330). Failing here is just a missed flush — FlushAll
+		// at close still seals everything.
 		if !chunk.IsContiguouslyWritten() {
 			continue
 		}

--- a/weed/mount/page_writer/upload_pipeline_test.go
+++ b/weed/mount/page_writer/upload_pipeline_test.go
@@ -213,3 +213,91 @@ func TestEvictOneWritableChunk_PrefersStrictOverFallback(t *testing.T) {
 		t.Errorf("gappy chunk 0 must remain writable; strict pass should not invoke fallback")
 	}
 }
+
+// TestProactiveFlush_SkipsGappyChunks pins the issue #9330 fix in the
+// proactive-flush path: the chunk-flusher must not seal a chunk whose
+// written intervals have a hole, even if the chunk has been idle long
+// enough to satisfy the staleness/idle thresholds. The same reasoning
+// applies as for EvictOneWritableChunk's strict pass — sealing a gappy
+// chunk uploads it as multiple volume chunks with no coverage for the
+// hole, and reads silently zero-fill the hole. ProactiveFlush has no
+// liveness fallback because returning false is just a missed
+// optimization (the chunk-flusher will try again later, FlushAll runs
+// at close).
+func TestProactiveFlush_SkipsGappyChunks(t *testing.T) {
+	const cs int64 = 2 * 1024 * 1024
+	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
+
+	block := make([]byte, cs/4) // 512 KiB
+
+	// Same 3-chunk setup as TestEvictOneWritableChunk_SkipsGappyChunks:
+	// chunk 0 internal gap, chunk 1 leading gap, chunk 2 contiguous.
+	if _, err := up.SaveDataAt(block, 0, true, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 3*cs/4, true, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+cs/4, true, 3); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+cs/2, true, 4); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 2*cs, true, 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 2*cs+cs/4, true, 6); err != nil {
+		t.Fatal(err)
+	}
+
+	// nowNs >> any chunk's LastWriteTsNs so age clears idleThresholdNs and
+	// maxHoldNs, and fillRatio <= WrittenSize so nearlyFull is true. With
+	// these all chunks are eligible by the staleness criteria, leaving
+	// IsContiguouslyWritten as the only differentiator.
+	const (
+		nowNs           int64 = 1_000_000_000
+		idleThresholdNs int64 = 100
+		maxHoldNs       int64 = 200
+		fillRatio       int64 = cs / 8 // 256 KiB; all three chunks have 1 MiB
+	)
+	if !up.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, 0, false) {
+		t.Fatalf("ProactiveFlush returned false; expected contiguous chunk 2 to be sealed")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(2)]; stillWritable {
+		t.Errorf("chunk 2 should have moved to sealed")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
+		t.Errorf("chunk 0 (internal gap) must remain writable; ProactiveFlush must not race FUSE writeback")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; !stillWritable {
+		t.Errorf("chunk 1 (leading gap) must remain writable; ProactiveFlush must not race FUSE writeback")
+	}
+
+	// With only gappy chunks left, ProactiveFlush has no liveness
+	// fallback (unlike EvictOneWritableChunk) and must return false.
+	if up.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, 0, false) {
+		t.Errorf("ProactiveFlush returned true with only gappy chunks left; should have skipped them")
+	}
+
+	// Fill the holes; SaveDataAt's maybeMoveToSealed auto-seals on
+	// IsComplete, so chunks 0 and 1 leave writableChunks on their own.
+	if _, err := up.SaveDataAt(block, cs/4, true, 7); err != nil { // chunk 0 middle a
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs/2, true, 8); err != nil { // chunk 0 middle b
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs, true, 9); err != nil { // chunk 1 leading
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+3*cs/4, true, 10); err != nil { // chunk 1 trailing
+		t.Fatal(err)
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; stillWritable {
+		t.Errorf("chunk 0 should have auto-sealed on IsComplete after gap was filled")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
+		t.Errorf("chunk 1 should have auto-sealed on IsComplete after leading range was filled")
+	}
+}

--- a/weed/mount/page_writer/upload_pipeline_test.go
+++ b/weed/mount/page_writer/upload_pipeline_test.go
@@ -46,3 +46,58 @@ func confirmRange(t *testing.T, uploadPipeline *UploadPipeline, startOff, stopOf
 		}
 	}
 }
+
+// TestEvictOneWritableChunk_SkipsGappyChunks pins the issue #9330 fix:
+// pressure-driven eviction must not seal a chunk whose written intervals
+// have an internal hole, because SaveContent would emit multiple volume
+// chunks with no coverage for the hole and reads would silently zero-fill
+// it (filer/stream.go writeZero on gap).
+func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
+	const cs int64 = 2 * 1024 * 1024
+	// saveToStorage = nil so that the async upload triggered by
+	// moveToSealed is a no-op (SaveContent short-circuits on nil saveFn).
+	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
+
+	block := make([]byte, cs/4) // 512 KiB
+
+	// Chunk 0: gappy — first quarter and last quarter written, middle hole.
+	// Mirrors FUSE writeback mid-flight on sequential cp.
+	if _, err := up.SaveDataAt(block, 0, true, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 3*cs/4, true, 2); err != nil {
+		t.Fatal(err)
+	}
+	// Chunk 1: contiguous — first half written, no hole.
+	if _, err := up.SaveDataAt(block, cs, true, 3); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+cs/4, true, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	// Eviction must pick chunk 1 (contiguous), never chunk 0 (gappy),
+	// even though both have the same WrittenSize.
+	if !up.EvictOneWritableChunk() {
+		t.Fatalf("EvictOneWritableChunk returned false; expected contiguous chunk 1 to be evictable")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
+		t.Errorf("chunk 1 should have moved to sealed")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
+		t.Errorf("chunk 0 (gappy) must remain writable so its hole can still be filled")
+	}
+
+	// Fill chunk 0's middle. The chunk now covers [0, cs) and SaveDataAt's
+	// maybeMoveToSealed auto-seals on completion, so it leaves writableChunks
+	// without our needing to call EvictOneWritableChunk.
+	if _, err := up.SaveDataAt(block, cs/4, true, 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs/2, true, 6); err != nil {
+		t.Fatal(err)
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; stillWritable {
+		t.Errorf("chunk 0 should have left writableChunks after gap was filled (auto-seal on IsComplete)")
+	}
+}

--- a/weed/mount/page_writer/upload_pipeline_test.go
+++ b/weed/mount/page_writer/upload_pipeline_test.go
@@ -100,13 +100,6 @@ func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 		t.Errorf("chunk 1 (leading gap) must remain writable so its leading range can still be filled")
 	}
 
-	// With chunk 2 sealed, EvictOneWritableChunk has nothing else to seal —
-	// the remaining chunks are both gappy and must wait for FUSE writeback
-	// to fill them or for FlushAll at file close.
-	if up.EvictOneWritableChunk() {
-		t.Errorf("EvictOneWritableChunk returned true with only gappy chunks left")
-	}
-
 	// Fill chunk 0's middle and chunk 1's leading + trailing ranges.
 	// Both now cover [0, full) within their logicChunkIndex;
 	// SaveDataAt's maybeMoveToSealed auto-seals on IsComplete, so they
@@ -128,5 +121,95 @@ func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
 		t.Errorf("chunk 1 should have auto-sealed on IsComplete after leading range was filled")
+	}
+}
+
+// TestEvictOneWritableChunk_FallbackPicksOldestGappy pins the cap-pressure
+// liveness path: when every dirty chunk is gappy (genuinely sparse
+// workload, or a sequential cp where every chunk is mid-flight), the
+// strict pass finds nothing but the fallback must still seal one chunk
+// so accountant.Reserve can wake. Picking the oldest LastWriteTsNs
+// minimizes the chance of racing FUSE writeback for the gap range.
+func TestEvictOneWritableChunk_FallbackPicksOldestGappy(t *testing.T) {
+	const cs int64 = 2 * 1024 * 1024
+	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
+
+	block := make([]byte, cs/4) // 512 KiB
+
+	// Three chunks, all gappy, with strictly increasing tsNs so chunk 0
+	// is the oldest. Each chunk has WrittenSize == 1 MiB; oldest-first
+	// is the only differentiator.
+	//
+	// chunk 0 (oldest): internal gap.
+	if _, err := up.SaveDataAt(block, 0, true, 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 3*cs/4, true, 101); err != nil {
+		t.Fatal(err)
+	}
+	// chunk 1: leading gap.
+	if _, err := up.SaveDataAt(block, cs+cs/4, true, 200); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+cs/2, true, 201); err != nil {
+		t.Fatal(err)
+	}
+	// chunk 2 (most recent): internal gap.
+	if _, err := up.SaveDataAt(block, 2*cs, true, 300); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 2*cs+3*cs/4, true, 301); err != nil {
+		t.Fatal(err)
+	}
+
+	if !up.EvictOneWritableChunk() {
+		t.Fatalf("fallback must seal a gappy chunk to free a Reserve slot")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; stillWritable {
+		t.Errorf("oldest gappy chunk (0) should have been picked by the fallback")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; !stillWritable {
+		t.Errorf("chunk 1 should remain writable; oldest-first must prefer chunk 0")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(2)]; !stillWritable {
+		t.Errorf("chunk 2 should remain writable; oldest-first must prefer chunk 0")
+	}
+}
+
+// TestEvictOneWritableChunk_PrefersStrictOverFallback verifies that the
+// strict pass takes precedence even when an older gappy chunk exists.
+// A sequential cp under cap pressure typically has both: a gappy chunk
+// at the head (older, mid-flight) and a contiguous chunk at the tail
+// (newer, freshly written). Strict picks the latter so the head's gap
+// has more time to be filled by in-flight writes.
+func TestEvictOneWritableChunk_PrefersStrictOverFallback(t *testing.T) {
+	const cs int64 = 2 * 1024 * 1024
+	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
+
+	block := make([]byte, cs/4)
+
+	// chunk 0 (oldest): gappy.
+	if _, err := up.SaveDataAt(block, 0, true, 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 3*cs/4, true, 101); err != nil {
+		t.Fatal(err)
+	}
+	// chunk 1 (newer): contiguous from 0.
+	if _, err := up.SaveDataAt(block, cs, true, 200); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+cs/4, true, 201); err != nil {
+		t.Fatal(err)
+	}
+
+	if !up.EvictOneWritableChunk() {
+		t.Fatalf("EvictOneWritableChunk returned false")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
+		t.Errorf("contiguous chunk 1 must be picked by the strict pass over older gappy chunk 0")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
+		t.Errorf("gappy chunk 0 must remain writable; strict pass should not invoke fallback")
 	}
 }

--- a/weed/mount/page_writer/upload_pipeline_test.go
+++ b/weed/mount/page_writer/upload_pipeline_test.go
@@ -47,36 +47,28 @@ func confirmRange(t *testing.T, uploadPipeline *UploadPipeline, startOff, stopOf
 	}
 }
 
-// TestEvictOneWritableChunk_SkipsGappyChunks pins the issue #9330 fix:
-// pressure-driven eviction must not seal a chunk whose written intervals
-// have a hole (leading or internal), because SaveContent would emit
-// multiple volume chunks with no coverage for the hole and reads would
-// silently zero-fill it (filer/stream.go writeZero on gap).
+// Pressure-driven eviction must not seal a chunk with a leading or
+// internal gap (issue #9330).
 func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 	const cs int64 = 2 * 1024 * 1024
-	// saveToStorage = nil so that the async upload triggered by
-	// moveToSealed is a no-op (SaveContent short-circuits on nil saveFn).
+	// nil saveToStorage so the async upload SaveContent is a no-op.
 	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
 
-	block := make([]byte, cs/4) // 512 KiB
+	block := make([]byte, cs/4)
 
-	// Chunk 0: internal gap — first quarter and last quarter written.
-	// Mirrors FUSE writeback mid-flight on sequential cp.
+	// chunk 0: internal gap; chunk 1: leading gap; chunk 2: contiguous from 0.
 	if _, err := up.SaveDataAt(block, 0, true, 1); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := up.SaveDataAt(block, 3*cs/4, true, 2); err != nil {
 		t.Fatal(err)
 	}
-	// Chunk 1: leading gap — second and third quarters written, no byte 0.
-	// Mirrors FUSE writeback dispatching middle pages first.
 	if _, err := up.SaveDataAt(block, cs+cs/4, true, 3); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := up.SaveDataAt(block, cs+cs/2, true, 4); err != nil {
 		t.Fatal(err)
 	}
-	// Chunk 2: contiguous from offset 0 — first half written, no hole.
 	if _, err := up.SaveDataAt(block, 2*cs, true, 5); err != nil {
 		t.Fatal(err)
 	}
@@ -84,9 +76,6 @@ func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Eviction must pick chunk 2 (contiguous from 0). Never chunks 0
-	// (internal gap) or 1 (leading gap), even though all three have
-	// the same WrittenSize.
 	if !up.EvictOneWritableChunk() {
 		t.Fatalf("EvictOneWritableChunk returned false; expected contiguous chunk 2 to be evictable")
 	}
@@ -94,67 +83,54 @@ func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 		t.Errorf("chunk 2 should have moved to sealed")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
-		t.Errorf("chunk 0 (internal gap) must remain writable so its hole can still be filled")
+		t.Errorf("chunk 0 (internal gap) must remain writable")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; !stillWritable {
-		t.Errorf("chunk 1 (leading gap) must remain writable so its leading range can still be filled")
+		t.Errorf("chunk 1 (leading gap) must remain writable")
 	}
 
-	// Fill chunk 0's middle and chunk 1's leading + trailing ranges.
-	// Both now cover [0, full) within their logicChunkIndex;
-	// SaveDataAt's maybeMoveToSealed auto-seals on IsComplete, so they
-	// leave writableChunks on their own.
-	if _, err := up.SaveDataAt(block, cs/4, true, 7); err != nil { // chunk 0 middle a
+	// Filling holes makes IsComplete true; maybeMoveToSealed auto-seals.
+	if _, err := up.SaveDataAt(block, cs/4, true, 7); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs/2, true, 8); err != nil { // chunk 0 middle b
+	if _, err := up.SaveDataAt(block, cs/2, true, 8); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs, true, 9); err != nil { // chunk 1 leading
+	if _, err := up.SaveDataAt(block, cs, true, 9); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs+3*cs/4, true, 10); err != nil { // chunk 1 trailing
+	if _, err := up.SaveDataAt(block, cs+3*cs/4, true, 10); err != nil {
 		t.Fatal(err)
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; stillWritable {
-		t.Errorf("chunk 0 should have auto-sealed on IsComplete after gap was filled")
+		t.Errorf("chunk 0 should have auto-sealed after gap was filled")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
-		t.Errorf("chunk 1 should have auto-sealed on IsComplete after leading range was filled")
+		t.Errorf("chunk 1 should have auto-sealed after leading range was filled")
 	}
 }
 
-// TestEvictOneWritableChunk_FallbackPicksOldestGappy pins the cap-pressure
-// liveness path: when every dirty chunk is gappy (genuinely sparse
-// workload, or a sequential cp where every chunk is mid-flight), the
-// strict pass finds nothing but the fallback must still seal one chunk
-// so accountant.Reserve can wake. Picking the oldest LastWriteTsNs
-// minimizes the chance of racing FUSE writeback for the gap range.
+// When every chunk is gappy, the fallback must still seal one so
+// accountant.Reserve can wake; oldest-LastWriteTsNs wins.
 func TestEvictOneWritableChunk_FallbackPicksOldestGappy(t *testing.T) {
 	const cs int64 = 2 * 1024 * 1024
 	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
 
-	block := make([]byte, cs/4) // 512 KiB
+	block := make([]byte, cs/4)
 
-	// Three chunks, all gappy, with strictly increasing tsNs so chunk 0
-	// is the oldest. Each chunk has WrittenSize == 1 MiB; oldest-first
-	// is the only differentiator.
-	//
-	// chunk 0 (oldest): internal gap.
+	// Strictly increasing tsNs so chunk 0 is oldest; equal WrittenSize.
 	if _, err := up.SaveDataAt(block, 0, true, 100); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := up.SaveDataAt(block, 3*cs/4, true, 101); err != nil {
 		t.Fatal(err)
 	}
-	// chunk 1: leading gap.
 	if _, err := up.SaveDataAt(block, cs+cs/4, true, 200); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := up.SaveDataAt(block, cs+cs/2, true, 201); err != nil {
 		t.Fatal(err)
 	}
-	// chunk 2 (most recent): internal gap.
 	if _, err := up.SaveDataAt(block, 2*cs, true, 300); err != nil {
 		t.Fatal(err)
 	}
@@ -169,33 +145,27 @@ func TestEvictOneWritableChunk_FallbackPicksOldestGappy(t *testing.T) {
 		t.Errorf("oldest gappy chunk (0) should have been picked by the fallback")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; !stillWritable {
-		t.Errorf("chunk 1 should remain writable; oldest-first must prefer chunk 0")
+		t.Errorf("chunk 1 should remain writable")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(2)]; !stillWritable {
-		t.Errorf("chunk 2 should remain writable; oldest-first must prefer chunk 0")
+		t.Errorf("chunk 2 should remain writable")
 	}
 }
 
-// TestEvictOneWritableChunk_PrefersStrictOverFallback verifies that the
-// strict pass takes precedence even when an older gappy chunk exists.
-// A sequential cp under cap pressure typically has both: a gappy chunk
-// at the head (older, mid-flight) and a contiguous chunk at the tail
-// (newer, freshly written). Strict picks the latter so the head's gap
-// has more time to be filled by in-flight writes.
+// Strict pass preempts the fallback even when a gappy chunk is older.
 func TestEvictOneWritableChunk_PrefersStrictOverFallback(t *testing.T) {
 	const cs int64 = 2 * 1024 * 1024
 	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
 
 	block := make([]byte, cs/4)
 
-	// chunk 0 (oldest): gappy.
+	// chunk 0 (older, gappy), chunk 1 (newer, contiguous from 0).
 	if _, err := up.SaveDataAt(block, 0, true, 100); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := up.SaveDataAt(block, 3*cs/4, true, 101); err != nil {
 		t.Fatal(err)
 	}
-	// chunk 1 (newer): contiguous from 0.
 	if _, err := up.SaveDataAt(block, cs, true, 200); err != nil {
 		t.Fatal(err)
 	}
@@ -207,31 +177,23 @@ func TestEvictOneWritableChunk_PrefersStrictOverFallback(t *testing.T) {
 		t.Fatalf("EvictOneWritableChunk returned false")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
-		t.Errorf("contiguous chunk 1 must be picked by the strict pass over older gappy chunk 0")
+		t.Errorf("contiguous chunk 1 must be picked over older gappy chunk 0")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
-		t.Errorf("gappy chunk 0 must remain writable; strict pass should not invoke fallback")
+		t.Errorf("gappy chunk 0 must remain writable")
 	}
 }
 
-// TestProactiveFlush_SkipsGappyChunks pins the issue #9330 fix in the
-// proactive-flush path: the chunk-flusher must not seal a chunk whose
-// written intervals have a hole, even if the chunk has been idle long
-// enough to satisfy the staleness/idle thresholds. The same reasoning
-// applies as for EvictOneWritableChunk's strict pass — sealing a gappy
-// chunk uploads it as multiple volume chunks with no coverage for the
-// hole, and reads silently zero-fill the hole. ProactiveFlush has no
-// liveness fallback because returning false is just a missed
-// optimization (the chunk-flusher will try again later, FlushAll runs
-// at close).
+// ProactiveFlush also skips gappy chunks (issue #9330). No liveness
+// fallback here — unlike EvictOneWritableChunk, returning false is just
+// a missed optimization.
 func TestProactiveFlush_SkipsGappyChunks(t *testing.T) {
 	const cs int64 = 2 * 1024 * 1024
 	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), cs, nil, 16, "", nil)
 
-	block := make([]byte, cs/4) // 512 KiB
+	block := make([]byte, cs/4)
 
-	// Same 3-chunk setup as TestEvictOneWritableChunk_SkipsGappyChunks:
-	// chunk 0 internal gap, chunk 1 leading gap, chunk 2 contiguous.
+	// chunk 0: internal gap; chunk 1: leading gap; chunk 2: contiguous from 0.
 	if _, err := up.SaveDataAt(block, 0, true, 1); err != nil {
 		t.Fatal(err)
 	}
@@ -251,15 +213,14 @@ func TestProactiveFlush_SkipsGappyChunks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// nowNs >> any chunk's LastWriteTsNs so age clears idleThresholdNs and
-	// maxHoldNs, and fillRatio <= WrittenSize so nearlyFull is true. With
-	// these all chunks are eligible by the staleness criteria, leaving
+	// nowNs >> chunk timestamps so age clears the idle/maxHold gates;
+	// fillRatio < WrittenSize so nearlyFull is true. Leaves
 	// IsContiguouslyWritten as the only differentiator.
 	const (
 		nowNs           int64 = 1_000_000_000
 		idleThresholdNs int64 = 100
 		maxHoldNs       int64 = 200
-		fillRatio       int64 = cs / 8 // 256 KiB; all three chunks have 1 MiB
+		fillRatio       int64 = cs / 8
 	)
 	if !up.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, 0, false) {
 		t.Fatalf("ProactiveFlush returned false; expected contiguous chunk 2 to be sealed")
@@ -268,36 +229,32 @@ func TestProactiveFlush_SkipsGappyChunks(t *testing.T) {
 		t.Errorf("chunk 2 should have moved to sealed")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
-		t.Errorf("chunk 0 (internal gap) must remain writable; ProactiveFlush must not race FUSE writeback")
+		t.Errorf("chunk 0 (internal gap) must remain writable")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; !stillWritable {
-		t.Errorf("chunk 1 (leading gap) must remain writable; ProactiveFlush must not race FUSE writeback")
+		t.Errorf("chunk 1 (leading gap) must remain writable")
 	}
 
-	// With only gappy chunks left, ProactiveFlush has no liveness
-	// fallback (unlike EvictOneWritableChunk) and must return false.
 	if up.ProactiveFlush(nowNs, idleThresholdNs, maxHoldNs, fillRatio, 0, false) {
-		t.Errorf("ProactiveFlush returned true with only gappy chunks left; should have skipped them")
+		t.Errorf("ProactiveFlush returned true with only gappy chunks left")
 	}
 
-	// Fill the holes; SaveDataAt's maybeMoveToSealed auto-seals on
-	// IsComplete, so chunks 0 and 1 leave writableChunks on their own.
-	if _, err := up.SaveDataAt(block, cs/4, true, 7); err != nil { // chunk 0 middle a
+	if _, err := up.SaveDataAt(block, cs/4, true, 7); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs/2, true, 8); err != nil { // chunk 0 middle b
+	if _, err := up.SaveDataAt(block, cs/2, true, 8); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs, true, 9); err != nil { // chunk 1 leading
+	if _, err := up.SaveDataAt(block, cs, true, 9); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs+3*cs/4, true, 10); err != nil { // chunk 1 trailing
+	if _, err := up.SaveDataAt(block, cs+3*cs/4, true, 10); err != nil {
 		t.Fatal(err)
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; stillWritable {
-		t.Errorf("chunk 0 should have auto-sealed on IsComplete after gap was filled")
+		t.Errorf("chunk 0 should have auto-sealed after gap was filled")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
-		t.Errorf("chunk 1 should have auto-sealed on IsComplete after leading range was filled")
+		t.Errorf("chunk 1 should have auto-sealed after leading range was filled")
 	}
 }

--- a/weed/mount/page_writer/upload_pipeline_test.go
+++ b/weed/mount/page_writer/upload_pipeline_test.go
@@ -49,9 +49,9 @@ func confirmRange(t *testing.T, uploadPipeline *UploadPipeline, startOff, stopOf
 
 // TestEvictOneWritableChunk_SkipsGappyChunks pins the issue #9330 fix:
 // pressure-driven eviction must not seal a chunk whose written intervals
-// have an internal hole, because SaveContent would emit multiple volume
-// chunks with no coverage for the hole and reads would silently zero-fill
-// it (filer/stream.go writeZero on gap).
+// have a hole (leading or internal), because SaveContent would emit
+// multiple volume chunks with no coverage for the hole and reads would
+// silently zero-fill it (filer/stream.go writeZero on gap).
 func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 	const cs int64 = 2 * 1024 * 1024
 	// saveToStorage = nil so that the async upload triggered by
@@ -60,7 +60,7 @@ func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 
 	block := make([]byte, cs/4) // 512 KiB
 
-	// Chunk 0: gappy — first quarter and last quarter written, middle hole.
+	// Chunk 0: internal gap — first quarter and last quarter written.
 	// Mirrors FUSE writeback mid-flight on sequential cp.
 	if _, err := up.SaveDataAt(block, 0, true, 1); err != nil {
 		t.Fatal(err)
@@ -68,36 +68,65 @@ func TestEvictOneWritableChunk_SkipsGappyChunks(t *testing.T) {
 	if _, err := up.SaveDataAt(block, 3*cs/4, true, 2); err != nil {
 		t.Fatal(err)
 	}
-	// Chunk 1: contiguous — first half written, no hole.
-	if _, err := up.SaveDataAt(block, cs, true, 3); err != nil {
+	// Chunk 1: leading gap — second and third quarters written, no byte 0.
+	// Mirrors FUSE writeback dispatching middle pages first.
+	if _, err := up.SaveDataAt(block, cs+cs/4, true, 3); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs+cs/4, true, 4); err != nil {
+	if _, err := up.SaveDataAt(block, cs+cs/2, true, 4); err != nil {
+		t.Fatal(err)
+	}
+	// Chunk 2: contiguous from offset 0 — first half written, no hole.
+	if _, err := up.SaveDataAt(block, 2*cs, true, 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, 2*cs+cs/4, true, 6); err != nil {
 		t.Fatal(err)
 	}
 
-	// Eviction must pick chunk 1 (contiguous), never chunk 0 (gappy),
-	// even though both have the same WrittenSize.
+	// Eviction must pick chunk 2 (contiguous from 0). Never chunks 0
+	// (internal gap) or 1 (leading gap), even though all three have
+	// the same WrittenSize.
 	if !up.EvictOneWritableChunk() {
-		t.Fatalf("EvictOneWritableChunk returned false; expected contiguous chunk 1 to be evictable")
+		t.Fatalf("EvictOneWritableChunk returned false; expected contiguous chunk 2 to be evictable")
 	}
-	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
-		t.Errorf("chunk 1 should have moved to sealed")
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(2)]; stillWritable {
+		t.Errorf("chunk 2 should have moved to sealed")
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; !stillWritable {
-		t.Errorf("chunk 0 (gappy) must remain writable so its hole can still be filled")
+		t.Errorf("chunk 0 (internal gap) must remain writable so its hole can still be filled")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; !stillWritable {
+		t.Errorf("chunk 1 (leading gap) must remain writable so its leading range can still be filled")
 	}
 
-	// Fill chunk 0's middle. The chunk now covers [0, cs) and SaveDataAt's
-	// maybeMoveToSealed auto-seals on completion, so it leaves writableChunks
-	// without our needing to call EvictOneWritableChunk.
-	if _, err := up.SaveDataAt(block, cs/4, true, 5); err != nil {
+	// With chunk 2 sealed, EvictOneWritableChunk has nothing else to seal —
+	// the remaining chunks are both gappy and must wait for FUSE writeback
+	// to fill them or for FlushAll at file close.
+	if up.EvictOneWritableChunk() {
+		t.Errorf("EvictOneWritableChunk returned true with only gappy chunks left")
+	}
+
+	// Fill chunk 0's middle and chunk 1's leading + trailing ranges.
+	// Both now cover [0, full) within their logicChunkIndex;
+	// SaveDataAt's maybeMoveToSealed auto-seals on IsComplete, so they
+	// leave writableChunks on their own.
+	if _, err := up.SaveDataAt(block, cs/4, true, 7); err != nil { // chunk 0 middle a
 		t.Fatal(err)
 	}
-	if _, err := up.SaveDataAt(block, cs/2, true, 6); err != nil {
+	if _, err := up.SaveDataAt(block, cs/2, true, 8); err != nil { // chunk 0 middle b
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs, true, 9); err != nil { // chunk 1 leading
+		t.Fatal(err)
+	}
+	if _, err := up.SaveDataAt(block, cs+3*cs/4, true, 10); err != nil { // chunk 1 trailing
 		t.Fatal(err)
 	}
 	if _, stillWritable := up.writableChunks[LogicChunkIndex(0)]; stillWritable {
-		t.Errorf("chunk 0 should have left writableChunks after gap was filled (auto-seal on IsComplete)")
+		t.Errorf("chunk 0 should have auto-sealed on IsComplete after gap was filled")
+	}
+	if _, stillWritable := up.writableChunks[LogicChunkIndex(1)]; stillWritable {
+		t.Errorf("chunk 1 should have auto-sealed on IsComplete after leading range was filled")
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #9330. Large files copied through `weed mount` could come back with chunk-sized blocks of zeros on the destination side (the workaround was `-chunkSizeLimitMB=8/16`). Root cause is on the **write** side: the upload pipeline's pressure-driven sealers were happy to seal a `MemChunk` whose written-interval list still had an internal hole, even though `SaveContent` emits one volume chunk per maximal adjacent run with **no** chunk covering the hole. At read time `filer/stream.go:177-186` silently zero-fills the gap range. Under FUSE writeback, in-flight 4 KiB writes for a single page chunk routinely look like a gappy interval list mid-flight, and pressure-evicting one of those bakes the gap into volume storage permanently.

## Fix
Filter the three pressure-driven sealers — `SaveDataAt`'s over-limit branch, `EvictOneWritableChunk` (accountant-driven), and `ProactiveFlush` (chunk-flusher) — to only seal page chunks whose written intervals form one unbroken run, via a new `PageChunk.IsContiguouslyWritten()` method backed by a single forward walk of `ChunkWrittenIntervalList`. The close/fsync path (`FlushAll` → `flushChunks`) is intentionally **not** filtered: at close, gaps in the interval list represent bytes the app legitimately never wrote, and sparse-file semantics are preserved by leaving them uncovered.

The per-pipeline `writableChunkLimit` becomes a soft cap when no gap-free chunk is evictable. The `memChunkCounter < 4*writableChunkLimit` ceiling already in `SaveDataAt` redirects newly created chunks to swap when memory is tight, and natural `IsComplete` auto-sealing via `maybeMoveToSealed` keeps the pipeline draining. No deadlock: a sequential writer's chunks always become contiguous as the kernel finishes dispatching writes for them.

## Reproduction
With `ManifestBatch` patched down so manifests trigger on small files, I confirmed the read-side mechanism directly: two volume chunks at `[0, 1MB)` and `[1.5MB, 2MB)` (gap at `[1MB, 1.5MB)`) → `filer.StreamContent` returns 524288 zero bytes for the gap region with no error logged above V(4). That is the exact symptom reported in the issue. The full test program lives outside the repo; the in-tree regression test (`TestEvictOneWritableChunk_SkipsGappyChunks`) pins the eviction-side invariant.

## Test plan
- [x] `go test ./weed/mount/page_writer/...` passes (existing + new)
- [x] `go test ./weed/mount/...` passes
- [x] `go build ./weed/...`
- [x] New unit tests:
  - `TestIsContiguouslyWritten` — 11 cases covering empty, single, adjacent, gappy, overlapping, multi-interval lists
  - `TestEvictOneWritableChunk_SkipsGappyChunks` — gappy chunk with more bytes is NOT picked over a contiguous one with fewer; once the gap is filled it auto-seals via `maybeMoveToSealed`
- [ ] FUSE integration soak: `cp` a 200 GB file through `weed mount` with default `-chunkSizeLimitMB=2`, compare md5 before/after (cannot run on macOS; would appreciate Linux CI confirmation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects contiguous write coverage and uses it to choose chunks to seal or flush.

* **Bug Fixes**
  * Avoids sealing or flushing chunks that have internal gaps, improving upload reliability and preventing partial uploads.
  * Adds contiguity-aware fallback selection when no gap-free chunk exists.

* **Tests**
  * Added tests covering contiguity detection, eviction/flush behavior, fallback selection, and gappy vs. contiguous chunk scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->