### PR TITLE
fix(shell): scope volume.fsck filer walk when -volumeId selects one bucketed collection

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -52,6 +52,7 @@ type commandVolumeFsck struct {
 	bucketsPath               string
 	collection                *string
 	volumeIds                 map[uint32]bool
+	scopedFilerPath           string
 	tempFolder                string
 	verbose                   *bool
 	forcePurging              *bool
@@ -183,6 +184,18 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 			sort.Slice(missing, func(i, j int) bool { return missing[i] < missing[j] })
 			return fmt.Errorf("volume(s) not found on master: %v", missing)
 		}
+	}
+
+	// Resolve the filer subtree to walk. -collection wins; otherwise, when
+	// -volumeId is set and every requested volume shares one non-empty
+	// collection that maps to an existing bucket directory, scope the BFS to
+	// that bucket. This relies on the convention that a collection named like
+	// a bucket only holds chunks for entries under <bucketsPath>/<bucket>;
+	// any deviation (empty collection, no matching bucket, multi-collection
+	// selection) falls back to walking from "/".
+	c.scopedFilerPath = c.resolveScopedFilerPath(dataNodeVolumeIdToVInfo)
+	if *c.verbose && c.scopedFilerPath != "/" {
+		fmt.Fprintf(c.writer, "scoping filer walk to %s\n", c.scopedFilerPath)
 	}
 
 	var collectCutoffFromAtNs int64 = 0
@@ -854,10 +867,78 @@ func (c *commandVolumeFsck) purgeFileIdsForOneVolume(volumeId uint32, fileIds []
 }
 
 func (c *commandVolumeFsck) getCollectFilerFilePath() string {
+	if c.scopedFilerPath != "" {
+		return c.scopedFilerPath
+	}
 	if *c.collection != "" {
 		return fmt.Sprintf("%s/%s", c.bucketsPath, *c.collection)
 	}
 	return "/"
+}
+
+// resolveScopedFilerPath narrows the BFS root to a bucket subtree when it's
+// safe to do so. Returns "/" (the original behavior) for any case the
+// optimization can't justify.
+func (c *commandVolumeFsck) resolveScopedFilerPath(dataNodeVolumeIdToVInfo map[string]map[uint32]VInfo) string {
+	if *c.collection != "" {
+		return fmt.Sprintf("%s/%s", c.bucketsPath, *c.collection)
+	}
+	if len(c.volumeIds) == 0 {
+		return "/"
+	}
+	// Gather collections of the requested volumes only.
+	collections := make(map[string]struct{})
+	for _, vidMap := range dataNodeVolumeIdToVInfo {
+		for vid, vinfo := range vidMap {
+			if _, ok := c.volumeIds[vid]; !ok {
+				continue
+			}
+			// Empty collection means the volume can be referenced from
+			// anywhere in the namespace; can't scope.
+			if vinfo.collection == "" {
+				return "/"
+			}
+			collections[vinfo.collection] = struct{}{}
+			if len(collections) > 1 {
+				return "/"
+			}
+		}
+	}
+	if len(collections) != 1 {
+		return "/"
+	}
+	var collection string
+	for c := range collections {
+		collection = c
+	}
+	// Confirm the collection name corresponds to an existing bucket directory.
+	// If it doesn't, fall back rather than walk a path that may not exist.
+	exists, err := c.bucketDirExists(collection)
+	if err != nil || !exists {
+		return "/"
+	}
+	return fmt.Sprintf("%s/%s", c.bucketsPath, collection)
+}
+
+func (c *commandVolumeFsck) bucketDirExists(name string) (bool, error) {
+	var found bool
+	err := c.env.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+		resp, err := client.LookupDirectoryEntry(context.Background(), &filer_pb.LookupDirectoryEntryRequest{
+			Directory: c.bucketsPath,
+			Name:      name,
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), filer_pb.ErrNotFound.Error()) {
+				return nil
+			}
+			return err
+		}
+		if resp.Entry != nil && resp.Entry.IsDirectory {
+			found = true
+		}
+		return nil
+	})
+	return found, err
 }
 
 func getVolumeFileIdFile(tempFolder string, dataNodeid string, vid uint32) string {

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -186,13 +186,6 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 		}
 	}
 
-	// Resolve the filer subtree to walk. -collection wins; otherwise, when
-	// -volumeId is set and every requested volume shares one non-empty
-	// collection that maps to an existing bucket directory, scope the BFS to
-	// that bucket. This relies on the convention that a collection named like
-	// a bucket only holds chunks for entries under <bucketsPath>/<bucket>;
-	// any deviation (empty collection, no matching bucket, multi-collection
-	// selection) falls back to walking from "/".
 	c.scopedFilerPath = c.resolveScopedFilerPath(dataNodeVolumeIdToVInfo)
 	if *c.verbose && c.scopedFilerPath != "/" {
 		fmt.Fprintf(c.writer, "scoping filer walk to %s\n", c.scopedFilerPath)
@@ -876,9 +869,6 @@ func (c *commandVolumeFsck) getCollectFilerFilePath() string {
 	return "/"
 }
 
-// resolveScopedFilerPath narrows the BFS root to a bucket subtree when it's
-// safe to do so. Returns "/" (the original behavior) for any case the
-// optimization can't justify.
 func (c *commandVolumeFsck) resolveScopedFilerPath(dataNodeVolumeIdToVInfo map[string]map[uint32]VInfo) string {
 	if *c.collection != "" {
 		return fmt.Sprintf("%s/%s", c.bucketsPath, *c.collection)
@@ -886,15 +876,13 @@ func (c *commandVolumeFsck) resolveScopedFilerPath(dataNodeVolumeIdToVInfo map[s
 	if len(c.volumeIds) == 0 {
 		return "/"
 	}
-	// Gather collections of the requested volumes only.
 	collections := make(map[string]struct{})
 	for _, vidMap := range dataNodeVolumeIdToVInfo {
 		for vid, vinfo := range vidMap {
 			if _, ok := c.volumeIds[vid]; !ok {
 				continue
 			}
-			// Empty collection means the volume can be referenced from
-			// anywhere in the namespace; can't scope.
+			// empty collection: volume can be referenced from anywhere
 			if vinfo.collection == "" {
 				return "/"
 			}
@@ -911,8 +899,6 @@ func (c *commandVolumeFsck) resolveScopedFilerPath(dataNodeVolumeIdToVInfo map[s
 	for c := range collections {
 		collection = c
 	}
-	// Confirm the collection name corresponds to an existing bucket directory.
-	// If it doesn't, fall back rather than walk a path that may not exist.
 	exists, err := c.bucketDirExists(collection)
 	if err != nil || !exists {
 		return "/"

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -860,13 +860,7 @@ func (c *commandVolumeFsck) purgeFileIdsForOneVolume(volumeId uint32, fileIds []
 }
 
 func (c *commandVolumeFsck) getCollectFilerFilePath() string {
-	if c.scopedFilerPath != "" {
-		return c.scopedFilerPath
-	}
-	if *c.collection != "" {
-		return fmt.Sprintf("%s/%s", c.bucketsPath, *c.collection)
-	}
-	return "/"
+	return c.scopedFilerPath
 }
 
 func (c *commandVolumeFsck) resolveScopedFilerPath(dataNodeVolumeIdToVInfo map[string]map[uint32]VInfo) string {
@@ -896,8 +890,8 @@ func (c *commandVolumeFsck) resolveScopedFilerPath(dataNodeVolumeIdToVInfo map[s
 		return "/"
 	}
 	var collection string
-	for c := range collections {
-		collection = c
+	for col := range collections {
+		collection = col
 	}
 	exists, err := c.bucketDirExists(collection)
 	if err != nil || !exists {


### PR DESCRIPTION
Closes #9345.

`volume.fsck -volumeId=XX -v` looked like it was ignoring `-volumeId` because the verbose output listed directories from every bucket. The flag *was* filtering volume-side scanning; the filer-side BFS just always walked from `/`, since chunk-to-volume membership isn't visible from a path.

When all requested volumes share a single non-empty collection that maps to an existing `<bucketsPath>/<collection>` directory, restrict the BFS root to that bucket. Anything that breaks the convention — empty collection on any selected volume, multi-collection selection, no matching bucket directory — falls back to walking `/` so non-S3 setups behave exactly as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `volume.fsck` command scoping logic to correctly handle collection-based traversal. The command now respects explicit collection filters and intelligently determines traversal scope based on volume configurations, with better fallback handling for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->