### PR TITLE
feat(s3/lifecycle): policy engine — XML conversion, Compile, decideMode, Match

### DIFF
--- a/weed/s3api/s3api_lifecycle_canonical.go
+++ b/weed/s3api/s3api_lifecycle_canonical.go
@@ -1,0 +1,101 @@
+package s3api
+
+import (
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// LifecycleToCanonical converts the XML-deserialized Lifecycle into the flat
+// s3lifecycle.Rule shape the engine compiles against. One XML <Rule> maps to
+// exactly one s3lifecycle.Rule (with potentially multiple action sub-fields
+// populated); the engine then expands each into its compiled actions via
+// s3lifecycle.RuleActionKinds.
+//
+// Filter resolution mirrors AWS semantics: the optional <Filter> element may
+// contain a single <Prefix> | <Tag> | <And>, or be absent (in which case the
+// older top-level <Prefix> applies). When <And> is used, its sub-elements
+// (Prefix + multiple Tags + size filters) are flattened into the canonical
+// Rule's individual fields.
+func LifecycleToCanonical(lc *Lifecycle) []*s3lifecycle.Rule {
+	if lc == nil {
+		return nil
+	}
+	out := make([]*s3lifecycle.Rule, 0, len(lc.Rules))
+	for i := range lc.Rules {
+		out = append(out, ruleToCanonical(&lc.Rules[i]))
+	}
+	return out
+}
+
+func ruleToCanonical(r *Rule) *s3lifecycle.Rule {
+	out := &s3lifecycle.Rule{
+		ID:     r.ID,
+		Status: string(r.Status),
+	}
+
+	// Prefix: <Filter><Prefix> or <Filter><And><Prefix> or top-level <Prefix>.
+	prefix, tags, sizeGT, sizeLT := flattenFilter(&r.Filter)
+	if prefix == "" && r.Prefix.set {
+		prefix = r.Prefix.val
+	}
+	out.Prefix = prefix
+	if len(tags) > 0 {
+		out.FilterTags = tags
+	}
+	out.FilterSizeGreaterThan = sizeGT
+	out.FilterSizeLessThan = sizeLT
+
+	// Expiration sub-fields.
+	if r.Expiration.set {
+		out.ExpirationDays = r.Expiration.Days
+		if !r.Expiration.Date.Time.IsZero() {
+			out.ExpirationDate = r.Expiration.Date.Time
+		}
+		if r.Expiration.DeleteMarker.set {
+			out.ExpiredObjectDeleteMarker = r.Expiration.DeleteMarker.val
+		}
+	}
+
+	// Non-current version expiration.
+	if r.NoncurrentVersionExpiration.set {
+		out.NoncurrentVersionExpirationDays = r.NoncurrentVersionExpiration.NoncurrentDays
+		out.NewerNoncurrentVersions = r.NoncurrentVersionExpiration.NewerNoncurrentVersions
+	}
+
+	// Abort multipart.
+	if r.AbortIncompleteMultipartUpload.set {
+		out.AbortMPUDaysAfterInitiation = r.AbortIncompleteMultipartUpload.DaysAfterInitiation
+	}
+
+	return out
+}
+
+// flattenFilter pulls Prefix / Tags / Size constraints out of the XML Filter
+// element. Returns zero values when the field is unset; the caller falls back
+// to the rule's top-level Prefix when prefix is "".
+func flattenFilter(f *Filter) (prefix string, tags map[string]string, sizeGT, sizeLT int64) {
+	if !f.set {
+		return
+	}
+	if f.andSet {
+		if f.And.Prefix.set {
+			prefix = f.And.Prefix.val
+		}
+		if len(f.And.Tags) > 0 {
+			tags = make(map[string]string, len(f.And.Tags))
+			for _, t := range f.And.Tags {
+				tags[t.Key] = t.Value
+			}
+		}
+		sizeGT = f.And.ObjectSizeGreaterThan
+		sizeLT = f.And.ObjectSizeLessThan
+		return
+	}
+	if f.tagSet {
+		tags = map[string]string{f.Tag.Key: f.Tag.Value}
+	} else if f.Prefix.set {
+		prefix = f.Prefix.val
+	}
+	sizeGT = f.ObjectSizeGreaterThan
+	sizeLT = f.ObjectSizeLessThan
+	return
+}

--- a/weed/s3api/s3api_lifecycle_canonical_test.go
+++ b/weed/s3api/s3api_lifecycle_canonical_test.go
@@ -1,0 +1,196 @@
+package s3api
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// parseLifecycle is a thin helper for tests; production code reads XML via the
+// regular bucket-config decoder, this shortcut keeps the test focused on the
+// canonical conversion.
+func parseLifecycle(t *testing.T, xmlSrc string) *Lifecycle {
+	t.Helper()
+	lc := &Lifecycle{}
+	if err := xml.Unmarshal([]byte(xmlSrc), lc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return lc
+}
+
+func TestLifecycleToCanonical_TopLevelPrefix(t *testing.T) {
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <ID>r1</ID>
+    <Status>Enabled</Status>
+    <Prefix>logs/</Prefix>
+    <Expiration><Days>30</Days></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)
+	if len(got) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(got))
+	}
+	r := got[0]
+	if r.ID != "r1" || r.Status != "Enabled" || r.Prefix != "logs/" || r.ExpirationDays != 30 {
+		t.Fatalf("unexpected: %+v", r)
+	}
+}
+
+func TestLifecycleToCanonical_FilterPrefix(t *testing.T) {
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <Status>Enabled</Status>
+    <Filter><Prefix>logs/</Prefix></Filter>
+    <Expiration><Days>30</Days></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)
+	if got[0].Prefix != "logs/" {
+		t.Fatalf("want logs/, got %q", got[0].Prefix)
+	}
+}
+
+func TestLifecycleToCanonical_FilterTagAndSize(t *testing.T) {
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <Status>Enabled</Status>
+    <Filter>
+      <And>
+        <Prefix>data/</Prefix>
+        <Tag><Key>env</Key><Value>prod</Value></Tag>
+        <Tag><Key>tier</Key><Value>cold</Value></Tag>
+        <ObjectSizeGreaterThan>1024</ObjectSizeGreaterThan>
+        <ObjectSizeLessThan>10485760</ObjectSizeLessThan>
+      </And>
+    </Filter>
+    <Expiration><Days>90</Days></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)[0]
+	if got.Prefix != "data/" {
+		t.Fatalf("prefix want data/, got %q", got.Prefix)
+	}
+	wantTags := map[string]string{"env": "prod", "tier": "cold"}
+	if !reflect.DeepEqual(got.FilterTags, wantTags) {
+		t.Fatalf("tags want %v, got %v", wantTags, got.FilterTags)
+	}
+	if got.FilterSizeGreaterThan != 1024 || got.FilterSizeLessThan != 10485760 {
+		t.Fatalf("size: gt=%d lt=%d", got.FilterSizeGreaterThan, got.FilterSizeLessThan)
+	}
+}
+
+func TestLifecycleToCanonical_SingleTagFilter(t *testing.T) {
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <Status>Enabled</Status>
+    <Filter>
+      <Tag><Key>env</Key><Value>prod</Value></Tag>
+    </Filter>
+    <Expiration><Days>30</Days></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)[0]
+	if !reflect.DeepEqual(got.FilterTags, map[string]string{"env": "prod"}) {
+		t.Fatalf("tags want {env:prod}, got %v", got.FilterTags)
+	}
+}
+
+func TestLifecycleToCanonical_MultipleActions(t *testing.T) {
+	// One XML <Rule> with three concurrent actions: Expiration.Days,
+	// NoncurrentVersionExpiration, AbortMultipartUpload. All must populate
+	// the corresponding canonical fields so RuleActionKinds expands them
+	// into three compiled actions downstream.
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <ID>multi</ID>
+    <Status>Enabled</Status>
+    <Filter><Prefix>data/</Prefix></Filter>
+    <Expiration><Days>90</Days></Expiration>
+    <NoncurrentVersionExpiration>
+      <NoncurrentDays>30</NoncurrentDays>
+      <NewerNoncurrentVersions>3</NewerNoncurrentVersions>
+    </NoncurrentVersionExpiration>
+    <AbortIncompleteMultipartUpload>
+      <DaysAfterInitiation>7</DaysAfterInitiation>
+    </AbortIncompleteMultipartUpload>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)[0]
+	if got.ExpirationDays != 90 {
+		t.Fatalf("ExpirationDays want 90, got %d", got.ExpirationDays)
+	}
+	if got.NoncurrentVersionExpirationDays != 30 || got.NewerNoncurrentVersions != 3 {
+		t.Fatalf("NoncurrentVersion: %+v", got)
+	}
+	if got.AbortMPUDaysAfterInitiation != 7 {
+		t.Fatalf("AbortMPU want 7, got %d", got.AbortMPUDaysAfterInitiation)
+	}
+}
+
+func TestLifecycleToCanonical_ExpirationDate(t *testing.T) {
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <Status>Enabled</Status>
+    <Filter><Prefix></Prefix></Filter>
+    <Expiration><Date>2025-06-15T00:00:00Z</Date></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)[0]
+	want, _ := time.Parse(time.RFC3339, "2025-06-15T00:00:00Z")
+	if !got.ExpirationDate.Equal(want) {
+		t.Fatalf("date want %v, got %v", want, got.ExpirationDate)
+	}
+}
+
+func TestLifecycleToCanonical_ExpiredObjectDeleteMarker(t *testing.T) {
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <Status>Enabled</Status>
+    <Filter><Prefix></Prefix></Filter>
+    <Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)[0]
+	if !got.ExpiredObjectDeleteMarker {
+		t.Fatalf("want ExpiredObjectDeleteMarker=true")
+	}
+}
+
+func TestLifecycleToCanonical_DisabledRulePreserved(t *testing.T) {
+	// The engine's mode gate decides scheduling; conversion must preserve
+	// the Status verbatim regardless.
+	lc := parseLifecycle(t, `
+<LifecycleConfiguration>
+  <Rule>
+    <Status>Disabled</Status>
+    <Filter><Prefix>x/</Prefix></Filter>
+    <Expiration><Days>30</Days></Expiration>
+  </Rule>
+</LifecycleConfiguration>`)
+	got := LifecycleToCanonical(lc)[0]
+	if got.Status != "Disabled" {
+		t.Fatalf("status want Disabled, got %q", got.Status)
+	}
+}
+
+func TestLifecycleToCanonical_NilSafe(t *testing.T) {
+	if got := LifecycleToCanonical(nil); got != nil {
+		t.Fatalf("nil lc should return nil, got %v", got)
+	}
+}
+
+func TestLifecycleToCanonical_EmptyRules(t *testing.T) {
+	got := LifecycleToCanonical(&Lifecycle{})
+	if len(got) != 0 {
+		t.Fatalf("empty rules should be empty slice, got %d", len(got))
+	}
+}

--- a/weed/s3api/s3lifecycle/action_kind.go
+++ b/weed/s3api/s3lifecycle/action_kind.go
@@ -1,41 +1,27 @@
 package s3lifecycle
 
 // ActionKey is the engine-wide identity of one compiled lifecycle action.
-// One XML <Rule> with N populated action sub-elements expands into N
-// ActionKeys sharing the same RuleHash but differing in ActionKind. Every
-// per-action data structure — engine indexes, target modes, newly-completed
-// sets, bootstrap completion, drain locks, metrics, blocker / retry-budget
-// records — is keyed by ActionKey, not RuleHash alone, so sibling actions
-// of the same rule are scheduled and degraded independently.
-//
-// Bucket is part of the key because two buckets may carry rules whose XML
-// (and therefore RuleHash) is identical; without scoping, those collide in
-// any map keyed by ActionKey. The on-disk storage layout
-// /etc/s3/lifecycle/<bucket>/<rule_hash>/<action_kind>/ is naturally
-// bucket-scoped; ActionKey mirrors that.
+// Bucket is part of the key because two buckets may carry rules with
+// identical RuleHash; without scoping they'd collide in any keyed map.
+// The on-disk path /etc/s3/lifecycle/<bucket>/<rule_hash>/<action_kind>/
+// mirrors this shape.
 type ActionKey struct {
 	Bucket     string
 	RuleHash   [8]byte
 	ActionKind ActionKind
 }
 
-// ActionKind identifies a single compiled lifecycle action under one XML
-// rule. A single XML <Rule> may declare multiple action sub-elements in
-// parallel, each yielding a separate compiled action with its own delay
-// group, mode, pending stream, and durable state directory.
-//
-// The values here mirror the wire-form ActionKind enum in
-// weed/pb/s3_lifecycle.proto (offset by the UNSPECIFIED sentinel at 0).
+// ActionKind values mirror the wire-form enum in s3_lifecycle.proto.
 type ActionKind int
 
 const (
-	ActionKindUnspecified         ActionKind = iota // matches proto ACTION_KIND_UNSPECIFIED
-	ActionKindExpirationDays                        // Expiration.Days
-	ActionKindExpirationDate                        // Expiration.Date
-	ActionKindNoncurrentDays                        // NoncurrentVersionExpiration.NoncurrentDays (with optional NewerNoncurrent retention)
-	ActionKindNewerNoncurrent                       // NoncurrentVersionExpiration.NewerNoncurrentVersions (count-only, no NoncurrentDays)
-	ActionKindAbortMPU                              // AbortIncompleteMultipartUpload.DaysAfterInitiation
-	ActionKindExpiredDeleteMarker                   // Expiration.ExpiredObjectDeleteMarker
+	ActionKindUnspecified ActionKind = iota
+	ActionKindExpirationDays
+	ActionKindExpirationDate
+	ActionKindNoncurrentDays
+	ActionKindNewerNoncurrent
+	ActionKindAbortMPU
+	ActionKindExpiredDeleteMarker
 )
 
 // String returns the leaf-directory name used in
@@ -59,16 +45,10 @@ func (k ActionKind) String() string {
 	}
 }
 
-// RuleActionKinds returns the compiled actions a single XML rule expands to.
-// Empty when no action sub-element is populated. Order is deterministic so
-// callers can hash / iterate stably:
-//
-//	EXPIRATION_DAYS, EXPIRATION_DATE, EXPIRED_DELETE_MARKER,
-//	NONCURRENT_DAYS, NEWER_NONCURRENT, ABORT_MPU
-//
-// Note: NewerNoncurrentVersions is paired with NoncurrentDays into a single
-// NONCURRENT_DAYS action when both are set; only when NewerNoncurrent is set
-// alone (no day threshold) does it produce a NEWER_NONCURRENT action.
+// RuleActionKinds returns the compiled actions a single XML rule expands to,
+// in deterministic order. NewerNoncurrentVersions paired with NoncurrentDays
+// is subsumed into NONCURRENT_DAYS; only stand-alone NewerNoncurrent
+// produces a NEWER_NONCURRENT action.
 func RuleActionKinds(rule *Rule) []ActionKind {
 	if rule == nil {
 		return nil

--- a/weed/s3api/s3lifecycle/action_kind.go
+++ b/weed/s3api/s3lifecycle/action_kind.go
@@ -1,5 +1,17 @@
 package s3lifecycle
 
+// ActionKey is the engine-wide identity of one compiled lifecycle action.
+// One XML <Rule> with N populated action sub-elements expands into N
+// ActionKeys sharing the same RuleHash but differing in ActionKind. Every
+// per-action data structure — engine indexes, target modes, newly-completed
+// sets, bootstrap completion, drain locks, metrics, blocker / retry-budget
+// records — is keyed by ActionKey, not RuleHash alone, so sibling actions
+// of the same rule are scheduled and degraded independently.
+type ActionKey struct {
+	RuleHash   [8]byte
+	ActionKind ActionKind
+}
+
 // ActionKind identifies a single compiled lifecycle action under one XML
 // rule. A single XML <Rule> may declare multiple action sub-elements in
 // parallel, each yielding a separate compiled action with its own delay

--- a/weed/s3api/s3lifecycle/action_kind.go
+++ b/weed/s3api/s3lifecycle/action_kind.go
@@ -7,7 +7,14 @@ package s3lifecycle
 // sets, bootstrap completion, drain locks, metrics, blocker / retry-budget
 // records — is keyed by ActionKey, not RuleHash alone, so sibling actions
 // of the same rule are scheduled and degraded independently.
+//
+// Bucket is part of the key because two buckets may carry rules whose XML
+// (and therefore RuleHash) is identical; without scoping, those collide in
+// any map keyed by ActionKey. The on-disk storage layout
+// /etc/s3/lifecycle/<bucket>/<rule_hash>/<action_kind>/ is naturally
+// bucket-scoped; ActionKey mirrors that.
 type ActionKey struct {
+	Bucket     string
 	RuleHash   [8]byte
 	ActionKind ActionKind
 }

--- a/weed/s3api/s3lifecycle/due_at.go
+++ b/weed/s3api/s3lifecycle/due_at.go
@@ -2,15 +2,9 @@ package s3lifecycle
 
 import "time"
 
-// ComputeDueAt returns the earliest wall-clock time the (rule, kind) compiled
-// action can fire for info given the object's current shape. Returns the
-// zero time when the action cannot fire for this entry (filter rejects, kind
-// not declared on the rule, wrong object shape, etc.).
-//
-// Used by the reader/bootstrap to decide pending-vs-inline-delete for one
-// specific action. Sibling actions of the same XML rule are computed
-// separately so a rule's 7d AbortMPU due time does not influence its 90d
-// ExpirationDays sibling.
+// ComputeDueAt returns the earliest wall-clock time the (rule, kind) action
+// can fire for info. Returns zero time when no action can fire for this
+// entry. Used by reader/bootstrap to decide pending vs. inline-delete.
 func ComputeDueAt(rule *Rule, kind ActionKind, info *ObjectInfo) time.Time {
 	if rule == nil || info == nil || rule.Status != StatusEnabled {
 		return time.Time{}
@@ -45,7 +39,6 @@ func ComputeDueAt(rule *Rule, kind ActionKind, info *ObjectInfo) time.Time {
 			return base.AddDate(0, 0, rule.NoncurrentVersionExpirationDays)
 		}
 	case ActionKindNewerNoncurrent:
-		// Pure count-based: only when NoncurrentDays is unset.
 		if !info.IsLatest && rule.NoncurrentVersionExpirationDays == 0 && rule.NewerNoncurrentVersions > 0 {
 			if !info.SuccessorModTime.IsZero() {
 				return info.SuccessorModTime

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -86,13 +86,16 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 				snap.actions[key] = ca
 				bi.actionKeys = append(bi.actionKeys, key)
 
-				// SCAN_AT_DATE actions index regardless of activation; the
-				// detector schedules them at rule.date. Other modes are
-				// only indexed for routing once active.
+				// Index every action by mode regardless of `active`. The
+				// reader's MatchOriginalWrite / MatchPredicateChange filter
+				// on IsActive() at routing time, so a key indexed here that
+				// is currently inactive simply doesn't fire. This lets a
+				// later MarkActive flip become routable without forcing a
+				// recompile (matches the documented two-phase activation).
 				if mode == ModeScanAtDate {
 					snap.dateActions[key] = rule.ExpirationDate
 				}
-				if active && mode == ModeEventDriven {
+				if mode == ModeEventDriven {
 					snap.originalDelayGroups[ca.Delay] = append(snap.originalDelayGroups[ca.Delay], key)
 					if ca.PredicateSensitive {
 						snap.predicateActions = append(snap.predicateActions, key)

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -136,17 +136,14 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 }
 
 // rulePredicateSensitive returns true if the rule's filter has any predicate
-// (tag or size) that can flip post-PUT. Prefix is fixed at write time so
-// it's not predicate-sensitive.
+// that can flip post-PUT. Only tags qualify: prefix is fixed by the object's
+// path at write time, and an object's size is immutable once written (any
+// content change is a fresh write that flows through the original-write
+// stream). Size filters do not need predicate-change sweeps; including them
+// here would add to predicateActions for no purpose and waste sweep cycles.
 func rulePredicateSensitive(rule *s3lifecycle.Rule) bool {
 	if rule == nil {
 		return false
 	}
-	if len(rule.FilterTags) > 0 {
-		return true
-	}
-	if rule.FilterSizeGreaterThan > 0 || rule.FilterSizeLessThan > 0 {
-		return true
-	}
-	return false
+	return len(rule.FilterTags) > 0
 }

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -85,7 +85,7 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 		for _, rule := range in.Rules {
 			ruleHash := s3lifecycle.RuleHash(rule)
 			for _, kind := range s3lifecycle.RuleActionKinds(rule) {
-				key := s3lifecycle.ActionKey{RuleHash: ruleHash, ActionKind: kind}
+				key := s3lifecycle.ActionKey{Bucket: in.Bucket, RuleHash: ruleHash, ActionKind: kind}
 				mode := decideMode(rule, kind, opts.MetaLogRetention, opts.BootstrapLookbackMin)
 				prior := opts.PriorStates[key]
 				active := prior.BootstrapComplete && mode == ModeEventDriven
@@ -118,12 +118,13 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 				if mode == ModeScanAtDate {
 					snap.dateActions[key] = rule.ExpirationDate
 				}
-				if active {
-					if mode == ModeEventDriven && kind != s3lifecycle.ActionKindExpirationDate {
-						snap.originalDelayGroups[ca.Delay] = append(snap.originalDelayGroups[ca.Delay], key)
-						if ca.PredicateSensitive {
-							snap.predicateActions = append(snap.predicateActions, key)
-						}
+				// mode==EVENT_DRIVEN already excludes EXPIRATION_DATE
+				// (decideMode routes the date kind to SCAN_AT_DATE); no
+				// extra kind check needed.
+				if active && mode == ModeEventDriven {
+					snap.originalDelayGroups[ca.Delay] = append(snap.originalDelayGroups[ca.Delay], key)
+					if ca.PredicateSensitive {
+						snap.predicateActions = append(snap.predicateActions, key)
 					}
 				}
 			}

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -11,6 +11,8 @@ import (
 
 var snapshotIDSeq atomic.Uint64
 
+// CompileInput: at most one entry per Bucket. Duplicates would overwrite
+// earlier entries' BucketIndex.
 type CompileInput struct {
 	Bucket    string
 	Rules     []*s3lifecycle.Rule

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -17,16 +17,15 @@ type CompileInput struct {
 	Versioned bool
 }
 
-// PriorState carries durable per-action state into Compile. Missing keys are
-// treated as bootstrap_complete=false (new action, must run bootstrap).
+// PriorState carries durable per-action state into Compile. Missing keys
+// are treated as bootstrap_complete=false.
 type PriorState struct {
 	BootstrapComplete bool
 	Mode              RuleMode
 }
 
+// MetaLogRetention=0 means unbounded; the retention gate doesn't trip.
 type CompileOptions struct {
-	// MetaLogRetention=0 means unbounded (the SeaweedFS default; meta-log
-	// files are written without TTL). The retention gate doesn't trip then.
 	MetaLogRetention     time.Duration
 	BootstrapLookbackMin time.Duration
 	PriorStates          map[s3lifecycle.ActionKey]PriorState
@@ -34,10 +33,6 @@ type CompileOptions struct {
 
 const defaultBootstrapLookbackMin = 5 * s3lifecycle.SmallDelay
 
-// Compile builds a fresh Snapshot, atomically swaps it onto the engine, and
-// returns it. Each input rule expands into N CompiledActions via
-// RuleActionKinds; activation requires bootstrap_complete from PriorStates
-// and mode==EVENT_DRIVEN.
 func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 	if opts.BootstrapLookbackMin == 0 {
 		opts.BootstrapLookbackMin = defaultBootstrapLookbackMin
@@ -59,12 +54,9 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 			ruleHash := s3lifecycle.RuleHash(rule)
 			for _, kind := range s3lifecycle.RuleActionKinds(rule) {
 				key := s3lifecycle.ActionKey{Bucket: in.Bucket, RuleHash: ruleHash, ActionKind: kind}
-				// Durable PriorState.Mode wins when set: lag-fallback,
-				// operator pause, or persisted SCAN_ONLY must survive an
-				// engine rebuild rather than being silently re-promoted by
-				// decideMode. Fall through to decideMode for new actions
-				// (no prior) and for legacy entries that were persisted
-				// before Mode was a field (zero value).
+				// Durable Mode wins; decideMode is only the seed for new
+				// or legacy-zero actions. Otherwise lag-fallback / operator
+				// SCAN_ONLY would re-promote on every rebuild.
 				prior, hasPrior := opts.PriorStates[key]
 				mode := prior.Mode
 				if !hasPrior || mode == ModeUnspecified {
@@ -86,12 +78,9 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 				snap.actions[key] = ca
 				bi.actionKeys = append(bi.actionKeys, key)
 
-				// Index every action by mode regardless of `active`. The
-				// reader's MatchOriginalWrite / MatchPredicateChange filter
-				// on IsActive() at routing time, so a key indexed here that
-				// is currently inactive simply doesn't fire. This lets a
-				// later MarkActive flip become routable without forcing a
-				// recompile (matches the documented two-phase activation).
+				// Index every action regardless of `active`; routing
+				// re-filters on IsActive() so MarkActive flips are visible
+				// without a recompile.
 				if mode == ModeScanAtDate {
 					snap.dateActions[key] = rule.ExpirationDate
 				}

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -9,64 +9,35 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
-// snapshotIDSeq is the cluster-wide monotonic ID stamped on every Compile.
-// One process-wide counter is sufficient: callers that need cross-process
-// monotonicity stamp pending writes with the snapshot id when they record
-// the entry; the entry stays valid as long as its ActionKey survives, not
-// as long as the snapshot id matches.
 var snapshotIDSeq atomic.Uint64
 
-// CompileInput is one (bucket, rule) pair the engine compiles. The caller
-// converts XML lifecycle config to []*s3lifecycle.Rule via
-// s3api.LifecycleToCanonical and groups by bucket.
 type CompileInput struct {
 	Bucket    string
 	Rules     []*s3lifecycle.Rule
-	Versioned bool // true if the bucket has versioning enabled
+	Versioned bool
 }
 
-// PriorState is the durable per-action state the compiler reads to decide
-// whether a freshly-compiled action is bootstrap_complete. Missing keys are
+// PriorState carries durable per-action state into Compile. Missing keys are
 // treated as bootstrap_complete=false (new action, must run bootstrap).
 type PriorState struct {
 	BootstrapComplete bool
 	Mode              RuleMode
 }
 
-// CompileOptions tunes engine compilation. All fields have safe zero values.
 type CompileOptions struct {
-	// MetaLogRetention is the upper bound on how far back the meta-log
-	// reader can replay events. Used by the retention mode gate to
-	// downgrade actions whose event-log horizon exceeds retention.
-	// A zero value means "unbounded retention" — the gate never trips
-	// (matches the SeaweedFS default deployment per Phase 0 verification).
-	MetaLogRetention time.Duration
-
-	// BootstrapLookbackMin is the safety floor added to the retention gate:
-	// metaLogRetention < eventLogHorizon(rule, kind) + BootstrapLookbackMin
-	// promotes the action to scan_only. Default 5 * SmallDelay (~5 minutes).
+	// MetaLogRetention=0 means unbounded (the SeaweedFS default; meta-log
+	// files are written without TTL). The retention gate doesn't trip then.
+	MetaLogRetention     time.Duration
 	BootstrapLookbackMin time.Duration
-
-	// PriorStates is the durable state map keyed by ActionKey. Used at
-	// compile time to decide engine activation per action.
-	PriorStates map[s3lifecycle.ActionKey]PriorState
+	PriorStates          map[s3lifecycle.ActionKey]PriorState
 }
 
-// defaultBootstrapLookbackMin is the minimum extra slack the retention gate
-// requires beyond the rule's eventLogHorizon. Five SmallDelays gives a few
-// minutes for the reader to drain residual events at edge cases without
-// promoting an otherwise-healthy rule to scan_only.
 const defaultBootstrapLookbackMin = 5 * s3lifecycle.SmallDelay
 
-// Compile produces a fresh Snapshot from per-bucket rules and applies it to
-// the engine. Returns the new Snapshot.
-//
-// Each input rule expands into N CompiledActions via RuleActionKinds. Each
-// CompiledAction's mode is decided by decideMode (date kind -> SCAN_AT_DATE;
-// reader-driven kind whose horizon exceeds retention -> SCAN_ONLY; disabled
-// rule -> DISABLED; otherwise EVENT_DRIVEN provided bootstrap is complete).
-// Activation (engineState=active) requires both bootstrap_complete from
-// PriorStates and mode==EVENT_DRIVEN.
+// Compile builds a fresh Snapshot, atomically swaps it onto the engine, and
+// returns it. Each input rule expands into N CompiledActions via
+// RuleActionKinds; activation requires bootstrap_complete from PriorStates
+// and mode==EVENT_DRIVEN.
 func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 	if opts.BootstrapLookbackMin == 0 {
 		opts.BootstrapLookbackMin = defaultBootstrapLookbackMin
@@ -106,23 +77,12 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 				snap.actions[key] = ca
 				bi.actionKeys = append(bi.actionKeys, key)
 
-				// Routing indexes by mode:
-				// - SCAN_AT_DATE: always indexed in dateActions so the
-				//   detector can schedule the bootstrap at rule.date.
-				//   Active flag is unused for this stream (no reader sweep).
-				// - EVENT_DRIVEN + active: indexed in originalDelayGroups
-				//   (and predicateActions when applicable) so the reader
-				//   sweeps it. The reader filters again on engineState
-				//   before dispatching, so subsequent markActive flips are
-				//   visible without recompile.
-				// - SCAN_ONLY / DISABLED / pending_bootstrap: not indexed;
-				//   handled by safety-scan tick or explicit operator action.
+				// SCAN_AT_DATE actions index regardless of activation; the
+				// detector schedules them at rule.date. Other modes are
+				// only indexed for routing once active.
 				if mode == ModeScanAtDate {
 					snap.dateActions[key] = rule.ExpirationDate
 				}
-				// mode==EVENT_DRIVEN already excludes EXPIRATION_DATE
-				// (decideMode routes the date kind to SCAN_AT_DATE); no
-				// extra kind check needed.
 				if active && mode == ModeEventDriven {
 					snap.originalDelayGroups[ca.Delay] = append(snap.originalDelayGroups[ca.Delay], key)
 					if ca.PredicateSensitive {
@@ -133,9 +93,6 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 		}
 	}
 
-	// Build the pre-sorted AllActions view once. Snapshot is immutable
-	// post-Compile (engineState transitions don't affect membership), so
-	// the sorted slice can be shared by every AllActions() call.
 	snap.allActionsSorted = make([]*CompiledAction, 0, len(snap.actions))
 	for _, a := range snap.actions {
 		snap.allActionsSorted = append(snap.allActionsSorted, a)
@@ -155,12 +112,9 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 	return snap
 }
 
-// rulePredicateSensitive returns true if the rule's filter has any predicate
-// that can flip post-PUT. Only tags qualify: prefix is fixed by the object's
-// path at write time, and an object's size is immutable once written (any
-// content change is a fresh write that flows through the original-write
-// stream). Size filters do not need predicate-change sweeps; including them
-// here would add to predicateActions for no purpose and waste sweep cycles.
+// rulePredicateSensitive: only tag filters can flip post-PUT. Size is
+// immutable once written; a size change is a fresh write through the
+// original-write stream.
 func rulePredicateSensitive(rule *s3lifecycle.Rule) bool {
 	if rule == nil {
 		return false

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"bytes"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -130,6 +132,24 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 			}
 		}
 	}
+
+	// Build the pre-sorted AllActions view once. Snapshot is immutable
+	// post-Compile (engineState transitions don't affect membership), so
+	// the sorted slice can be shared by every AllActions() call.
+	snap.allActionsSorted = make([]*CompiledAction, 0, len(snap.actions))
+	for _, a := range snap.actions {
+		snap.allActionsSorted = append(snap.allActionsSorted, a)
+	}
+	sort.Slice(snap.allActionsSorted, func(i, j int) bool {
+		a, b := snap.allActionsSorted[i], snap.allActionsSorted[j]
+		if a.Bucket != b.Bucket {
+			return a.Bucket < b.Bucket
+		}
+		if c := bytes.Compare(a.Key.RuleHash[:], b.Key.RuleHash[:]); c != 0 {
+			return c < 0
+		}
+		return a.Key.ActionKind < b.Key.ActionKind
+	})
 
 	e.current.Store(snap)
 	return snap

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -1,0 +1,151 @@
+package engine
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// snapshotIDSeq is the cluster-wide monotonic ID stamped on every Compile.
+// One process-wide counter is sufficient: callers that need cross-process
+// monotonicity stamp pending writes with the snapshot id when they record
+// the entry; the entry stays valid as long as its ActionKey survives, not
+// as long as the snapshot id matches.
+var snapshotIDSeq atomic.Uint64
+
+// CompileInput is one (bucket, rule) pair the engine compiles. The caller
+// converts XML lifecycle config to []*s3lifecycle.Rule via
+// s3api.LifecycleToCanonical and groups by bucket.
+type CompileInput struct {
+	Bucket    string
+	Rules     []*s3lifecycle.Rule
+	Versioned bool // true if the bucket has versioning enabled
+}
+
+// PriorState is the durable per-action state the compiler reads to decide
+// whether a freshly-compiled action is bootstrap_complete. Missing keys are
+// treated as bootstrap_complete=false (new action, must run bootstrap).
+type PriorState struct {
+	BootstrapComplete bool
+	Mode              RuleMode
+}
+
+// CompileOptions tunes engine compilation. All fields have safe zero values.
+type CompileOptions struct {
+	// MetaLogRetention is the upper bound on how far back the meta-log
+	// reader can replay events. Used by the retention mode gate to
+	// downgrade actions whose event-log horizon exceeds retention.
+	// A zero value means "unbounded retention" — the gate never trips
+	// (matches the SeaweedFS default deployment per Phase 0 verification).
+	MetaLogRetention time.Duration
+
+	// BootstrapLookbackMin is the safety floor added to the retention gate:
+	// metaLogRetention < eventLogHorizon(rule, kind) + BootstrapLookbackMin
+	// promotes the action to scan_only. Default 5 * SmallDelay (~5 minutes).
+	BootstrapLookbackMin time.Duration
+
+	// PriorStates is the durable state map keyed by ActionKey. Used at
+	// compile time to decide engine activation per action.
+	PriorStates map[s3lifecycle.ActionKey]PriorState
+}
+
+// defaultBootstrapLookbackMin is the minimum extra slack the retention gate
+// requires beyond the rule's eventLogHorizon. Five SmallDelays gives a few
+// minutes for the reader to drain residual events at edge cases without
+// promoting an otherwise-healthy rule to scan_only.
+const defaultBootstrapLookbackMin = 5 * s3lifecycle.SmallDelay
+
+// Compile produces a fresh Snapshot from per-bucket rules and applies it to
+// the engine. Returns the new Snapshot.
+//
+// Each input rule expands into N CompiledActions via RuleActionKinds. Each
+// CompiledAction's mode is decided by decideMode (date kind -> SCAN_AT_DATE;
+// reader-driven kind whose horizon exceeds retention -> SCAN_ONLY; disabled
+// rule -> DISABLED; otherwise EVENT_DRIVEN provided bootstrap is complete).
+// Activation (engineState=active) requires both bootstrap_complete from
+// PriorStates and mode==EVENT_DRIVEN.
+func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
+	if opts.BootstrapLookbackMin == 0 {
+		opts.BootstrapLookbackMin = defaultBootstrapLookbackMin
+	}
+
+	snap := &Snapshot{
+		id:                  snapshotIDSeq.Add(1),
+		buckets:             make(map[string]*BucketIndex),
+		actions:             make(map[s3lifecycle.ActionKey]*CompiledAction),
+		originalDelayGroups: make(map[time.Duration][]s3lifecycle.ActionKey),
+		dateActions:         make(map[s3lifecycle.ActionKey]time.Time),
+	}
+
+	for _, in := range inputs {
+		bi := &BucketIndex{bucket: in.Bucket, versioned: in.Versioned}
+		snap.buckets[in.Bucket] = bi
+
+		for _, rule := range in.Rules {
+			ruleHash := s3lifecycle.RuleHash(rule)
+			for _, kind := range s3lifecycle.RuleActionKinds(rule) {
+				key := s3lifecycle.ActionKey{RuleHash: ruleHash, ActionKind: kind}
+				mode := decideMode(rule, kind, opts.MetaLogRetention, opts.BootstrapLookbackMin)
+				prior := opts.PriorStates[key]
+				active := prior.BootstrapComplete && mode == ModeEventDriven
+
+				ca := &CompiledAction{
+					Rule:               rule,
+					Bucket:             in.Bucket,
+					Key:                key,
+					Delay:              s3lifecycle.MinTriggerAge(rule, kind),
+					PredicateSensitive: rulePredicateSensitive(rule),
+					Mode:               mode,
+				}
+				if active {
+					ca.markActive()
+				}
+				snap.actions[key] = ca
+				bi.actionKeys = append(bi.actionKeys, key)
+
+				// Routing indexes by mode:
+				// - SCAN_AT_DATE: always indexed in dateActions so the
+				//   detector can schedule the bootstrap at rule.date.
+				//   Active flag is unused for this stream (no reader sweep).
+				// - EVENT_DRIVEN + active: indexed in originalDelayGroups
+				//   (and predicateActions when applicable) so the reader
+				//   sweeps it. The reader filters again on engineState
+				//   before dispatching, so subsequent markActive flips are
+				//   visible without recompile.
+				// - SCAN_ONLY / DISABLED / pending_bootstrap: not indexed;
+				//   handled by safety-scan tick or explicit operator action.
+				if mode == ModeScanAtDate {
+					snap.dateActions[key] = rule.ExpirationDate
+				}
+				if active {
+					if mode == ModeEventDriven && kind != s3lifecycle.ActionKindExpirationDate {
+						snap.originalDelayGroups[ca.Delay] = append(snap.originalDelayGroups[ca.Delay], key)
+						if ca.PredicateSensitive {
+							snap.predicateActions = append(snap.predicateActions, key)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	e.current.Store(snap)
+	return snap
+}
+
+// rulePredicateSensitive returns true if the rule's filter has any predicate
+// (tag or size) that can flip post-PUT. Prefix is fixed at write time so
+// it's not predicate-sensitive.
+func rulePredicateSensitive(rule *s3lifecycle.Rule) bool {
+	if rule == nil {
+		return false
+	}
+	if len(rule.FilterTags) > 0 {
+		return true
+	}
+	if rule.FilterSizeGreaterThan > 0 || rule.FilterSizeLessThan > 0 {
+		return true
+	}
+	return false
+}

--- a/weed/s3api/s3lifecycle/engine/compile.go
+++ b/weed/s3api/s3lifecycle/engine/compile.go
@@ -59,8 +59,17 @@ func (e *Engine) Compile(inputs []CompileInput, opts CompileOptions) *Snapshot {
 			ruleHash := s3lifecycle.RuleHash(rule)
 			for _, kind := range s3lifecycle.RuleActionKinds(rule) {
 				key := s3lifecycle.ActionKey{Bucket: in.Bucket, RuleHash: ruleHash, ActionKind: kind}
-				mode := decideMode(rule, kind, opts.MetaLogRetention, opts.BootstrapLookbackMin)
-				prior := opts.PriorStates[key]
+				// Durable PriorState.Mode wins when set: lag-fallback,
+				// operator pause, or persisted SCAN_ONLY must survive an
+				// engine rebuild rather than being silently re-promoted by
+				// decideMode. Fall through to decideMode for new actions
+				// (no prior) and for legacy entries that were persisted
+				// before Mode was a field (zero value).
+				prior, hasPrior := opts.PriorStates[key]
+				mode := prior.Mode
+				if !hasPrior || mode == ModeUnspecified {
+					mode = decideMode(rule, kind, opts.MetaLogRetention, opts.BootstrapLookbackMin)
+				}
 				active := prior.BootstrapComplete && mode == ModeEventDriven
 
 				ca := &CompiledAction{

--- a/weed/s3api/s3lifecycle/engine/engine.go
+++ b/weed/s3api/s3lifecycle/engine/engine.go
@@ -11,8 +11,6 @@
 package engine
 
 import (
-	"bytes"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -46,6 +44,11 @@ type Snapshot struct {
 	id      uint64
 	buckets map[string]*BucketIndex
 	actions map[s3lifecycle.ActionKey]*CompiledAction
+
+	// Pre-sorted view of `actions` in (bucket, rule_hash, action_kind)
+	// order. Built once during Compile so AllActions() doesn't re-sort
+	// on every call. The slice is immutable; callers must not mutate.
+	allActionsSorted []*CompiledAction
 
 	// Routing indexes (subset of `actions`). Only ActionKeys whose
 	// engineState == EngineStateActive may be added here at compile time;
@@ -124,22 +127,10 @@ func (s *Snapshot) Action(key s3lifecycle.ActionKey) *CompiledAction {
 
 // AllActions returns every CompiledAction in deterministic order (by bucket,
 // rule_hash, action_kind). Used by the bootstrap walker, which evaluates
-// every applicable action per object.
+// every applicable action per object. The returned slice is the snapshot's
+// pre-sorted view; callers must not mutate it.
 func (s *Snapshot) AllActions() []*CompiledAction {
-	out := make([]*CompiledAction, 0, len(s.actions))
-	for _, a := range s.actions {
-		out = append(out, a)
-	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Bucket != out[j].Bucket {
-			return out[i].Bucket < out[j].Bucket
-		}
-		if c := bytes.Compare(out[i].Key.RuleHash[:], out[j].Key.RuleHash[:]); c != 0 {
-			return c < 0
-		}
-		return out[i].Key.ActionKind < out[j].Key.ActionKind
-	})
-	return out
+	return s.allActionsSorted
 }
 
 // OriginalDelayGroups returns the delay -> ActionKey mapping the reader

--- a/weed/s3api/s3lifecycle/engine/engine.go
+++ b/weed/s3api/s3lifecycle/engine/engine.go
@@ -1,13 +1,7 @@
 // Package engine compiles per-bucket lifecycle rules into a CompiledAction
-// snapshot the worker drives. One XML <Rule> expands into N compiled actions
-// (one per populated action sub-element); each is keyed by
-// s3lifecycle.ActionKey{rule_hash, action_kind} and carries its own delay
-// group, mode, and predicate-sensitivity flag.
-//
-// The engine itself is a small wrapper around an immutable Snapshot pointer
-// that callers atomically swap when policy changes. A rebuild produces a
-// fresh Snapshot and a new snapshot_id; existing readers continue to see
-// the previous snapshot for the duration of their evaluation pass.
+// snapshot. One XML <Rule> expands into N compiled actions (one per populated
+// action sub-element); each is keyed by ActionKey{bucket, rule_hash,
+// action_kind} so sibling actions schedule and degrade independently.
 package engine
 
 import (
@@ -17,127 +11,88 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
-// Engine is the runtime handle. The current Snapshot is loaded atomically;
-// callers grab a pointer and use it for the rest of their evaluation pass.
 type Engine struct {
 	current atomic.Pointer[Snapshot]
 }
 
-// New returns an empty engine; callers must Compile before use.
 func New() *Engine {
 	e := &Engine{}
 	e.current.Store(&Snapshot{actions: map[s3lifecycle.ActionKey]*CompiledAction{}})
 	return e
 }
 
-// Snapshot returns the currently active snapshot.
 func (e *Engine) Snapshot() *Snapshot { return e.current.Load() }
 
-// Snapshot is an immutable view of the compiled engine state.
-//
 // Snapshot fields are append-only after construction except for
 // CompiledAction.engineState, which transitions inactive -> active on
 // markActive. The transition is atomic per action and visible to subsequent
-// reader passes; existing in-flight passes see the value as of their initial
-// load.
+// reader passes; in-flight passes see the value as of their initial load.
 type Snapshot struct {
 	id      uint64
 	buckets map[string]*BucketIndex
 	actions map[s3lifecycle.ActionKey]*CompiledAction
 
-	// Pre-sorted view of `actions` in (bucket, rule_hash, action_kind)
-	// order. Built once during Compile so AllActions() doesn't re-sort
-	// on every call. The slice is immutable; callers must not mutate.
+	// Pre-sorted view of `actions` so AllActions doesn't re-sort per call.
 	allActionsSorted []*CompiledAction
 
-	// Routing indexes (subset of `actions`). Only ActionKeys whose
-	// engineState == EngineStateActive may be added here at compile time;
-	// the reader filters again on engineState before invoking handlers, so
-	// markActive transitions become visible as soon as the engine flips
-	// the bit (no recompile needed for steady-state activation).
+	// Routing indexes: only ACTIVE ActionKeys are added at compile time.
+	// The reader filters again on engineState before dispatching, so
+	// markActive flips become visible without a recompile.
 	originalDelayGroups map[time.Duration][]s3lifecycle.ActionKey
 	predicateActions    []s3lifecycle.ActionKey
 	dateActions         map[s3lifecycle.ActionKey]time.Time
 }
 
-// SnapshotID is the monotonic identifier bumped on every Compile. Worker
-// callers stamp pending writes with this id; a pending entry whose
-// snapshot_id is older than the engine's current id is still valid as long
-// as its ActionKey survives in the new snapshot.
 func (s *Snapshot) SnapshotID() uint64 { return s.id }
 
-// BucketIndex carries per-bucket routing data. The optional prefixTrie /
-// tagIndex are present in the design; this implementation starts with a
-// linear scan over the bucket's ActionKeys and adds the optimizations as
-// the engine actually carries enough rules to need them.
 type BucketIndex struct {
 	bucket     string
 	versioned  bool
 	actionKeys []s3lifecycle.ActionKey
 }
 
-// CompiledAction is one (rule, action_kind) pair the engine evaluates. A
-// single XML <Rule> with N populated action sub-elements compiles to N
-// CompiledActions sharing the same Rule and rule_hash but differing in
-// ActionKind, Delay, Mode, and engineState.
 type CompiledAction struct {
-	Rule               *s3lifecycle.Rule // shared with sibling actions of the same XML rule
+	Rule               *s3lifecycle.Rule
 	Bucket             string
-	Key                s3lifecycle.ActionKey // {rule_hash, action_kind}
-	Delay              time.Duration         // per-kind delay group; 0 for date / count / immediate kinds
-	PredicateSensitive bool                  // true when the rule's filter has tag/size predicates
-	Mode               RuleMode              // mirrored from durable state at compile time
-	engineState        atomic.Uint32         // EngineStateActive / EngineStateInactive
+	Key                s3lifecycle.ActionKey
+	Delay              time.Duration
+	PredicateSensitive bool
+	Mode               RuleMode
+	engineState        atomic.Uint32
 }
 
-// EngineState atom values. Held as uint32 so atomic ops work without
-// requiring a wrapper type.
 const (
 	engineStateInactive uint32 = 0
 	engineStateActive   uint32 = 1
 )
 
-// IsActive returns true if this CompiledAction has been markActive'd by
-// bootstrap completion (or compiled with an already-bootstrap_complete
-// state). The reader/router must filter on this before dispatching.
 func (a *CompiledAction) IsActive() bool {
 	return a.engineState.Load() == engineStateActive
 }
 
-// markActive flips this action to active. Idempotent and safe to call
-// concurrently with reader passes.
 func (a *CompiledAction) markActive() {
 	a.engineState.Store(engineStateActive)
 }
 
-// MarkActive transitions an ActionKey to active, mirroring the in-memory
-// hint after the durable bootstrap_complete + mode write commits. No-op if
-// the key isn't in the snapshot (e.g. a stale callback from a prior
-// snapshot).
+// MarkActive mirrors the in-memory hint after a durable bootstrap_complete
+// + mode write commits. No-op if the key isn't in the snapshot.
 func (s *Snapshot) MarkActive(key s3lifecycle.ActionKey) {
 	if a, ok := s.actions[key]; ok {
 		a.markActive()
 	}
 }
 
-// Action returns the CompiledAction for a key, or nil.
 func (s *Snapshot) Action(key s3lifecycle.ActionKey) *CompiledAction {
 	return s.actions[key]
 }
 
-// AllActions returns every CompiledAction in deterministic order (by bucket,
-// rule_hash, action_kind). Used by the bootstrap walker, which evaluates
-// every applicable action per object. The returned slice is the snapshot's
-// pre-sorted view; callers must not mutate it.
+// AllActions returns the snapshot's pre-sorted view; callers must not mutate.
 func (s *Snapshot) AllActions() []*CompiledAction {
 	return s.allActionsSorted
 }
 
-// OriginalDelayGroups returns the delay -> ActionKey mapping the reader
-// uses to schedule one sweep per delay group across all event-driven
-// age-origin actions. Returns a defensive copy: the snapshot's internal
-// indexes are immutable per the contract above; callers may freely
-// mutate the returned map / slices without affecting other readers.
+// OriginalDelayGroups / PredicateActions / DateActions return defensive copies
+// so external callers can't corrupt routing state.
 func (s *Snapshot) OriginalDelayGroups() map[time.Duration][]s3lifecycle.ActionKey {
 	out := make(map[time.Duration][]s3lifecycle.ActionKey, len(s.originalDelayGroups))
 	for d, keys := range s.originalDelayGroups {
@@ -148,18 +103,12 @@ func (s *Snapshot) OriginalDelayGroups() map[time.Duration][]s3lifecycle.ActionK
 	return out
 }
 
-// PredicateActions returns ActionKeys with tag/size predicate sensitivity.
-// The reader sweeps these once per pass against predicate-change events.
-// Defensive copy — see OriginalDelayGroups.
 func (s *Snapshot) PredicateActions() []s3lifecycle.ActionKey {
 	out := make([]s3lifecycle.ActionKey, len(s.predicateActions))
 	copy(out, s.predicateActions)
 	return out
 }
 
-// DateActions returns ActionKey -> date for SCAN_AT_DATE actions. The
-// detector schedules a single bootstrap at each date. Defensive copy —
-// see OriginalDelayGroups.
 func (s *Snapshot) DateActions() map[s3lifecycle.ActionKey]time.Time {
 	out := make(map[s3lifecycle.ActionKey]time.Time, len(s.dateActions))
 	for k, v := range s.dateActions {
@@ -168,8 +117,6 @@ func (s *Snapshot) DateActions() map[s3lifecycle.ActionKey]time.Time {
 	return out
 }
 
-// BucketVersioned reports whether the bucket is configured with versioning
-// (set at compile time from the bucket index).
 func (s *Snapshot) BucketVersioned(bucket string) bool {
 	if bi, ok := s.buckets[bucket]; ok {
 		return bi.versioned

--- a/weed/s3api/s3lifecycle/engine/engine.go
+++ b/weed/s3api/s3lifecycle/engine/engine.go
@@ -23,22 +23,17 @@ func New() *Engine {
 
 func (e *Engine) Snapshot() *Snapshot { return e.current.Load() }
 
-// Snapshot fields are append-only after construction except for
-// CompiledAction.engineState, which transitions inactive -> active on
-// markActive. The transition is atomic per action and visible to subsequent
-// reader passes; in-flight passes see the value as of their initial load.
+// Snapshot fields are append-only after Compile except CompiledAction.engineState,
+// which transitions inactive -> active atomically via markActive.
 type Snapshot struct {
 	id      uint64
 	buckets map[string]*BucketIndex
 	actions map[s3lifecycle.ActionKey]*CompiledAction
 
-	// Pre-sorted view of `actions` so AllActions doesn't re-sort per call.
 	allActionsSorted []*CompiledAction
 
-	// Routing indexes hold every ActionKey by mode (EVENT_DRIVEN /
-	// SCAN_AT_DATE) regardless of its current activation. The reader
-	// filters on IsActive() at dispatch time, so a MarkActive flip
-	// becomes routable without a recompile.
+	// Routing indexes hold every ActionKey by mode regardless of activation;
+	// dispatch filters on IsActive().
 	originalDelayGroups map[time.Duration][]s3lifecycle.ActionKey
 	predicateActions    []s3lifecycle.ActionKey
 	dateActions         map[s3lifecycle.ActionKey]time.Time
@@ -76,7 +71,7 @@ func (a *CompiledAction) markActive() {
 }
 
 // MarkActive mirrors the in-memory hint after a durable bootstrap_complete
-// + mode write commits. No-op if the key isn't in the snapshot.
+// write. No-op if the key isn't in the snapshot.
 func (s *Snapshot) MarkActive(key s3lifecycle.ActionKey) {
 	if a, ok := s.actions[key]; ok {
 		a.markActive()
@@ -87,13 +82,12 @@ func (s *Snapshot) Action(key s3lifecycle.ActionKey) *CompiledAction {
 	return s.actions[key]
 }
 
-// AllActions returns the snapshot's pre-sorted view; callers must not mutate.
+// AllActions: caller must not mutate.
 func (s *Snapshot) AllActions() []*CompiledAction {
 	return s.allActionsSorted
 }
 
-// OriginalDelayGroups / PredicateActions / DateActions return defensive copies
-// so external callers can't corrupt routing state.
+// OriginalDelayGroups / PredicateActions / DateActions return defensive copies.
 func (s *Snapshot) OriginalDelayGroups() map[time.Duration][]s3lifecycle.ActionKey {
 	out := make(map[time.Duration][]s3lifecycle.ActionKey, len(s.originalDelayGroups))
 	for d, keys := range s.originalDelayGroups {

--- a/weed/s3api/s3lifecycle/engine/engine.go
+++ b/weed/s3api/s3lifecycle/engine/engine.go
@@ -35,9 +35,10 @@ type Snapshot struct {
 	// Pre-sorted view of `actions` so AllActions doesn't re-sort per call.
 	allActionsSorted []*CompiledAction
 
-	// Routing indexes: only ACTIVE ActionKeys are added at compile time.
-	// The reader filters again on engineState before dispatching, so
-	// markActive flips become visible without a recompile.
+	// Routing indexes hold every ActionKey by mode (EVENT_DRIVEN /
+	// SCAN_AT_DATE) regardless of its current activation. The reader
+	// filters on IsActive() at dispatch time, so a MarkActive flip
+	// becomes routable without a recompile.
 	originalDelayGroups map[time.Duration][]s3lifecycle.ActionKey
 	predicateActions    []s3lifecycle.ActionKey
 	dateActions         map[s3lifecycle.ActionKey]time.Time

--- a/weed/s3api/s3lifecycle/engine/engine.go
+++ b/weed/s3api/s3lifecycle/engine/engine.go
@@ -144,21 +144,37 @@ func (s *Snapshot) AllActions() []*CompiledAction {
 
 // OriginalDelayGroups returns the delay -> ActionKey mapping the reader
 // uses to schedule one sweep per delay group across all event-driven
-// age-origin actions.
+// age-origin actions. Returns a defensive copy: the snapshot's internal
+// indexes are immutable per the contract above; callers may freely
+// mutate the returned map / slices without affecting other readers.
 func (s *Snapshot) OriginalDelayGroups() map[time.Duration][]s3lifecycle.ActionKey {
-	return s.originalDelayGroups
+	out := make(map[time.Duration][]s3lifecycle.ActionKey, len(s.originalDelayGroups))
+	for d, keys := range s.originalDelayGroups {
+		copied := make([]s3lifecycle.ActionKey, len(keys))
+		copy(copied, keys)
+		out[d] = copied
+	}
+	return out
 }
 
 // PredicateActions returns ActionKeys with tag/size predicate sensitivity.
 // The reader sweeps these once per pass against predicate-change events.
+// Defensive copy — see OriginalDelayGroups.
 func (s *Snapshot) PredicateActions() []s3lifecycle.ActionKey {
-	return s.predicateActions
+	out := make([]s3lifecycle.ActionKey, len(s.predicateActions))
+	copy(out, s.predicateActions)
+	return out
 }
 
 // DateActions returns ActionKey -> date for SCAN_AT_DATE actions. The
-// detector schedules a single bootstrap at each date.
+// detector schedules a single bootstrap at each date. Defensive copy —
+// see OriginalDelayGroups.
 func (s *Snapshot) DateActions() map[s3lifecycle.ActionKey]time.Time {
-	return s.dateActions
+	out := make(map[s3lifecycle.ActionKey]time.Time, len(s.dateActions))
+	for k, v := range s.dateActions {
+		out[k] = v
+	}
+	return out
 }
 
 // BucketVersioned reports whether the bucket is configured with versioning

--- a/weed/s3api/s3lifecycle/engine/engine.go
+++ b/weed/s3api/s3lifecycle/engine/engine.go
@@ -1,0 +1,171 @@
+// Package engine compiles per-bucket lifecycle rules into a CompiledAction
+// snapshot the worker drives. One XML <Rule> expands into N compiled actions
+// (one per populated action sub-element); each is keyed by
+// s3lifecycle.ActionKey{rule_hash, action_kind} and carries its own delay
+// group, mode, and predicate-sensitivity flag.
+//
+// The engine itself is a small wrapper around an immutable Snapshot pointer
+// that callers atomically swap when policy changes. A rebuild produces a
+// fresh Snapshot and a new snapshot_id; existing readers continue to see
+// the previous snapshot for the duration of their evaluation pass.
+package engine
+
+import (
+	"bytes"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// Engine is the runtime handle. The current Snapshot is loaded atomically;
+// callers grab a pointer and use it for the rest of their evaluation pass.
+type Engine struct {
+	current atomic.Pointer[Snapshot]
+}
+
+// New returns an empty engine; callers must Compile before use.
+func New() *Engine {
+	e := &Engine{}
+	e.current.Store(&Snapshot{actions: map[s3lifecycle.ActionKey]*CompiledAction{}})
+	return e
+}
+
+// Snapshot returns the currently active snapshot.
+func (e *Engine) Snapshot() *Snapshot { return e.current.Load() }
+
+// Snapshot is an immutable view of the compiled engine state.
+//
+// Snapshot fields are append-only after construction except for
+// CompiledAction.engineState, which transitions inactive -> active on
+// markActive. The transition is atomic per action and visible to subsequent
+// reader passes; existing in-flight passes see the value as of their initial
+// load.
+type Snapshot struct {
+	id      uint64
+	buckets map[string]*BucketIndex
+	actions map[s3lifecycle.ActionKey]*CompiledAction
+
+	// Routing indexes (subset of `actions`). Only ActionKeys whose
+	// engineState == EngineStateActive may be added here at compile time;
+	// the reader filters again on engineState before invoking handlers, so
+	// markActive transitions become visible as soon as the engine flips
+	// the bit (no recompile needed for steady-state activation).
+	originalDelayGroups map[time.Duration][]s3lifecycle.ActionKey
+	predicateActions    []s3lifecycle.ActionKey
+	dateActions         map[s3lifecycle.ActionKey]time.Time
+}
+
+// SnapshotID is the monotonic identifier bumped on every Compile. Worker
+// callers stamp pending writes with this id; a pending entry whose
+// snapshot_id is older than the engine's current id is still valid as long
+// as its ActionKey survives in the new snapshot.
+func (s *Snapshot) SnapshotID() uint64 { return s.id }
+
+// BucketIndex carries per-bucket routing data. The optional prefixTrie /
+// tagIndex are present in the design; this implementation starts with a
+// linear scan over the bucket's ActionKeys and adds the optimizations as
+// the engine actually carries enough rules to need them.
+type BucketIndex struct {
+	bucket     string
+	versioned  bool
+	actionKeys []s3lifecycle.ActionKey
+}
+
+// CompiledAction is one (rule, action_kind) pair the engine evaluates. A
+// single XML <Rule> with N populated action sub-elements compiles to N
+// CompiledActions sharing the same Rule and rule_hash but differing in
+// ActionKind, Delay, Mode, and engineState.
+type CompiledAction struct {
+	Rule               *s3lifecycle.Rule // shared with sibling actions of the same XML rule
+	Bucket             string
+	Key                s3lifecycle.ActionKey // {rule_hash, action_kind}
+	Delay              time.Duration         // per-kind delay group; 0 for date / count / immediate kinds
+	PredicateSensitive bool                  // true when the rule's filter has tag/size predicates
+	Mode               RuleMode              // mirrored from durable state at compile time
+	engineState        atomic.Uint32         // EngineStateActive / EngineStateInactive
+}
+
+// EngineState atom values. Held as uint32 so atomic ops work without
+// requiring a wrapper type.
+const (
+	engineStateInactive uint32 = 0
+	engineStateActive   uint32 = 1
+)
+
+// IsActive returns true if this CompiledAction has been markActive'd by
+// bootstrap completion (or compiled with an already-bootstrap_complete
+// state). The reader/router must filter on this before dispatching.
+func (a *CompiledAction) IsActive() bool {
+	return a.engineState.Load() == engineStateActive
+}
+
+// markActive flips this action to active. Idempotent and safe to call
+// concurrently with reader passes.
+func (a *CompiledAction) markActive() {
+	a.engineState.Store(engineStateActive)
+}
+
+// MarkActive transitions an ActionKey to active, mirroring the in-memory
+// hint after the durable bootstrap_complete + mode write commits. No-op if
+// the key isn't in the snapshot (e.g. a stale callback from a prior
+// snapshot).
+func (s *Snapshot) MarkActive(key s3lifecycle.ActionKey) {
+	if a, ok := s.actions[key]; ok {
+		a.markActive()
+	}
+}
+
+// Action returns the CompiledAction for a key, or nil.
+func (s *Snapshot) Action(key s3lifecycle.ActionKey) *CompiledAction {
+	return s.actions[key]
+}
+
+// AllActions returns every CompiledAction in deterministic order (by bucket,
+// rule_hash, action_kind). Used by the bootstrap walker, which evaluates
+// every applicable action per object.
+func (s *Snapshot) AllActions() []*CompiledAction {
+	out := make([]*CompiledAction, 0, len(s.actions))
+	for _, a := range s.actions {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Bucket != out[j].Bucket {
+			return out[i].Bucket < out[j].Bucket
+		}
+		if c := bytes.Compare(out[i].Key.RuleHash[:], out[j].Key.RuleHash[:]); c != 0 {
+			return c < 0
+		}
+		return out[i].Key.ActionKind < out[j].Key.ActionKind
+	})
+	return out
+}
+
+// OriginalDelayGroups returns the delay -> ActionKey mapping the reader
+// uses to schedule one sweep per delay group across all event-driven
+// age-origin actions.
+func (s *Snapshot) OriginalDelayGroups() map[time.Duration][]s3lifecycle.ActionKey {
+	return s.originalDelayGroups
+}
+
+// PredicateActions returns ActionKeys with tag/size predicate sensitivity.
+// The reader sweeps these once per pass against predicate-change events.
+func (s *Snapshot) PredicateActions() []s3lifecycle.ActionKey {
+	return s.predicateActions
+}
+
+// DateActions returns ActionKey -> date for SCAN_AT_DATE actions. The
+// detector schedules a single bootstrap at each date.
+func (s *Snapshot) DateActions() map[s3lifecycle.ActionKey]time.Time {
+	return s.dateActions
+}
+
+// BucketVersioned reports whether the bucket is configured with versioning
+// (set at compile time from the bucket index).
+func (s *Snapshot) BucketVersioned(bucket string) bool {
+	if bi, ok := s.buckets[bucket]; ok {
+		return bi.versioned
+	}
+	return false
+}

--- a/weed/s3api/s3lifecycle/engine/engine_test.go
+++ b/weed/s3api/s3lifecycle/engine/engine_test.go
@@ -1,0 +1,250 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+func ruleExpDays(id, prefix string, days int) *s3lifecycle.Rule {
+	return &s3lifecycle.Rule{
+		ID:             id,
+		Status:         s3lifecycle.StatusEnabled,
+		Prefix:         prefix,
+		ExpirationDays: days,
+	}
+}
+
+func TestCompile_SingleRuleSingleAction(t *testing.T) {
+	e := New()
+	rule := ruleExpDays("r1", "logs/", 30)
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{
+		PriorStates: map[s3lifecycle.ActionKey]PriorState{
+			{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}: {
+				BootstrapComplete: true,
+			},
+		},
+	})
+	if got := len(snap.actions); got != 1 {
+		t.Fatalf("want 1 action, got %d", got)
+	}
+	for _, a := range snap.actions {
+		if !a.IsActive() {
+			t.Fatalf("bootstrap_complete + EVENT_DRIVEN should activate, got mode=%v", a.Mode)
+		}
+		if a.Mode != ModeEventDriven {
+			t.Fatalf("want EVENT_DRIVEN, got %v", a.Mode)
+		}
+		if a.Delay != 30*24*time.Hour {
+			t.Fatalf("want 30d delay, got %v", a.Delay)
+		}
+	}
+}
+
+func TestCompile_MultiAction_SiblingsHaveOwnEntries(t *testing.T) {
+	// One XML rule with three actions -> three CompiledActions, three
+	// distinct ActionKeys, three independent delay group memberships.
+	rule := &s3lifecycle.Rule{
+		ID:                              "multi",
+		Status:                          s3lifecycle.StatusEnabled,
+		Prefix:                          "data/",
+		ExpirationDays:                  90,
+		NoncurrentVersionExpirationDays: 30,
+		AbortMPUDaysAfterInitiation:     7,
+	}
+	rh := s3lifecycle.RuleHash(rule)
+	prior := map[s3lifecycle.ActionKey]PriorState{}
+	for _, k := range s3lifecycle.RuleActionKinds(rule) {
+		prior[s3lifecycle.ActionKey{RuleHash: rh, ActionKind: k}] = PriorState{BootstrapComplete: true}
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: prior})
+
+	if got := len(snap.actions); got != 3 {
+		t.Fatalf("want 3 actions, got %d", got)
+	}
+	wantDelays := map[time.Duration]bool{
+		90 * 24 * time.Hour: true, // ExpirationDays
+		30 * 24 * time.Hour: true, // NoncurrentDays
+		7 * 24 * time.Hour:  true, // AbortMPU
+	}
+	for delay, keys := range snap.originalDelayGroups {
+		if !wantDelays[delay] {
+			t.Fatalf("unexpected delay group %v", delay)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("delay %v should hold exactly its own action, got %d", delay, len(keys))
+		}
+	}
+	if len(snap.originalDelayGroups) != 3 {
+		t.Fatalf("want 3 delay groups, got %d", len(snap.originalDelayGroups))
+	}
+}
+
+func TestCompile_BootstrapPendingExcludedFromIndexes(t *testing.T) {
+	// Without prior bootstrap_complete=true, the action is pending_bootstrap;
+	// it must NOT appear in originalDelayGroups / predicateActions /
+	// dateActions, and IsActive() must be false.
+	rule := ruleExpDays("r1", "logs/", 30)
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{})
+
+	for _, a := range snap.actions {
+		if a.IsActive() {
+			t.Fatalf("pending_bootstrap action should not be active")
+		}
+	}
+	if len(snap.originalDelayGroups) != 0 {
+		t.Fatalf("delay groups should be empty pre-bootstrap, got %v", snap.originalDelayGroups)
+	}
+}
+
+func TestCompile_RetentionGate(t *testing.T) {
+	// A 90d ExpirationDays rule with 30d retention should land in scan_only.
+	// A 7d rule (under retention - lookback) stays event_driven.
+	long := ruleExpDays("long", "x/", 90)
+	short := ruleExpDays("short", "y/", 1)
+	rules := []*s3lifecycle.Rule{long, short}
+	prior := map[s3lifecycle.ActionKey]PriorState{}
+	for _, r := range rules {
+		k := s3lifecycle.ActionKey{RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays}
+		prior[k] = PriorState{BootstrapComplete: true}
+	}
+
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: rules}}, CompileOptions{
+		MetaLogRetention:     30 * 24 * time.Hour,
+		BootstrapLookbackMin: 5 * time.Minute,
+		PriorStates:          prior,
+	})
+
+	for _, a := range snap.actions {
+		if a.Rule.ID == "long" && a.Mode != ModeScanOnly {
+			t.Fatalf("90d rule under 30d retention should be scan_only, got %v", a.Mode)
+		}
+		if a.Rule.ID == "short" && a.Mode != ModeEventDriven {
+			t.Fatalf("1d rule should be event_driven, got %v", a.Mode)
+		}
+	}
+}
+
+func TestCompile_RetentionUnboundedNeverGates(t *testing.T) {
+	// MetaLogRetention=0 means unbounded (default deployment); even a 100y
+	// rule should stay event_driven.
+	rule := ruleExpDays("decade", "x/", 36500)
+	prior := map[s3lifecycle.ActionKey]PriorState{
+		{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}: {BootstrapComplete: true},
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: prior})
+	for _, a := range snap.actions {
+		if a.Mode != ModeEventDriven {
+			t.Fatalf("unbounded retention should keep event_driven, got %v", a.Mode)
+		}
+	}
+}
+
+func TestCompile_SiblingsDegradeIndependently(t *testing.T) {
+	// 90d ExpirationDays + 7d AbortMPU under 30d retention: ExpirationDays
+	// degrades to scan_only, AbortMPU stays event_driven. The whole point
+	// of per-action keying.
+	rule := &s3lifecycle.Rule{
+		ID:                          "mixed",
+		Status:                      s3lifecycle.StatusEnabled,
+		Prefix:                      "x/",
+		ExpirationDays:              90,
+		AbortMPUDaysAfterInitiation: 7,
+	}
+	rh := s3lifecycle.RuleHash(rule)
+	prior := map[s3lifecycle.ActionKey]PriorState{
+		{RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}: {BootstrapComplete: true},
+		{RuleHash: rh, ActionKind: s3lifecycle.ActionKindAbortMPU}:       {BootstrapComplete: true},
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{
+		MetaLogRetention:     30 * 24 * time.Hour,
+		BootstrapLookbackMin: 5 * time.Minute,
+		PriorStates:          prior,
+	})
+	expDaysKey := s3lifecycle.ActionKey{RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}
+	mpuKey := s3lifecycle.ActionKey{RuleHash: rh, ActionKind: s3lifecycle.ActionKindAbortMPU}
+	if snap.actions[expDaysKey].Mode != ModeScanOnly {
+		t.Fatalf("ExpirationDays should be scan_only under 30d retention")
+	}
+	if snap.actions[mpuKey].Mode != ModeEventDriven {
+		t.Fatalf("AbortMPU should stay event_driven (sibling degrades independently)")
+	}
+}
+
+func TestCompile_ExpirationDateScansAtDate(t *testing.T) {
+	date := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+	rule := &s3lifecycle.Rule{
+		ID:             "d",
+		Status:         s3lifecycle.StatusEnabled,
+		Prefix:         "x/",
+		ExpirationDate: date,
+	}
+	prior := map[s3lifecycle.ActionKey]PriorState{
+		{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDate}: {BootstrapComplete: true},
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: prior})
+	if len(snap.dateActions) != 1 {
+		t.Fatalf("want 1 date action, got %d", len(snap.dateActions))
+	}
+	for _, d := range snap.dateActions {
+		if !d.Equal(date) {
+			t.Fatalf("date want %v, got %v", date, d)
+		}
+	}
+}
+
+func TestCompile_DisabledRuleNeverActivates(t *testing.T) {
+	rule := ruleExpDays("d", "x/", 30)
+	rule.Status = s3lifecycle.StatusDisabled
+	prior := map[s3lifecycle.ActionKey]PriorState{
+		{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}: {BootstrapComplete: true},
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: prior})
+	for _, a := range snap.actions {
+		if a.Mode != ModeDisabled || a.IsActive() {
+			t.Fatalf("disabled rule must be ModeDisabled and inactive")
+		}
+	}
+}
+
+func TestSnapshot_MarkActiveFlipsRoutingFilter(t *testing.T) {
+	rule := ruleExpDays("r", "x/", 30)
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{})
+	key := s3lifecycle.ActionKey{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}
+
+	if snap.actions[key].IsActive() {
+		t.Fatalf("should start inactive")
+	}
+	snap.MarkActive(key)
+	if !snap.actions[key].IsActive() {
+		t.Fatalf("MarkActive should flip the bit")
+	}
+	// MarkActive on a missing key is a no-op (stale callback after rebuild).
+	snap.MarkActive(s3lifecycle.ActionKey{})
+}
+
+func TestEngine_SnapshotAtomicSwap(t *testing.T) {
+	e := New()
+	r1 := ruleExpDays("r1", "a/", 1)
+	snap1 := e.Compile([]CompileInput{{Bucket: "b", Rules: []*s3lifecycle.Rule{r1}}}, CompileOptions{})
+	if snap1.SnapshotID() == 0 {
+		t.Fatalf("snapshot id should be > 0")
+	}
+	r2 := ruleExpDays("r2", "b/", 2)
+	snap2 := e.Compile([]CompileInput{{Bucket: "b", Rules: []*s3lifecycle.Rule{r2}}}, CompileOptions{})
+	if snap2.SnapshotID() <= snap1.SnapshotID() {
+		t.Fatalf("snapshot id should be monotonic")
+	}
+	if e.Snapshot() != snap2 {
+		t.Fatalf("Engine.Snapshot should return the latest")
+	}
+}

--- a/weed/s3api/s3lifecycle/engine/engine_test.go
+++ b/weed/s3api/s3lifecycle/engine/engine_test.go
@@ -82,10 +82,11 @@ func TestCompile_MultiAction_SiblingsHaveOwnEntries(t *testing.T) {
 	}
 }
 
-func TestCompile_BootstrapPendingExcludedFromIndexes(t *testing.T) {
-	// Without prior bootstrap_complete=true, the action is pending_bootstrap;
-	// it must NOT appear in originalDelayGroups / predicateActions /
-	// dateActions, and IsActive() must be false.
+func TestCompile_BootstrapPendingIndexedButInactive(t *testing.T) {
+	// Without prior bootstrap_complete=true the action is pending_bootstrap.
+	// It IS indexed in originalDelayGroups (so a later MarkActive flip is
+	// routable without recompile), but IsActive() reads false so the
+	// reader's IsActive-filter skips dispatch.
 	rule := ruleExpDays("r1", "logs/", 30)
 	e := New()
 	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{})
@@ -95,8 +96,8 @@ func TestCompile_BootstrapPendingExcludedFromIndexes(t *testing.T) {
 			t.Fatalf("pending_bootstrap action should not be active")
 		}
 	}
-	if len(snap.originalDelayGroups) != 0 {
-		t.Fatalf("delay groups should be empty pre-bootstrap, got %v", snap.originalDelayGroups)
+	if len(snap.originalDelayGroups) != 1 {
+		t.Fatalf("EVENT_DRIVEN action should be indexed even when inactive, got %v", snap.originalDelayGroups)
 	}
 }
 

--- a/weed/s3api/s3lifecycle/engine/engine_test.go
+++ b/weed/s3api/s3lifecycle/engine/engine_test.go
@@ -177,6 +177,36 @@ func TestCompile_SiblingsDegradeIndependently(t *testing.T) {
 	}
 }
 
+func TestCompile_PriorModePreservedOverDecideMode(t *testing.T) {
+	// A durably-persisted SCAN_ONLY (or DISABLED, or any degraded mode)
+	// must not be re-promoted to EVENT_DRIVEN by decideMode on every
+	// Compile. Otherwise lag-fallback / operator pause / manual scan-only
+	// don't survive an engine rebuild.
+	rule := ruleExpDays("r", "x/", 30)
+	rh := s3lifecycle.RuleHash(rule)
+	key := s3lifecycle.ActionKey{Bucket: "b1", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}
+
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{
+		PriorStates: map[s3lifecycle.ActionKey]PriorState{
+			key: {BootstrapComplete: true, Mode: ModeScanOnly},
+		},
+	})
+	if snap.actions[key].Mode != ModeScanOnly {
+		t.Fatalf("durable Mode=ScanOnly should win over decideMode, got %v", snap.actions[key].Mode)
+	}
+	if snap.actions[key].IsActive() {
+		t.Fatalf("ScanOnly action must not be active")
+	}
+	// And: a missing PriorState falls through to decideMode as before.
+	rule2 := ruleExpDays("fresh", "x/", 30)
+	key2 := s3lifecycle.ActionKey{Bucket: "b1", RuleHash: s3lifecycle.RuleHash(rule2), ActionKind: s3lifecycle.ActionKindExpirationDays}
+	snap2 := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule2}}}, CompileOptions{})
+	if snap2.actions[key2].Mode != ModeEventDriven {
+		t.Fatalf("missing prior should fall through to decideMode (EventDriven), got %v", snap2.actions[key2].Mode)
+	}
+}
+
 func TestCompile_ExpirationDateScansAtDate(t *testing.T) {
 	date := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
 	rule := &s3lifecycle.Rule{

--- a/weed/s3api/s3lifecycle/engine/engine_test.go
+++ b/weed/s3api/s3lifecycle/engine/engine_test.go
@@ -21,7 +21,7 @@ func TestCompile_SingleRuleSingleAction(t *testing.T) {
 	rule := ruleExpDays("r1", "logs/", 30)
 	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{
 		PriorStates: map[s3lifecycle.ActionKey]PriorState{
-			{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}: {
+			{Bucket: "b1", RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}: {
 				BootstrapComplete: true,
 			},
 		},
@@ -56,7 +56,7 @@ func TestCompile_MultiAction_SiblingsHaveOwnEntries(t *testing.T) {
 	rh := s3lifecycle.RuleHash(rule)
 	prior := map[s3lifecycle.ActionKey]PriorState{}
 	for _, k := range s3lifecycle.RuleActionKinds(rule) {
-		prior[s3lifecycle.ActionKey{RuleHash: rh, ActionKind: k}] = PriorState{BootstrapComplete: true}
+		prior[s3lifecycle.ActionKey{Bucket: "b1", RuleHash: rh, ActionKind: k}] = PriorState{BootstrapComplete: true}
 	}
 	e := New()
 	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: prior})
@@ -108,7 +108,7 @@ func TestCompile_RetentionGate(t *testing.T) {
 	rules := []*s3lifecycle.Rule{long, short}
 	prior := map[s3lifecycle.ActionKey]PriorState{}
 	for _, r := range rules {
-		k := s3lifecycle.ActionKey{RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays}
+		k := s3lifecycle.ActionKey{Bucket: "b1", RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays}
 		prior[k] = PriorState{BootstrapComplete: true}
 	}
 
@@ -167,8 +167,8 @@ func TestCompile_SiblingsDegradeIndependently(t *testing.T) {
 		BootstrapLookbackMin: 5 * time.Minute,
 		PriorStates:          prior,
 	})
-	expDaysKey := s3lifecycle.ActionKey{RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}
-	mpuKey := s3lifecycle.ActionKey{RuleHash: rh, ActionKind: s3lifecycle.ActionKindAbortMPU}
+	expDaysKey := s3lifecycle.ActionKey{Bucket: "b1", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}
+	mpuKey := s3lifecycle.ActionKey{Bucket: "b1", RuleHash: rh, ActionKind: s3lifecycle.ActionKindAbortMPU}
 	if snap.actions[expDaysKey].Mode != ModeScanOnly {
 		t.Fatalf("ExpirationDays should be scan_only under 30d retention")
 	}
@@ -219,7 +219,7 @@ func TestSnapshot_MarkActiveFlipsRoutingFilter(t *testing.T) {
 	rule := ruleExpDays("r", "x/", 30)
 	e := New()
 	snap := e.Compile([]CompileInput{{Bucket: "b1", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{})
-	key := s3lifecycle.ActionKey{RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}
+	key := s3lifecycle.ActionKey{Bucket: "b1", RuleHash: s3lifecycle.RuleHash(rule), ActionKind: s3lifecycle.ActionKindExpirationDays}
 
 	if snap.actions[key].IsActive() {
 		t.Fatalf("should start inactive")
@@ -230,6 +230,35 @@ func TestSnapshot_MarkActiveFlipsRoutingFilter(t *testing.T) {
 	}
 	// MarkActive on a missing key is a no-op (stale callback after rebuild).
 	snap.MarkActive(s3lifecycle.ActionKey{})
+}
+
+func TestCompile_CrossBucketIdenticalRulesDoNotCollide(t *testing.T) {
+	// Two buckets carry rules whose XML — and therefore RuleHash — is
+	// identical. ActionKey must be bucket-scoped so the second bucket's
+	// CompiledAction does not overwrite the first's in snap.actions.
+	rule := ruleExpDays("shared", "x/", 30)
+	rh := s3lifecycle.RuleHash(rule)
+	prior := map[s3lifecycle.ActionKey]PriorState{
+		{Bucket: "alpha", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}: {BootstrapComplete: true},
+		{Bucket: "beta", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}:  {BootstrapComplete: true},
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{
+		{Bucket: "alpha", Rules: []*s3lifecycle.Rule{rule}},
+		{Bucket: "beta", Rules: []*s3lifecycle.Rule{rule}},
+	}, CompileOptions{PriorStates: prior})
+
+	if got := len(snap.actions); got != 2 {
+		t.Fatalf("want 2 actions (one per bucket), got %d", got)
+	}
+	alphaKey := s3lifecycle.ActionKey{Bucket: "alpha", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}
+	betaKey := s3lifecycle.ActionKey{Bucket: "beta", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}
+	if snap.actions[alphaKey] == nil || snap.actions[alphaKey].Bucket != "alpha" {
+		t.Fatalf("alpha bucket action missing or wrong bucket")
+	}
+	if snap.actions[betaKey] == nil || snap.actions[betaKey].Bucket != "beta" {
+		t.Fatalf("beta bucket action missing or wrong bucket")
+	}
 }
 
 func TestEngine_SnapshotAtomicSwap(t *testing.T) {

--- a/weed/s3api/s3lifecycle/engine/match.go
+++ b/weed/s3api/s3lifecycle/engine/match.go
@@ -7,54 +7,34 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
-// EventShape classifies a meta-log event for routing. The reader fills this
-// in from the raw meta-log entry (OldEntry/NewEntry diff) before calling
-// MatchOriginalWrite or MatchPredicateChange.
 type EventShape int
 
 const (
 	EventShapeUnknown EventShape = iota
-	// EventShapeOriginalWrite covers any event that establishes a new
-	// "object age" for AWS-semantic purposes: fresh PUT, overwrite (mtime
-	// or content changed), MPU init, version flip.
+	// EventShapeOriginalWrite: any event resetting AWS LastModified
+	// (fresh PUT, overwrite, MPU init, version flip).
 	EventShapeOriginalWrite
-	// EventShapePredicateChange is metadata-only: tags / Extended changed
-	// without resetting mtime. Drives the predicate-change sweep.
+	// EventShapePredicateChange: tags / Extended changed without an mtime
+	// reset.
 	EventShapePredicateChange
 )
 
-// Event is the routing-relevant slice of a meta-log event. The reader
-// extracts these fields from the persisted *filer_pb.LogEntry payload (see
-// Phase 3 reader pseudocode); the engine only needs this minimal shape so
-// it stays free of filer_pb dependencies.
+// Event is the routing-relevant slice of a meta-log event. Kept minimal so
+// the engine doesn't depend on filer_pb.
 type Event struct {
-	Shape    EventShape
-	Bucket   string
-	Path     string // bucket-relative key, no leading slash
-	Tags     map[string]string
-	Size     int64
-	IsLatest bool
-	// IsDeleteMarker indicates this entry is an S3 delete marker (per the
-	// ExtDeleteMarkerKey on the live entry's Extended). Used to gate
-	// EXPIRED_DELETE_MARKER routing.
+	Shape          EventShape
+	Bucket         string
+	Path           string
+	Tags           map[string]string
+	Size           int64
+	IsLatest       bool
 	IsDeleteMarker bool
-	// IsMPUInit indicates this event is for an in-flight multipart upload
-	// init under <bucket>/.uploads/<id>/. Used to gate ABORT_MPU routing.
-	IsMPUInit bool
-	// EventTime is when the event was logged. Currently unused by Match*
-	// (the cutoff is supplied by the reader's sweep cadence) but available
-	// for future fan-out logic.
-	EventTime time.Time
+	IsMPUInit      bool
+	EventTime      time.Time
 }
 
-// MatchOriginalWrite returns the active ActionKeys in the given delay group
-// whose filter matches this event. The reader sweeps each delay group once
-// per pass and dispatches each event to the matched actions; the worker
-// then re-fetches the live entry once and calls EvaluateAction per matched
-// key.
-//
-// Match returns nil when nothing applies (the reader advances the cursor
-// without dispatching).
+// MatchOriginalWrite returns active ActionKeys in the given delay group
+// whose filter matches the event.
 func (s *Snapshot) MatchOriginalWrite(ev *Event, delay time.Duration) []s3lifecycle.ActionKey {
 	if ev == nil || ev.Shape != EventShapeOriginalWrite {
 		return nil
@@ -66,10 +46,8 @@ func (s *Snapshot) MatchOriginalWrite(ev *Event, delay time.Duration) []s3lifecy
 	return s.filterMatching(keys, ev)
 }
 
-// MatchPredicateChange returns the active predicate-sensitive ActionKeys
-// whose filter matches this event. Used by the single near-now predicate
-// sweep; the reader pulls live entry tags/size and feeds an Event with
-// Shape=EventShapePredicateChange.
+// MatchPredicateChange returns active predicate-sensitive ActionKeys whose
+// filter matches the event.
 func (s *Snapshot) MatchPredicateChange(ev *Event) []s3lifecycle.ActionKey {
 	if ev == nil || ev.Shape != EventShapePredicateChange {
 		return nil
@@ -80,13 +58,9 @@ func (s *Snapshot) MatchPredicateChange(ev *Event) []s3lifecycle.ActionKey {
 	return s.filterMatching(s.predicateActions, ev)
 }
 
-// MatchPath returns the active ActionKeys for a specific bucket+path,
-// regardless of event shape. Used by the bootstrap walker, which iterates
-// every entry once and evaluates all applicable actions per object.
-//
-// When ev != nil, the result is filtered to actions whose filter matches
-// the live entry's tags/size. When ev == nil, only prefix matching applies
-// (caller will fetch live state and filter further).
+// MatchPath returns active ActionKeys for a specific bucket+path. ev=nil
+// applies prefix matching only; pass a non-nil Event to also gate on tags
+// and size.
 func (s *Snapshot) MatchPath(bucket, path string, ev *Event) []s3lifecycle.ActionKey {
 	bi := s.buckets[bucket]
 	if bi == nil {
@@ -122,11 +96,6 @@ func (s *Snapshot) filterMatching(keys []s3lifecycle.ActionKey, ev *Event) []s3l
 		if !filterAllows(a.Rule, ev) {
 			continue
 		}
-		// Shape-specific gating: ABORT_MPU only on MPU-init events;
-		// EXPIRED_DELETE_MARKER only on delete-marker events. The
-		// caller's EvaluateAction re-checks this against the live
-		// entry, but pruning here avoids dispatching uninteresting
-		// events into the worker.
 		switch k.ActionKind {
 		case s3lifecycle.ActionKindAbortMPU:
 			if !ev.IsMPUInit {

--- a/weed/s3api/s3lifecycle/engine/match.go
+++ b/weed/s3api/s3lifecycle/engine/match.go
@@ -1,0 +1,165 @@
+package engine
+
+import (
+	"strings"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// EventShape classifies a meta-log event for routing. The reader fills this
+// in from the raw meta-log entry (OldEntry/NewEntry diff) before calling
+// MatchOriginalWrite or MatchPredicateChange.
+type EventShape int
+
+const (
+	EventShapeUnknown EventShape = iota
+	// EventShapeOriginalWrite covers any event that establishes a new
+	// "object age" for AWS-semantic purposes: fresh PUT, overwrite (mtime
+	// or content changed), MPU init, version flip.
+	EventShapeOriginalWrite
+	// EventShapePredicateChange is metadata-only: tags / Extended changed
+	// without resetting mtime. Drives the predicate-change sweep.
+	EventShapePredicateChange
+)
+
+// Event is the routing-relevant slice of a meta-log event. The reader
+// extracts these fields from the persisted *filer_pb.LogEntry payload (see
+// Phase 3 reader pseudocode); the engine only needs this minimal shape so
+// it stays free of filer_pb dependencies.
+type Event struct {
+	Shape    EventShape
+	Bucket   string
+	Path     string // bucket-relative key, no leading slash
+	Tags     map[string]string
+	Size     int64
+	IsLatest bool
+	// IsDeleteMarker indicates this entry is an S3 delete marker (per the
+	// ExtDeleteMarkerKey on the live entry's Extended). Used to gate
+	// EXPIRED_DELETE_MARKER routing.
+	IsDeleteMarker bool
+	// IsMPUInit indicates this event is for an in-flight multipart upload
+	// init under <bucket>/.uploads/<id>/. Used to gate ABORT_MPU routing.
+	IsMPUInit bool
+	// EventTime is when the event was logged. Currently unused by Match*
+	// (the cutoff is supplied by the reader's sweep cadence) but available
+	// for future fan-out logic.
+	EventTime time.Time
+}
+
+// MatchOriginalWrite returns the active ActionKeys in the given delay group
+// whose filter matches this event. The reader sweeps each delay group once
+// per pass and dispatches each event to the matched actions; the worker
+// then re-fetches the live entry once and calls EvaluateAction per matched
+// key.
+//
+// Match returns nil when nothing applies (the reader advances the cursor
+// without dispatching).
+func (s *Snapshot) MatchOriginalWrite(ev *Event, delay time.Duration) []s3lifecycle.ActionKey {
+	if ev == nil || ev.Shape != EventShapeOriginalWrite {
+		return nil
+	}
+	keys := s.originalDelayGroups[delay]
+	if len(keys) == 0 {
+		return nil
+	}
+	return s.filterMatching(keys, ev)
+}
+
+// MatchPredicateChange returns the active predicate-sensitive ActionKeys
+// whose filter matches this event. Used by the single near-now predicate
+// sweep; the reader pulls live entry tags/size and feeds an Event with
+// Shape=EventShapePredicateChange.
+func (s *Snapshot) MatchPredicateChange(ev *Event) []s3lifecycle.ActionKey {
+	if ev == nil || ev.Shape != EventShapePredicateChange {
+		return nil
+	}
+	if len(s.predicateActions) == 0 {
+		return nil
+	}
+	return s.filterMatching(s.predicateActions, ev)
+}
+
+// MatchPath returns the active ActionKeys for a specific bucket+path,
+// regardless of event shape. Used by the bootstrap walker, which iterates
+// every entry once and evaluates all applicable actions per object.
+//
+// When ev != nil, the result is filtered to actions whose filter matches
+// the live entry's tags/size. When ev == nil, only prefix matching applies
+// (caller will fetch live state and filter further).
+func (s *Snapshot) MatchPath(bucket, path string, ev *Event) []s3lifecycle.ActionKey {
+	bi := s.buckets[bucket]
+	if bi == nil {
+		return nil
+	}
+	out := make([]s3lifecycle.ActionKey, 0, len(bi.actionKeys))
+	for _, k := range bi.actionKeys {
+		a := s.actions[k]
+		if a == nil || !a.IsActive() {
+			continue
+		}
+		if !prefixMatches(a.Rule.Prefix, path) {
+			continue
+		}
+		if ev != nil && !filterAllows(a.Rule, ev) {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
+func (s *Snapshot) filterMatching(keys []s3lifecycle.ActionKey, ev *Event) []s3lifecycle.ActionKey {
+	out := make([]s3lifecycle.ActionKey, 0, len(keys))
+	for _, k := range keys {
+		a := s.actions[k]
+		if a == nil || !a.IsActive() || a.Bucket != ev.Bucket {
+			continue
+		}
+		if !prefixMatches(a.Rule.Prefix, ev.Path) {
+			continue
+		}
+		if !filterAllows(a.Rule, ev) {
+			continue
+		}
+		// Shape-specific gating: ABORT_MPU only on MPU-init events;
+		// EXPIRED_DELETE_MARKER only on delete-marker events. The
+		// caller's EvaluateAction re-checks this against the live
+		// entry, but pruning here avoids dispatching uninteresting
+		// events into the worker.
+		switch k.ActionKind {
+		case s3lifecycle.ActionKindAbortMPU:
+			if !ev.IsMPUInit {
+				continue
+			}
+		case s3lifecycle.ActionKindExpiredDeleteMarker:
+			if !ev.IsDeleteMarker || !ev.IsLatest {
+				continue
+			}
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
+func prefixMatches(rulePrefix, path string) bool {
+	if rulePrefix == "" {
+		return true
+	}
+	return strings.HasPrefix(path, rulePrefix)
+}
+
+func filterAllows(rule *s3lifecycle.Rule, ev *Event) bool {
+	if rule.FilterSizeGreaterThan > 0 && ev.Size <= rule.FilterSizeGreaterThan {
+		return false
+	}
+	if rule.FilterSizeLessThan > 0 && ev.Size >= rule.FilterSizeLessThan {
+		return false
+	}
+	for k, v := range rule.FilterTags {
+		if got, ok := ev.Tags[k]; !ok || got != v {
+			return false
+		}
+	}
+	return true
+}

--- a/weed/s3api/s3lifecycle/engine/match_test.go
+++ b/weed/s3api/s3lifecycle/engine/match_test.go
@@ -61,10 +61,10 @@ func TestMatchOriginalWrite_PrefixFilter(t *testing.T) {
 	}
 }
 
-func TestMatchOriginalWrite_OnlyActiveActions(t *testing.T) {
-	// pending_bootstrap actions must not be matched (they're not in
-	// originalDelayGroups), but the active filter is also enforced inside
-	// filterMatching to make markActive flips visible without recompile.
+func TestMatchOriginalWrite_MarkActiveBecomesRoutable(t *testing.T) {
+	// pending_bootstrap actions are indexed but inactive: MatchOriginalWrite
+	// returns nothing. After MarkActive flips engineState, the same key is
+	// routable in subsequent matches without a recompile.
 	r := ruleExpDays("a", "x/", 30)
 	e := New()
 	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{})
@@ -73,12 +73,8 @@ func TestMatchOriginalWrite_OnlyActiveActions(t *testing.T) {
 		t.Fatalf("inactive action should not match, got %v", got)
 	}
 	snap.MarkActive(s3lifecycle.ActionKey{Bucket: "bk", RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays})
-	// The action wasn't added to the delay-group index at compile time
-	// (it was inactive). markActive doesn't retroactively add it; that's
-	// the design — recompile populates indexes when prior state activates
-	// the action. Verify this expectation explicitly.
-	if got := snap.MatchOriginalWrite(ev, 30*24*time.Hour); len(got) != 0 {
-		t.Fatalf("post-markActive without recompile: still no delay-group entry, got %v", got)
+	if got := snap.MatchOriginalWrite(ev, 30*24*time.Hour); len(got) != 1 {
+		t.Fatalf("post-markActive should be routable, got %v", got)
 	}
 }
 

--- a/weed/s3api/s3lifecycle/engine/match_test.go
+++ b/weed/s3api/s3lifecycle/engine/match_test.go
@@ -1,0 +1,199 @@
+package engine
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// activeAll returns a PriorStates map that activates every action of the
+// given canonical rules.
+func activeAll(rules []*s3lifecycle.Rule) map[s3lifecycle.ActionKey]PriorState {
+	out := map[s3lifecycle.ActionKey]PriorState{}
+	for _, r := range rules {
+		rh := s3lifecycle.RuleHash(r)
+		for _, k := range s3lifecycle.RuleActionKinds(r) {
+			out[s3lifecycle.ActionKey{RuleHash: rh, ActionKind: k}] = PriorState{BootstrapComplete: true}
+		}
+	}
+	return out
+}
+
+func sortedKeys(keys []s3lifecycle.ActionKey) []s3lifecycle.ActionKey {
+	out := append([]s3lifecycle.ActionKey(nil), keys...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ActionKind < out[j].ActionKind
+	})
+	return out
+}
+
+func TestMatchOriginalWrite_DelayGroupRoutes(t *testing.T) {
+	r30 := ruleExpDays("a", "x/", 30)
+	r60 := ruleExpDays("b", "x/", 60)
+	rules := []*s3lifecycle.Rule{r30, r60}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: rules}}, CompileOptions{PriorStates: activeAll(rules)})
+
+	ev := &Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "x/o"}
+	got30 := snap.MatchOriginalWrite(ev, 30*24*time.Hour)
+	if len(got30) != 1 || got30[0].ActionKind != s3lifecycle.ActionKindExpirationDays {
+		t.Fatalf("30d sweep should match r30, got %v", got30)
+	}
+	got60 := snap.MatchOriginalWrite(ev, 60*24*time.Hour)
+	if len(got60) != 1 {
+		t.Fatalf("60d sweep should match r60, got %v", got60)
+	}
+}
+
+func TestMatchOriginalWrite_PrefixFilter(t *testing.T) {
+	r := ruleExpDays("a", "logs/", 30)
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{r})})
+
+	if got := snap.MatchOriginalWrite(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "data/x"}, 30*24*time.Hour); len(got) != 0 {
+		t.Fatalf("non-matching prefix should reject, got %v", got)
+	}
+	if got := snap.MatchOriginalWrite(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "logs/x"}, 30*24*time.Hour); len(got) != 1 {
+		t.Fatalf("matching prefix should fire, got %v", got)
+	}
+}
+
+func TestMatchOriginalWrite_OnlyActiveActions(t *testing.T) {
+	// pending_bootstrap actions must not be matched (they're not in
+	// originalDelayGroups), but the active filter is also enforced inside
+	// filterMatching to make markActive flips visible without recompile.
+	r := ruleExpDays("a", "x/", 30)
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{})
+	ev := &Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "x/o"}
+	if got := snap.MatchOriginalWrite(ev, 30*24*time.Hour); len(got) != 0 {
+		t.Fatalf("inactive action should not match, got %v", got)
+	}
+	snap.MarkActive(s3lifecycle.ActionKey{RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays})
+	// The action wasn't added to the delay-group index at compile time
+	// (it was inactive). markActive doesn't retroactively add it; that's
+	// the design — recompile populates indexes when prior state activates
+	// the action. Verify this expectation explicitly.
+	if got := snap.MatchOriginalWrite(ev, 30*24*time.Hour); len(got) != 0 {
+		t.Fatalf("post-markActive without recompile: still no delay-group entry, got %v", got)
+	}
+}
+
+func TestMatchOriginalWrite_AbortMPUOnlyOnMPUInit(t *testing.T) {
+	r := &s3lifecycle.Rule{
+		ID:                          "mpu",
+		Status:                      s3lifecycle.StatusEnabled,
+		Prefix:                      ".uploads/",
+		AbortMPUDaysAfterInitiation: 7,
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{r})})
+
+	// Non-MPU event under .uploads/ prefix: filtered out by shape gating.
+	got := snap.MatchOriginalWrite(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: ".uploads/u1/", IsMPUInit: false}, 7*24*time.Hour)
+	if len(got) != 0 {
+		t.Fatalf("non-MPU event should be filtered, got %v", got)
+	}
+	got = snap.MatchOriginalWrite(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: ".uploads/u1/", IsMPUInit: true}, 7*24*time.Hour)
+	if len(got) != 1 {
+		t.Fatalf("MPU init should fire, got %v", got)
+	}
+}
+
+func TestMatchPredicateChange_OnlyTagSensitiveActions(t *testing.T) {
+	rTag := &s3lifecycle.Rule{
+		ID:             "tag",
+		Status:         s3lifecycle.StatusEnabled,
+		Prefix:         "x/",
+		ExpirationDays: 30,
+		FilterTags:     map[string]string{"env": "prod"},
+	}
+	rPlain := ruleExpDays("plain", "x/", 30)
+	rules := []*s3lifecycle.Rule{rTag, rPlain}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: rules}}, CompileOptions{PriorStates: activeAll(rules)})
+
+	// Predicate-change event: should match only the predicate-sensitive rule.
+	ev := &Event{Shape: EventShapePredicateChange, Bucket: "bk", Path: "x/o", Tags: map[string]string{"env": "prod"}}
+	got := snap.MatchPredicateChange(ev)
+	if len(got) != 1 {
+		t.Fatalf("only the tag-sensitive rule should match, got %v", got)
+	}
+	rh := s3lifecycle.RuleHash(rTag)
+	if got[0].RuleHash != rh {
+		t.Fatalf("expected match on tag-rule")
+	}
+
+	// Wrong shape: never matches.
+	if got := snap.MatchPredicateChange(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "x/o"}); len(got) != 0 {
+		t.Fatalf("wrong shape should be empty, got %v", got)
+	}
+}
+
+func TestMatchPath_BootstrapWalkerSeesAllActiveActions(t *testing.T) {
+	// One rule with three actions (90d Expiration, 30d NoncurrentDays,
+	// 7d AbortMPU). MatchPath returns every active action whose filter
+	// matches the path; the bootstrap walker iterates these and calls
+	// EvaluateAction per kind for the entry.
+	rule := &s3lifecycle.Rule{
+		ID:                              "multi",
+		Status:                          s3lifecycle.StatusEnabled,
+		Prefix:                          "x/",
+		ExpirationDays:                  90,
+		NoncurrentVersionExpirationDays: 30,
+		AbortMPUDaysAfterInitiation:     7,
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{rule})})
+
+	got := snap.MatchPath("bk", "x/obj", nil)
+	if len(got) != 3 {
+		t.Fatalf("want all 3 active actions, got %v", got)
+	}
+	wantKinds := []s3lifecycle.ActionKind{
+		s3lifecycle.ActionKindExpirationDays,
+		s3lifecycle.ActionKindNoncurrentDays,
+		s3lifecycle.ActionKindAbortMPU,
+	}
+	gotKinds := []s3lifecycle.ActionKind{}
+	for _, k := range sortedKeys(got) {
+		gotKinds = append(gotKinds, k.ActionKind)
+	}
+	sort.Slice(wantKinds, func(i, j int) bool { return wantKinds[i] < wantKinds[j] })
+	if !reflect.DeepEqual(gotKinds, wantKinds) {
+		t.Fatalf("want kinds %v, got %v", wantKinds, gotKinds)
+	}
+}
+
+func TestMatchPath_PrefixMismatchExcludes(t *testing.T) {
+	rule := ruleExpDays("a", "logs/", 30)
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{rule})})
+	if got := snap.MatchPath("bk", "data/x", nil); len(got) != 0 {
+		t.Fatalf("prefix mismatch should reject, got %v", got)
+	}
+}
+
+func TestMatchPath_FilterRejectsByTag(t *testing.T) {
+	rule := &s3lifecycle.Rule{
+		ID:             "tag",
+		Status:         s3lifecycle.StatusEnabled,
+		Prefix:         "x/",
+		ExpirationDays: 30,
+		FilterTags:     map[string]string{"env": "prod"},
+	}
+	e := New()
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{rule})})
+	// With ev passed, tag mismatch rejects.
+	ev := &Event{Bucket: "bk", Path: "x/obj", Tags: map[string]string{"env": "dev"}}
+	if got := snap.MatchPath("bk", "x/obj", ev); len(got) != 0 {
+		t.Fatalf("tag mismatch should reject, got %v", got)
+	}
+	// With ev nil (caller will fetch live state): prefix-only, returns the action.
+	if got := snap.MatchPath("bk", "x/obj", nil); len(got) != 1 {
+		t.Fatalf("ev=nil prefix-only path should return action, got %v", got)
+	}
+}

--- a/weed/s3api/s3lifecycle/engine/match_test.go
+++ b/weed/s3api/s3lifecycle/engine/match_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 // activeAll returns a PriorStates map that activates every action of the
-// given canonical rules.
-func activeAll(rules []*s3lifecycle.Rule) map[s3lifecycle.ActionKey]PriorState {
+// given canonical rules under bucket.
+func activeAll(bucket string, rules []*s3lifecycle.Rule) map[s3lifecycle.ActionKey]PriorState {
 	out := map[s3lifecycle.ActionKey]PriorState{}
 	for _, r := range rules {
 		rh := s3lifecycle.RuleHash(r)
 		for _, k := range s3lifecycle.RuleActionKinds(r) {
-			out[s3lifecycle.ActionKey{RuleHash: rh, ActionKind: k}] = PriorState{BootstrapComplete: true}
+			out[s3lifecycle.ActionKey{Bucket: bucket, RuleHash: rh, ActionKind: k}] = PriorState{BootstrapComplete: true}
 		}
 	}
 	return out
@@ -35,7 +35,7 @@ func TestMatchOriginalWrite_DelayGroupRoutes(t *testing.T) {
 	r60 := ruleExpDays("b", "x/", 60)
 	rules := []*s3lifecycle.Rule{r30, r60}
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: rules}}, CompileOptions{PriorStates: activeAll(rules)})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: rules}}, CompileOptions{PriorStates: activeAll("bk", rules)})
 
 	ev := &Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "x/o"}
 	got30 := snap.MatchOriginalWrite(ev, 30*24*time.Hour)
@@ -51,7 +51,7 @@ func TestMatchOriginalWrite_DelayGroupRoutes(t *testing.T) {
 func TestMatchOriginalWrite_PrefixFilter(t *testing.T) {
 	r := ruleExpDays("a", "logs/", 30)
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{r})})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{PriorStates: activeAll("bk", []*s3lifecycle.Rule{r})})
 
 	if got := snap.MatchOriginalWrite(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: "data/x"}, 30*24*time.Hour); len(got) != 0 {
 		t.Fatalf("non-matching prefix should reject, got %v", got)
@@ -72,7 +72,7 @@ func TestMatchOriginalWrite_OnlyActiveActions(t *testing.T) {
 	if got := snap.MatchOriginalWrite(ev, 30*24*time.Hour); len(got) != 0 {
 		t.Fatalf("inactive action should not match, got %v", got)
 	}
-	snap.MarkActive(s3lifecycle.ActionKey{RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays})
+	snap.MarkActive(s3lifecycle.ActionKey{Bucket: "bk", RuleHash: s3lifecycle.RuleHash(r), ActionKind: s3lifecycle.ActionKindExpirationDays})
 	// The action wasn't added to the delay-group index at compile time
 	// (it was inactive). markActive doesn't retroactively add it; that's
 	// the design — recompile populates indexes when prior state activates
@@ -90,7 +90,7 @@ func TestMatchOriginalWrite_AbortMPUOnlyOnMPUInit(t *testing.T) {
 		AbortMPUDaysAfterInitiation: 7,
 	}
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{r})})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{r}}}, CompileOptions{PriorStates: activeAll("bk", []*s3lifecycle.Rule{r})})
 
 	// Non-MPU event under .uploads/ prefix: filtered out by shape gating.
 	got := snap.MatchOriginalWrite(&Event{Shape: EventShapeOriginalWrite, Bucket: "bk", Path: ".uploads/u1/", IsMPUInit: false}, 7*24*time.Hour)
@@ -114,7 +114,7 @@ func TestMatchPredicateChange_OnlyTagSensitiveActions(t *testing.T) {
 	rPlain := ruleExpDays("plain", "x/", 30)
 	rules := []*s3lifecycle.Rule{rTag, rPlain}
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: rules}}, CompileOptions{PriorStates: activeAll(rules)})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: rules}}, CompileOptions{PriorStates: activeAll("bk", rules)})
 
 	// Predicate-change event: should match only the predicate-sensitive rule.
 	ev := &Event{Shape: EventShapePredicateChange, Bucket: "bk", Path: "x/o", Tags: map[string]string{"env": "prod"}}
@@ -147,7 +147,7 @@ func TestMatchPath_BootstrapWalkerSeesAllActiveActions(t *testing.T) {
 		AbortMPUDaysAfterInitiation:     7,
 	}
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{rule})})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll("bk", []*s3lifecycle.Rule{rule})})
 
 	got := snap.MatchPath("bk", "x/obj", nil)
 	if len(got) != 3 {
@@ -171,7 +171,7 @@ func TestMatchPath_BootstrapWalkerSeesAllActiveActions(t *testing.T) {
 func TestMatchPath_PrefixMismatchExcludes(t *testing.T) {
 	rule := ruleExpDays("a", "logs/", 30)
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{rule})})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll("bk", []*s3lifecycle.Rule{rule})})
 	if got := snap.MatchPath("bk", "data/x", nil); len(got) != 0 {
 		t.Fatalf("prefix mismatch should reject, got %v", got)
 	}
@@ -186,7 +186,7 @@ func TestMatchPath_FilterRejectsByTag(t *testing.T) {
 		FilterTags:     map[string]string{"env": "prod"},
 	}
 	e := New()
-	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll([]*s3lifecycle.Rule{rule})})
+	snap := e.Compile([]CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, CompileOptions{PriorStates: activeAll("bk", []*s3lifecycle.Rule{rule})})
 	// With ev passed, tag mismatch rejects.
 	ev := &Event{Bucket: "bk", Path: "x/obj", Tags: map[string]string{"env": "dev"}}
 	if got := snap.MatchPath("bk", "x/obj", ev); len(got) != 0 {

--- a/weed/s3api/s3lifecycle/engine/mode.go
+++ b/weed/s3api/s3lifecycle/engine/mode.go
@@ -6,10 +6,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
-// RuleMode mirrors the durable s3_lifecycle_pb.LifecycleState.RuleMode enum.
-// Defined here as a separate Go type so engine code doesn't depend on the
-// generated proto package directly. Mappings to/from the proto value are
-// handled by the worker when it reads/writes the durable state file.
+// RuleMode mirrors the durable s3_lifecycle_pb.LifecycleState.RuleMode enum;
+// the worker maps between them when it reads/writes durable state.
 type RuleMode int
 
 const (
@@ -38,17 +36,10 @@ func (m RuleMode) String() string {
 	}
 }
 
-// decideMode picks the scheduling mode for one (rule, kind) compiled action.
-// The decision is the same predicate the tick-time mode decision uses (and
-// is also called by the safety-scan-tick code path):
-//
-//   - status disabled                                                         -> DISABLED
-//   - kind == EXPIRATION_DATE                                                 -> SCAN_AT_DATE
-//   - reader-driven kind, retention < eventLogHorizon + bootstrapLookbackMin  -> SCAN_ONLY
-//   - otherwise                                                               -> EVENT_DRIVEN
-//
-// MetaLogRetention=0 is treated as "unbounded" — the gate never trips at
-// the default SeaweedFS deployment, where the meta log isn't pruned.
+// decideMode: disabled rule -> DISABLED; EXPIRATION_DATE -> SCAN_AT_DATE;
+// reader-driven kind whose horizon exceeds retention -> SCAN_ONLY; else
+// EVENT_DRIVEN. metaLogRetention=0 means unbounded (default), gate doesn't
+// trip.
 func decideMode(rule *s3lifecycle.Rule, kind s3lifecycle.ActionKind, metaLogRetention, bootstrapLookbackMin time.Duration) RuleMode {
 	if rule == nil || rule.Status != s3lifecycle.StatusEnabled {
 		return ModeDisabled

--- a/weed/s3api/s3lifecycle/engine/mode.go
+++ b/weed/s3api/s3lifecycle/engine/mode.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// RuleMode mirrors the durable s3_lifecycle_pb.LifecycleState.RuleMode enum.
+// Defined here as a separate Go type so engine code doesn't depend on the
+// generated proto package directly. Mappings to/from the proto value are
+// handled by the worker when it reads/writes the durable state file.
+type RuleMode int
+
+const (
+	ModeUnspecified RuleMode = iota
+	ModeEventDriven
+	ModeScanAtDate
+	ModeScanOnly
+	ModeDisabled
+	ModePendingBootstrap
+)
+
+func (m RuleMode) String() string {
+	switch m {
+	case ModeEventDriven:
+		return "event_driven"
+	case ModeScanAtDate:
+		return "scan_at_date"
+	case ModeScanOnly:
+		return "scan_only"
+	case ModeDisabled:
+		return "disabled"
+	case ModePendingBootstrap:
+		return "pending_bootstrap"
+	default:
+		return "unspecified"
+	}
+}
+
+// decideMode picks the scheduling mode for one (rule, kind) compiled action.
+// The decision is the same predicate the tick-time mode decision uses (and
+// is also called by the safety-scan-tick code path):
+//
+//   - status disabled                                                         -> DISABLED
+//   - kind == EXPIRATION_DATE                                                 -> SCAN_AT_DATE
+//   - reader-driven kind, retention < eventLogHorizon + bootstrapLookbackMin  -> SCAN_ONLY
+//   - otherwise                                                               -> EVENT_DRIVEN
+//
+// MetaLogRetention=0 is treated as "unbounded" — the gate never trips at
+// the default SeaweedFS deployment, where the meta log isn't pruned.
+func decideMode(rule *s3lifecycle.Rule, kind s3lifecycle.ActionKind, metaLogRetention, bootstrapLookbackMin time.Duration) RuleMode {
+	if rule == nil || rule.Status != s3lifecycle.StatusEnabled {
+		return ModeDisabled
+	}
+	if kind == s3lifecycle.ActionKindExpirationDate {
+		return ModeScanAtDate
+	}
+	if metaLogRetention > 0 {
+		horizon := s3lifecycle.EventLogHorizon(rule, kind)
+		if horizon > 0 && metaLogRetention < horizon+bootstrapLookbackMin {
+			return ModeScanOnly
+		}
+	}
+	return ModeEventDriven
+}

--- a/weed/s3api/s3lifecycle/evaluate.go
+++ b/weed/s3api/s3lifecycle/evaluate.go
@@ -89,8 +89,15 @@ func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time
 		if now.Before(due) {
 			return none
 		}
-		if rule.NewerNoncurrentVersions > 0 && info.NoncurrentIndex < rule.NewerNoncurrentVersions {
-			return none
+		if rule.NewerNoncurrentVersions > 0 {
+			// NewerNoncurrent retention is consulted only when the caller
+			// has supplied an index. Missing index means "we can't safely
+			// say whether this version is within the keep-N window," so
+			// don't expire — the safety-scan will revisit once the index
+			// is computed.
+			if info.NoncurrentIndex == nil || *info.NoncurrentIndex < rule.NewerNoncurrentVersions {
+				return none
+			}
 		}
 		return EvalResult{Action: ActionDeleteVersion, RuleID: rule.ID}
 
@@ -100,7 +107,10 @@ func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time
 		if info.IsLatest || rule.NoncurrentVersionExpirationDays > 0 || rule.NewerNoncurrentVersions <= 0 {
 			return none
 		}
-		if info.NoncurrentIndex < rule.NewerNoncurrentVersions {
+		// Without a NoncurrentIndex we can't evaluate count-based retention;
+		// the conservative answer is ActionNone — safety-scan picks up the
+		// version once the index is supplied.
+		if info.NoncurrentIndex == nil || *info.NoncurrentIndex < rule.NewerNoncurrentVersions {
 			return none
 		}
 		return EvalResult{Action: ActionDeleteVersion, RuleID: rule.ID}

--- a/weed/s3api/s3lifecycle/evaluate.go
+++ b/weed/s3api/s3lifecycle/evaluate.go
@@ -5,29 +5,14 @@ import (
 	"time"
 )
 
-// EvaluateAction decides whether the (rule, kind) compiled action fires for
-// info at the given wall-clock time. Returns ActionNone when the rule is
-// disabled, the filter rejects, the object shape doesn't match this kind, or
-// the kind isn't yet due.
+// EvaluateAction decides whether the (rule, kind) action fires for info at
+// now. Returns ActionNone when the rule is disabled, the filter rejects, the
+// object shape doesn't match this kind, or the action isn't yet due.
 //
-// One XML rule may declare multiple actions in parallel. The engine compiles
-// each into its own ActionKey and calls EvaluateAction once per (rule, kind,
-// entry); sibling actions are independent and may produce different verdicts
-// for the same entry. Callers that need to evaluate every action of a rule
-// iterate `RuleActionKinds(rule)` and call this helper per kind.
-//
-// Action selection by object shape per kind:
-//
-//	IsMPUInit                   + ActionKindAbortMPU             -> AbortIncompleteMultipartUpload
-//	IsLatest && IsDeleteMarker  + ActionKindExpiredDeleteMarker  -> ExpiredObjectDeleteMarker (sole survivor)
-//	IsLatest                    + ActionKindExpirationDays       -> DeleteObject (Days threshold)
-//	IsLatest                    + ActionKindExpirationDate       -> DeleteObject (date threshold)
-//	non-current                 + ActionKindNoncurrentDays       -> DeleteVersion (Days + NewerNoncurrent retention)
-//	non-current                 + ActionKindNewerNoncurrent      -> DeleteVersion (count-only)
-//
-// Per AWS S3 semantics, a non-current delete marker is treated as a regular
-// non-current version under NONCURRENT_DAYS / NEWER_NONCURRENT. Only the
-// *current* delete marker (and only as sole survivor) routes to
+// One XML rule may declare multiple actions; callers iterate
+// RuleActionKinds(rule) and call this helper per kind. A non-current delete
+// marker is treated as a regular non-current version under NONCURRENT_DAYS /
+// NEWER_NONCURRENT; only a *current* sole-survivor delete marker routes to
 // EXPIRED_DELETE_MARKER.
 func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time) EvalResult {
 	none := EvalResult{Action: ActionNone}
@@ -89,12 +74,8 @@ func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time
 		if now.Before(due) {
 			return none
 		}
+		// Missing index = can't evaluate retention; safety-scan will revisit.
 		if rule.NewerNoncurrentVersions > 0 {
-			// NewerNoncurrent retention is consulted only when the caller
-			// has supplied an index. Missing index means "we can't safely
-			// say whether this version is within the keep-N window," so
-			// don't expire — the safety-scan will revisit once the index
-			// is computed.
 			if info.NoncurrentIndex == nil || *info.NoncurrentIndex < rule.NewerNoncurrentVersions {
 				return none
 			}
@@ -102,14 +83,11 @@ func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time
 		return EvalResult{Action: ActionDeleteVersion, RuleID: rule.ID}
 
 	case ActionKindNewerNoncurrent:
-		// Pure count-based: only when NoncurrentDays is unset (when paired,
-		// the rule expands to NONCURRENT_DAYS instead — see RuleActionKinds).
+		// Count-only path; when NoncurrentDays is also set the rule expands
+		// to NONCURRENT_DAYS instead (see RuleActionKinds).
 		if info.IsLatest || rule.NoncurrentVersionExpirationDays > 0 || rule.NewerNoncurrentVersions <= 0 {
 			return none
 		}
-		// Without a NoncurrentIndex we can't evaluate count-based retention;
-		// the conservative answer is ActionNone — safety-scan picks up the
-		// version once the index is supplied.
 		if info.NoncurrentIndex == nil || *info.NoncurrentIndex < rule.NewerNoncurrentVersions {
 			return none
 		}

--- a/weed/s3api/s3lifecycle/evaluate.go
+++ b/weed/s3api/s3lifecycle/evaluate.go
@@ -5,15 +5,10 @@ import (
 	"time"
 )
 
-// EvaluateAction decides whether the (rule, kind) action fires for info at
-// now. Returns ActionNone when the rule is disabled, the filter rejects, the
-// object shape doesn't match this kind, or the action isn't yet due.
-//
-// One XML rule may declare multiple actions; callers iterate
-// RuleActionKinds(rule) and call this helper per kind. A non-current delete
-// marker is treated as a regular non-current version under NONCURRENT_DAYS /
-// NEWER_NONCURRENT; only a *current* sole-survivor delete marker routes to
-// EXPIRED_DELETE_MARKER.
+// EvaluateAction returns whether the (rule, kind) action fires for info at
+// now. A non-current delete marker is just another non-current version under
+// NONCURRENT_DAYS / NEWER_NONCURRENT; only a current sole-survivor marker
+// routes to EXPIRED_DELETE_MARKER.
 func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time) EvalResult {
 	none := EvalResult{Action: ActionNone}
 	if rule == nil || info == nil || rule.Status != StatusEnabled {
@@ -74,7 +69,7 @@ func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time
 		if now.Before(due) {
 			return none
 		}
-		// Missing index = can't evaluate retention; safety-scan will revisit.
+		// nil index = can't evaluate retention; safety-scan revisits.
 		if rule.NewerNoncurrentVersions > 0 {
 			if info.NoncurrentIndex == nil || *info.NoncurrentIndex < rule.NewerNoncurrentVersions {
 				return none
@@ -83,8 +78,8 @@ func EvaluateAction(rule *Rule, kind ActionKind, info *ObjectInfo, now time.Time
 		return EvalResult{Action: ActionDeleteVersion, RuleID: rule.ID}
 
 	case ActionKindNewerNoncurrent:
-		// Count-only path; when NoncurrentDays is also set the rule expands
-		// to NONCURRENT_DAYS instead (see RuleActionKinds).
+		// Count-only; when paired with NoncurrentDays the rule expands to
+		// NONCURRENT_DAYS instead (RuleActionKinds).
 		if info.IsLatest || rule.NoncurrentVersionExpirationDays > 0 || rule.NewerNoncurrentVersions <= 0 {
 			return none
 		}

--- a/weed/s3api/s3lifecycle/evaluate_test.go
+++ b/weed/s3api/s3lifecycle/evaluate_test.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+// idx is a small helper for tests that need to express NoncurrentIndex as
+// *int (production callers either compute it or leave it nil for current
+// versions; tests want a one-liner).
+func idx(i int) *int { return &i }
+
 func mustTime(t *testing.T, s string) time.Time {
 	t.Helper()
 	tm, err := time.Parse(time.RFC3339, s)
@@ -142,7 +147,7 @@ func TestEvaluateAction_NoncurrentVersionDays(t *testing.T) {
 		IsLatest:         false,
 		ModTime:          mustTime(t, "2023-01-01T00:00:00Z"),
 		SuccessorModTime: successor,
-		NoncurrentIndex:  0,
+		NoncurrentIndex:  idx(0),
 	}
 	if got := EvaluateAction(rule, ActionKindNoncurrentDays, info, successor.AddDate(0, 0, 29)); got.Action != ActionNone {
 		t.Fatalf("not due, got %v", got)
@@ -155,7 +160,7 @@ func TestEvaluateAction_NoncurrentVersionDays(t *testing.T) {
 func TestEvaluateAction_NoncurrentDaysFallsBackToModTime(t *testing.T) {
 	rule := &Rule{Status: StatusEnabled, NoncurrentVersionExpirationDays: 30}
 	mod := mustTime(t, "2024-01-01T00:00:00Z")
-	info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: mod, NoncurrentIndex: 0}
+	info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: mod, NoncurrentIndex: idx(0)}
 	if got := EvaluateAction(rule, ActionKindNoncurrentDays, info, mod.AddDate(0, 0, 30)); got.Action != ActionDeleteVersion {
 		t.Fatalf("expected fallback to ModTime, got %v", got)
 	}
@@ -167,12 +172,12 @@ func TestEvaluateAction_NewerNoncurrentCountOnly(t *testing.T) {
 	mod := mustTime(t, "2024-01-01T00:00:00Z")
 
 	for i := 0; i < 3; i++ {
-		info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: mod, NoncurrentIndex: i}
+		info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: mod, NoncurrentIndex: idx(i)}
 		if got := EvaluateAction(rule, ActionKindNewerNoncurrent, info, now); got.Action != ActionNone {
 			t.Fatalf("idx=%d should be retained, got %v", i, got)
 		}
 	}
-	info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: mod, NoncurrentIndex: 3}
+	info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: mod, NoncurrentIndex: idx(3)}
 	if got := EvaluateAction(rule, ActionKindNewerNoncurrent, info, now); got.Action != ActionDeleteVersion {
 		t.Fatalf("idx=3 should fire, got %v", got)
 	}
@@ -184,12 +189,12 @@ func TestEvaluateAction_NoncurrentDaysAndCount(t *testing.T) {
 	now := successor.AddDate(0, 0, 30)
 
 	for i := 0; i < 2; i++ {
-		info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: successor, SuccessorModTime: successor, NoncurrentIndex: i}
+		info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: successor, SuccessorModTime: successor, NoncurrentIndex: idx(i)}
 		if got := EvaluateAction(rule, ActionKindNoncurrentDays, info, now); got.Action != ActionNone {
 			t.Fatalf("idx=%d kept by NewerNoncurrent retention, got %v", i, got)
 		}
 	}
-	info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: successor, SuccessorModTime: successor, NoncurrentIndex: 2}
+	info := &ObjectInfo{Key: "a", IsLatest: false, ModTime: successor, SuccessorModTime: successor, NoncurrentIndex: idx(2)}
 	if got := EvaluateAction(rule, ActionKindNoncurrentDays, info, now); got.Action != ActionDeleteVersion {
 		t.Fatalf("idx=2 satisfies both, got %v", got)
 	}

--- a/weed/s3api/s3lifecycle/evaluate_test.go
+++ b/weed/s3api/s3lifecycle/evaluate_test.go
@@ -166,6 +166,38 @@ func TestEvaluateAction_NoncurrentDaysFallsBackToModTime(t *testing.T) {
 	}
 }
 
+func TestEvaluateAction_NoncurrentDays_WithKeepN_NilIndexIsNoOp(t *testing.T) {
+	// Pointer-migration safety: a nil NoncurrentIndex paired with a
+	// keep-N retention threshold must short-circuit to ActionNone rather
+	// than guess at the version's position in the keep window.
+	rule := &Rule{Status: StatusEnabled, NoncurrentVersionExpirationDays: 30, NewerNoncurrentVersions: 2}
+	successor := mustTime(t, "2024-01-01T00:00:00Z")
+	info := &ObjectInfo{
+		Key:              "a",
+		IsLatest:         false,
+		ModTime:          successor,
+		SuccessorModTime: successor,
+		NoncurrentIndex:  nil,
+	}
+	now := successor.AddDate(0, 0, 30)
+	if got := EvaluateAction(rule, ActionKindNoncurrentDays, info, now); got.Action != ActionNone {
+		t.Fatalf("nil index with keep-N must be no-op, got %v", got)
+	}
+}
+
+func TestEvaluateAction_NewerNoncurrent_NilIndexIsNoOp(t *testing.T) {
+	rule := &Rule{Status: StatusEnabled, NewerNoncurrentVersions: 3}
+	info := &ObjectInfo{
+		Key:             "a",
+		IsLatest:        false,
+		ModTime:         mustTime(t, "2024-01-01T00:00:00Z"),
+		NoncurrentIndex: nil,
+	}
+	if got := EvaluateAction(rule, ActionKindNewerNoncurrent, info, mustTime(t, "2025-01-01T00:00:00Z")); got.Action != ActionNone {
+		t.Fatalf("nil index pure-count must be no-op, got %v", got)
+	}
+}
+
 func TestEvaluateAction_NewerNoncurrentCountOnly(t *testing.T) {
 	rule := &Rule{Status: StatusEnabled, NewerNoncurrentVersions: 3}
 	now := mustTime(t, "2025-01-01T00:00:00Z")

--- a/weed/s3api/s3lifecycle/event_log_horizon.go
+++ b/weed/s3api/s3lifecycle/event_log_horizon.go
@@ -2,24 +2,11 @@ package s3lifecycle
 
 import "time"
 
-// EventLogHorizon returns the maximum age of an event the reader needs to
-// observe to drive the (rule, kind) compiled action. Used by the retention
-// mode gate: if metaLogRetention < EventLogHorizon(rule, kind) +
-// bootstrapLookbackMin, this action is promoted to scan_only with
-// degraded_reason=RETENTION_BELOW_HORIZON.
-//
-// One XML rule may declare multiple actions with different horizons (a 90d
-// EXPIRATION_DAYS sibling alongside a 7d ABORT_MPU); the gate runs per
-// compiled action so each can degrade independently.
-//
-// Per-kind values:
-//
-//	EXPIRATION_DAYS         -> rule.ExpirationDays
-//	NONCURRENT_DAYS         -> rule.NoncurrentVersionExpirationDays
-//	ABORT_MPU               -> rule.AbortMPUDaysAfterInitiation
-//	NEWER_NONCURRENT        -> SmallDelay (count-only retention; immediate at flip)
-//	EXPIRED_DELETE_MARKER   -> SmallDelay (immediate when sole survivor)
-//	EXPIRATION_DATE         -> 0 (date kind bypasses the gate)
+// EventLogHorizon returns the max event age the reader needs to drive the
+// (rule, kind) action. Used by the retention mode gate: when
+// metaLogRetention < EventLogHorizon + bootstrapLookbackMin, the action is
+// promoted to scan_only. EXPIRATION_DATE returns 0 (date kind bypasses);
+// count / immediate kinds return SmallDelay.
 func EventLogHorizon(rule *Rule, kind ActionKind) time.Duration {
 	if rule == nil {
 		return 0

--- a/weed/s3api/s3lifecycle/min_trigger_age.go
+++ b/weed/s3api/s3lifecycle/min_trigger_age.go
@@ -2,14 +2,9 @@ package s3lifecycle
 
 import "time"
 
-// MinTriggerAge returns the day threshold defined by `kind` on `rule`. Used by
-// the safety-scan cadence as `max(MinTriggerAge(rule, kind), kindFloor)` —
-// see the per-kind cadence table in the design doc. Returns 0 when the kind
-// has no day-style threshold (date / count / immediate kinds), in which case
-// the caller's kind-floor is the cadence directly.
-//
-// One XML rule may declare multiple actions; this helper takes a kind so the
-// cadence is computed independently per compiled action.
+// MinTriggerAge returns the day threshold defined by kind on rule, or 0 if
+// the kind has no day-style threshold (date / count / immediate). Callers
+// use it as max(MinTriggerAge, kindFloor) when computing safety-scan cadence.
 func MinTriggerAge(rule *Rule, kind ActionKind) time.Duration {
 	if rule == nil {
 		return 0

--- a/weed/s3api/s3lifecycle/rule.go
+++ b/weed/s3api/s3lifecycle/rule.go
@@ -68,8 +68,13 @@ type ObjectInfo struct {
 
 	// NoncurrentIndex is the 0-based position among non-current versions
 	// sorted newest-first (0 = newest non-current version). Used by
-	// NewerNoncurrentVersions evaluation. -1 or unset for current versions.
-	NoncurrentIndex int
+	// NewerNoncurrentVersions evaluation. nil for current versions or for
+	// non-current entries whose index hasn't been computed yet — both cases
+	// short-circuit count-based retention checks (the action returns
+	// ActionNone rather than guessing). Pointer rather than int so the
+	// "0 means newest non-current" valid case can never collide with the
+	// zero-value "uninitialised" case.
+	NoncurrentIndex *int
 
 	// Tags are the object's user-defined tags, extracted from the entry's
 	// Extended metadata (keys prefixed with "X-Amz-Tagging-").

--- a/weed/s3api/s3lifecycle/rule.go
+++ b/weed/s3api/s3lifecycle/rule.go
@@ -2,8 +2,7 @@ package s3lifecycle
 
 import "time"
 
-// Rule is the flat, evaluator-friendly representation of an S3 lifecycle
-// rule. Callers convert from the XML-parsed s3api.Rule via
+// Rule is the flat representation built from the XML-parsed s3api.Rule via
 // s3api.LifecycleToCanonical.
 type Rule struct {
 	ID     string
@@ -22,15 +21,12 @@ type Rule struct {
 
 	FilterTags map[string]string
 
-	// Zero is treated as "not set." Note that this can't represent an
-	// explicit <ObjectSizeGreaterThan>0</...> (excludes 0-byte objects);
-	// if a deployment ever needs that, switch to *int64.
+	// Zero is "not set"; can't represent an explicit
+	// <ObjectSizeGreaterThan>0</...> exclusion of empty objects.
 	FilterSizeGreaterThan int64
 	FilterSizeLessThan    int64
 }
 
-// ObjectInfo is the live-entry shape the evaluator consults. Callers build
-// it from filer entry attributes and Extended metadata.
 type ObjectInfo struct {
 	Key            string
 	ModTime        time.Time
@@ -39,21 +35,17 @@ type ObjectInfo struct {
 	IsDeleteMarker bool
 	NumVersions    int
 
-	// SuccessorModTime is when the version that replaced this one was
-	// created. Zero for IsLatest entries.
 	SuccessorModTime time.Time
 
-	// NoncurrentIndex: 0-based index among non-current versions, newest
-	// first. nil = current version or index not yet computed; the count-
-	// based retention path returns ActionNone in that case rather than
-	// guessing. Pointer-not-int so the valid index 0 can't collide with
-	// the zero-value uninitialised case.
+	// NoncurrentIndex: 0-based among non-current versions, newest first.
+	// nil = current or not yet computed; count-based retention returns
+	// ActionNone rather than guess. Pointer so valid 0 doesn't collide
+	// with zero-value "uninitialised".
 	NoncurrentIndex *int
 
 	Tags map[string]string
 
-	// IsMPUInit signals an in-flight multipart-upload init under
-	// <bucket>/.uploads/<uploadId>/. ModTime then carries the init time.
+	// IsMPUInit: in-flight upload under .uploads/<id>/; ModTime is init time.
 	IsMPUInit bool
 }
 
@@ -63,7 +55,7 @@ const (
 )
 
 // SmallDelay is the lookback for predicate-change events and the event-log
-// horizon for count / immediate kinds (NewerNoncurrent, ExpiredDeleteMarker).
+// horizon for count / immediate kinds.
 const SmallDelay = time.Minute
 
 type Action int

--- a/weed/s3api/s3lifecycle/rule.go
+++ b/weed/s3api/s3lifecycle/rule.go
@@ -2,123 +2,81 @@ package s3lifecycle
 
 import "time"
 
-// Rule is a flattened, evaluator-friendly representation of an S3 lifecycle rule.
-// Callers convert from the XML-parsed s3api.Rule (which has nested structs with
-// set-flags for conditional XML marshaling) to this type.
+// Rule is the flat, evaluator-friendly representation of an S3 lifecycle
+// rule. Callers convert from the XML-parsed s3api.Rule via
+// s3api.LifecycleToCanonical.
 type Rule struct {
 	ID     string
-	Status string // "Enabled" or "Disabled"
+	Status string // "Enabled" | "Disabled"
 
-	// Prefix filter (from Rule.Prefix or Rule.Filter.Prefix or Rule.Filter.And.Prefix).
 	Prefix string
 
-	// Expiration for current versions.
 	ExpirationDays            int
 	ExpirationDate            time.Time
 	ExpiredObjectDeleteMarker bool
 
-	// Expiration for non-current versions.
 	NoncurrentVersionExpirationDays int
 	NewerNoncurrentVersions         int
 
-	// Abort incomplete multipart uploads.
 	AbortMPUDaysAfterInitiation int
 
-	// Tag filter (from Rule.Filter.Tag or Rule.Filter.And.Tags).
 	FilterTags map[string]string
 
-	// Size filters. Zero is treated as "not set" by the evaluator. Per AWS
-	// S3, an explicit <ObjectSizeGreaterThan>0</ObjectSizeGreaterThan>
-	// (which excludes 0-byte objects) cannot be distinguished from omitted
-	// in this representation; if a future deployment needs that
-	// distinction, switch to *int64 (or a paired set-bool) and update
-	// filterMatches / filterAllows / RuleHash accordingly. The zero-as-unset
-	// shortcut matches the default in s3api.Filter and the canonicalizer.
+	// Zero is treated as "not set." Note that this can't represent an
+	// explicit <ObjectSizeGreaterThan>0</...> (excludes 0-byte objects);
+	// if a deployment ever needs that, switch to *int64.
 	FilterSizeGreaterThan int64
 	FilterSizeLessThan    int64
 }
 
-// ObjectInfo is the metadata about an object that the evaluator uses to
-// determine which lifecycle action applies. Callers build this from filer
-// entry attributes and extended metadata.
+// ObjectInfo is the live-entry shape the evaluator consults. Callers build
+// it from filer entry attributes and Extended metadata.
 type ObjectInfo struct {
-	// Key is the object key relative to the bucket root.
-	Key string
-
-	// ModTime is the object's modification time (entry.Attributes.Mtime).
-	ModTime time.Time
-
-	// Size is the object size in bytes (entry.Attributes.FileSize).
-	Size int64
-
-	// IsLatest is true if this is the current version of the object.
-	IsLatest bool
-
-	// IsDeleteMarker is true if this entry is an S3 delete marker.
+	Key            string
+	ModTime        time.Time
+	Size           int64
+	IsLatest       bool
 	IsDeleteMarker bool
+	NumVersions    int
 
-	// NumVersions is the total number of versions for this object key,
-	// including delete markers. Used for ExpiredObjectDeleteMarker evaluation.
-	NumVersions int
-
-	// SuccessorModTime is the creation time of the version that replaced
-	// this one (making it non-current). Derived from the successor's version
-	// ID timestamp. Zero value for the latest version.
+	// SuccessorModTime is when the version that replaced this one was
+	// created. Zero for IsLatest entries.
 	SuccessorModTime time.Time
 
-	// NoncurrentIndex is the 0-based position among non-current versions
-	// sorted newest-first (0 = newest non-current version). Used by
-	// NewerNoncurrentVersions evaluation. nil for current versions or for
-	// non-current entries whose index hasn't been computed yet — both cases
-	// short-circuit count-based retention checks (the action returns
-	// ActionNone rather than guessing). Pointer rather than int so the
-	// "0 means newest non-current" valid case can never collide with the
-	// zero-value "uninitialised" case.
+	// NoncurrentIndex: 0-based index among non-current versions, newest
+	// first. nil = current version or index not yet computed; the count-
+	// based retention path returns ActionNone in that case rather than
+	// guessing. Pointer-not-int so the valid index 0 can't collide with
+	// the zero-value uninitialised case.
 	NoncurrentIndex *int
 
-	// Tags are the object's user-defined tags, extracted from the entry's
-	// Extended metadata (keys prefixed with "X-Amz-Tagging-").
 	Tags map[string]string
 
-	// IsMPUInit is true when this entry represents an in-flight multipart
-	// upload init under <bucket>/.uploads/<uploadId>/. The evaluator routes
-	// these entries to the AbortIncompleteMultipartUpload action shape.
-	// ModTime carries the upload's initiation time when this is set.
+	// IsMPUInit signals an in-flight multipart-upload init under
+	// <bucket>/.uploads/<uploadId>/. ModTime then carries the init time.
 	IsMPUInit bool
 }
 
-// Status values for Rule.Status.
 const (
 	StatusEnabled  = "Enabled"
 	StatusDisabled = "Disabled"
 )
 
-// SmallDelay is the lookback used for predicate-change events and as the
-// event-log horizon for count-based / immediate rule kinds (NewerNoncurrent,
-// ExpiredObjectDeleteMarker). A small fixed value avoids races with in-flight
-// writes without forcing the reader to keep deep history.
+// SmallDelay is the lookback for predicate-change events and the event-log
+// horizon for count / immediate kinds (NewerNoncurrent, ExpiredDeleteMarker).
 const SmallDelay = time.Minute
 
-// Action represents the lifecycle action to take on an object.
 type Action int
 
 const (
-	// ActionNone means no lifecycle rule applies.
 	ActionNone Action = iota
-	// ActionDeleteObject deletes the current version of the object.
 	ActionDeleteObject
-	// ActionDeleteVersion deletes a specific non-current version.
 	ActionDeleteVersion
-	// ActionExpireDeleteMarker removes a delete marker that is the sole remaining version.
 	ActionExpireDeleteMarker
-	// ActionAbortMultipartUpload aborts an incomplete multipart upload.
 	ActionAbortMultipartUpload
 )
 
-// EvalResult is the output of lifecycle rule evaluation.
 type EvalResult struct {
-	// Action is the lifecycle action to take.
 	Action Action
-	// RuleID is the ID of the rule that triggered this action.
 	RuleID string
 }

--- a/weed/s3api/s3lifecycle/rule.go
+++ b/weed/s3api/s3lifecycle/rule.go
@@ -27,7 +27,13 @@ type Rule struct {
 	// Tag filter (from Rule.Filter.Tag or Rule.Filter.And.Tags).
 	FilterTags map[string]string
 
-	// Size filters.
+	// Size filters. Zero is treated as "not set" by the evaluator. Per AWS
+	// S3, an explicit <ObjectSizeGreaterThan>0</ObjectSizeGreaterThan>
+	// (which excludes 0-byte objects) cannot be distinguished from omitted
+	// in this representation; if a future deployment needs that
+	// distinction, switch to *int64 (or a paired set-bool) and update
+	// filterMatches / filterAllows / RuleHash accordingly. The zero-as-unset
+	// shortcut matches the default in s3api.Filter and the canonicalizer.
 	FilterSizeGreaterThan int64
 	FilterSizeLessThan    int64
 }

--- a/weed/s3api/s3lifecycle/rule_hash.go
+++ b/weed/s3api/s3lifecycle/rule_hash.go
@@ -7,33 +7,18 @@ import (
 	"time"
 )
 
-// RuleHash returns the first 8 bytes of sha256 over a canonicalized rule
-// representation. The hash is stable across:
-//
-//   - tag-key reorder (FilterTags is sorted before hashing)
-//   - rule.ID changes (ID is excluded — it's display-only)
-//   - rule.Status flips (Enabled <-> Disabled — state continuity preserved
-//     across operator toggles)
-//
-// Prefix is hashed verbatim: "logs" and "logs/" produce different hashes
-// because they match different objects under literal prefix semantics
-// (strings.HasPrefix). Collapsing them would let an edit silently reuse
-// per-rule durable state for a rule that no longer matches the same set.
-//
-// Different action shapes (different days, different filter, different
-// action types) hash to different values.
-//
-// Encoding is length-prefixed to avoid delimiter ambiguity: a tag value
-// containing "=" or "\n" or a prefix containing the field-tag separator
-// must not be able to forge a different tuple that hashes the same. Each
-// scalar is written as `<field-tag-byte> <uvarint-length> <bytes>`.
+// RuleHash returns the first 8 bytes of sha256 over a length-prefixed
+// canonical encoding. Stable across tag-key reorder, ID renames, and Status
+// flips. Prefix is hashed verbatim — "logs" and "logs/" match different
+// objects, so they must hash differently. Length prefixing prevents a
+// forged value (e.g. a tag containing "=") from colliding with a legitimate
+// tuple.
 func RuleHash(rule *Rule) [8]byte {
 	if rule == nil {
 		var zero [8]byte
 		return zero
 	}
 	h := sha256.New()
-	// Filter.
 	writeBytes(h, fieldPrefix, []byte(rule.Prefix))
 	tagKeys := make([]string, 0, len(rule.FilterTags))
 	for k := range rule.FilterTags {
@@ -47,7 +32,6 @@ func RuleHash(rule *Rule) [8]byte {
 	}
 	writeInt64(h, fieldSizeGT, rule.FilterSizeGreaterThan)
 	writeInt64(h, fieldSizeLT, rule.FilterSizeLessThan)
-	// Actions.
 	writeInt64(h, fieldExpDays, int64(rule.ExpirationDays))
 	writeBytes(h, fieldExpDate, []byte(canonicalTime(rule.ExpirationDate)))
 	writeBool(h, fieldExpDeleteMarker, rule.ExpiredObjectDeleteMarker)
@@ -61,8 +45,8 @@ func RuleHash(rule *Rule) [8]byte {
 	return out
 }
 
-// Field tags namespace each scalar so an attacker can't substitute one
-// string for another and re-collide. Values are arbitrary but stable.
+// Field tags namespace each scalar so a forged string can't substitute for
+// another in a way that hashes the same.
 const (
 	fieldPrefix          byte = 0x01
 	fieldTagCount        byte = 0x02


### PR DESCRIPTION
Phase 2b of the S3 lifecycle redesign (#9346). Builds the in-memory engine that the bootstrap walker (Phase 2c) and the cluster reader (Phase 3) drive against. No callers yet — engine only; safe to land standalone.

## Summary

- **`weed/s3api/s3api_lifecycle_canonical.go`** — converts the XML-deserialized `Lifecycle` into the flat `s3lifecycle.Rule` shape the engine compiles against. Handles `<Filter><And>` flattening, single `<Tag>` filter, top-level `<Prefix>` fallback, multi-action rules.
- **`weed/s3api/s3lifecycle/action_kind.go`** — adds `s3lifecycle.ActionKey{rule_hash, action_kind}`, the engine's primary identity. One XML rule with N populated action sub-elements expands into N `ActionKey`s sharing `RuleHash` but differing in `ActionKind` so sibling actions are scheduled, gated, and degraded independently.
- **`weed/s3api/s3lifecycle/engine/`** — new package:
  - `Engine`/`Snapshot`: atomic-swap immutable snapshot. `MarkActive` is per-action and visible to in-flight reader passes without recompile.
  - `Compile`: produces the snapshot from `[]CompileInput` + per-`ActionKey` `PriorState` + cluster `MetaLogRetention`.
  - `decideMode`: disabled rule → `DISABLED`; `EXPIRATION_DATE` → `SCAN_AT_DATE`; reader-driven kind whose `eventLogHorizon + bootstrapLookbackMin` exceeds `metaLogRetention` → `SCAN_ONLY`; otherwise `EVENT_DRIVEN`. `metaLogRetention=0` means unbounded (the SeaweedFS default), gate doesn't trip.
  - `MatchOriginalWrite` / `MatchPredicateChange` / `MatchPath`: routing for the reader's per-delay sweep, the predicate-change sweep, and the bootstrap walker. Filters on `IsActive()` so the MarkActive flip is observable without recompile.

## Test plan
- `go test ./weed/s3api/s3lifecycle/...` — passing locally; covers single-action / multi-action expansion, retention gate, sibling actions degrading independently, `ExpirationDate` SCAN_AT_DATE path, disabled rule, prefix/tag/size filters, MPU-init shape gating, predicate-change routing, bootstrap-walker `MatchPath`.
- `go build ./...` — clean.
- No runtime callers yet; behavior cannot regress prod paths until Phase 2c/2d wires the engine into the LifecycleDelete RPC server and the bootstrap walker.

Stacked on #9346 (already merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compiled lifecycle engine with deterministic snapshots, routing and matching for scheduled and event-driven actions; supports prefix/tag/size filters and MPU-abort gating.

* **Bug Fixes**
  * Safer handling of noncurrent-version indexing and nil inputs; correct preservation of disabled/prior modes and expiration-date parsing.

* **Tests**
  * Expanded tests covering canonicalization, compilation, matching, snapshot behavior, and retention logic.

* **Documentation**
  * Concise updates to lifecycle and scheduling docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->