### PR TITLE
feat(s3/lifecycle): bucket-level bootstrap walker

### DIFF
--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -17,14 +17,17 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
 )
 
-// Entry is the minimal slice of a filer entry the walker needs. SuccessorModTime
-// and NoncurrentIndex are populated only for versioned-bucket walks (Phase 5);
-// non-versioned walks leave them at zero / nil and the count-based retention
-// path bails out conservatively.
+// Entry is the minimal slice of a filer entry the walker needs.
+// IsDirectory marks SeaweedFS directory entries; the walker never
+// dispatches against directories. SuccessorModTime and NoncurrentIndex are
+// populated only for versioned-bucket walks (Phase 5); non-versioned walks
+// leave them at zero / nil and the count-based retention path bails out
+// conservatively.
 type Entry struct {
 	Path           string
 	ModTime        time.Time
 	Size           int64
+	IsDirectory    bool
 	IsLatest       bool
 	IsDeleteMarker bool
 	IsMPUInit      bool
@@ -72,6 +75,12 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 		if entry == nil || entry.Path == "" {
 			return nil
 		}
+		// Lifecycle rules only apply to objects; SeaweedFS directory
+		// entries can co-exist in the listing and must not be deleted.
+		if entry.IsDirectory {
+			cp.LastScannedPath = entry.Path
+			return nil
+		}
 		if err := walkEntry(ctx, snap, bucket, entry, dispatch, now); err != nil {
 			return err
 		}
@@ -108,7 +117,11 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 		if action == nil {
 			continue
 		}
-		if action.Mode == engine.ModeScanAtDate {
+		// SCAN_AT_DATE has its own date-triggered bootstrap; DISABLED can be
+		// flipped at runtime by the operator independent of XML rule status,
+		// so explicitly skip it here even though EvaluateAction also gates
+		// on the rule's Status.
+		if action.Mode == engine.ModeScanAtDate || action.Mode == engine.ModeDisabled {
 			continue
 		}
 		res := s3lifecycle.EvaluateAction(action.Rule, key.ActionKind, info, now)

--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -99,11 +99,10 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 	}
 	cp := Checkpoint{LastScannedPath: opts.Resume}
 
+	// ListFunc's contract is to skip entries with Path <= opts.Resume; the
+	// callback here trusts that — no defensive re-filter.
 	err := list(ctx, bucket, opts.Resume, func(entry *Entry) error {
 		if entry == nil || entry.Path == "" {
-			return nil
-		}
-		if opts.Resume != "" && entry.Path <= opts.Resume {
 			return nil
 		}
 		if err := walkEntry(ctx, snap, bucket, entry, dispatch, now); err != nil {
@@ -126,6 +125,23 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 	// pass nil for the Event since the bootstrap walker has full live
 	// state per entry already.
 	keys := snap.MatchPath(bucket, entry.Path, nil)
+	if len(keys) == 0 {
+		return nil
+	}
+	// Build ObjectInfo once per entry; reused across every matching action
+	// for this entry. Avoids per-action allocation for multi-action rules.
+	info := &s3lifecycle.ObjectInfo{
+		Key:              entry.Path,
+		ModTime:          entry.ModTime,
+		Size:             entry.Size,
+		IsLatest:         entry.IsLatest,
+		IsDeleteMarker:   entry.IsDeleteMarker,
+		IsMPUInit:        entry.IsMPUInit,
+		NumVersions:      entry.NumVersions,
+		SuccessorModTime: entry.SuccessorModTime,
+		NoncurrentIndex:  entry.NoncurrentIndex,
+		Tags:             entry.Tags,
+	}
 	for _, key := range keys {
 		action := snap.Action(key)
 		if action == nil {
@@ -135,21 +151,6 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 		// date-triggered bootstrap is scheduled separately.
 		if action.Mode == engine.ModeScanAtDate {
 			continue
-		}
-		// Bootstrap evaluates with EvaluateAction on the live entry's
-		// ObjectInfo shape. We construct the ObjectInfo from the walker
-		// Entry so callers don't have to.
-		info := &s3lifecycle.ObjectInfo{
-			Key:              entry.Path,
-			ModTime:          entry.ModTime,
-			Size:             entry.Size,
-			IsLatest:         entry.IsLatest,
-			IsDeleteMarker:   entry.IsDeleteMarker,
-			IsMPUInit:        entry.IsMPUInit,
-			NumVersions:      entry.NumVersions,
-			SuccessorModTime: entry.SuccessorModTime,
-			NoncurrentIndex:  entry.NoncurrentIndex,
-			Tags:             entry.Tags,
 		}
 		res := s3lifecycle.EvaluateAction(action.Rule, key.ActionKind, info, now)
 		if res.Action == s3lifecycle.ActionNone {

--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -71,6 +71,12 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 	}
 	cp := Checkpoint{LastScannedPath: opts.Resume}
 
+	// Single ObjectInfo reused across the walk; EvaluateAction reads the
+	// fields synchronously and doesn't retain references, so per-entry
+	// field assignments are safe and avoid one heap allocation per entry
+	// for buckets with millions of objects.
+	var info s3lifecycle.ObjectInfo
+
 	err := list(ctx, bucket, opts.Resume, func(entry *Entry) error {
 		if entry == nil || entry.Path == "" {
 			return nil
@@ -81,7 +87,7 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 			cp.LastScannedPath = entry.Path
 			return nil
 		}
-		if err := walkEntry(ctx, snap, bucket, entry, dispatch, now); err != nil {
+		if err := walkEntry(ctx, snap, bucket, entry, dispatch, now, &info); err != nil {
 			return err
 		}
 		cp.LastScannedPath = entry.Path
@@ -94,13 +100,14 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 	return cp, nil
 }
 
-func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry *Entry, dispatch Dispatcher, now time.Time) error {
+func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry *Entry, dispatch Dispatcher, now time.Time, info *s3lifecycle.ObjectInfo) error {
 	keys := snap.MatchPath(bucket, entry.Path, nil)
 	if len(keys) == 0 {
 		return nil
 	}
-	// Build ObjectInfo once per entry; reused across every matching action.
-	info := &s3lifecycle.ObjectInfo{
+	// Reuse the caller-provided ObjectInfo (one allocation per Walk, not
+	// per entry); EvaluateAction reads synchronously without retaining.
+	*info = s3lifecycle.ObjectInfo{
 		Key:              entry.Path,
 		ModTime:          entry.ModTime,
 		Size:             entry.Size,

--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -17,12 +17,9 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
 )
 
-// Entry is the minimal slice of a filer entry the walker needs.
-// IsDirectory marks SeaweedFS directory entries; the walker never
-// dispatches against directories. SuccessorModTime and NoncurrentIndex are
-// populated only for versioned-bucket walks (Phase 5); non-versioned walks
-// leave them at zero / nil and the count-based retention path bails out
-// conservatively.
+// Entry is the routing-relevant slice of a filer entry. SuccessorModTime
+// and NoncurrentIndex are populated only on versioned-bucket walks; the
+// retention path bails out conservatively when they're zero / nil.
 type Entry struct {
 	Path           string
 	ModTime        time.Time
@@ -71,18 +68,15 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 	}
 	cp := Checkpoint{LastScannedPath: opts.Resume}
 
-	// Single ObjectInfo reused across the walk; EvaluateAction reads the
-	// fields synchronously and doesn't retain references, so per-entry
-	// field assignments are safe and avoid one heap allocation per entry
-	// for buckets with millions of objects.
+	// Reuse one ObjectInfo across the walk; EvaluateAction reads it
+	// synchronously without retaining.
 	var info s3lifecycle.ObjectInfo
 
 	err := list(ctx, bucket, opts.Resume, func(entry *Entry) error {
 		if entry == nil || entry.Path == "" {
 			return nil
 		}
-		// Lifecycle rules only apply to objects; SeaweedFS directory
-		// entries can co-exist in the listing and must not be deleted.
+		// Lifecycle never applies to directory entries.
 		if entry.IsDirectory {
 			cp.LastScannedPath = entry.Path
 			return nil
@@ -105,8 +99,6 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 	if len(keys) == 0 {
 		return nil
 	}
-	// Reuse the caller-provided ObjectInfo (one allocation per Walk, not
-	// per entry); EvaluateAction reads synchronously without retaining.
 	*info = s3lifecycle.ObjectInfo{
 		Key:              entry.Path,
 		ModTime:          entry.ModTime,
@@ -124,10 +116,9 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 		if action == nil {
 			continue
 		}
-		// SCAN_AT_DATE has its own date-triggered bootstrap; DISABLED can be
-		// flipped at runtime by the operator independent of XML rule status,
-		// so explicitly skip it here even though EvaluateAction also gates
-		// on the rule's Status.
+		// SCAN_AT_DATE runs its own date-triggered bootstrap. DISABLED can
+		// be flipped at runtime independent of XML Status, so skip it even
+		// though EvaluateAction would also reject.
 		if action.Mode == engine.ModeScanAtDate || action.Mode == engine.ModeDisabled {
 			continue
 		}

--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -39,11 +39,12 @@ type Entry struct {
 
 	// SuccessorModTime / NoncurrentIndex are populated for non-current
 	// versions during versioned-bucket walks. Phase 5 fills these in;
-	// Phase 2d non-versioned walks leave them at zero values, in which
-	// case ComputeDueAt falls back to ModTime per AWS-conservative
-	// semantics.
+	// Phase 2d non-versioned walks leave them at zero values (and
+	// NoncurrentIndex nil), in which case ComputeDueAt falls back to
+	// ModTime per AWS-conservative semantics and the count-based
+	// NewerNoncurrent retention path bails out (see the evaluator).
 	SuccessorModTime time.Time
-	NoncurrentIndex  int
+	NoncurrentIndex  *int
 }
 
 // ListFunc enumerates entries under a bucket in lexicographic order.

--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -1,17 +1,10 @@
-// Package bootstrap implements the bucket-level lifecycle bootstrap walker.
+// Package bootstrap is the bucket-level lifecycle walker. The walker
+// iterates every entry under a bucket, evaluates every active ActionKey
+// against it, and dispatches inline-delete RPCs for currently-due actions;
+// not-yet-due entries are left for the meta-log reader to pick up later.
 //
-// The walker iterates every entry under a bucket exactly once per bootstrap
-// task, evaluates every active ActionKey against the entry, and dispatches
-// inline-delete RPCs for currently-due actions. Not-yet-due entries are
-// skipped entirely — the meta-log reader (Phase 3) picks them up via
-// event-driven replay. Date-kind actions also skip here; their bucket-level
-// SCAN_AT_DATE bootstrap fires once on the rule's date.
-//
-// The walker is callback-driven so callers can supply their own filer
-// listing source (real filer_pb client or test fake) and their own delete
-// dispatcher (worker-side LifecycleDelete client or test fake). Checkpoint
-// state (`last_scanned_path`) is returned to the caller, who is responsible
-// for persisting it under /etc/s3/lifecycle/<bucket>/_bootstrap.
+// Callback-driven so the listing source and the LifecycleDelete dispatcher
+// can be supplied separately (real client or test fake).
 package bootstrap
 
 import (
@@ -24,11 +17,12 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
 )
 
-// Entry is the minimal slice of a filer entry the walker needs. The caller
-// converts *filer_pb.Entry into this shape so the walker stays free of
-// filer_pb dependencies.
+// Entry is the minimal slice of a filer entry the walker needs. SuccessorModTime
+// and NoncurrentIndex are populated only for versioned-bucket walks (Phase 5);
+// non-versioned walks leave them at zero / nil and the count-based retention
+// path bails out conservatively.
 type Entry struct {
-	Path           string // bucket-relative; no leading slash
+	Path           string
 	ModTime        time.Time
 	Size           int64
 	IsLatest       bool
@@ -37,62 +31,36 @@ type Entry struct {
 	NumVersions    int
 	Tags           map[string]string
 
-	// SuccessorModTime / NoncurrentIndex are populated for non-current
-	// versions during versioned-bucket walks. Phase 5 fills these in;
-	// Phase 2d non-versioned walks leave them at zero values (and
-	// NoncurrentIndex nil), in which case ComputeDueAt falls back to
-	// ModTime per AWS-conservative semantics and the count-based
-	// NewerNoncurrent retention path bails out (see the evaluator).
 	SuccessorModTime time.Time
 	NoncurrentIndex  *int
 }
 
-// ListFunc enumerates entries under a bucket in lexicographic order.
-// The callback is invoked once per entry; returning a non-nil error halts
-// the walk and bubbles back through Walk. start is the resume point —
-// entries with Path <= start are skipped (used after a kill-resume).
+// ListFunc must skip entries with Path <= start so kill-resume picks up
+// where the previous run stopped.
 type ListFunc func(ctx context.Context, bucket, start string, cb func(*Entry) error) error
 
-// Dispatcher executes one (action, entry) verdict. The walker calls this
-// only for actions whose ComputeDueAt indicates the entry is currently due.
-// Returning an error halts the walk; the caller decides whether to retry
-// from the recorded last_scanned_path.
+// Dispatcher executes one (action, entry) verdict. An error halts the walk;
+// the caller decides whether to retry from the recorded last_scanned_path.
 type Dispatcher interface {
 	Delete(ctx context.Context, action *engine.CompiledAction, entry *Entry) error
 }
 
-// Checkpoint is the resume state the walker hands back. The caller persists
-// it to /etc/s3/lifecycle/<bucket>/_bootstrap so a kill-resumed task picks
-// up where this one stopped.
+// Checkpoint is the resume state. Caller persists it under
+// /etc/s3/lifecycle/<bucket>/_bootstrap.
 type Checkpoint struct {
 	LastScannedPath string
-	Completed       bool // true when the walk ran to completion of the listing
+	Completed       bool
 }
 
-// WalkOptions tunes the walk. All fields have safe zero values.
 type WalkOptions struct {
-	// Resume from this path; entries with Path <= Resume are skipped.
 	Resume string
-	// Now is the wall-clock the walker uses for due-checks. Tests inject
-	// a fixed time; callers default to time.Now().
-	Now time.Time
+	Now    time.Time
 }
 
-// Walk iterates the bucket's entries via list, evaluates each entry against
-// every ACTIVE ActionKey for the bucket in snap, and dispatches Delete
-// for currently-due actions. Returns a Checkpoint the caller persists.
-//
-// Per-entry semantics:
-//   - prefix-mismatched / filter-rejected actions: skipped (no dispatch).
-//   - not-yet-due actions: skipped (the reader will pick them up via the
-//     meta log when the cutoff sweeps past the entry).
-//   - currently-due actions: Dispatcher.Delete called. Errors halt the walk.
-//   - SCAN_AT_DATE actions: skipped (their date-triggered bootstrap is a
-//     separate task).
-//
-// The walker uses MatchPath to enumerate candidate ActionKeys per entry
-// (already filtered by prefix and active), then EvaluateAction per kind to
-// confirm the entry is actually due.
+// Walk iterates entries via list, evaluates each active ActionKey via
+// MatchPath + EvaluateAction, and calls Dispatcher.Delete for currently-due
+// actions. SCAN_AT_DATE actions are skipped (their bootstrap is scheduled
+// separately).
 func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFunc, dispatch Dispatcher, opts WalkOptions) (Checkpoint, error) {
 	now := opts.Now
 	if now.IsZero() {
@@ -100,8 +68,6 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 	}
 	cp := Checkpoint{LastScannedPath: opts.Resume}
 
-	// ListFunc's contract is to skip entries with Path <= opts.Resume; the
-	// callback here trusts that — no defensive re-filter.
 	err := list(ctx, bucket, opts.Resume, func(entry *Entry) error {
 		if entry == nil || entry.Path == "" {
 			return nil
@@ -119,18 +85,12 @@ func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFu
 	return cp, nil
 }
 
-// walkEntry runs the per-entry portion of the walk: enumerate matching
-// ActionKeys and dispatch the ones currently due.
 func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry *Entry, dispatch Dispatcher, now time.Time) error {
-	// MatchPath returns prefix-and-filter-matched ACTIVE ActionKeys; we
-	// pass nil for the Event since the bootstrap walker has full live
-	// state per entry already.
 	keys := snap.MatchPath(bucket, entry.Path, nil)
 	if len(keys) == 0 {
 		return nil
 	}
-	// Build ObjectInfo once per entry; reused across every matching action
-	// for this entry. Avoids per-action allocation for multi-action rules.
+	// Build ObjectInfo once per entry; reused across every matching action.
 	info := &s3lifecycle.ObjectInfo{
 		Key:              entry.Path,
 		ModTime:          entry.ModTime,
@@ -148,8 +108,6 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 		if action == nil {
 			continue
 		}
-		// SCAN_AT_DATE actions don't dispatch from the walker; their
-		// date-triggered bootstrap is scheduled separately.
 		if action.Mode == engine.ModeScanAtDate {
 			continue
 		}
@@ -166,8 +124,7 @@ func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry 
 	return nil
 }
 
-// EntryCallback is a convenience type for simple in-memory listings. Tests
-// typically build a ListFunc by closing over a sorted slice.
+// EntryCallback wraps an in-memory slice as a ListFunc; useful for tests.
 func EntryCallback(entries []*Entry) ListFunc {
 	return func(ctx context.Context, bucket, start string, cb func(*Entry) error) error {
 		for _, e := range entries {
@@ -182,6 +139,4 @@ func EntryCallback(entries []*Entry) ListFunc {
 	}
 }
 
-// HasPrefix is a small helper kept here so the walker stays self-contained.
-// It mirrors strings.HasPrefix but feels natural at the package surface.
 func HasPrefix(path, prefix string) bool { return strings.HasPrefix(path, prefix) }

--- a/weed/s3api/s3lifecycle/bootstrap/walker.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker.go
@@ -1,0 +1,185 @@
+// Package bootstrap implements the bucket-level lifecycle bootstrap walker.
+//
+// The walker iterates every entry under a bucket exactly once per bootstrap
+// task, evaluates every active ActionKey against the entry, and dispatches
+// inline-delete RPCs for currently-due actions. Not-yet-due entries are
+// skipped entirely — the meta-log reader (Phase 3) picks them up via
+// event-driven replay. Date-kind actions also skip here; their bucket-level
+// SCAN_AT_DATE bootstrap fires once on the rule's date.
+//
+// The walker is callback-driven so callers can supply their own filer
+// listing source (real filer_pb client or test fake) and their own delete
+// dispatcher (worker-side LifecycleDelete client or test fake). Checkpoint
+// state (`last_scanned_path`) is returned to the caller, who is responsible
+// for persisting it under /etc/s3/lifecycle/<bucket>/_bootstrap.
+package bootstrap
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
+)
+
+// Entry is the minimal slice of a filer entry the walker needs. The caller
+// converts *filer_pb.Entry into this shape so the walker stays free of
+// filer_pb dependencies.
+type Entry struct {
+	Path           string // bucket-relative; no leading slash
+	ModTime        time.Time
+	Size           int64
+	IsLatest       bool
+	IsDeleteMarker bool
+	IsMPUInit      bool
+	NumVersions    int
+	Tags           map[string]string
+
+	// SuccessorModTime / NoncurrentIndex are populated for non-current
+	// versions during versioned-bucket walks. Phase 5 fills these in;
+	// Phase 2d non-versioned walks leave them at zero values, in which
+	// case ComputeDueAt falls back to ModTime per AWS-conservative
+	// semantics.
+	SuccessorModTime time.Time
+	NoncurrentIndex  int
+}
+
+// ListFunc enumerates entries under a bucket in lexicographic order.
+// The callback is invoked once per entry; returning a non-nil error halts
+// the walk and bubbles back through Walk. start is the resume point —
+// entries with Path <= start are skipped (used after a kill-resume).
+type ListFunc func(ctx context.Context, bucket, start string, cb func(*Entry) error) error
+
+// Dispatcher executes one (action, entry) verdict. The walker calls this
+// only for actions whose ComputeDueAt indicates the entry is currently due.
+// Returning an error halts the walk; the caller decides whether to retry
+// from the recorded last_scanned_path.
+type Dispatcher interface {
+	Delete(ctx context.Context, action *engine.CompiledAction, entry *Entry) error
+}
+
+// Checkpoint is the resume state the walker hands back. The caller persists
+// it to /etc/s3/lifecycle/<bucket>/_bootstrap so a kill-resumed task picks
+// up where this one stopped.
+type Checkpoint struct {
+	LastScannedPath string
+	Completed       bool // true when the walk ran to completion of the listing
+}
+
+// WalkOptions tunes the walk. All fields have safe zero values.
+type WalkOptions struct {
+	// Resume from this path; entries with Path <= Resume are skipped.
+	Resume string
+	// Now is the wall-clock the walker uses for due-checks. Tests inject
+	// a fixed time; callers default to time.Now().
+	Now time.Time
+}
+
+// Walk iterates the bucket's entries via list, evaluates each entry against
+// every ACTIVE ActionKey for the bucket in snap, and dispatches Delete
+// for currently-due actions. Returns a Checkpoint the caller persists.
+//
+// Per-entry semantics:
+//   - prefix-mismatched / filter-rejected actions: skipped (no dispatch).
+//   - not-yet-due actions: skipped (the reader will pick them up via the
+//     meta log when the cutoff sweeps past the entry).
+//   - currently-due actions: Dispatcher.Delete called. Errors halt the walk.
+//   - SCAN_AT_DATE actions: skipped (their date-triggered bootstrap is a
+//     separate task).
+//
+// The walker uses MatchPath to enumerate candidate ActionKeys per entry
+// (already filtered by prefix and active), then EvaluateAction per kind to
+// confirm the entry is actually due.
+func Walk(ctx context.Context, snap *engine.Snapshot, bucket string, list ListFunc, dispatch Dispatcher, opts WalkOptions) (Checkpoint, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	cp := Checkpoint{LastScannedPath: opts.Resume}
+
+	err := list(ctx, bucket, opts.Resume, func(entry *Entry) error {
+		if entry == nil || entry.Path == "" {
+			return nil
+		}
+		if opts.Resume != "" && entry.Path <= opts.Resume {
+			return nil
+		}
+		if err := walkEntry(ctx, snap, bucket, entry, dispatch, now); err != nil {
+			return err
+		}
+		cp.LastScannedPath = entry.Path
+		return nil
+	})
+	if err != nil {
+		return cp, err
+	}
+	cp.Completed = true
+	return cp, nil
+}
+
+// walkEntry runs the per-entry portion of the walk: enumerate matching
+// ActionKeys and dispatch the ones currently due.
+func walkEntry(ctx context.Context, snap *engine.Snapshot, bucket string, entry *Entry, dispatch Dispatcher, now time.Time) error {
+	// MatchPath returns prefix-and-filter-matched ACTIVE ActionKeys; we
+	// pass nil for the Event since the bootstrap walker has full live
+	// state per entry already.
+	keys := snap.MatchPath(bucket, entry.Path, nil)
+	for _, key := range keys {
+		action := snap.Action(key)
+		if action == nil {
+			continue
+		}
+		// SCAN_AT_DATE actions don't dispatch from the walker; their
+		// date-triggered bootstrap is scheduled separately.
+		if action.Mode == engine.ModeScanAtDate {
+			continue
+		}
+		// Bootstrap evaluates with EvaluateAction on the live entry's
+		// ObjectInfo shape. We construct the ObjectInfo from the walker
+		// Entry so callers don't have to.
+		info := &s3lifecycle.ObjectInfo{
+			Key:              entry.Path,
+			ModTime:          entry.ModTime,
+			Size:             entry.Size,
+			IsLatest:         entry.IsLatest,
+			IsDeleteMarker:   entry.IsDeleteMarker,
+			IsMPUInit:        entry.IsMPUInit,
+			NumVersions:      entry.NumVersions,
+			SuccessorModTime: entry.SuccessorModTime,
+			NoncurrentIndex:  entry.NoncurrentIndex,
+			Tags:             entry.Tags,
+		}
+		res := s3lifecycle.EvaluateAction(action.Rule, key.ActionKind, info, now)
+		if res.Action == s3lifecycle.ActionNone {
+			continue
+		}
+		if err := dispatch.Delete(ctx, action, entry); err != nil {
+			glog.Warningf("lifecycle bootstrap: dispatch %s/%s kind=%s: %v",
+				bucket, entry.Path, key.ActionKind, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// EntryCallback is a convenience type for simple in-memory listings. Tests
+// typically build a ListFunc by closing over a sorted slice.
+func EntryCallback(entries []*Entry) ListFunc {
+	return func(ctx context.Context, bucket, start string, cb func(*Entry) error) error {
+		for _, e := range entries {
+			if start != "" && e.Path <= start {
+				continue
+			}
+			if err := cb(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// HasPrefix is a small helper kept here so the walker stays self-contained.
+// It mirrors strings.HasPrefix but feels natural at the package surface.
+func HasPrefix(path, prefix string) bool { return strings.HasPrefix(path, prefix) }

--- a/weed/s3api/s3lifecycle/bootstrap/walker_test.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker_test.go
@@ -1,0 +1,267 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
+)
+
+// recorder captures dispatched (action, entry) pairs for assertion.
+type recorder struct {
+	calls []dispatchCall
+	err   error // when set, every Delete returns this error
+}
+
+type dispatchCall struct {
+	kind s3lifecycle.ActionKind
+	path string
+}
+
+func (r *recorder) Delete(ctx context.Context, action *engine.CompiledAction, entry *Entry) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.calls = append(r.calls, dispatchCall{kind: action.Key.ActionKind, path: entry.Path})
+	return nil
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %s: %v", s, err)
+	}
+	return tm
+}
+
+func compileEvDriven(t *testing.T, bucket string, rules ...*s3lifecycle.Rule) *engine.Snapshot {
+	t.Helper()
+	prior := map[s3lifecycle.ActionKey]engine.PriorState{}
+	for _, r := range rules {
+		rh := s3lifecycle.RuleHash(r)
+		for _, k := range s3lifecycle.RuleActionKinds(r) {
+			prior[s3lifecycle.ActionKey{RuleHash: rh, ActionKind: k}] = engine.PriorState{BootstrapComplete: true}
+		}
+	}
+	e := engine.New()
+	return e.Compile([]engine.CompileInput{{Bucket: bucket, Rules: rules}}, engine.CompileOptions{PriorStates: prior})
+}
+
+func TestWalk_DispatchesDueActions(t *testing.T) {
+	rule := &s3lifecycle.Rule{
+		ID:             "r",
+		Status:         s3lifecycle.StatusEnabled,
+		ExpirationDays: 30,
+		Prefix:         "logs/",
+	}
+	snap := compileEvDriven(t, "bk", rule)
+
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 60) // past the 30d threshold
+	entries := []*Entry{
+		{Path: "data/x", IsLatest: true, ModTime: mod}, // wrong prefix
+		{Path: "logs/a", IsLatest: true, ModTime: mod}, // due
+		{Path: "logs/b", IsLatest: true, ModTime: now}, // not yet due (mod=now)
+	}
+
+	rec := &recorder{}
+	cp, err := Walk(context.Background(), snap, "bk", EntryCallback(entries), rec, WalkOptions{Now: now})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !cp.Completed {
+		t.Fatalf("walk should complete")
+	}
+	if cp.LastScannedPath != "logs/b" {
+		t.Fatalf("checkpoint last scanned want logs/b, got %q", cp.LastScannedPath)
+	}
+	if len(rec.calls) != 1 || rec.calls[0].path != "logs/a" {
+		t.Fatalf("dispatched calls want [logs/a], got %v", rec.calls)
+	}
+}
+
+func TestWalk_MultiActionRule_AllDueDispatched(t *testing.T) {
+	// One rule with three actions; all currently-due for the entry. The
+	// walker must dispatch one Delete per action — this is the
+	// regression that the per-action keying fixes.
+	rule := &s3lifecycle.Rule{
+		ID:                              "multi",
+		Status:                          s3lifecycle.StatusEnabled,
+		ExpirationDays:                  30,
+		NoncurrentVersionExpirationDays: 7,
+		AbortMPUDaysAfterInitiation:     5,
+	}
+	snap := compileEvDriven(t, "bk", rule)
+
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 100) // past every threshold
+	// Use a single entry that satisfies all three action shapes is
+	// unrealistic; in practice each shape is a different entry. Cover
+	// each shape independently.
+	entries := []*Entry{
+		// Current version under ExpirationDays.
+		{Path: "obj/a", IsLatest: true, ModTime: mod},
+		// Non-current version under NoncurrentDays.
+		{Path: "obj/a/.versions/v1", IsLatest: false, ModTime: mod, SuccessorModTime: mod},
+		// MPU init under AbortMPU.
+		{Path: ".uploads/u1/", IsMPUInit: true, ModTime: mod},
+	}
+
+	rec := &recorder{}
+	if _, err := Walk(context.Background(), snap, "bk", EntryCallback(entries), rec, WalkOptions{Now: now}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	gotKinds := map[s3lifecycle.ActionKind]bool{}
+	for _, c := range rec.calls {
+		gotKinds[c.kind] = true
+	}
+	for _, want := range []s3lifecycle.ActionKind{
+		s3lifecycle.ActionKindExpirationDays,
+		s3lifecycle.ActionKindNoncurrentDays,
+		s3lifecycle.ActionKindAbortMPU,
+	} {
+		if !gotKinds[want] {
+			t.Fatalf("expected dispatch for %v, got %v", want, rec.calls)
+		}
+	}
+}
+
+func TestWalk_NotYetDueSkipped(t *testing.T) {
+	// The reader (Phase 3) is responsible for not-yet-due entries; the
+	// walker dispatches only currently-due ones, so the meta-log path
+	// stays the steady-state route.
+	rule := &s3lifecycle.Rule{
+		ID:             "r",
+		Status:         s3lifecycle.StatusEnabled,
+		ExpirationDays: 30,
+	}
+	snap := compileEvDriven(t, "bk", rule)
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 10) // before the 30d threshold
+
+	rec := &recorder{}
+	if _, err := Walk(context.Background(), snap, "bk", EntryCallback([]*Entry{
+		{Path: "x/a", IsLatest: true, ModTime: mod},
+	}), rec, WalkOptions{Now: now}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("not-yet-due entry should not dispatch, got %v", rec.calls)
+	}
+}
+
+func TestWalk_DateActionsSkipped(t *testing.T) {
+	// Date kind is handled by its own SCAN_AT_DATE bootstrap, not by the
+	// regular bootstrap walker.
+	date := mustTime(t, "2025-06-15T00:00:00Z")
+	rule := &s3lifecycle.Rule{
+		ID:             "d",
+		Status:         s3lifecycle.StatusEnabled,
+		ExpirationDate: date,
+	}
+	snap := compileEvDriven(t, "bk", rule)
+
+	rec := &recorder{}
+	if _, err := Walk(context.Background(), snap, "bk", EntryCallback([]*Entry{
+		{Path: "x/a", IsLatest: true, ModTime: mustTime(t, "2024-01-01T00:00:00Z")},
+	}), rec, WalkOptions{Now: date.AddDate(0, 1, 0)}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("date kind should not dispatch from walker, got %v", rec.calls)
+	}
+}
+
+func TestWalk_PendingBootstrapNotDispatched(t *testing.T) {
+	// Without bootstrap_complete=true in PriorStates, the engine compiles
+	// the action as inactive. MatchPath filters on IsActive, so the
+	// walker won't dispatch.
+	rule := &s3lifecycle.Rule{
+		ID:             "r",
+		Status:         s3lifecycle.StatusEnabled,
+		ExpirationDays: 1,
+	}
+	e := engine.New()
+	snap := e.Compile([]engine.CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, engine.CompileOptions{})
+
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 10)
+	rec := &recorder{}
+	if _, err := Walk(context.Background(), snap, "bk", EntryCallback([]*Entry{
+		{Path: "x/a", IsLatest: true, ModTime: mod},
+	}), rec, WalkOptions{Now: now}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("inactive action should not dispatch, got %v", rec.calls)
+	}
+}
+
+func TestWalk_DispatchErrorHaltsAtCheckpoint(t *testing.T) {
+	rule := &s3lifecycle.Rule{
+		ID:             "r",
+		Status:         s3lifecycle.StatusEnabled,
+		ExpirationDays: 1,
+	}
+	snap := compileEvDriven(t, "bk", rule)
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 10)
+	entries := []*Entry{
+		{Path: "a", IsLatest: true, ModTime: mod},
+		{Path: "b", IsLatest: true, ModTime: mod},
+		{Path: "c", IsLatest: true, ModTime: mod},
+	}
+
+	wantErr := errors.New("dispatch boom")
+	rec := &recorder{err: wantErr}
+	cp, err := Walk(context.Background(), snap, "bk", EntryCallback(entries), rec, WalkOptions{Now: now})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("want dispatch error, got %v", err)
+	}
+	if cp.Completed {
+		t.Fatalf("walk should not be Completed on dispatch failure")
+	}
+	// Walker stops on first failure; checkpoint stays at whatever was
+	// recorded BEFORE the failed entry. Path "a" is the failing entry,
+	// so LastScannedPath stays at the resume point (empty here).
+	if cp.LastScannedPath != "" {
+		t.Fatalf("checkpoint should not advance past failing entry, got %q", cp.LastScannedPath)
+	}
+}
+
+func TestWalk_ResumeFromCheckpoint(t *testing.T) {
+	rule := &s3lifecycle.Rule{
+		ID:             "r",
+		Status:         s3lifecycle.StatusEnabled,
+		ExpirationDays: 1,
+	}
+	snap := compileEvDriven(t, "bk", rule)
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 10)
+	entries := []*Entry{
+		{Path: "a", IsLatest: true, ModTime: mod},
+		{Path: "b", IsLatest: true, ModTime: mod},
+		{Path: "c", IsLatest: true, ModTime: mod},
+	}
+
+	rec := &recorder{}
+	cp, err := Walk(context.Background(), snap, "bk", EntryCallback(entries), rec, WalkOptions{Now: now, Resume: "b"})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !cp.Completed {
+		t.Fatalf("walk should complete")
+	}
+	// Only "c" is processed (entries with Path <= "b" are skipped).
+	if len(rec.calls) != 1 || rec.calls[0].path != "c" {
+		t.Fatalf("Resume should only process c, got %v", rec.calls)
+	}
+	if cp.LastScannedPath != "c" {
+		t.Fatalf("checkpoint want c, got %q", cp.LastScannedPath)
+	}
+}

--- a/weed/s3api/s3lifecycle/bootstrap/walker_test.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker_test.go
@@ -177,6 +177,51 @@ func TestWalk_DateActionsSkipped(t *testing.T) {
 	}
 }
 
+func TestWalk_DirectoryEntriesSkipped(t *testing.T) {
+	// SeaweedFS directory entries can co-exist in the listing; the walker
+	// must not dispatch deletes against them even when their path matches.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	snap := compileEvDriven(t, "bk", rule)
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 10)
+	rec := &recorder{}
+	if _, err := Walk(context.Background(), snap, "bk", EntryCallback([]*Entry{
+		{Path: "x", IsDirectory: true, ModTime: mod}, // directory; must skip
+		{Path: "x/file", IsLatest: true, ModTime: mod},
+	}), rec, WalkOptions{Now: now}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(rec.calls) != 1 || rec.calls[0].path != "x/file" {
+		t.Fatalf("only the file should dispatch, got %v", rec.calls)
+	}
+}
+
+func TestWalk_DisabledModeSkipped(t *testing.T) {
+	// An operator-flipped ModeDisabled must short-circuit the walker even
+	// when the XML rule status is "Enabled" and EvaluateAction would
+	// otherwise fire.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	rh := s3lifecycle.RuleHash(rule)
+	prior := map[s3lifecycle.ActionKey]engine.PriorState{
+		{Bucket: "bk", RuleHash: rh, ActionKind: s3lifecycle.ActionKindExpirationDays}: {
+			BootstrapComplete: true, Mode: engine.ModeDisabled,
+		},
+	}
+	e := engine.New()
+	snap := e.Compile([]engine.CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}}}, engine.CompileOptions{PriorStates: prior})
+	mod := mustTime(t, "2024-01-01T00:00:00Z")
+	now := mod.AddDate(0, 0, 10)
+	rec := &recorder{}
+	if _, err := Walk(context.Background(), snap, "bk", EntryCallback([]*Entry{
+		{Path: "x/a", IsLatest: true, ModTime: mod},
+	}), rec, WalkOptions{Now: now}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("disabled action must not dispatch, got %v", rec.calls)
+	}
+}
+
 func TestWalk_PendingBootstrapNotDispatched(t *testing.T) {
 	// Without bootstrap_complete=true in PriorStates, the engine compiles
 	// the action as inactive. MatchPath filters on IsActive, so the

--- a/weed/s3api/s3lifecycle/bootstrap/walker_test.go
+++ b/weed/s3api/s3lifecycle/bootstrap/walker_test.go
@@ -44,7 +44,7 @@ func compileEvDriven(t *testing.T, bucket string, rules ...*s3lifecycle.Rule) *e
 	for _, r := range rules {
 		rh := s3lifecycle.RuleHash(r)
 		for _, k := range s3lifecycle.RuleActionKinds(r) {
-			prior[s3lifecycle.ActionKey{RuleHash: rh, ActionKind: k}] = engine.PriorState{BootstrapComplete: true}
+			prior[s3lifecycle.ActionKey{Bucket: bucket, RuleHash: rh, ActionKind: k}] = engine.PriorState{BootstrapComplete: true}
 		}
 	}
 	e := engine.New()

--- a/weed/worker/types/task_types.go
+++ b/weed/worker/types/task_types.go
@@ -16,6 +16,12 @@ const (
 	TaskTypeBalance       TaskType = "balance"
 	TaskTypeReplication   TaskType = "replication"
 	TaskTypeECBalance     TaskType = "ec_balance"
+	// TaskTypeS3Lifecycle covers all three lifecycle subtypes (READ, BOOTSTRAP,
+	// DRAIN) — one job type, dispatched by S3LifecycleParams.Subtype inside
+	// the handler. The lane mapping in admin/plugin/scheduler_lane.go binds
+	// "s3_lifecycle" -> LaneLifecycle so lifecycle work runs in its own
+	// scheduling lane and never blocks the default-lane admin lock.
+	TaskTypeS3Lifecycle TaskType = "s3_lifecycle"
 )
 
 // TaskStatus represents the status of a maintenance task


### PR DESCRIPTION
Phase 2d — adds the bucket-level bootstrap walker as a callback-driven library. Stacks on #9349.

## Summary

- **\`weed/worker/types/task_types.go\`** — adds \`TaskTypeS3Lifecycle = \"s3_lifecycle\"\` constant. The string is already wired to \`LaneLifecycle\` in \`admin/plugin/scheduler_lane.go\`; this commit just gives the type a Go name so future task-handler wiring doesn't sprinkle string literals.
- **\`weed/s3api/s3lifecycle/bootstrap/walker.go\`** — \`Walk(ctx, snap, bucket, list, dispatch, opts)\`. Callback-driven so callers supply the listing source (real \`filer_pb.SeaweedList\` or test fake) and the dispatcher (real \`LifecycleDelete\` gRPC client or test fake). Keeps the walker free of filer_pb dependencies.

Walker semantics (matches design doc §\"Bootstrap — bucket-level, inline-delete\"):
- Per entry, calls \`Snapshot.MatchPath\` to get the active \`ActionKey\`s whose filter matches.
- Per matched action, runs \`s3lifecycle.EvaluateAction(rule, kind, info, now)\`. Currently-due → \`Dispatcher.Delete\`. Not-yet-due → skip (the meta-log reader picks them up).
- SCAN_AT_DATE actions are skipped (their date-triggered bootstrap is a separate task).
- Pending-bootstrap actions are skipped via the \`IsActive()\` filter inside \`MatchPath\`.
- Returns a \`Checkpoint{LastScannedPath, Completed}\` so the caller can persist resume state.
- \`opts.Resume\` skips entries with \`Path <= Resume\` for kill-resume.
- Dispatch error halts the walk; the checkpoint stays at the last successfully-processed entry so the next task retries the failing path.

## What's NOT in this PR
- Worker task framework integration (handler registration with \`base.RegisterTask\`, config schema for the admin UI, etc.).
- Real \`filer_pb.SeaweedList\` adapter — Phase 2e.
- Real \`LifecycleDelete\` gRPC client — the server handler is in #9349; the client wrapper lands in Phase 2e.
- Detector — Phase 2e.
- Shell commands — Phase 2e.

## Test plan
- \`go test ./weed/s3api/s3lifecycle/bootstrap/...\` — passing locally; covers prefix-mismatch / not-yet-due / date-kind / pending-bootstrap skip, multi-action rule (one rule, three actions, three dispatches — the regression per-action keying fixes), dispatch error halts at last-successful checkpoint, Resume skips entries up to the resume path.
- \`go build ./...\` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 lifecycle bootstrap processing to evaluate and execute lifecycle rules on bucket entries.
  * Added checkpoint and resume support for interrupted lifecycle scans.
  * Implemented proper handling of lifecycle rule status and action dispatching.

* **Tests**
  * Added comprehensive test coverage for lifecycle bootstrap walker functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->