### PR TITLE
feat(pb): ReadLogFileRefsWithPosition for per-shard cursors

### DIFF
--- a/weed/pb/filer_pb_direct_read_with_position.go
+++ b/weed/pb/filer_pb_direct_read_with_position.go
@@ -96,7 +96,7 @@ func ReadLogFileRefsWithPosition(
 	var wg sync.WaitGroup
 	for _, fid := range filerOrder {
 		startPos := startPositions[fid]
-		paused := startPos.TsNs == MaxMessagePosition.TsNs && startPos.Offset == MaxMessagePosition.Offset
+		paused := startPos == MaxMessagePosition
 		ch := make(chan *filer_pb.LogEntry, 256)
 		errCh := make(chan error, 1)
 		s := &filerStream{id: fid, ch: ch, errCh: errCh, startPos: startPos, paused: paused}

--- a/weed/pb/filer_pb_direct_read_with_position.go
+++ b/weed/pb/filer_pb_direct_read_with_position.go
@@ -12,25 +12,20 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
-// MessagePosition is the per-shard cursor (ts_ns, offset). LogEntry.Offset
-// is per-buffer per-filer, so a single global cursor can't safely resume from
-// a multi-filer merged stream. Local to pb to avoid pulling log_buffer.
+// MessagePosition is the per-shard cursor. LogEntry.Offset is per-filer, so
+// a single global cursor can't resume safely from a merged stream.
 type MessagePosition struct {
 	TsNs   int64
 	Offset int64
 }
 
-// MaxMessagePosition returns the sentinel that pauses a shard's emission
-// entirely; used when the shard has an active blocker. Returned as a value
-// rather than an exported var so an importer can't accidentally mutate it
-// (e.g. `pb.MaxMessagePosition.TsNs = 0` would silently break every
-// `startPos == MaxMessagePosition()` check).
+// MaxMessagePosition pauses a shard's emission. Function-not-var so an
+// importer can't mutate the sentinel.
 func MaxMessagePosition() MessagePosition {
 	return MessagePosition{TsNs: 1<<63 - 1, Offset: 1<<63 - 1}
 }
 
-// LessOrEqual is the strict-`<=` skip predicate so the last resolved event
-// isn't replayed.
+// LessOrEqual: strict `<=` so the last resolved event isn't replayed.
 func (p MessagePosition) LessOrEqual(other MessagePosition) bool {
 	if p.TsNs != other.TsNs {
 		return p.TsNs < other.TsNs
@@ -38,17 +33,12 @@ func (p MessagePosition) LessOrEqual(other MessagePosition) bool {
 	return p.Offset <= other.Offset
 }
 
-// EventCallback receives one delivered event with its shard context. A
-// non-nil error halts the read.
+// EventCallback halts the read on a non-nil error.
 type EventCallback func(event *filer_pb.SubscribeMetadataResponse, filerId string, position MessagePosition) error
 
-// ReadLogFileRefsWithPosition is the per-shard variant of ReadLogFileRefs.
-// Events with (ts, offset) <= startPositions[filer_id] are skipped per
-// shard. Cross-filer ordering is (ts, filerId, offset) — the filerId
-// tiebreak makes retries from the same starting cursor see the same event
-// sequence.
-//
-// Returns lastByFiler so checkpoint writes are atomic.
+// ReadLogFileRefsWithPosition skips events with (ts, offset) <=
+// startPositions[filer_id]. Cross-filer ordering is (ts, filerId, offset)
+// so retries from the same cursor see the same event sequence.
 // startPositions[filer_id] = MaxMessagePosition() pauses that shard.
 func ReadLogFileRefsWithPosition(
 	refs []*filer_pb.LogFileChunkRef,
@@ -162,10 +152,10 @@ func streamEntriesWithPosition(
 	stopTsNs int64,
 	out chan<- *filer_pb.LogEntry,
 ) error {
+	// No file-level fast-skip: FileTsNs is flush-start; the file's last
+	// entry can be later. Without FileMaxTsNs on the ref the per-entry
+	// predicate is the only safe gate.
 	for _, ref := range refs {
-		// No file-level fast-skip: FileTsNs is the flush start, but the
-		// last entry can be later. Without a FileMaxTsNs we can't safely
-		// prune whole files.
 		entries, err := readLogFileEntries(newReader, ref.Chunks, 0, stopTsNs)
 		if err != nil {
 			if isChunkNotFound(err) {

--- a/weed/pb/filer_pb_direct_read_with_position.go
+++ b/weed/pb/filer_pb_direct_read_with_position.go
@@ -20,9 +20,14 @@ type MessagePosition struct {
 	Offset int64
 }
 
-// MaxMessagePosition pauses a shard's emission entirely; used when the shard
-// has an active blocker.
-var MaxMessagePosition = MessagePosition{TsNs: 1<<63 - 1, Offset: 1<<63 - 1}
+// MaxMessagePosition returns the sentinel that pauses a shard's emission
+// entirely; used when the shard has an active blocker. Returned as a value
+// rather than an exported var so an importer can't accidentally mutate it
+// (e.g. `pb.MaxMessagePosition.TsNs = 0` would silently break every
+// `startPos == MaxMessagePosition()` check).
+func MaxMessagePosition() MessagePosition {
+	return MessagePosition{TsNs: 1<<63 - 1, Offset: 1<<63 - 1}
+}
 
 // LessOrEqual is the strict-`<=` skip predicate so the last resolved event
 // isn't replayed.
@@ -44,7 +49,7 @@ type EventCallback func(event *filer_pb.SubscribeMetadataResponse, filerId strin
 // sequence.
 //
 // Returns lastByFiler so checkpoint writes are atomic.
-// startPositions[filer_id] = MaxMessagePosition pauses that shard.
+// startPositions[filer_id] = MaxMessagePosition() pauses that shard.
 func ReadLogFileRefsWithPosition(
 	refs []*filer_pb.LogFileChunkRef,
 	newReader LogFileReaderFn,
@@ -80,7 +85,7 @@ func ReadLogFileRefsWithPosition(
 	var wg sync.WaitGroup
 	for _, fid := range filerOrder {
 		startPos := startPositions[fid]
-		paused := startPos == MaxMessagePosition
+		paused := startPos == MaxMessagePosition()
 		ch := make(chan *filer_pb.LogEntry, 256)
 		errCh := make(chan error, 1)
 		s := &filerStream{id: fid, ch: ch, errCh: errCh, startPos: startPos, paused: paused}

--- a/weed/pb/filer_pb_direct_read_with_position.go
+++ b/weed/pb/filer_pb_direct_read_with_position.go
@@ -1,0 +1,267 @@
+package pb
+
+import (
+	"container/heap"
+	"fmt"
+	"sort"
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+// MessagePosition is the (ts_ns, offset) tuple the lifecycle reader uses as
+// a per-shard cursor. LogEntry.Offset is per-buffer per-filer (not globally
+// unique), so a single global cursor can't safely resume from a multi-filer
+// merged stream — each filer's cursor must be tracked independently.
+//
+// Defined locally to avoid pulling weed/util/log_buffer as a dep of pb.
+type MessagePosition struct {
+	TsNs   int64
+	Offset int64
+}
+
+// MaxMessagePosition is the sentinel "skip every event for this shard"
+// position. Use it in startPositions to pause a shard whose blocker is
+// active without removing it from the map.
+var MaxMessagePosition = MessagePosition{TsNs: 1<<63 - 1, Offset: 1<<63 - 1}
+
+// LessOrEqual reports whether p is at or before other in lex (ts, offset)
+// order. The reader's resume predicate is `entry-pos <= cursor`, strict
+// `<=` so the last resolved event isn't replayed.
+func (p MessagePosition) LessOrEqual(other MessagePosition) bool {
+	if p.TsNs != other.TsNs {
+		return p.TsNs < other.TsNs
+	}
+	return p.Offset <= other.Offset
+}
+
+// EventCallback is the per-event callback for ReadLogFileRefsWithPosition.
+// filerId is the shard the event came from; position is the entry's
+// (ts, offset). The callback returning a non-nil error halts the read.
+type EventCallback func(event *filer_pb.SubscribeMetadataResponse, filerId string, position MessagePosition) error
+
+// ReadLogFileRefsWithPosition is the per-shard variant of ReadLogFileRefs.
+// Each filer's events are skipped while (event.ts, event.offset) <=
+// startPositions[filer_id]. stopTsNs caps the upper bound (0 = no cap).
+//
+// Cross-filer ordering is by event TsNs primarily, then by filerId (stable
+// tiebreak). The reader's per-event resolution-or-stop logic depends on a
+// deterministic order so retries from the same starting cursor see the
+// same event sequence.
+//
+// Returns lastByFiler: the highest position observed per filer. Callers
+// merge this into reader_state.last_processed_*[delay_seconds][filer_id]
+// at checkpoint time.
+//
+// startPositions[filer_id] = MaxMessagePosition pauses that shard's
+// emission entirely (used when the shard has an active blocker; the cursor
+// stays at the position recorded in the BlockerRecord).
+func ReadLogFileRefsWithPosition(
+	refs []*filer_pb.LogFileChunkRef,
+	newReader LogFileReaderFn,
+	startPositions map[string]MessagePosition,
+	stopTsNs int64,
+	filter PathFilter,
+	cb EventCallback,
+) (lastByFiler map[string]MessagePosition, err error) {
+
+	lastByFiler = make(map[string]MessagePosition)
+	if len(refs) == 0 {
+		return
+	}
+
+	perFiler := make(map[string][]*filer_pb.LogFileChunkRef)
+	var filerOrder []string
+	for _, ref := range refs {
+		if len(ref.Chunks) == 0 {
+			continue
+		}
+		if _, seen := perFiler[ref.FilerId]; !seen {
+			filerOrder = append(filerOrder, ref.FilerId)
+		}
+		perFiler[ref.FilerId] = append(perFiler[ref.FilerId], ref)
+	}
+	sort.Strings(filerOrder) // deterministic tiebreak across runs
+
+	if len(filerOrder) == 0 {
+		return
+	}
+
+	// Per-filer reader: streams entries through a channel; the merge loop
+	// pops the smallest (ts, filerId, offset) tuple and dispatches.
+	streams := make([]*filerStream, 0, len(filerOrder))
+	var wg sync.WaitGroup
+	for _, fid := range filerOrder {
+		startPos := startPositions[fid]
+		paused := startPos.TsNs == MaxMessagePosition.TsNs && startPos.Offset == MaxMessagePosition.Offset
+		ch := make(chan *filer_pb.LogEntry, 256)
+		errCh := make(chan error, 1)
+		s := &filerStream{id: fid, ch: ch, errCh: errCh, startPos: startPos, paused: paused}
+		streams = append(streams, s)
+		if paused {
+			close(ch)
+			errCh <- nil
+			close(errCh)
+			continue
+		}
+		wg.Add(1)
+		go func(refs []*filer_pb.LogFileChunkRef, sendCh chan<- *filer_pb.LogEntry, sendErr chan<- error, startPos MessagePosition) {
+			defer wg.Done()
+			defer close(sendCh)
+			err := streamEntriesWithPosition(refs, newReader, startPos, stopTsNs, sendCh)
+			sendErr <- err
+			close(sendErr)
+		}(perFiler[fid], ch, errCh, startPos)
+	}
+
+	// Merge streams via min-heap on (ts, filerId, offset).
+	h := &filerStreamHeap{}
+	heap.Init(h)
+	for _, s := range streams {
+		entry, ok := <-s.ch
+		if !ok {
+			continue
+		}
+		heap.Push(h, &filerStreamHeapItem{stream: s, entry: entry})
+	}
+
+	for h.Len() > 0 {
+		top := heap.Pop(h).(*filerStreamHeapItem)
+		pos := MessagePosition{TsNs: top.entry.TsNs, Offset: top.entry.Offset}
+		if cbErr := dispatchOneEntryWithPosition(top.entry, top.stream.id, pos, filter, cb); cbErr != nil {
+			err = cbErr
+			break
+		}
+		lastByFiler[top.stream.id] = pos
+		if next, ok := <-top.stream.ch; ok {
+			heap.Push(h, &filerStreamHeapItem{stream: top.stream, entry: next})
+		}
+	}
+	// Drain remaining channels so producer goroutines don't leak.
+	for h.Len() > 0 {
+		heap.Pop(h)
+	}
+	for _, s := range streams {
+		if s.paused {
+			continue
+		}
+		for range s.ch { // drain
+		}
+	}
+	wg.Wait()
+
+	// Surface the first producer error if no callback error already set.
+	if err == nil {
+		for _, s := range streams {
+			if s.paused {
+				continue
+			}
+			if pErr, ok := <-s.errCh; ok && pErr != nil {
+				err = fmt.Errorf("read filer %s: %w", s.id, pErr)
+				break
+			}
+		}
+	}
+	return
+}
+
+// streamEntriesWithPosition reads chunk-file entries for one filer in
+// sequential file order, applies the per-shard skip predicate, and
+// emits entries on out. Returns once all chunks are read or an
+// unrecoverable error occurs.
+func streamEntriesWithPosition(
+	refs []*filer_pb.LogFileChunkRef,
+	newReader LogFileReaderFn,
+	startPos MessagePosition,
+	stopTsNs int64,
+	out chan<- *filer_pb.LogEntry,
+) error {
+	for _, ref := range refs {
+		// Optimization: skip entire file if its FileTsNs is provably before startPos.
+		// LogEntry.TsNs is monotonically >= FileTsNs within a file, but a file's
+		// last entry can be later; we conservatively only skip when FileTsNs is
+		// strictly less than startPos.TsNs (leave equal-ts files for per-entry check).
+		if ref.FileTsNs < startPos.TsNs {
+			// fall through; the per-entry predicate handles edge cases
+		}
+		entries, err := readLogFileEntries(newReader, ref.Chunks, 0, stopTsNs)
+		if err != nil {
+			if isChunkNotFound(err) {
+				glog.V(0).Infof("skip log file filer=%s ts=%d: %v", ref.FilerId, ref.FileTsNs, err)
+				continue
+			}
+			return fmt.Errorf("read log file filer=%s ts=%d: %w", ref.FilerId, ref.FileTsNs, err)
+		}
+		for _, entry := range entries {
+			pos := MessagePosition{TsNs: entry.TsNs, Offset: entry.Offset}
+			if pos.LessOrEqual(startPos) {
+				continue
+			}
+			out <- entry
+		}
+	}
+	return nil
+}
+
+// dispatchOneEntryWithPosition unmarshals one log entry, applies the path
+// filter, and invokes the per-event callback with shard context.
+func dispatchOneEntryWithPosition(
+	logEntry *filer_pb.LogEntry,
+	filerId string,
+	pos MessagePosition,
+	filter PathFilter,
+	cb EventCallback,
+) error {
+	event := &filer_pb.SubscribeMetadataResponse{}
+	if err := proto.Unmarshal(logEntry.Data, event); err != nil {
+		glog.Errorf("unmarshal log entry: %v", err)
+		return nil // skip corrupt entries
+	}
+	if !matchesFilter(event, filter) {
+		return nil
+	}
+	return cb(event, filerId, pos)
+}
+
+// --- merge heap on (ts, filerId, offset) ---
+
+type filerStream struct {
+	id       string
+	ch       <-chan *filer_pb.LogEntry
+	errCh    <-chan error
+	startPos MessagePosition
+	paused   bool
+}
+
+type filerStreamHeapItem struct {
+	stream *filerStream
+	entry  *filer_pb.LogEntry
+}
+
+type filerStreamHeap []*filerStreamHeapItem
+
+func (h filerStreamHeap) Len() int { return len(h) }
+func (h filerStreamHeap) Less(i, j int) bool {
+	a, b := h[i].entry, h[j].entry
+	if a.TsNs != b.TsNs {
+		return a.TsNs < b.TsNs
+	}
+	if h[i].stream.id != h[j].stream.id {
+		return h[i].stream.id < h[j].stream.id
+	}
+	return a.Offset < b.Offset
+}
+func (h filerStreamHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *filerStreamHeap) Push(x any)   { *h = append(*h, x.(*filerStreamHeapItem)) }
+func (h *filerStreamHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	return item
+}
+

--- a/weed/pb/filer_pb_direct_read_with_position.go
+++ b/weed/pb/filer_pb_direct_read_with_position.go
@@ -12,25 +12,20 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
-// MessagePosition is the (ts_ns, offset) tuple the lifecycle reader uses as
-// a per-shard cursor. LogEntry.Offset is per-buffer per-filer (not globally
-// unique), so a single global cursor can't safely resume from a multi-filer
-// merged stream — each filer's cursor must be tracked independently.
-//
-// Defined locally to avoid pulling weed/util/log_buffer as a dep of pb.
+// MessagePosition is the per-shard cursor (ts_ns, offset). LogEntry.Offset
+// is per-buffer per-filer, so a single global cursor can't safely resume from
+// a multi-filer merged stream. Local to pb to avoid pulling log_buffer.
 type MessagePosition struct {
 	TsNs   int64
 	Offset int64
 }
 
-// MaxMessagePosition is the sentinel "skip every event for this shard"
-// position. Use it in startPositions to pause a shard whose blocker is
-// active without removing it from the map.
+// MaxMessagePosition pauses a shard's emission entirely; used when the shard
+// has an active blocker.
 var MaxMessagePosition = MessagePosition{TsNs: 1<<63 - 1, Offset: 1<<63 - 1}
 
-// LessOrEqual reports whether p is at or before other in lex (ts, offset)
-// order. The reader's resume predicate is `entry-pos <= cursor`, strict
-// `<=` so the last resolved event isn't replayed.
+// LessOrEqual is the strict-`<=` skip predicate so the last resolved event
+// isn't replayed.
 func (p MessagePosition) LessOrEqual(other MessagePosition) bool {
 	if p.TsNs != other.TsNs {
 		return p.TsNs < other.TsNs
@@ -38,27 +33,18 @@ func (p MessagePosition) LessOrEqual(other MessagePosition) bool {
 	return p.Offset <= other.Offset
 }
 
-// EventCallback is the per-event callback for ReadLogFileRefsWithPosition.
-// filerId is the shard the event came from; position is the entry's
-// (ts, offset). The callback returning a non-nil error halts the read.
+// EventCallback receives one delivered event with its shard context. A
+// non-nil error halts the read.
 type EventCallback func(event *filer_pb.SubscribeMetadataResponse, filerId string, position MessagePosition) error
 
 // ReadLogFileRefsWithPosition is the per-shard variant of ReadLogFileRefs.
-// Each filer's events are skipped while (event.ts, event.offset) <=
-// startPositions[filer_id]. stopTsNs caps the upper bound (0 = no cap).
+// Events with (ts, offset) <= startPositions[filer_id] are skipped per
+// shard. Cross-filer ordering is (ts, filerId, offset) — the filerId
+// tiebreak makes retries from the same starting cursor see the same event
+// sequence.
 //
-// Cross-filer ordering is by event TsNs primarily, then by filerId (stable
-// tiebreak). The reader's per-event resolution-or-stop logic depends on a
-// deterministic order so retries from the same starting cursor see the
-// same event sequence.
-//
-// Returns lastByFiler: the highest position observed per filer. Callers
-// merge this into reader_state.last_processed_*[delay_seconds][filer_id]
-// at checkpoint time.
-//
-// startPositions[filer_id] = MaxMessagePosition pauses that shard's
-// emission entirely (used when the shard has an active blocker; the cursor
-// stays at the position recorded in the BlockerRecord).
+// Returns lastByFiler so checkpoint writes are atomic.
+// startPositions[filer_id] = MaxMessagePosition pauses that shard.
 func ReadLogFileRefsWithPosition(
 	refs []*filer_pb.LogFileChunkRef,
 	newReader LogFileReaderFn,
@@ -84,14 +70,12 @@ func ReadLogFileRefsWithPosition(
 		}
 		perFiler[ref.FilerId] = append(perFiler[ref.FilerId], ref)
 	}
-	sort.Strings(filerOrder) // deterministic tiebreak across runs
+	sort.Strings(filerOrder)
 
 	if len(filerOrder) == 0 {
 		return
 	}
 
-	// Per-filer reader: streams entries through a channel; the merge loop
-	// pops the smallest (ts, filerId, offset) tuple and dispatches.
 	streams := make([]*filerStream, 0, len(filerOrder))
 	var wg sync.WaitGroup
 	for _, fid := range filerOrder {
@@ -117,7 +101,6 @@ func ReadLogFileRefsWithPosition(
 		}(perFiler[fid], ch, errCh, startPos)
 	}
 
-	// Merge streams via min-heap on (ts, filerId, offset).
 	h := &filerStreamHeap{}
 	heap.Init(h)
 	for _, s := range streams {
@@ -140,7 +123,7 @@ func ReadLogFileRefsWithPosition(
 			heap.Push(h, &filerStreamHeapItem{stream: top.stream, entry: next})
 		}
 	}
-	// Drain remaining channels so producer goroutines don't leak.
+	// Drain so producer goroutines don't leak.
 	for h.Len() > 0 {
 		heap.Pop(h)
 	}
@@ -148,12 +131,11 @@ func ReadLogFileRefsWithPosition(
 		if s.paused {
 			continue
 		}
-		for range s.ch { // drain
+		for range s.ch {
 		}
 	}
 	wg.Wait()
 
-	// Surface the first producer error if no callback error already set.
 	if err == nil {
 		for _, s := range streams {
 			if s.paused {
@@ -168,10 +150,6 @@ func ReadLogFileRefsWithPosition(
 	return
 }
 
-// streamEntriesWithPosition reads chunk-file entries for one filer in
-// sequential file order, applies the per-shard skip predicate, and
-// emits entries on out. Returns once all chunks are read or an
-// unrecoverable error occurs.
 func streamEntriesWithPosition(
 	refs []*filer_pb.LogFileChunkRef,
 	newReader LogFileReaderFn,
@@ -180,11 +158,9 @@ func streamEntriesWithPosition(
 	out chan<- *filer_pb.LogEntry,
 ) error {
 	for _, ref := range refs {
-		// No file-level fast-skip: the chunk's FileTsNs is the start time
-		// of the flush, but its last entry can have a TsNs later than any
-		// other file in the sequence. Without a FileMaxTsNs on the ref we
-		// can't safely prune whole files; the per-entry predicate below
-		// handles every case correctly.
+		// No file-level fast-skip: FileTsNs is the flush start, but the
+		// last entry can be later. Without a FileMaxTsNs we can't safely
+		// prune whole files.
 		entries, err := readLogFileEntries(newReader, ref.Chunks, 0, stopTsNs)
 		if err != nil {
 			if isChunkNotFound(err) {
@@ -204,8 +180,6 @@ func streamEntriesWithPosition(
 	return nil
 }
 
-// dispatchOneEntryWithPosition unmarshals one log entry, applies the path
-// filter, and invokes the per-event callback with shard context.
 func dispatchOneEntryWithPosition(
 	logEntry *filer_pb.LogEntry,
 	filerId string,
@@ -216,15 +190,13 @@ func dispatchOneEntryWithPosition(
 	event := &filer_pb.SubscribeMetadataResponse{}
 	if err := proto.Unmarshal(logEntry.Data, event); err != nil {
 		glog.Errorf("unmarshal log entry: %v", err)
-		return nil // skip corrupt entries
+		return nil
 	}
 	if !matchesFilter(event, filter) {
 		return nil
 	}
 	return cb(event, filerId, pos)
 }
-
-// --- merge heap on (ts, filerId, offset) ---
 
 type filerStream struct {
 	id       string
@@ -262,4 +234,3 @@ func (h *filerStreamHeap) Pop() any {
 	*h = old[:n-1]
 	return item
 }
-

--- a/weed/pb/filer_pb_direct_read_with_position.go
+++ b/weed/pb/filer_pb_direct_read_with_position.go
@@ -180,13 +180,11 @@ func streamEntriesWithPosition(
 	out chan<- *filer_pb.LogEntry,
 ) error {
 	for _, ref := range refs {
-		// Optimization: skip entire file if its FileTsNs is provably before startPos.
-		// LogEntry.TsNs is monotonically >= FileTsNs within a file, but a file's
-		// last entry can be later; we conservatively only skip when FileTsNs is
-		// strictly less than startPos.TsNs (leave equal-ts files for per-entry check).
-		if ref.FileTsNs < startPos.TsNs {
-			// fall through; the per-entry predicate handles edge cases
-		}
+		// No file-level fast-skip: the chunk's FileTsNs is the start time
+		// of the flush, but its last entry can have a TsNs later than any
+		// other file in the sequence. Without a FileMaxTsNs on the ref we
+		// can't safely prune whole files; the per-entry predicate below
+		// handles every case correctly.
 		entries, err := readLogFileEntries(newReader, ref.Chunks, 0, stopTsNs)
 		if err != nil {
 			if isChunkNotFound(err) {

--- a/weed/pb/filer_pb_direct_read_with_position_test.go
+++ b/weed/pb/filer_pb_direct_read_with_position_test.go
@@ -1,0 +1,250 @@
+package pb
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// buildPositionedLogFile constructs the on-disk log file format with entries
+// that carry both TsNs and Offset, so per-shard cursor tests can probe the
+// strict (ts, offset) skip predicate.
+func buildPositionedLogFile(entries []*filer_pb.LogEntry) []byte {
+	var buf bytes.Buffer
+	for _, le := range entries {
+		// Wrap LogEntry's Data with a SubscribeMetadataResponse so the
+		// path-filter step accepts it.
+		event := &filer_pb.SubscribeMetadataResponse{
+			Directory:         "/data/x",
+			TsNs:              le.TsNs,
+			EventNotification: &filer_pb.EventNotification{NewEntry: &filer_pb.Entry{Name: "obj"}},
+		}
+		eventBytes, _ := proto.Marshal(event)
+		le.Data = eventBytes
+		entryBytes, _ := proto.Marshal(le)
+		sizeBuf := make([]byte, 4)
+		util.Uint32toBytes(sizeBuf, uint32(len(entryBytes)))
+		buf.Write(sizeBuf)
+		buf.Write(entryBytes)
+	}
+	return buf.Bytes()
+}
+
+type positionedTest struct {
+	refs     []*filer_pb.LogFileChunkRef
+	fileData map[string][]byte
+}
+
+func (p *positionedTest) reader() LogFileReaderFn {
+	return func(chunks []*filer_pb.FileChunk) (io.ReadCloser, error) {
+		if len(chunks) == 0 {
+			return nil, fmt.Errorf("no chunks")
+		}
+		key := chunks[0].FileId
+		data, ok := p.fileData[key]
+		if !ok {
+			return nil, fmt.Errorf("file not found: %s", key)
+		}
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+}
+
+// newPositionedTest creates 2 filers, 1 file each, 4 entries per file with
+// distinct (ts, offset) tuples. Useful for testing the merge order and skip
+// predicate.
+func newPositionedTest() *positionedTest {
+	pt := &positionedTest{fileData: map[string][]byte{}}
+	base := time.Now().Add(-time.Hour).UnixNano()
+	build := func(filerId string, offsets []int64, tsBase int64) {
+		entries := make([]*filer_pb.LogEntry, 0, len(offsets))
+		for _, off := range offsets {
+			entries = append(entries, &filer_pb.LogEntry{TsNs: tsBase + off, Offset: off})
+		}
+		key := filerId + ":" + filerId
+		pt.fileData[key] = buildPositionedLogFile(entries)
+		pt.refs = append(pt.refs, &filer_pb.LogFileChunkRef{
+			Chunks:   []*filer_pb.FileChunk{{FileId: key}},
+			FileTsNs: tsBase,
+			FilerId:  filerId,
+		})
+	}
+	build("alpha", []int64{0, 1, 2, 3}, base)
+	build("beta", []int64{0, 1, 2, 3}, base) // identical timestamps -> tied; merge tiebreak by filerId
+	return pt
+}
+
+func TestReadLogFileRefsWithPosition_OrderAndCursor(t *testing.T) {
+	pt := newPositionedTest()
+	startPositions := map[string]MessagePosition{
+		"alpha": {TsNs: 0, Offset: 0},
+		"beta":  {TsNs: 0, Offset: 0},
+	}
+	type emit struct {
+		filer string
+		pos   MessagePosition
+	}
+	var emits []emit
+	last, err := ReadLogFileRefsWithPosition(pt.refs, pt.reader(), startPositions, 0, PathFilter{PathPrefix: "/"},
+		func(event *filer_pb.SubscribeMetadataResponse, filerId string, pos MessagePosition) error {
+			emits = append(emits, emit{filerId, pos})
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// 8 events total (4 per filer); merge order is (ts, filerId, offset).
+	if len(emits) != 8 {
+		t.Fatalf("want 8 emits, got %d", len(emits))
+	}
+	// Verify monotonic non-decreasing TsNs. Tied ts -> alpha before beta
+	// (deterministic filerId sort).
+	for i := 1; i < len(emits); i++ {
+		if emits[i].pos.TsNs < emits[i-1].pos.TsNs {
+			t.Fatalf("emit %d: ts went backwards: %d -> %d", i, emits[i-1].pos.TsNs, emits[i].pos.TsNs)
+		}
+	}
+	if last["alpha"].Offset != 3 || last["beta"].Offset != 3 {
+		t.Fatalf("lastByFiler want offset 3 each, got %v", last)
+	}
+}
+
+func TestReadLogFileRefsWithPosition_PerShardSkip(t *testing.T) {
+	pt := newPositionedTest()
+	// Tell alpha to skip its first two entries (offsets 0 and 1); beta starts fresh.
+	startPositions := map[string]MessagePosition{
+		"alpha": {TsNs: 0, Offset: 1}, // strict <=, so offset 0 and 1 are skipped
+		"beta":  {TsNs: 0, Offset: 0},
+	}
+	// The startPositions reference TsNs=0 won't actually drop alpha's entries
+	// because their TsNs is base+offset (much larger than 0). To exercise the
+	// (ts, offset) compound predicate, we set startPositions to alpha's
+	// second entry's exact (ts, offset).
+	base := pt.refs[0].FileTsNs
+	startPositions["alpha"] = MessagePosition{TsNs: base + 1, Offset: 1}
+
+	var alphaEmits, betaEmits int
+	last, err := ReadLogFileRefsWithPosition(pt.refs, pt.reader(), startPositions, 0, PathFilter{PathPrefix: "/"},
+		func(event *filer_pb.SubscribeMetadataResponse, filerId string, pos MessagePosition) error {
+			if filerId == "alpha" {
+				alphaEmits++
+			} else {
+				betaEmits++
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// alpha startPos is (base+1, 1); strict <= skips offsets 0 and 1, leaving 2 and 3.
+	if alphaEmits != 2 {
+		t.Fatalf("alpha want 2 emits, got %d", alphaEmits)
+	}
+	// beta unchanged: 4 emits.
+	if betaEmits != 4 {
+		t.Fatalf("beta want 4 emits, got %d", betaEmits)
+	}
+	if last["alpha"].Offset != 3 {
+		t.Fatalf("alpha lastByFiler want offset 3, got %v", last["alpha"])
+	}
+}
+
+func TestReadLogFileRefsWithPosition_PausedShardEmitsNothing(t *testing.T) {
+	pt := newPositionedTest()
+	startPositions := map[string]MessagePosition{
+		"alpha": MaxMessagePosition, // paused (active blocker on shard alpha)
+		"beta":  {TsNs: 0, Offset: 0},
+	}
+	var alphaEmits, betaEmits int
+	last, err := ReadLogFileRefsWithPosition(pt.refs, pt.reader(), startPositions, 0, PathFilter{PathPrefix: "/"},
+		func(event *filer_pb.SubscribeMetadataResponse, filerId string, pos MessagePosition) error {
+			if filerId == "alpha" {
+				alphaEmits++
+			} else {
+				betaEmits++
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if alphaEmits != 0 {
+		t.Fatalf("paused alpha should emit 0, got %d", alphaEmits)
+	}
+	if betaEmits != 4 {
+		t.Fatalf("beta unaffected, want 4 emits, got %d", betaEmits)
+	}
+	if _, has := last["alpha"]; has {
+		t.Fatalf("paused alpha should not produce a lastByFiler entry, got %v", last["alpha"])
+	}
+}
+
+func TestReadLogFileRefsWithPosition_StopTsNsCaps(t *testing.T) {
+	pt := newPositionedTest()
+	startPositions := map[string]MessagePosition{
+		"alpha": {TsNs: 0, Offset: 0},
+		"beta":  {TsNs: 0, Offset: 0},
+	}
+	base := pt.refs[0].FileTsNs
+	stopTsNs := base + 1 // only entries with TsNs <= base+1 should pass
+
+	var emits int
+	_, err := ReadLogFileRefsWithPosition(pt.refs, pt.reader(), startPositions, stopTsNs, PathFilter{PathPrefix: "/"},
+		func(event *filer_pb.SubscribeMetadataResponse, filerId string, pos MessagePosition) error {
+			emits++
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Each filer has entries at TsNs in {base, base+1, base+2, base+3}; with
+	// stopTsNs = base+1, two entries pass per filer (ts <= base+1). 2*2 = 4.
+	if emits != 4 {
+		t.Fatalf("with stop=%d want 4 emits, got %d", stopTsNs, emits)
+	}
+}
+
+func TestReadLogFileRefsWithPosition_CallbackErrorHalts(t *testing.T) {
+	pt := newPositionedTest()
+	startPositions := map[string]MessagePosition{
+		"alpha": {TsNs: 0, Offset: 0},
+		"beta":  {TsNs: 0, Offset: 0},
+	}
+	wantErr := fmt.Errorf("halt")
+	var emits int
+	_, err := ReadLogFileRefsWithPosition(pt.refs, pt.reader(), startPositions, 0, PathFilter{PathPrefix: "/"},
+		func(event *filer_pb.SubscribeMetadataResponse, filerId string, pos MessagePosition) error {
+			emits++
+			if emits == 2 {
+				return wantErr
+			}
+			return nil
+		})
+	if err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("want halt err, got %v", err)
+	}
+}
+
+func TestMessagePosition_LessOrEqual(t *testing.T) {
+	cases := []struct {
+		a, b MessagePosition
+		le   bool
+	}{
+		{MessagePosition{1, 0}, MessagePosition{2, 0}, true},
+		{MessagePosition{2, 0}, MessagePosition{1, 0}, false},
+		{MessagePosition{1, 5}, MessagePosition{1, 5}, true},  // equal
+		{MessagePosition{1, 4}, MessagePosition{1, 5}, true},  // tied ts, smaller offset
+		{MessagePosition{1, 6}, MessagePosition{1, 5}, false}, // tied ts, larger offset
+	}
+	for _, c := range cases {
+		if got := c.a.LessOrEqual(c.b); got != c.le {
+			t.Fatalf("(%v).LessOrEqual(%v) want %v, got %v", c.a, c.b, c.le, got)
+		}
+	}
+}

--- a/weed/pb/filer_pb_direct_read_with_position_test.go
+++ b/weed/pb/filer_pb_direct_read_with_position_test.go
@@ -104,10 +104,16 @@ func TestReadLogFileRefsWithPosition_OrderAndCursor(t *testing.T) {
 		t.Fatalf("want 8 emits, got %d", len(emits))
 	}
 	// Verify monotonic non-decreasing TsNs. Tied ts -> alpha before beta
-	// (deterministic filerId sort).
+	// (deterministic filerId sort) — pinning the tiebreak is the central
+	// guarantee of this API; without it, retries from the same starting
+	// cursor could see a different event order.
 	for i := 1; i < len(emits); i++ {
 		if emits[i].pos.TsNs < emits[i-1].pos.TsNs {
 			t.Fatalf("emit %d: ts went backwards: %d -> %d", i, emits[i-1].pos.TsNs, emits[i].pos.TsNs)
+		}
+		if emits[i].pos.TsNs == emits[i-1].pos.TsNs && emits[i-1].filer > emits[i].filer {
+			t.Fatalf("emit %d: tied ts %d but filer order %s -> %s violates (ts, filerId) tiebreak",
+				i, emits[i].pos.TsNs, emits[i-1].filer, emits[i].filer)
 		}
 	}
 	if last["alpha"].Offset != 3 || last["beta"].Offset != 3 {
@@ -117,17 +123,14 @@ func TestReadLogFileRefsWithPosition_OrderAndCursor(t *testing.T) {
 
 func TestReadLogFileRefsWithPosition_PerShardSkip(t *testing.T) {
 	pt := newPositionedTest()
-	// Tell alpha to skip its first two entries (offsets 0 and 1); beta starts fresh.
+	// Skip alpha's first two entries (offsets 0 and 1) by anchoring its
+	// cursor on the second entry's exact (ts, offset). Strict <= drops
+	// offsets 0 and 1; beta starts fresh and emits all four.
+	base := pt.refs[0].FileTsNs
 	startPositions := map[string]MessagePosition{
-		"alpha": {TsNs: 0, Offset: 1}, // strict <=, so offset 0 and 1 are skipped
+		"alpha": {TsNs: base + 1, Offset: 1},
 		"beta":  {TsNs: 0, Offset: 0},
 	}
-	// The startPositions reference TsNs=0 won't actually drop alpha's entries
-	// because their TsNs is base+offset (much larger than 0). To exercise the
-	// (ts, offset) compound predicate, we set startPositions to alpha's
-	// second entry's exact (ts, offset).
-	base := pt.refs[0].FileTsNs
-	startPositions["alpha"] = MessagePosition{TsNs: base + 1, Offset: 1}
 
 	var alphaEmits, betaEmits int
 	last, err := ReadLogFileRefsWithPosition(pt.refs, pt.reader(), startPositions, 0, PathFilter{PathPrefix: "/"},

--- a/weed/pb/filer_pb_direct_read_with_position_test.go
+++ b/weed/pb/filer_pb_direct_read_with_position_test.go
@@ -161,7 +161,7 @@ func TestReadLogFileRefsWithPosition_PerShardSkip(t *testing.T) {
 func TestReadLogFileRefsWithPosition_PausedShardEmitsNothing(t *testing.T) {
 	pt := newPositionedTest()
 	startPositions := map[string]MessagePosition{
-		"alpha": MaxMessagePosition, // paused (active blocker on shard alpha)
+		"alpha": MaxMessagePosition(), // paused (active blocker on shard alpha)
 		"beta":  {TsNs: 0, Offset: 0},
 	}
 	var alphaEmits, betaEmits int


### PR DESCRIPTION
Phase 0 / Phase 3 prerequisite (Task #19) — adds the per-shard variant of \`ReadLogFileRefs\` that the lifecycle reader (Phase 3) drives the meta log through. Lands on master directly (not stacked) since it's a generic pb-package addition with no dependencies on the lifecycle PRs.

## Why per-shard

\`LogEntry.Offset\` is per-buffer per-filer, not globally unique. A single uniform startTsNs (the existing \`ReadLogFileRefs\` API) is fine for a single subscriber, but the lifecycle reader heap-merges chunks from multiple filers and needs to skip per-filer past the last resolved cursor. A single global cursor would either miss events or replay them.

## API

- **\`MessagePosition{TsNs, Offset}\`** — local to pb to avoid pulling \`weed/util/log_buffer\`.
- **\`MaxMessagePosition\`** — sentinel meaning \"skip every event for this shard\". Used by the reader when a shard has an active \`BlockerRecord\`; the cursor stays at the position recorded in the blocker.
- **\`ReadLogFileRefsWithPosition(refs, newReader, startPositions, stopTsNs, filter, cb)\`**:
  - \`startPositions[filer_id]\` is the strict-\`<=\` skip predicate (events with \`(ts, offset) <= start\` are skipped).
  - \`cb(event, filer_id, position)\` lets the caller update its per-shard cursor map after each delivered event.
  - Returns \`lastByFiler\` so the worker's checkpoint write is atomic.
  - Cross-filer ordering: \`(event.ts, filer_id, event.offset)\`. The \`filer_id\` tiebreak makes retries from the same starting cursor see the same event sequence, which the per-event resolution-or-stop logic depends on.

## What's NOT in this PR

\`EarliestRetainedPositionPerShard\` and \`RetainedLogRangePerShard\` are the other two APIs Task #19 calls out; they walk \`SystemLogDir\` to build the lazy-seeding floor and tail-drain GC inputs. They're additions to the same package but a separate concern; they'll land in a follow-up so this PR stays focused.

## Test plan

- \`go test ./weed/pb/ -run TestReadLogFileRefsWithPosition -run TestMessagePosition\` — passing locally; covers order + cursor return, per-shard skip via \`(ts, offset)\` compound predicate, paused shard via \`MaxMessagePosition\`, \`stopTsNs\` cap, callback-error halt, and \`MessagePosition.LessOrEqual\` boundary cases.
- \`go build ./...\` — clean.

No callers yet — the existing \`ReadLogFileRefs\` is unchanged. The lifecycle reader (Phase 3) will be the first caller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resumable log reading with per-stream position cursors and a sentinel to fully pause a stream
  * Deterministic merge of events from multiple sources ordered by timestamp with a stable tie-break
  * Position-aware emission: per-event position info, stop-time cap, and callback-driven delivery; callback errors halt processing and are reported
  * Returns last-seen position per active stream

* **Tests**
  * Comprehensive tests for merge ordering, per-stream skipping/pausing, stop-time capping, ordering semantics, and callback error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->