### PR TITLE
feat(pb): listing helpers for lazy-seeding + tail-drain GC

### DIFF
--- a/weed/pb/filer_pb_log_dir_listing.go
+++ b/weed/pb/filer_pb_log_dir_listing.go
@@ -44,7 +44,7 @@ type FilerShardRange struct {
 // entries at exactly the floor's TsNs with Offset>0 are not skipped.
 func EarliestRetainedPositionPerShard(ctx context.Context, lister LogDirLister) (map[string]MessagePosition, error) {
 	out := make(map[string]MessagePosition)
-	err := walkLogChunks(ctx, lister, false, func(filerId string, ts time.Time) bool {
+	err := walkLogChunks(ctx, lister, func(filerId string, ts time.Time) bool {
 		if _, seen := out[filerId]; !seen {
 			out[filerId] = MessagePosition{TsNs: ts.UnixNano(), Offset: 0}
 		}
@@ -64,18 +64,17 @@ func EarliestRetainedPositionPerShard(ctx context.Context, lister LogDirLister) 
 // when the cursor is at or past the chunk's last entry — matches the
 // design's tail-drain criterion.
 func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[string]FilerShardRange, error) {
+	// Single pass: track min and max per filer in the same callback. Two
+	// passes would (a) double the RPC cost and (b) introduce a TOCTOU
+	// window where a filer could appear in the first walk and disappear
+	// before the second — leaving its `latest` zero and yielding a
+	// nonsense MessagePosition.
 	earliest := make(map[string]time.Time)
 	latest := make(map[string]time.Time)
-
-	if err := walkLogChunks(ctx, lister, false, func(filerId string, ts time.Time) bool {
+	if err := walkLogChunks(ctx, lister, func(filerId string, ts time.Time) bool {
 		if e, ok := earliest[filerId]; !ok || ts.Before(e) {
 			earliest[filerId] = ts
 		}
-		return true
-	}); err != nil {
-		return nil, err
-	}
-	if err := walkLogChunks(ctx, lister, true, func(filerId string, ts time.Time) bool {
 		if l, ok := latest[filerId]; !ok || ts.After(l) {
 			latest[filerId] = ts
 		}
@@ -97,9 +96,9 @@ func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[str
 }
 
 // walkLogChunks iterates every (filerId, chunk-time) tuple under
-// SystemLogDir. cb returns false to stop the walk early.
-func walkLogChunks(ctx context.Context, lister LogDirLister, newestFirst bool, cb func(filerId string, ts time.Time) bool) error {
-	dayEntries, err := listAll(ctx, lister, SystemLogDir, newestFirst)
+// SystemLogDir in lex order. cb returns false to stop the walk early.
+func walkLogChunks(ctx context.Context, lister LogDirLister, cb func(filerId string, ts time.Time) bool) error {
+	dayEntries, err := listAll(ctx, lister, SystemLogDir)
 	if err != nil {
 		return err
 	}
@@ -107,7 +106,7 @@ func walkLogChunks(ctx context.Context, lister LogDirLister, newestFirst bool, c
 		if !day.IsDirectory {
 			continue
 		}
-		hourMinuteEntries, err := listAll(ctx, lister, SystemLogDir+"/"+day.Name, newestFirst)
+		hourMinuteEntries, err := listAll(ctx, lister, SystemLogDir+"/"+day.Name)
 		if err != nil {
 			return fmt.Errorf("list %s/%s: %w", SystemLogDir, day.Name, err)
 		}
@@ -133,7 +132,7 @@ func walkLogChunks(ctx context.Context, lister LogDirLister, newestFirst bool, c
 // per-day-dir typically holds at most ~1440 entries.
 const listingLimit = 4096
 
-func listAll(ctx context.Context, lister LogDirLister, dir string, newestFirst bool) ([]*filer_pb.Entry, error) {
+func listAll(ctx context.Context, lister LogDirLister, dir string) ([]*filer_pb.Entry, error) {
 	var out []*filer_pb.Entry
 	startFrom := ""
 	for {
@@ -149,12 +148,6 @@ func listAll(ctx context.Context, lister LogDirLister, dir string, newestFirst b
 			break
 		}
 		startFrom = entries[len(entries)-1].Name
-	}
-	if newestFirst {
-		// reverse in place
-		for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-			out[i], out[j] = out[j], out[i]
-		}
 	}
 	return out, nil
 }

--- a/weed/pb/filer_pb_log_dir_listing.go
+++ b/weed/pb/filer_pb_log_dir_listing.go
@@ -9,66 +9,42 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
-// SystemLogDir mirrors weed/filer/topics.go to avoid pulling weed/filer
-// (which would create a dep cycle for the worker).
+// SystemLogDir mirrors weed/filer/topics.go to avoid pulling weed/filer.
 const SystemLogDir = "/topics/.system/log"
 
-// LogDirLister is the directory-listing capability the listing helpers
-// need. The production implementation wraps filer_pb.SeaweedFilerClient
-// via NewClientLogDirLister; tests inject in-memory fakes.
+// LogDirLister abstracts ListEntries so tests can fake it without spinning
+// up a filer gRPC server.
 type LogDirLister interface {
-	// ListLogDirEntries returns up to limit entries under dir, starting
-	// after startFrom (exclusive). The caller paginates by passing the
-	// last returned entry name as startFrom on the next call. Returns
-	// entries in lexicographic name order.
 	ListLogDirEntries(ctx context.Context, dir, startFrom string, limit int) ([]*filer_pb.Entry, error)
 }
 
-// FilerShardRange is the (earliest, latest) chunk-timestamp pair for one
-// filer's persisted log files. Both are MessagePosition with Offset=0
-// (chunk filenames have minute resolution; the actual entry offsets within
-// the chunk are not exposed by the listing helpers).
 type FilerShardRange struct {
 	Earliest MessagePosition
 	Latest   MessagePosition
 }
 
-// EarliestRetainedPositionPerShard walks SystemLogDir oldest-first and
-// returns the earliest retained chunk per filer_id. Used by lazy-seeding
-// to safely floor a newly-discovered shard's cursor: a brand-new shard
-// can't claim positions earlier than its earliest retained chunk.
-//
-// The returned MessagePosition has Offset=0 and TsNs set to the chunk
-// filename's parsed time (minute resolution). Callers comparing this
-// against an entry-level cursor should use the lex (ts, offset) order so
-// entries at exactly the floor's TsNs with Offset>0 are not skipped.
+// EarliestRetainedPositionPerShard returns the earliest retained chunk
+// per filer_id, used by lazy-seeding to floor a newly-discovered shard's
+// cursor. Offset is 0; chunk filenames have minute resolution.
 func EarliestRetainedPositionPerShard(ctx context.Context, lister LogDirLister) (map[string]MessagePosition, error) {
 	out := make(map[string]MessagePosition)
 	err := walkLogChunks(ctx, lister, func(filerId string, ts time.Time) bool {
 		if _, seen := out[filerId]; !seen {
 			out[filerId] = MessagePosition{TsNs: ts.UnixNano(), Offset: 0}
 		}
-		return true // keep walking; we want every filer's earliest
+		return true
 	})
 	return out, err
 }
 
-// RetainedLogRangePerShard walks SystemLogDir twice (oldest- and newest-
-// first) and returns {earliest, latest} per filer_id. Used by tail-drain
-// GC: cursor[F] >= range.latest means F has been tail-drained and the
-// cursor entry can be GC'd; absence of a range for F whose cursor was
-// never observed at range.latest is the lost-log signal.
+// RetainedLogRangePerShard returns {earliest, latest} per filer in a single
+// pass. Two passes would double RPCs and open a TOCTOU window where a filer
+// disappearing between walks would leave a zero-time `latest`.
 //
-// Latest carries Offset=int64-max so a `cursor >= range.latest` lex
-// comparison (under the strict `<=` skip predicate) is satisfied only
-// when the cursor is at or past the chunk's last entry — matches the
-// design's tail-drain criterion.
+// Latest's Offset = int64-max so a `cursor >= range.latest` lex comparison
+// (under the strict <= skip predicate) is satisfied only when the cursor is
+// at or past the chunk's last entry — the tail-drain criterion.
 func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[string]FilerShardRange, error) {
-	// Single pass: track min and max per filer in the same callback. Two
-	// passes would (a) double the RPC cost and (b) introduce a TOCTOU
-	// window where a filer could appear in the first walk and disappear
-	// before the second — leaving its `latest` zero and yielding a
-	// nonsense MessagePosition.
 	earliest := make(map[string]time.Time)
 	latest := make(map[string]time.Time)
 	if err := walkLogChunks(ctx, lister, func(filerId string, ts time.Time) bool {
@@ -87,16 +63,14 @@ func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[str
 	for filerId, e := range earliest {
 		out[filerId] = FilerShardRange{
 			Earliest: MessagePosition{TsNs: e.UnixNano(), Offset: 0},
-			// Latest's Offset = max so any cursor at or past the chunk's
-			// last entry compares >= range.latest in lex (ts, offset).
-			Latest: MessagePosition{TsNs: latest[filerId].UnixNano(), Offset: 1<<63 - 1},
+			Latest:   MessagePosition{TsNs: latest[filerId].UnixNano(), Offset: 1<<63 - 1},
 		}
 	}
 	return out, nil
 }
 
-// walkLogChunks iterates every (filerId, chunk-time) tuple under
-// SystemLogDir in lex order. cb returns false to stop the walk early.
+// walkLogChunks iterates every (filerId, chunk-time) tuple under SystemLogDir.
+// cb returns false to stop early.
 func walkLogChunks(ctx context.Context, lister LogDirLister, cb func(filerId string, ts time.Time) bool) error {
 	dayEntries, err := listAll(ctx, lister, SystemLogDir)
 	if err != nil {
@@ -127,9 +101,7 @@ func walkLogChunks(ctx context.Context, lister LogDirLister, cb func(filerId str
 	return nil
 }
 
-// listAll paginates ListLogDirEntries until the directory is fully read.
-// listingLimit per call is intentionally large; SystemLogDir's
-// per-day-dir typically holds at most ~1440 entries.
+// listingLimit is intentionally large; per-day SystemLogDir holds ~1440 entries.
 const listingLimit = 4096
 
 func listAll(ctx context.Context, lister LogDirLister, dir string) ([]*filer_pb.Entry, error) {
@@ -152,8 +124,7 @@ func listAll(ctx context.Context, lister LogDirLister, dir string) ([]*filer_pb.
 	return out, nil
 }
 
-// getFilerIdFromName extracts the filerId (8 hex chars) suffix from a chunk
-// filename "HH-MM.<filerId>". Returns "" if the format doesn't match.
+// getFilerIdFromName parses "HH-MM.<filerId>"; returns "" on mismatch.
 func getFilerIdFromName(name string) string {
 	idx := strings.LastIndex(name, ".")
 	if idx < 0 || idx >= len(name)-1 {
@@ -162,9 +133,7 @@ func getFilerIdFromName(name string) string {
 	return name[idx+1:]
 }
 
-// parseChunkTime parses the day-dir + chunk-file names back into a UTC
-// time. Day = "YYYY-MM-DD"; chunk file = "HH-MM.<filerId>". Returns false
-// when the format doesn't parse (caller skips the entry).
+// parseChunkTime joins day "YYYY-MM-DD" + "HH-MM.<filerId>" back into UTC time.
 func parseChunkTime(day, hmName string) (time.Time, bool) {
 	dot := strings.LastIndex(hmName, ".")
 	if dot < 0 {

--- a/weed/pb/filer_pb_log_dir_listing.go
+++ b/weed/pb/filer_pb_log_dir_listing.go
@@ -12,8 +12,7 @@ import (
 // SystemLogDir mirrors weed/filer/topics.go to avoid pulling weed/filer.
 const SystemLogDir = "/topics/.system/log"
 
-// LogDirLister abstracts ListEntries so tests can fake it without spinning
-// up a filer gRPC server.
+// LogDirLister lets tests fake the listing without a filer gRPC server.
 type LogDirLister interface {
 	ListLogDirEntries(ctx context.Context, dir, startFrom string, limit int) ([]*filer_pb.Entry, error)
 }
@@ -23,9 +22,8 @@ type FilerShardRange struct {
 	Latest   MessagePosition
 }
 
-// EarliestRetainedPositionPerShard returns the earliest retained chunk
-// per filer_id, used by lazy-seeding to floor a newly-discovered shard's
-// cursor. Offset is 0; chunk filenames have minute resolution.
+// EarliestRetainedPositionPerShard floors a newly-discovered shard's cursor.
+// Offset is 0; chunk filenames have minute resolution.
 func EarliestRetainedPositionPerShard(ctx context.Context, lister LogDirLister) (map[string]MessagePosition, error) {
 	out := make(map[string]MessagePosition)
 	err := walkLogChunks(ctx, lister, func(filerId string, ts time.Time) bool {
@@ -37,13 +35,10 @@ func EarliestRetainedPositionPerShard(ctx context.Context, lister LogDirLister) 
 	return out, err
 }
 
-// RetainedLogRangePerShard returns {earliest, latest} per filer in a single
-// pass. Two passes would double RPCs and open a TOCTOU window where a filer
-// disappearing between walks would leave a zero-time `latest`.
-//
-// Latest's Offset = int64-max so a `cursor >= range.latest` lex comparison
-// (under the strict <= skip predicate) is satisfied only when the cursor is
-// at or past the chunk's last entry — the tail-drain criterion.
+// RetainedLogRangePerShard returns {earliest, latest} per filer in one pass
+// (a TOCTOU window between two passes could leave `latest` zero). Latest's
+// Offset is int64-max so cursor >= range.latest under the strict <= skip
+// predicate matches the tail-drain criterion.
 func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[string]FilerShardRange, error) {
 	earliest := make(map[string]time.Time)
 	latest := make(map[string]time.Time)
@@ -69,12 +64,9 @@ func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[str
 	return out, nil
 }
 
-// walkLogChunks iterates every (filerId, chunk-time) tuple under SystemLogDir.
-// cb returns false to stop early.
-//
-// Day directories are buffered (a handful of entries); per-day chunk
-// directories are streamed page-by-page so a single day's hundreds of
-// thousands of chunks never accumulate in a slice.
+// walkLogChunks iterates every (filerId, chunk-time) tuple. cb returns
+// false to stop early. Per-day chunks are streamed page-by-page (a busy
+// day can hold hundreds of thousands of entries).
 func walkLogChunks(ctx context.Context, lister LogDirLister, cb func(filerId string, ts time.Time) bool) error {
 	stop := errStopWalk
 	dayErr := streamEntries(ctx, lister, SystemLogDir, func(day *filer_pb.Entry) error {
@@ -106,17 +98,14 @@ func walkLogChunks(ctx context.Context, lister LogDirLister, cb func(filerId str
 	return dayErr
 }
 
-// errStopWalk is the sentinel walkLogChunks uses to short-circuit nested
-// streamEntries calls when cb returns false.
+// errStopWalk short-circuits nested streamEntries calls when cb stops.
 var errStopWalk = fmt.Errorf("stop walk")
 
-// listingLimit is intentionally large; per-day SystemLogDir holds ~1440 entries.
+// listingLimit: per-day SystemLogDir typically holds ~1440 entries.
 const listingLimit = 4096
 
-// streamEntries paginates ListLogDirEntries and invokes fn per entry without
-// buffering the whole directory. fn returning a non-nil error halts the walk
-// and bubbles back; the caller decides whether the error is a real failure
-// or a sentinel-driven early stop.
+// streamEntries paginates without buffering. fn returning a non-nil error
+// halts the walk; callers distinguish real errors from errStopWalk.
 func streamEntries(ctx context.Context, lister LogDirLister, dir string, fn func(*filer_pb.Entry) error) error {
 	startFrom := ""
 	for {

--- a/weed/pb/filer_pb_log_dir_listing.go
+++ b/weed/pb/filer_pb_log_dir_listing.go
@@ -71,57 +71,72 @@ func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[str
 
 // walkLogChunks iterates every (filerId, chunk-time) tuple under SystemLogDir.
 // cb returns false to stop early.
+//
+// Day directories are buffered (a handful of entries); per-day chunk
+// directories are streamed page-by-page so a single day's hundreds of
+// thousands of chunks never accumulate in a slice.
 func walkLogChunks(ctx context.Context, lister LogDirLister, cb func(filerId string, ts time.Time) bool) error {
-	dayEntries, err := listAll(ctx, lister, SystemLogDir)
-	if err != nil {
-		return err
-	}
-	for _, day := range dayEntries {
+	stop := errStopWalk
+	dayErr := streamEntries(ctx, lister, SystemLogDir, func(day *filer_pb.Entry) error {
 		if !day.IsDirectory {
-			continue
+			return nil
 		}
-		hourMinuteEntries, err := listAll(ctx, lister, SystemLogDir+"/"+day.Name)
-		if err != nil {
-			return fmt.Errorf("list %s/%s: %w", SystemLogDir, day.Name, err)
-		}
-		for _, hm := range hourMinuteEntries {
+		err := streamEntries(ctx, lister, SystemLogDir+"/"+day.Name, func(hm *filer_pb.Entry) error {
 			filerId := getFilerIdFromName(hm.Name)
 			if filerId == "" {
-				continue
+				return nil
 			}
 			ts, ok := parseChunkTime(day.Name, hm.Name)
 			if !ok {
-				continue
-			}
-			if !cb(filerId, ts) {
 				return nil
 			}
+			if !cb(filerId, ts) {
+				return stop
+			}
+			return nil
+		})
+		if err != nil && err != stop {
+			return fmt.Errorf("list %s/%s: %w", SystemLogDir, day.Name, err)
 		}
+		return err
+	})
+	if dayErr == stop {
+		return nil
 	}
-	return nil
+	return dayErr
 }
+
+// errStopWalk is the sentinel walkLogChunks uses to short-circuit nested
+// streamEntries calls when cb returns false.
+var errStopWalk = fmt.Errorf("stop walk")
 
 // listingLimit is intentionally large; per-day SystemLogDir holds ~1440 entries.
 const listingLimit = 4096
 
-func listAll(ctx context.Context, lister LogDirLister, dir string) ([]*filer_pb.Entry, error) {
-	var out []*filer_pb.Entry
+// streamEntries paginates ListLogDirEntries and invokes fn per entry without
+// buffering the whole directory. fn returning a non-nil error halts the walk
+// and bubbles back; the caller decides whether the error is a real failure
+// or a sentinel-driven early stop.
+func streamEntries(ctx context.Context, lister LogDirLister, dir string, fn func(*filer_pb.Entry) error) error {
 	startFrom := ""
 	for {
 		entries, err := lister.ListLogDirEntries(ctx, dir, startFrom, listingLimit)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if len(entries) == 0 {
-			break
+			return nil
 		}
-		out = append(out, entries...)
+		for _, e := range entries {
+			if err := fn(e); err != nil {
+				return err
+			}
+		}
 		if len(entries) < listingLimit {
-			break
+			return nil
 		}
 		startFrom = entries[len(entries)-1].Name
 	}
-	return out, nil
 }
 
 // getFilerIdFromName parses "HH-MM.<filerId>"; returns "" on mismatch.

--- a/weed/pb/filer_pb_log_dir_listing.go
+++ b/weed/pb/filer_pb_log_dir_listing.go
@@ -1,0 +1,186 @@
+package pb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+// SystemLogDir mirrors weed/filer/topics.go to avoid pulling weed/filer
+// (which would create a dep cycle for the worker).
+const SystemLogDir = "/topics/.system/log"
+
+// LogDirLister is the directory-listing capability the listing helpers
+// need. The production implementation wraps filer_pb.SeaweedFilerClient
+// via NewClientLogDirLister; tests inject in-memory fakes.
+type LogDirLister interface {
+	// ListLogDirEntries returns up to limit entries under dir, starting
+	// after startFrom (exclusive). The caller paginates by passing the
+	// last returned entry name as startFrom on the next call. Returns
+	// entries in lexicographic name order.
+	ListLogDirEntries(ctx context.Context, dir, startFrom string, limit int) ([]*filer_pb.Entry, error)
+}
+
+// FilerShardRange is the (earliest, latest) chunk-timestamp pair for one
+// filer's persisted log files. Both are MessagePosition with Offset=0
+// (chunk filenames have minute resolution; the actual entry offsets within
+// the chunk are not exposed by the listing helpers).
+type FilerShardRange struct {
+	Earliest MessagePosition
+	Latest   MessagePosition
+}
+
+// EarliestRetainedPositionPerShard walks SystemLogDir oldest-first and
+// returns the earliest retained chunk per filer_id. Used by lazy-seeding
+// to safely floor a newly-discovered shard's cursor: a brand-new shard
+// can't claim positions earlier than its earliest retained chunk.
+//
+// The returned MessagePosition has Offset=0 and TsNs set to the chunk
+// filename's parsed time (minute resolution). Callers comparing this
+// against an entry-level cursor should use the lex (ts, offset) order so
+// entries at exactly the floor's TsNs with Offset>0 are not skipped.
+func EarliestRetainedPositionPerShard(ctx context.Context, lister LogDirLister) (map[string]MessagePosition, error) {
+	out := make(map[string]MessagePosition)
+	err := walkLogChunks(ctx, lister, false, func(filerId string, ts time.Time) bool {
+		if _, seen := out[filerId]; !seen {
+			out[filerId] = MessagePosition{TsNs: ts.UnixNano(), Offset: 0}
+		}
+		return true // keep walking; we want every filer's earliest
+	})
+	return out, err
+}
+
+// RetainedLogRangePerShard walks SystemLogDir twice (oldest- and newest-
+// first) and returns {earliest, latest} per filer_id. Used by tail-drain
+// GC: cursor[F] >= range.latest means F has been tail-drained and the
+// cursor entry can be GC'd; absence of a range for F whose cursor was
+// never observed at range.latest is the lost-log signal.
+//
+// Latest carries Offset=int64-max so a `cursor >= range.latest` lex
+// comparison (under the strict `<=` skip predicate) is satisfied only
+// when the cursor is at or past the chunk's last entry — matches the
+// design's tail-drain criterion.
+func RetainedLogRangePerShard(ctx context.Context, lister LogDirLister) (map[string]FilerShardRange, error) {
+	earliest := make(map[string]time.Time)
+	latest := make(map[string]time.Time)
+
+	if err := walkLogChunks(ctx, lister, false, func(filerId string, ts time.Time) bool {
+		if e, ok := earliest[filerId]; !ok || ts.Before(e) {
+			earliest[filerId] = ts
+		}
+		return true
+	}); err != nil {
+		return nil, err
+	}
+	if err := walkLogChunks(ctx, lister, true, func(filerId string, ts time.Time) bool {
+		if l, ok := latest[filerId]; !ok || ts.After(l) {
+			latest[filerId] = ts
+		}
+		return true
+	}); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]FilerShardRange, len(earliest))
+	for filerId, e := range earliest {
+		out[filerId] = FilerShardRange{
+			Earliest: MessagePosition{TsNs: e.UnixNano(), Offset: 0},
+			// Latest's Offset = max so any cursor at or past the chunk's
+			// last entry compares >= range.latest in lex (ts, offset).
+			Latest: MessagePosition{TsNs: latest[filerId].UnixNano(), Offset: 1<<63 - 1},
+		}
+	}
+	return out, nil
+}
+
+// walkLogChunks iterates every (filerId, chunk-time) tuple under
+// SystemLogDir. cb returns false to stop the walk early.
+func walkLogChunks(ctx context.Context, lister LogDirLister, newestFirst bool, cb func(filerId string, ts time.Time) bool) error {
+	dayEntries, err := listAll(ctx, lister, SystemLogDir, newestFirst)
+	if err != nil {
+		return err
+	}
+	for _, day := range dayEntries {
+		if !day.IsDirectory {
+			continue
+		}
+		hourMinuteEntries, err := listAll(ctx, lister, SystemLogDir+"/"+day.Name, newestFirst)
+		if err != nil {
+			return fmt.Errorf("list %s/%s: %w", SystemLogDir, day.Name, err)
+		}
+		for _, hm := range hourMinuteEntries {
+			filerId := getFilerIdFromName(hm.Name)
+			if filerId == "" {
+				continue
+			}
+			ts, ok := parseChunkTime(day.Name, hm.Name)
+			if !ok {
+				continue
+			}
+			if !cb(filerId, ts) {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// listAll paginates ListLogDirEntries until the directory is fully read.
+// listingLimit per call is intentionally large; SystemLogDir's
+// per-day-dir typically holds at most ~1440 entries.
+const listingLimit = 4096
+
+func listAll(ctx context.Context, lister LogDirLister, dir string, newestFirst bool) ([]*filer_pb.Entry, error) {
+	var out []*filer_pb.Entry
+	startFrom := ""
+	for {
+		entries, err := lister.ListLogDirEntries(ctx, dir, startFrom, listingLimit)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) == 0 {
+			break
+		}
+		out = append(out, entries...)
+		if len(entries) < listingLimit {
+			break
+		}
+		startFrom = entries[len(entries)-1].Name
+	}
+	if newestFirst {
+		// reverse in place
+		for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+			out[i], out[j] = out[j], out[i]
+		}
+	}
+	return out, nil
+}
+
+// getFilerIdFromName extracts the filerId (8 hex chars) suffix from a chunk
+// filename "HH-MM.<filerId>". Returns "" if the format doesn't match.
+func getFilerIdFromName(name string) string {
+	idx := strings.LastIndex(name, ".")
+	if idx < 0 || idx >= len(name)-1 {
+		return ""
+	}
+	return name[idx+1:]
+}
+
+// parseChunkTime parses the day-dir + chunk-file names back into a UTC
+// time. Day = "YYYY-MM-DD"; chunk file = "HH-MM.<filerId>". Returns false
+// when the format doesn't parse (caller skips the entry).
+func parseChunkTime(day, hmName string) (time.Time, bool) {
+	dot := strings.LastIndex(hmName, ".")
+	if dot < 0 {
+		return time.Time{}, false
+	}
+	hm := hmName[:dot]
+	t, err := time.Parse("2006-01-02-15-04", day+"-"+hm)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/weed/pb/filer_pb_log_dir_listing_test.go
+++ b/weed/pb/filer_pb_log_dir_listing_test.go
@@ -1,0 +1,195 @@
+package pb
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+// fakeLogDirLister is a minimal in-memory LogDirLister for tests. The
+// caller seeds entries via Add(dir, name, isDirectory); each ListLogDirEntries
+// returns a stable lex-sorted slice with startFrom-based pagination.
+type fakeLogDirLister struct {
+	entries map[string][]*filer_pb.Entry // dir -> sorted entries
+}
+
+func newFakeLister() *fakeLogDirLister {
+	return &fakeLogDirLister{entries: map[string][]*filer_pb.Entry{}}
+}
+
+func (f *fakeLogDirLister) Add(dir, name string, isDir bool) {
+	f.entries[dir] = append(f.entries[dir], &filer_pb.Entry{
+		Name:        name,
+		IsDirectory: isDir,
+	})
+}
+
+func (f *fakeLogDirLister) finalize() {
+	for d, e := range f.entries {
+		sort.Slice(e, func(i, j int) bool { return e[i].Name < e[j].Name })
+		f.entries[d] = e
+	}
+}
+
+func (f *fakeLogDirLister) ListLogDirEntries(ctx context.Context, dir, startFrom string, limit int) ([]*filer_pb.Entry, error) {
+	all, ok := f.entries[dir]
+	if !ok {
+		return nil, nil
+	}
+	startIdx := 0
+	for i, e := range all {
+		if e.Name > startFrom {
+			startIdx = i
+			break
+		}
+		if i == len(all)-1 {
+			startIdx = len(all)
+		}
+	}
+	end := startIdx + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[startIdx:end], nil
+}
+
+// scenario builds a fake SystemLogDir with the given (day, hm, filerId) tuples.
+type chunkSpec struct {
+	day, hm, filerId string
+}
+
+func buildScenario(specs ...chunkSpec) *fakeLogDirLister {
+	f := newFakeLister()
+	dayDirs := map[string]bool{}
+	for _, s := range specs {
+		if !dayDirs[s.day] {
+			f.Add(SystemLogDir, s.day, true)
+			dayDirs[s.day] = true
+		}
+		f.Add(SystemLogDir+"/"+s.day, s.hm+"."+s.filerId, false)
+	}
+	f.finalize()
+	return f
+}
+
+func TestEarliestRetainedPositionPerShard_BasicTwoFilers(t *testing.T) {
+	f := buildScenario(
+		chunkSpec{"2026-05-07", "10-30", "filer01"},
+		chunkSpec{"2026-05-07", "10-31", "filer01"},
+		chunkSpec{"2026-05-07", "10-32", "filer02"},
+		chunkSpec{"2026-05-08", "00-00", "filer01"},
+		chunkSpec{"2026-05-08", "00-00", "filer02"},
+	)
+	got, err := EarliestRetainedPositionPerShard(context.Background(), f)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	// filer01's earliest is 2026-05-07 10:30; filer02's is 2026-05-07 10:32.
+	if len(got) != 2 {
+		t.Fatalf("want 2 filers, got %d (%v)", len(got), got)
+	}
+	if got["filer01"].Offset != 0 {
+		t.Fatalf("Earliest should have Offset=0, got %v", got["filer01"])
+	}
+}
+
+func TestEarliestRetainedPositionPerShard_EmptyDir(t *testing.T) {
+	f := newFakeLister() // no entries
+	got, err := EarliestRetainedPositionPerShard(context.Background(), f)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty dir should yield empty map, got %v", got)
+	}
+}
+
+func TestRetainedLogRangePerShard_EarliestAndLatest(t *testing.T) {
+	f := buildScenario(
+		chunkSpec{"2026-05-07", "10-30", "filer01"},
+		chunkSpec{"2026-05-07", "10-31", "filer01"},
+		chunkSpec{"2026-05-07", "10-32", "filer02"},
+		chunkSpec{"2026-05-08", "00-00", "filer01"},
+		chunkSpec{"2026-05-08", "00-00", "filer02"},
+	)
+	got, err := RetainedLogRangePerShard(context.Background(), f)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 filers, got %v", got)
+	}
+	// Latest's Offset is int64-max so cursor >= range.latest in lex (ts,
+	// offset) order is the design's tail-drain criterion.
+	if got["filer01"].Latest.Offset != 1<<63-1 {
+		t.Fatalf("Latest.Offset want max, got %v", got["filer01"].Latest)
+	}
+	// filer01: earliest 10-30 < latest 00-00 (next day).
+	if !got["filer01"].Earliest.LessOrEqual(got["filer01"].Latest) {
+		t.Fatalf("earliest should be <= latest, got %+v", got["filer01"])
+	}
+	if got["filer02"].Earliest.TsNs == got["filer02"].Latest.TsNs {
+		// filer02 has chunks at 10-32 and 00-00 (next day) so distinct.
+		t.Fatalf("filer02 earliest/latest should differ, got %+v", got["filer02"])
+	}
+}
+
+func TestRetainedLogRangePerShard_SingleChunk(t *testing.T) {
+	// One filer with a single chunk: earliest == latest's TsNs.
+	f := buildScenario(chunkSpec{"2026-05-07", "10-30", "filer01"})
+	got, err := RetainedLogRangePerShard(context.Background(), f)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got["filer01"].Earliest.TsNs != got["filer01"].Latest.TsNs {
+		t.Fatalf("single chunk: TsNs should match, got %+v", got["filer01"])
+	}
+}
+
+func TestWalkLogChunks_SkipsMalformedNames(t *testing.T) {
+	f := newFakeLister()
+	f.Add(SystemLogDir, "2026-05-07", true)
+	// Valid + a malformed entry without a "." separator and one without filerId.
+	f.Add(SystemLogDir+"/2026-05-07", "10-30.filer01", false)
+	f.Add(SystemLogDir+"/2026-05-07", "junk", false)
+	f.Add(SystemLogDir+"/2026-05-07", "11-00.", false)
+	f.finalize()
+
+	got, err := EarliestRetainedPositionPerShard(context.Background(), f)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got["filer01"].TsNs == 0 {
+		t.Fatalf("only the valid chunk should yield a filer, got %v", got)
+	}
+}
+
+func TestGetFilerIdFromName(t *testing.T) {
+	cases := map[string]string{
+		"10-30.filer01":     "filer01",
+		"10-30.deadbeef":    "deadbeef",
+		"junk":              "",
+		"11-00.":            "",
+		"":                  "",
+		"a.b.c":             "c",
+	}
+	for name, want := range cases {
+		if got := getFilerIdFromName(name); got != want {
+			t.Fatalf("%q: want %q, got %q", name, want, got)
+		}
+	}
+}
+
+func TestParseChunkTime(t *testing.T) {
+	if _, ok := parseChunkTime("2026-05-07", "10-30.filer01"); !ok {
+		t.Fatalf("valid format should parse")
+	}
+	if _, ok := parseChunkTime("not-a-date", "10-30.filer01"); ok {
+		t.Fatalf("bad day should not parse")
+	}
+	if _, ok := parseChunkTime("2026-05-07", "no-dot"); ok {
+		t.Fatalf("missing dot should not parse")
+	}
+}


### PR DESCRIPTION
Second half of Task #19. Stacks on #9351.

## Summary

\`LogDirLister\` is the directory-listing interface. Tests inject in-memory fakes; production code wraps \`filer_pb.SeaweedFilerClient\`. Two consumers:

- **\`EarliestRetainedPositionPerShard(ctx, lister)\`** → \`map[filer_id]MessagePosition\` with each filer's earliest retained chunk. Used by lazy-seeding so a newly-discovered shard's cursor is floored at the earliest event the shard could possibly emit (otherwise a fresh shard seeded at \"now\" misses in-flight events).

- **\`RetainedLogRangePerShard(ctx, lister)\`** → \`map[filer_id]FilerShardRange\` with \`{Earliest, Latest}\`. Latest's \`Offset\` is \`int64-max\` so a \`cursor >= range.latest\` lex comparison (under the strict \`<=\` skip predicate) is satisfied only when the cursor is at or past the chunk's last entry. This matches the design's tail-drain criterion exactly.

The reader's \`gcDepartedShards\` (Phase 3) consumes \`RetainedLogRangePerShard\`:
- \`cursor[F] >= range.latest\` → safe to GC F's cursor (record in \`tail_drained_streams\`).
- \`F\` has no range AND \`tail_drained_streams[F]\` is unset → lost-log; downgrade reader-driven rules to \`scan_only\` with \`degraded_reason = LOST_LOG\`.

## Test plan
- \`go test ./weed/pb/ -run TestEarliestRetainedPositionPerShard -run TestRetainedLogRangePerShard -run TestWalkLogChunks -run TestGetFilerIdFromName -run TestParseChunkTime\` — passing locally; covers two-filer earliest, empty-dir, range earliest/latest for distinct chunks, single-chunk case, malformed-name skip, helper-function boundary cases.
- \`go build ./...\` — clean.

A \`filer_pb.SeaweedFilerClient\`-backed \`LogDirLister\` adapter will land alongside the Phase 3 reader (which is the first caller). This PR keeps the \`pb\` package free of gRPC streaming mechanics in the unit tests.