### PR TITLE
feat(s3): register SeaweedS3LifecycleInternal gRPC service

### DIFF
--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/s3_lifecycle_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/iceberg"
@@ -406,6 +407,7 @@ func (s3opt *S3Options) startS3Server() bool {
 	}
 	grpcS := pb.NewGrpcServer(security.LoadServerTLS(util.GetViper(), "grpc.s3"))
 	s3_pb.RegisterSeaweedS3IamCacheServer(grpcS, s3ApiServer)
+	s3_lifecycle_pb.RegisterSeaweedS3LifecycleInternalServer(grpcS, s3ApiServer)
 	reflection.Register(grpcS)
 	if grpcLocalL != nil {
 		go grpcS.Serve(grpcLocalL)

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/iam/policy"
 	"github.com/seaweedfs/seaweedfs/weed/iam/sts"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/s3_lifecycle_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
 	. "github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -74,6 +75,7 @@ const s3ChunkCacheChunkSizeMB = 4
 
 type S3ApiServer struct {
 	s3_pb.UnimplementedSeaweedS3IamCacheServer
+	s3_lifecycle_pb.UnimplementedSeaweedS3LifecycleInternalServer
 	option                *S3ApiServerOption
 	iam                   *IdentityAccessManagement
 	iamIntegration        *S3IAMIntegration // Advanced IAM integration for JWT authentication


### PR DESCRIPTION
## Summary
Phase 2 (#9349) added the \`LifecycleDelete\` handler on \`S3ApiServer\` but never registered it on a running gRPC server, so workers had no endpoint to dial.

- Embed \`s3_lifecycle_pb.UnimplementedSeaweedS3LifecycleInternalServer\` on \`S3ApiServer\`
- Register \`SeaweedS3LifecycleInternalServer\` on the s3 command's gRPC server alongside \`SeaweedS3IamCacheServer\`

## Stack
This is the small wiring half of Phase 3 follow-up (b). The shell command originally planned in this PR (\`s3.lifecycle.run-shard\`) hit an import cycle: \`shell -> s3api -> server -> shell\`. Cleanly resolving that requires moving the Lifecycle XML structs and \`LifecycleToCanonical\` out of \`s3api/\` into a leaf package — non-trivial refactor that belongs in a separate PR.

## Test plan
- [x] \`go build ./...\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 lifecycle management support to the SeaweedFS S3 server, enabling automated object retention and deletion policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->