### PR TITLE
fix(mount): preserve user-set mtime through async/periodic flush (#9363)

### DIFF
--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -201,11 +201,9 @@ func (wfs *WFS) flushMetadataToFiler(fh *FileHandle, dir, name string, uid, gid 
 		if entry.Attributes.Gid == 0 {
 			entry.Attributes.Gid = gid
 		}
-		flushNow := time.Now()
-		entry.Attributes.Mtime = flushNow.Unix()
-		entry.Attributes.MtimeNs = int32(flushNow.Nanosecond())
-		entry.Attributes.Ctime = flushNow.Unix()
-		entry.Attributes.CtimeNs = int32(flushNow.Nanosecond())
+		// Do not stamp mtime/ctime here. Write/SetAttr already maintain
+		// them on the entry; overwriting at flush time clobbered user-set
+		// mtime (utimes/touch -m -d) once the deferred flush ran.
 	}
 
 	glog.V(4).Infof("%s set chunks: %v", fileFullPath, len(entry.GetChunks()))

--- a/weed/mount/weedfs_file_write.go
+++ b/weed/mount/weedfs_file_write.go
@@ -66,6 +66,15 @@ func (wfs *WFS) Write(cancel <-chan struct{}, in *fuse.WriteIn, data []byte) (wr
 	newFileSize := max(offset+int64(len(data)), oldFileSize)
 	entry.Attributes.FileSize = uint64(newFileSize)
 
+	// POSIX: writes update mtime and ctime. Stamp the entry now so the
+	// flush path persists the write time rather than overwriting any
+	// user-set mtime (e.g., utimes/touch -m -d) at flush time.
+	writeNow := time.Unix(0, tsNs)
+	entry.Attributes.Mtime = writeNow.Unix()
+	entry.Attributes.MtimeNs = int32(writeNow.Nanosecond())
+	entry.Attributes.Ctime = writeNow.Unix()
+	entry.Attributes.CtimeNs = int32(writeNow.Nanosecond())
+
 	// Track uncommitted bytes for real-time quota enforcement.
 	// Only count the new bytes being added beyond the current file size.
 	if newFileSize > oldFileSize {

--- a/weed/mount/weedfs_metadata_flush.go
+++ b/weed/mount/weedfs_metadata_flush.go
@@ -110,13 +110,9 @@ func (wfs *WFS) flushFileMetadata(fh *FileHandle) error {
 	}
 	entry.Name = name
 
-	if entry.Attributes != nil {
-		metaNow := time.Now()
-		entry.Attributes.Mtime = metaNow.Unix()
-		entry.Attributes.MtimeNs = int32(metaNow.Nanosecond())
-		entry.Attributes.Ctime = metaNow.Unix()
-		entry.Attributes.CtimeNs = int32(metaNow.Nanosecond())
-	}
+	// Do not stamp mtime/ctime here. Write/SetAttr already maintain
+	// them on the entry; overwriting at periodic-flush time clobbered
+	// user-set mtime (utimes/touch -m -d) once the timer fired.
 
 	// Get current chunks - these include chunks that have been uploaded
 	// but not yet persisted to filer metadata

--- a/weed/mount/weedfs_metadata_flush_mtime_test.go
+++ b/weed/mount/weedfs_metadata_flush_mtime_test.go
@@ -31,7 +31,9 @@ func TestFlushFileMetadataPreservesUserMtime(t *testing.T) {
 	fullPath := util.FullPath("/dir/sample.txt")
 	wfs.inodeToPath.Lookup(fullPath, 1, false, false, inode, true)
 
-	userMtime := time.Date(2020, 1, 15, 12, 34, 56, 0, time.UTC)
+	// Use a non-zero nanosecond so the *Ns assertions below catch a regression
+	// that zeroes the field instead of preserving it.
+	userMtime := time.Date(2020, 1, 15, 12, 34, 56, 123456789, time.UTC)
 	entry := &filer_pb.Entry{
 		Name: "sample.txt",
 		Attributes: &filer_pb.FuseAttributes{
@@ -62,41 +64,7 @@ func TestFlushFileMetadataPreservesUserMtime(t *testing.T) {
 	if got := entry.Attributes.Ctime; got != userMtime.Unix() {
 		t.Errorf("ctime sec changed: got %d, want %d", got, userMtime.Unix())
 	}
-}
-
-// TestWriteStampsEntryMtime verifies the companion behavior: Write() must
-// update entry.Attributes.Mtime/Ctime so flush has the correct value to
-// persist. The previous design relied on flush to synthesize mtime, which is
-// what allowed flush to clobber a user-set utimes value.
-//
-// The test exercises the stamp logic against a hand-built entry rather than
-// driving the full Write() path, which would require a real PageWriter and
-// chunk-allocation pipeline.
-func TestWriteStampsEntryMtime(t *testing.T) {
-	original := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
-	entry := &filer_pb.Entry{
-		Attributes: &filer_pb.FuseAttributes{
-			Mtime:   original.Unix(),
-			MtimeNs: int32(original.Nanosecond()),
-			Ctime:   original.Unix(),
-			CtimeNs: int32(original.Nanosecond()),
-		},
-	}
-
-	tsNs := time.Now().UnixNano()
-	writeNow := time.Unix(0, tsNs)
-	entry.Attributes.Mtime = writeNow.Unix()
-	entry.Attributes.MtimeNs = int32(writeNow.Nanosecond())
-	entry.Attributes.Ctime = writeNow.Unix()
-	entry.Attributes.CtimeNs = int32(writeNow.Nanosecond())
-
-	if entry.Attributes.Mtime == original.Unix() {
-		t.Fatal("mtime sec was not advanced from the original value")
-	}
-	if entry.Attributes.Mtime != writeNow.Unix() {
-		t.Errorf("mtime sec = %d, want %d", entry.Attributes.Mtime, writeNow.Unix())
-	}
-	if entry.Attributes.MtimeNs != int32(writeNow.Nanosecond()) {
-		t.Errorf("mtime ns = %d, want %d", entry.Attributes.MtimeNs, writeNow.Nanosecond())
+	if got := entry.Attributes.CtimeNs; got != int32(userMtime.Nanosecond()) {
+		t.Errorf("ctime ns changed: got %d, want %d", got, userMtime.Nanosecond())
 	}
 }

--- a/weed/mount/weedfs_metadata_flush_mtime_test.go
+++ b/weed/mount/weedfs_metadata_flush_mtime_test.go
@@ -1,0 +1,102 @@
+package mount
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// TestFlushFileMetadataPreservesUserMtime is a regression test for issue #9363.
+//
+// Before the fix, flushFileMetadata stamped entry.Attributes.Mtime/Ctime with
+// time.Now() on every flush, clobbering the value SetAttr stored on the entry
+// when the user ran utimes()/touch -m -d while a file handle was still open.
+//
+// The flush has no business inventing timestamps: Write and SetAttr already
+// maintain mtime/ctime on the entry, and the flush should just persist them.
+//
+// The test sets a user-chosen mtime far in the past, runs flushFileMetadata
+// with no chunks (so it returns before the streamCreateEntry RPC), and asserts
+// the entry's mtime is unchanged.
+func TestFlushFileMetadataPreservesUserMtime(t *testing.T) {
+	wfs := &WFS{
+		inodeToPath:  NewInodeToPath(util.FullPath("/"), 0),
+		fhLockTable:  util.NewLockTable[FileHandleId](),
+		option:       &Option{},
+	}
+
+	const inode = uint64(42)
+	fullPath := util.FullPath("/dir/sample.txt")
+	wfs.inodeToPath.Lookup(fullPath, 1, false, false, inode, true)
+
+	userMtime := time.Date(2020, 1, 15, 12, 34, 56, 0, time.UTC)
+	entry := &filer_pb.Entry{
+		Name: "sample.txt",
+		Attributes: &filer_pb.FuseAttributes{
+			Mtime:   userMtime.Unix(),
+			MtimeNs: int32(userMtime.Nanosecond()),
+			Ctime:   userMtime.Unix(),
+			CtimeNs: int32(userMtime.Nanosecond()),
+		},
+	}
+	fh := &FileHandle{
+		fh:            FileHandleId(1),
+		inode:         inode,
+		wfs:           wfs,
+		entry:         &LockedEntry{Entry: entry},
+		dirtyMetadata: true,
+	}
+
+	if err := wfs.flushFileMetadata(fh); err != nil {
+		t.Fatalf("flushFileMetadata returned error: %v", err)
+	}
+
+	if got := entry.Attributes.Mtime; got != userMtime.Unix() {
+		t.Errorf("mtime sec changed: got %d, want %d", got, userMtime.Unix())
+	}
+	if got := entry.Attributes.MtimeNs; got != int32(userMtime.Nanosecond()) {
+		t.Errorf("mtime ns changed: got %d, want %d", got, userMtime.Nanosecond())
+	}
+	if got := entry.Attributes.Ctime; got != userMtime.Unix() {
+		t.Errorf("ctime sec changed: got %d, want %d", got, userMtime.Unix())
+	}
+}
+
+// TestWriteStampsEntryMtime verifies the companion behavior: Write() must
+// update entry.Attributes.Mtime/Ctime so flush has the correct value to
+// persist. The previous design relied on flush to synthesize mtime, which is
+// what allowed flush to clobber a user-set utimes value.
+//
+// The test exercises the stamp logic against a hand-built entry rather than
+// driving the full Write() path, which would require a real PageWriter and
+// chunk-allocation pipeline.
+func TestWriteStampsEntryMtime(t *testing.T) {
+	original := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
+	entry := &filer_pb.Entry{
+		Attributes: &filer_pb.FuseAttributes{
+			Mtime:   original.Unix(),
+			MtimeNs: int32(original.Nanosecond()),
+			Ctime:   original.Unix(),
+			CtimeNs: int32(original.Nanosecond()),
+		},
+	}
+
+	tsNs := time.Now().UnixNano()
+	writeNow := time.Unix(0, tsNs)
+	entry.Attributes.Mtime = writeNow.Unix()
+	entry.Attributes.MtimeNs = int32(writeNow.Nanosecond())
+	entry.Attributes.Ctime = writeNow.Unix()
+	entry.Attributes.CtimeNs = int32(writeNow.Nanosecond())
+
+	if entry.Attributes.Mtime == original.Unix() {
+		t.Fatal("mtime sec was not advanced from the original value")
+	}
+	if entry.Attributes.Mtime != writeNow.Unix() {
+		t.Errorf("mtime sec = %d, want %d", entry.Attributes.Mtime, writeNow.Unix())
+	}
+	if entry.Attributes.MtimeNs != int32(writeNow.Nanosecond()) {
+		t.Errorf("mtime ns = %d, want %d", entry.Attributes.MtimeNs, writeNow.Nanosecond())
+	}
+}


### PR DESCRIPTION
Fixes #9363.

## Problem

`touch -m -d '2020-01-15T12:34:56' file` (and any `utimes()`-based timestamp update) is applied correctly at first, but ~1 second later the mtime flips to "now". `rsync -t` and `cp -p` therefore lose the timestamp.

## Root cause

Two flush paths unconditionally stamped `time.Now()` onto the entry before sending it to the filer:

- `flushMetadataToFiler` — sync close (`Flush`/`fsync`) and writebackCache async close
- `flushFileMetadata` — periodic timer

The user's mtime lived correctly in `entry.Attributes.Mtime` after `SetAttr`; the next flush rewrote it. The reproducer hit it after ~1 s because the writebackCache deferred close from the prior `echo data > sample.txt` was still pending and ran `flushMetadataToFiler` after the user's `touch`.

## Fix

- `Write` now stamps `entry.Attributes.Mtime`/`Ctime` at write time. This is where POSIX expects mtime to advance, and it gives the flush something correct to persist.
- `flushMetadataToFiler` and `flushFileMetadata` no longer touch mtime/ctime. They are pure persist — whatever `Write` or `SetAttr` (utimes) put on the entry is what reaches the filer.

## Test

`TestFlushFileMetadataPreservesUserMtime` builds a `FileHandle` with a user-set mtime (2020-01-15), calls `flushFileMetadata`, and asserts mtime/ctime are unchanged. Verified the test fails on the buggy code (`mtime sec changed: got <now>, want 1579091696`) and passes after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve user-set file modification and change times during periodic metadata flushes; writes now record timestamps immediately so they persist correctly.
* **Tests**
  * Added regression tests ensuring user-provided timestamps are preserved across metadata operations and that write-time updates are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->