### PR TITLE
fix(ec): planner treats each (server, disk_id) as a distinct target (#9369)

### DIFF
--- a/weed/admin/topology/active_topology_test.go
+++ b/weed/admin/topology/active_topology_test.go
@@ -408,16 +408,11 @@ func TestECPlanningNotBlockedByUnrelatedBalance(t *testing.T) {
 		"EC must still see all 4 disks even with an unrelated in-flight balance")
 }
 
-// TestECPlannerSeesEachPhysicalDisk reproduces #9369: when a volume server has
-// multiple physical disks of the same type (e.g. -dir=/d1,/d2 → diskIds 0,1),
-// the master collapses them into a single DiskInfo entry keyed by disk type.
-// The active topology must still expose one entry per physical disk_id so the
-// EC planner can place at most one shard per disk.
+// #9369: same-type physical disks collapse into one DiskInfo at the master;
+// the active topology must still expose one entry per physical disk_id.
 func TestECPlannerSeesEachPhysicalDisk(t *testing.T) {
 	topology := NewActiveTopology(10)
 
-	// 7 volume servers, each with 2 physical HDDs visible only via per-volume
-	// disk_id annotations on the single "hdd" DiskInfo entry.
 	const numServers = 7
 	const disksPerServer = 2
 	nodes := make([]*master_pb.DataNodeInfo, 0, numServers)
@@ -434,9 +429,9 @@ func TestECPlannerSeesEachPhysicalDisk(t *testing.T) {
 			Id: fmt.Sprintf("127.0.0.1:%d", 8080+i),
 			DiskInfos: map[string]*master_pb.DiskInfo{
 				"hdd": {
-					DiskId:         0, // master only retains one DiskId per type
+					DiskId:         0,
 					VolumeCount:    int64(disksPerServer),
-					MaxVolumeCount: 200, // aggregated across both physical disks
+					MaxVolumeCount: 200,
 					VolumeInfos:    volumeInfos,
 				},
 			},
@@ -454,12 +449,8 @@ func TestECPlannerSeesEachPhysicalDisk(t *testing.T) {
 	}))
 
 	candidates := topology.GetDisksWithEffectiveCapacity(TaskTypeErasureCoding, "", 0)
-	assert.Equal(t, numServers*disksPerServer, len(candidates),
-		"EC planner must see %d physical disks (#9369: %d servers × %d disks)",
-		numServers*disksPerServer, numServers, disksPerServer)
+	assert.Equal(t, numServers*disksPerServer, len(candidates))
 
-	// Every (server, disk_id) tuple must be distinct so the planner can spread
-	// shards 1-per-disk instead of doubling up on the same physical disk.
 	seen := make(map[string]bool, len(candidates))
 	for _, c := range candidates {
 		key := fmt.Sprintf("%s:%d", c.NodeID, c.DiskID)

--- a/weed/admin/topology/active_topology_test.go
+++ b/weed/admin/topology/active_topology_test.go
@@ -408,6 +408,66 @@ func TestECPlanningNotBlockedByUnrelatedBalance(t *testing.T) {
 		"EC must still see all 4 disks even with an unrelated in-flight balance")
 }
 
+// TestECPlannerSeesEachPhysicalDisk reproduces #9369: when a volume server has
+// multiple physical disks of the same type (e.g. -dir=/d1,/d2 → diskIds 0,1),
+// the master collapses them into a single DiskInfo entry keyed by disk type.
+// The active topology must still expose one entry per physical disk_id so the
+// EC planner can place at most one shard per disk.
+func TestECPlannerSeesEachPhysicalDisk(t *testing.T) {
+	topology := NewActiveTopology(10)
+
+	// 7 volume servers, each with 2 physical HDDs visible only via per-volume
+	// disk_id annotations on the single "hdd" DiskInfo entry.
+	const numServers = 7
+	const disksPerServer = 2
+	nodes := make([]*master_pb.DataNodeInfo, 0, numServers)
+	for i := 1; i <= numServers; i++ {
+		volumeInfos := make([]*master_pb.VolumeInformationMessage, 0, disksPerServer)
+		for d := uint32(0); d < disksPerServer; d++ {
+			volumeInfos = append(volumeInfos, &master_pb.VolumeInformationMessage{
+				Id:       uint32(i*10 + int(d)),
+				DiskId:   d,
+				DiskType: "hdd",
+			})
+		}
+		nodes = append(nodes, &master_pb.DataNodeInfo{
+			Id: fmt.Sprintf("127.0.0.1:%d", 8080+i),
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"hdd": {
+					DiskId:         0, // master only retains one DiskId per type
+					VolumeCount:    int64(disksPerServer),
+					MaxVolumeCount: 200, // aggregated across both physical disks
+					VolumeInfos:    volumeInfos,
+				},
+			},
+		})
+	}
+
+	require.NoError(t, topology.UpdateTopology(&master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id:            "rack1",
+				DataNodeInfos: nodes,
+			}},
+		}},
+	}))
+
+	candidates := topology.GetDisksWithEffectiveCapacity(TaskTypeErasureCoding, "", 0)
+	assert.Equal(t, numServers*disksPerServer, len(candidates),
+		"EC planner must see %d physical disks (#9369: %d servers × %d disks)",
+		numServers*disksPerServer, numServers, disksPerServer)
+
+	// Every (server, disk_id) tuple must be distinct so the planner can spread
+	// shards 1-per-disk instead of doubling up on the same physical disk.
+	seen := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		key := fmt.Sprintf("%s:%d", c.NodeID, c.DiskID)
+		assert.False(t, seen[key], "duplicate placement target %s", key)
+		seen[key] = true
+	}
+}
+
 // TestPublicInterfaces tests the public interface methods
 func TestPublicInterfaces(t *testing.T) {
 	topology := NewActiveTopology(10)

--- a/weed/admin/topology/topology_management.go
+++ b/weed/admin/topology/topology_management.go
@@ -8,6 +8,83 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 )
 
+// splitDiskInfoByPhysicalDisk returns one master_pb.DiskInfo per physical disk
+// observed inside the given (per-disk-type) entry. Multiple physical disks of
+// the same type collapse into a single DiskInfo at the master, but per-volume
+// and per-EC-shard records still carry their original disk_id, so we can
+// reconstruct the per-disk view here. Aggregate capacity (MaxVolumeCount,
+// VolumeCount) is split evenly across the discovered disks — exact per-disk
+// numbers are not preserved on the wire today.
+func splitDiskInfoByPhysicalDisk(diskInfo *master_pb.DiskInfo) []*master_pb.DiskInfo {
+	if diskInfo == nil {
+		return nil
+	}
+
+	// Normalize each record's DiskId: if a volume/shard reports DiskId=0 while
+	// the outer DiskInfo.DiskId is non-zero, treat it as belonging to the
+	// outer disk. This handles fixtures (and older payloads) that don't
+	// populate the per-record DiskId. The same fallback is applied in
+	// rebuildIndexes so the volume index and the activeDisk map agree.
+	normalize := func(id uint32) uint32 {
+		if id == 0 && diskInfo.DiskId != 0 {
+			return diskInfo.DiskId
+		}
+		return id
+	}
+
+	diskIDs := make(map[uint32]struct{})
+	for _, vi := range diskInfo.VolumeInfos {
+		diskIDs[normalize(vi.DiskId)] = struct{}{}
+	}
+	for _, eci := range diskInfo.EcShardInfos {
+		diskIDs[normalize(eci.DiskId)] = struct{}{}
+	}
+	if len(diskIDs) == 0 {
+		// Empty DiskInfo (no volumes or shards) — keep one entry under the
+		// reported outer DiskId so the disk still shows up for placement.
+		diskIDs[diskInfo.DiskId] = struct{}{}
+	}
+
+	if len(diskIDs) == 1 {
+		// Single physical disk — keep as-is so existing DiskInfo identity /
+		// capacity numbers are unchanged.
+		for diskID := range diskIDs {
+			if diskID == diskInfo.DiskId {
+				return []*master_pb.DiskInfo{diskInfo}
+			}
+		}
+	}
+
+	perDiskVolumes := make(map[uint32][]*master_pb.VolumeInformationMessage)
+	for _, vi := range diskInfo.VolumeInfos {
+		perDiskVolumes[normalize(vi.DiskId)] = append(perDiskVolumes[normalize(vi.DiskId)], vi)
+	}
+	perDiskShards := make(map[uint32][]*master_pb.VolumeEcShardInformationMessage)
+	for _, eci := range diskInfo.EcShardInfos {
+		perDiskShards[normalize(eci.DiskId)] = append(perDiskShards[normalize(eci.DiskId)], eci)
+	}
+
+	count := int64(len(diskIDs))
+	share := func(total int64) int64 { return total / count }
+
+	result := make([]*master_pb.DiskInfo, 0, len(diskIDs))
+	for diskID := range diskIDs {
+		result = append(result, &master_pb.DiskInfo{
+			Type:              diskInfo.Type,
+			MaxVolumeCount:    share(diskInfo.MaxVolumeCount),
+			VolumeCount:       int64(len(perDiskVolumes[diskID])),
+			FreeVolumeCount:   share(diskInfo.FreeVolumeCount),
+			ActiveVolumeCount: share(diskInfo.ActiveVolumeCount),
+			RemoteVolumeCount: share(diskInfo.RemoteVolumeCount),
+			VolumeInfos:       perDiskVolumes[diskID],
+			EcShardInfos:      perDiskShards[diskID],
+			DiskId:            diskID,
+			Tags:              append([]string(nil), diskInfo.Tags...),
+		})
+	}
+	return result
+}
+
 // CountTopologyResources counts datacenters, nodes, and disks in topology info
 func CountTopologyResources(topologyInfo *master_pb.TopologyInfo) (dcCount, nodeCount, diskCount int) {
 	if topologyInfo == nil {
@@ -73,24 +150,33 @@ func (at *ActiveTopology) UpdateTopology(topologyInfo *master_pb.TopologyInfo) e
 					disks:      make(map[uint32]*activeDisk),
 				}
 
-				// Add disks for this node
+				// Add disks for this node. master_pb.DataNodeInfo.DiskInfos is
+				// keyed by disk type, so a server with N physical disks of the
+				// same type collapses into a single entry. Per-physical-disk
+				// attribution survives only inside VolumeInfos[].DiskId and
+				// EcShardInfos[].DiskId. Expand back to one activeDisk per
+				// physical disk_id so EC placement (and any other per-disk
+				// scheduling) treats them as distinct targets — see #9369.
 				for diskType, diskInfo := range nodeInfo.DiskInfos {
-					disk := &activeDisk{
-						DiskInfo: &DiskInfo{
-							NodeID:     nodeInfo.Id,
-							DiskID:     diskInfo.DiskId,
-							DiskType:   diskType,
-							DataCenter: dc.Id,
-							Rack:       rack.Id,
-							DiskInfo:   diskInfo,
-						},
-					}
+					perDiskInfos := splitDiskInfoByPhysicalDisk(diskInfo)
+					for _, perDisk := range perDiskInfos {
+						disk := &activeDisk{
+							DiskInfo: &DiskInfo{
+								NodeID:     nodeInfo.Id,
+								DiskID:     perDisk.DiskId,
+								DiskType:   diskType,
+								DataCenter: dc.Id,
+								Rack:       rack.Id,
+								DiskInfo:   perDisk,
+							},
+						}
 
-					diskKey := fmt.Sprintf("%s:%d", nodeInfo.Id, diskInfo.DiskId)
-					glog.V(3).Infof("UpdateTopology: adding disk key=%q nodeId=%q diskId=%d diskType=%q address=%q grpcPort=%d volumes=%d maxVolumes=%d",
-						diskKey, nodeInfo.Id, diskInfo.DiskId, diskType, nodeInfo.Address, nodeInfo.GrpcPort, diskInfo.VolumeCount, diskInfo.MaxVolumeCount)
-					node.disks[diskInfo.DiskId] = disk
-					at.disks[diskKey] = disk
+						diskKey := fmt.Sprintf("%s:%d", nodeInfo.Id, perDisk.DiskId)
+						glog.V(3).Infof("UpdateTopology: adding disk key=%q nodeId=%q diskId=%d diskType=%q address=%q grpcPort=%d volumes=%d maxVolumes=%d",
+							diskKey, nodeInfo.Id, perDisk.DiskId, diskType, nodeInfo.Address, nodeInfo.GrpcPort, perDisk.VolumeCount, perDisk.MaxVolumeCount)
+						node.disks[perDisk.DiskId] = disk
+						at.disks[diskKey] = disk
+					}
 				}
 
 				at.nodes[nodeInfo.Id] = node
@@ -205,23 +291,34 @@ func (at *ActiveTopology) rebuildIndexes() {
 	at.volumeIndex = make(map[uint32][]string)
 	at.ecShardIndex = make(map[uint32][]string)
 
-	// Rebuild indexes from current topology
+	// Rebuild indexes from current topology. We index by the per-volume /
+	// per-EC-shard DiskId (not the outer DiskInfo.DiskId) so the result lines
+	// up with the per-physical-disk activeDisk entries built by UpdateTopology
+	// — see splitDiskInfoByPhysicalDisk and #9369.
 	for _, dc := range at.topologyInfo.DataCenterInfos {
 		for _, rack := range dc.RackInfos {
 			for _, nodeInfo := range rack.DataNodeInfos {
 				for _, diskInfo := range nodeInfo.DiskInfos {
-					diskKey := fmt.Sprintf("%s:%d", nodeInfo.Id, diskInfo.DiskId)
-
-					// Index volumes
+					// Index volumes by their own DiskId (falling back to the
+					// outer DiskId for entries that omit it, e.g. older test
+					// fixtures).
 					for _, volumeInfo := range diskInfo.VolumeInfos {
-						volumeID := volumeInfo.Id
-						at.volumeIndex[volumeID] = append(at.volumeIndex[volumeID], diskKey)
+						diskID := volumeInfo.DiskId
+						if diskID == 0 && diskInfo.DiskId != 0 {
+							diskID = diskInfo.DiskId
+						}
+						diskKey := fmt.Sprintf("%s:%d", nodeInfo.Id, diskID)
+						at.volumeIndex[volumeInfo.Id] = append(at.volumeIndex[volumeInfo.Id], diskKey)
 					}
 
-					// Index EC shards
+					// Index EC shards by their own DiskId.
 					for _, ecShardInfo := range diskInfo.EcShardInfos {
-						volumeID := ecShardInfo.Id
-						at.ecShardIndex[volumeID] = append(at.ecShardIndex[volumeID], diskKey)
+						diskID := ecShardInfo.DiskId
+						if diskID == 0 && diskInfo.DiskId != 0 {
+							diskID = diskInfo.DiskId
+						}
+						diskKey := fmt.Sprintf("%s:%d", nodeInfo.Id, diskID)
+						at.ecShardIndex[ecShardInfo.Id] = append(at.ecShardIndex[ecShardInfo.Id], diskKey)
 					}
 				}
 			}

--- a/weed/admin/topology/topology_management.go
+++ b/weed/admin/topology/topology_management.go
@@ -8,23 +8,18 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 )
 
-// splitDiskInfoByPhysicalDisk returns one master_pb.DiskInfo per physical disk
-// observed inside the given (per-disk-type) entry. Multiple physical disks of
-// the same type collapse into a single DiskInfo at the master, but per-volume
-// and per-EC-shard records still carry their original disk_id, so we can
-// reconstruct the per-disk view here. Aggregate capacity (MaxVolumeCount,
-// VolumeCount) is split evenly across the discovered disks — exact per-disk
-// numbers are not preserved on the wire today.
+// splitDiskInfoByPhysicalDisk returns one master_pb.DiskInfo per physical
+// disk_id observed in VolumeInfos / EcShardInfos. Multiple same-type physical
+// disks collapse to one DiskInfo at the master; per-volume/per-shard records
+// keep the original disk_id and are the authoritative signal here. Capacity
+// is split evenly — the wire format doesn't carry per-disk capacity yet.
 func splitDiskInfoByPhysicalDisk(diskInfo *master_pb.DiskInfo) []*master_pb.DiskInfo {
 	if diskInfo == nil {
 		return nil
 	}
 
-	// Normalize each record's DiskId: if a volume/shard reports DiskId=0 while
-	// the outer DiskInfo.DiskId is non-zero, treat it as belonging to the
-	// outer disk. This handles fixtures (and older payloads) that don't
-	// populate the per-record DiskId. The same fallback is applied in
-	// rebuildIndexes so the volume index and the activeDisk map agree.
+	// Records with DiskId=0 and a non-zero outer DiskId belong to the outer
+	// disk — handles older payloads / fixtures that omit the per-record id.
 	normalize := func(id uint32) uint32 {
 		if id == 0 && diskInfo.DiskId != 0 {
 			return diskInfo.DiskId
@@ -40,14 +35,10 @@ func splitDiskInfoByPhysicalDisk(diskInfo *master_pb.DiskInfo) []*master_pb.Disk
 		diskIDs[normalize(eci.DiskId)] = struct{}{}
 	}
 	if len(diskIDs) == 0 {
-		// Empty DiskInfo (no volumes or shards) — keep one entry under the
-		// reported outer DiskId so the disk still shows up for placement.
 		diskIDs[diskInfo.DiskId] = struct{}{}
 	}
 
 	if len(diskIDs) == 1 {
-		// Single physical disk — keep as-is so existing DiskInfo identity /
-		// capacity numbers are unchanged.
 		for diskID := range diskIDs {
 			if diskID == diskInfo.DiskId {
 				return []*master_pb.DiskInfo{diskInfo}
@@ -150,13 +141,8 @@ func (at *ActiveTopology) UpdateTopology(topologyInfo *master_pb.TopologyInfo) e
 					disks:      make(map[uint32]*activeDisk),
 				}
 
-				// Add disks for this node. master_pb.DataNodeInfo.DiskInfos is
-				// keyed by disk type, so a server with N physical disks of the
-				// same type collapses into a single entry. Per-physical-disk
-				// attribution survives only inside VolumeInfos[].DiskId and
-				// EcShardInfos[].DiskId. Expand back to one activeDisk per
-				// physical disk_id so EC placement (and any other per-disk
-				// scheduling) treats them as distinct targets — see #9369.
+				// One activeDisk per physical disk_id (#9369): the master keys
+				// DiskInfos by disk type, so same-type disks must be split out.
 				for diskType, diskInfo := range nodeInfo.DiskInfos {
 					perDiskInfos := splitDiskInfoByPhysicalDisk(diskInfo)
 					for _, perDisk := range perDiskInfos {
@@ -291,17 +277,12 @@ func (at *ActiveTopology) rebuildIndexes() {
 	at.volumeIndex = make(map[uint32][]string)
 	at.ecShardIndex = make(map[uint32][]string)
 
-	// Rebuild indexes from current topology. We index by the per-volume /
-	// per-EC-shard DiskId (not the outer DiskInfo.DiskId) so the result lines
-	// up with the per-physical-disk activeDisk entries built by UpdateTopology
-	// — see splitDiskInfoByPhysicalDisk and #9369.
+	// Index by the per-record DiskId (not the outer DiskInfo.DiskId) so the
+	// keys match the per-physical-disk activeDisk entries — see #9369.
 	for _, dc := range at.topologyInfo.DataCenterInfos {
 		for _, rack := range dc.RackInfos {
 			for _, nodeInfo := range rack.DataNodeInfos {
 				for _, diskInfo := range nodeInfo.DiskInfos {
-					// Index volumes by their own DiskId (falling back to the
-					// outer DiskId for entries that omit it, e.g. older test
-					// fixtures).
 					for _, volumeInfo := range diskInfo.VolumeInfos {
 						diskID := volumeInfo.DiskId
 						if diskID == 0 && diskInfo.DiskId != 0 {
@@ -310,8 +291,6 @@ func (at *ActiveTopology) rebuildIndexes() {
 						diskKey := fmt.Sprintf("%s:%d", nodeInfo.Id, diskID)
 						at.volumeIndex[volumeInfo.Id] = append(at.volumeIndex[volumeInfo.Id], diskKey)
 					}
-
-					// Index EC shards by their own DiskId.
 					for _, ecShardInfo := range diskInfo.EcShardInfos {
 						diskID := ecShardInfo.DiskId
 						if diskID == 0 && diskInfo.DiskId != 0 {

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -593,10 +593,8 @@ func (p *ecPlacementPlanner) buildCandidateSets(shardsNeeded int) [][]*placement
 	return candidateSets
 }
 
-// planECDestinations plans the destinations for erasure coding operation
-// This function implements EC destination planning logic directly in the detection phase.
-// dataShards/parityShards are taken as parameters so callers (and forks running
-// non-default ratios) can drive placement without relying on the OSS 10+4 constants.
+// planECDestinations plans the destinations for erasure coding operation.
+// dataShards/parityShards are parameters so callers can drive non-10+4 ratios.
 func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthMetrics, ecConfig *Config, dataShards, parityShards uint32) (*topology.MultiDestinationPlan, error) {
 	if planner == nil || planner.activeTopology == nil {
 		return nil, fmt.Errorf("active topology not available for EC placement")
@@ -605,12 +603,7 @@ func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthM
 		return nil, fmt.Errorf("invalid EC ratio: dataShards=%d parityShards=%d", dataShards, parityShards)
 	}
 	totalShards := int(dataShards + parityShards)
-	// minTotalDisks mirrors erasure_coding.MinTotalDisks: total/parity + 1, i.e.
-	// strictly more than one shard-stripe per disk so a single disk loss never
-	// takes out more than parityShards shards.
 	minTotalDisks := totalShards/int(parityShards) + 1
-
-	// Calculate expected shard size for EC operation
 	expectedShardSize := uint64(metric.Size) / uint64(dataShards)
 
 	// Get source node information from topology
@@ -646,12 +639,10 @@ func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthM
 	if len(selectedDisks) < minTotalDisks {
 		return nil, fmt.Errorf("found %d disks, but could not find %d suitable destinations for EC placement", len(selectedDisks), minTotalDisks)
 	}
-	// #9369 / #9185: with disk_id-aware ReceiveFile, two shards on the same
-	// (server, disk_id) target collide. If the planner could not give us one
-	// distinct disk per shard, fail the plan rather than letting createECTargets
-	// pack multiple shards onto the same physical disk.
+	// One shard per (server, disk_id): #9185's disk_id-aware ReceiveFile rejects
+	// a second shard on the same disk.
 	if len(selectedDisks) < totalShards {
-		return nil, fmt.Errorf("found %d disks, but EC %d+%d needs %d distinct (server, disk_id) targets so each shard lands on its own disk",
+		return nil, fmt.Errorf("found %d disks, but EC %d+%d needs %d distinct (server, disk_id) targets",
 			len(selectedDisks), dataShards, parityShards, totalShards)
 	}
 
@@ -709,42 +700,33 @@ func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthM
 	}, nil
 }
 
-// createECTargets creates unified TaskTarget structures from the multi-destination plan
-// with proper shard ID assignment during planning phase. dataShards/parityShards
-// drive the data-vs-parity classification and the total shard count, so the
-// function does not depend on the OSS 10+4 constants.
+// createECTargets builds TaskTargets with one shard per plan entry.
+// planECDestinations ensures numTargets == totalShards.
 func createECTargets(multiPlan *topology.MultiDestinationPlan, dataShards, parityShards uint32) []*worker_pb.TaskTarget {
 	var targets []*worker_pb.TaskTarget
 	numTargets := len(multiPlan.Plans)
 	totalShards := dataShards + parityShards
 
-	// Create shard assignment arrays for each target (round-robin distribution)
 	targetShards := make([][]uint32, numTargets)
 	for i := range targetShards {
 		targetShards[i] = make([]uint32, 0)
 	}
-
-	// Distribute shards in round-robin fashion to spread both data and parity shards
-	// across targets. planECDestinations guarantees numTargets == totalShards, so
-	// each target receives exactly one shard.
 	for shardId := uint32(0); shardId < totalShards; shardId++ {
 		targetIndex := int(shardId) % numTargets
 		targetShards[targetIndex] = append(targetShards[targetIndex], shardId)
 	}
 
-	// Create targets with assigned shard IDs
 	for i, plan := range multiPlan.Plans {
 		target := &worker_pb.TaskTarget{
 			Node:          plan.TargetAddress,
 			DiskId:        plan.TargetDisk,
 			Rack:          plan.TargetRack,
 			DataCenter:    plan.TargetDC,
-			ShardIds:      targetShards[i], // Round-robin assigned shards
+			ShardIds:      targetShards[i],
 			EstimatedSize: plan.ExpectedSize,
 		}
 		targets = append(targets, target)
 
-		// Log shard assignment with data/parity classification
 		assignedData := make([]uint32, 0)
 		assignedParity := make([]uint32, 0)
 		for _, shardId := range targetShards[i] {

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -151,7 +151,9 @@ func Detection(ctx context.Context, metrics []*types.VolumeHealthMetrics, cluste
 				if planner == nil {
 					planner = newECPlacementPlanner(clusterInfo.ActiveTopology, ecConfig.PreferredTags)
 				}
-				multiPlan, err := planECDestinations(planner, metric, ecConfig)
+				dataShards := uint32(erasure_coding.DataShardsCount)
+				parityShards := uint32(erasure_coding.ParityShardsCount)
+				multiPlan, err := planECDestinations(planner, metric, ecConfig, dataShards, parityShards)
 				if err != nil {
 					glog.Warningf("Failed to plan EC destinations for volume %d: %v", metric.VolumeID, err)
 					consecutivePlanningFailures++
@@ -168,7 +170,7 @@ func Detection(ctx context.Context, metrics []*types.VolumeHealthMetrics, cluste
 
 				// Calculate expected shard size for EC operation
 				// Each data shard will be approximately volumeSize / dataShards
-				expectedShardSize := uint64(metric.Size) / uint64(erasure_coding.DataShardsCount)
+				expectedShardSize := uint64(metric.Size) / uint64(dataShards)
 
 				// Add pending EC shard task to ActiveTopology for capacity management
 
@@ -281,10 +283,10 @@ func Detection(ctx context.Context, metrics []*types.VolumeHealthMetrics, cluste
 					Sources: sourcesProto,
 
 					// Unified targets - all EC shard destinations
-					Targets: createECTargets(multiPlan),
+					Targets: createECTargets(multiPlan, dataShards, parityShards),
 
 					TaskParams: &worker_pb.TaskParams_ErasureCodingParams{
-						ErasureCodingParams: createECTaskParams(multiPlan),
+						ErasureCodingParams: createECTaskParams(multiPlan, dataShards, parityShards),
 					},
 				}
 
@@ -592,13 +594,24 @@ func (p *ecPlacementPlanner) buildCandidateSets(shardsNeeded int) [][]*placement
 }
 
 // planECDestinations plans the destinations for erasure coding operation
-// This function implements EC destination planning logic directly in the detection phase
-func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthMetrics, ecConfig *Config) (*topology.MultiDestinationPlan, error) {
+// This function implements EC destination planning logic directly in the detection phase.
+// dataShards/parityShards are taken as parameters so callers (and forks running
+// non-default ratios) can drive placement without relying on the OSS 10+4 constants.
+func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthMetrics, ecConfig *Config, dataShards, parityShards uint32) (*topology.MultiDestinationPlan, error) {
 	if planner == nil || planner.activeTopology == nil {
 		return nil, fmt.Errorf("active topology not available for EC placement")
 	}
+	if dataShards == 0 || parityShards == 0 {
+		return nil, fmt.Errorf("invalid EC ratio: dataShards=%d parityShards=%d", dataShards, parityShards)
+	}
+	totalShards := int(dataShards + parityShards)
+	// minTotalDisks mirrors erasure_coding.MinTotalDisks: total/parity + 1, i.e.
+	// strictly more than one shard-stripe per disk so a single disk loss never
+	// takes out more than parityShards shards.
+	minTotalDisks := totalShards/int(parityShards) + 1
+
 	// Calculate expected shard size for EC operation
-	expectedShardSize := uint64(metric.Size) / uint64(erasure_coding.DataShardsCount)
+	expectedShardSize := uint64(metric.Size) / uint64(dataShards)
 
 	// Get source node information from topology
 	var sourceRack, sourceDC string
@@ -626,12 +639,20 @@ func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthM
 	}
 
 	// Select best disks for EC placement with rack/DC diversity using the cached planner
-	selectedDisks, err := planner.selectDestinations(sourceRack, sourceDC, erasure_coding.TotalShardsCount)
+	selectedDisks, err := planner.selectDestinations(sourceRack, sourceDC, totalShards)
 	if err != nil {
 		return nil, err
 	}
-	if len(selectedDisks) < erasure_coding.MinTotalDisks {
-		return nil, fmt.Errorf("found %d disks, but could not find %d suitable destinations for EC placement", len(selectedDisks), erasure_coding.MinTotalDisks)
+	if len(selectedDisks) < minTotalDisks {
+		return nil, fmt.Errorf("found %d disks, but could not find %d suitable destinations for EC placement", len(selectedDisks), minTotalDisks)
+	}
+	// #9369 / #9185: with disk_id-aware ReceiveFile, two shards on the same
+	// (server, disk_id) target collide. If the planner could not give us one
+	// distinct disk per shard, fail the plan rather than letting createECTargets
+	// pack multiple shards onto the same physical disk.
+	if len(selectedDisks) < totalShards {
+		return nil, fmt.Errorf("found %d disks, but EC %d+%d needs %d distinct (server, disk_id) targets so each shard lands on its own disk",
+			len(selectedDisks), dataShards, parityShards, totalShards)
 	}
 
 	var plans []*topology.DestinationPlan
@@ -689,10 +710,13 @@ func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthM
 }
 
 // createECTargets creates unified TaskTarget structures from the multi-destination plan
-// with proper shard ID assignment during planning phase
-func createECTargets(multiPlan *topology.MultiDestinationPlan) []*worker_pb.TaskTarget {
+// with proper shard ID assignment during planning phase. dataShards/parityShards
+// drive the data-vs-parity classification and the total shard count, so the
+// function does not depend on the OSS 10+4 constants.
+func createECTargets(multiPlan *topology.MultiDestinationPlan, dataShards, parityShards uint32) []*worker_pb.TaskTarget {
 	var targets []*worker_pb.TaskTarget
 	numTargets := len(multiPlan.Plans)
+	totalShards := dataShards + parityShards
 
 	// Create shard assignment arrays for each target (round-robin distribution)
 	targetShards := make([][]uint32, numTargets)
@@ -701,8 +725,9 @@ func createECTargets(multiPlan *topology.MultiDestinationPlan) []*worker_pb.Task
 	}
 
 	// Distribute shards in round-robin fashion to spread both data and parity shards
-	// This ensures each target gets a mix of data shards (0-9) and parity shards (10-13)
-	for shardId := uint32(0); shardId < uint32(erasure_coding.TotalShardsCount); shardId++ {
+	// across targets. planECDestinations guarantees numTargets == totalShards, so
+	// each target receives exactly one shard.
+	for shardId := uint32(0); shardId < totalShards; shardId++ {
 		targetIndex := int(shardId) % numTargets
 		targetShards[targetIndex] = append(targetShards[targetIndex], shardId)
 	}
@@ -720,22 +745,21 @@ func createECTargets(multiPlan *topology.MultiDestinationPlan) []*worker_pb.Task
 		targets = append(targets, target)
 
 		// Log shard assignment with data/parity classification
-		dataShards := make([]uint32, 0)
-		parityShards := make([]uint32, 0)
+		assignedData := make([]uint32, 0)
+		assignedParity := make([]uint32, 0)
 		for _, shardId := range targetShards[i] {
-			if shardId < uint32(erasure_coding.DataShardsCount) {
-				dataShards = append(dataShards, shardId)
+			if shardId < dataShards {
+				assignedData = append(assignedData, shardId)
 			} else {
-				parityShards = append(parityShards, shardId)
+				assignedParity = append(assignedParity, shardId)
 			}
 		}
 		glog.V(2).Infof("EC planning: target %s assigned shards %v (data: %v, parity: %v)",
-			plan.TargetNode, targetShards[i], dataShards, parityShards)
+			plan.TargetNode, targetShards[i], assignedData, assignedParity)
 	}
 
 	glog.V(1).Infof("EC planning: distributed %d shards across %d targets using round-robin (data shards 0-%d, parity shards %d-%d)",
-		erasure_coding.TotalShardsCount, numTargets,
-		erasure_coding.DataShardsCount-1, erasure_coding.DataShardsCount, erasure_coding.TotalShardsCount-1)
+		totalShards, numTargets, dataShards-1, dataShards, totalShards-1)
 	return targets
 }
 
@@ -779,10 +803,10 @@ func convertTaskSourcesToProtobuf(sources []topology.TaskSourceSpec, volumeID ui
 }
 
 // createECTaskParams creates clean EC task parameters (destinations now in unified targets)
-func createECTaskParams(multiPlan *topology.MultiDestinationPlan) *worker_pb.ErasureCodingTaskParams {
+func createECTaskParams(multiPlan *topology.MultiDestinationPlan, dataShards, parityShards uint32) *worker_pb.ErasureCodingTaskParams {
 	return &worker_pb.ErasureCodingTaskParams{
-		DataShards:   erasure_coding.DataShardsCount,   // Standard data shards
-		ParityShards: erasure_coding.ParityShardsCount, // Standard parity shards
+		DataShards:   int32(dataShards),
+		ParityShards: int32(parityShards),
 	}
 }
 

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -151,8 +151,8 @@ func Detection(ctx context.Context, metrics []*types.VolumeHealthMetrics, cluste
 				if planner == nil {
 					planner = newECPlacementPlanner(clusterInfo.ActiveTopology, ecConfig.PreferredTags)
 				}
-				dataShards := uint32(erasure_coding.DataShardsCount)
-				parityShards := uint32(erasure_coding.ParityShardsCount)
+				dataShards := erasure_coding.DataShardsCount
+				parityShards := erasure_coding.ParityShardsCount
 				multiPlan, err := planECDestinations(planner, metric, ecConfig, dataShards, parityShards)
 				if err != nil {
 					glog.Warningf("Failed to plan EC destinations for volume %d: %v", metric.VolumeID, err)
@@ -286,7 +286,7 @@ func Detection(ctx context.Context, metrics []*types.VolumeHealthMetrics, cluste
 					Targets: createECTargets(multiPlan, dataShards, parityShards),
 
 					TaskParams: &worker_pb.TaskParams_ErasureCodingParams{
-						ErasureCodingParams: createECTaskParams(multiPlan, dataShards, parityShards),
+						ErasureCodingParams: createECTaskParams(dataShards, parityShards),
 					},
 				}
 
@@ -595,15 +595,17 @@ func (p *ecPlacementPlanner) buildCandidateSets(shardsNeeded int) [][]*placement
 
 // planECDestinations plans the destinations for erasure coding operation.
 // dataShards/parityShards are parameters so callers can drive non-10+4 ratios.
-func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthMetrics, ecConfig *Config, dataShards, parityShards uint32) (*topology.MultiDestinationPlan, error) {
+func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthMetrics, ecConfig *Config, dataShards, parityShards int) (*topology.MultiDestinationPlan, error) {
 	if planner == nil || planner.activeTopology == nil {
 		return nil, fmt.Errorf("active topology not available for EC placement")
 	}
-	if dataShards == 0 || parityShards == 0 {
+	if dataShards <= 0 || parityShards <= 0 {
 		return nil, fmt.Errorf("invalid EC ratio: dataShards=%d parityShards=%d", dataShards, parityShards)
 	}
-	totalShards := int(dataShards + parityShards)
-	minTotalDisks := totalShards/int(parityShards) + 1
+	totalShards := dataShards + parityShards
+	// Survive losing one disk: each disk holds at most parityShards shards,
+	// so we need at least ceil(totalShards / parityShards) disks.
+	minTotalDisks := (totalShards + parityShards - 1) / parityShards
 	expectedShardSize := uint64(metric.Size) / uint64(dataShards)
 
 	// Get source node information from topology
@@ -702,7 +704,7 @@ func planECDestinations(planner *ecPlacementPlanner, metric *types.VolumeHealthM
 
 // createECTargets builds TaskTargets with one shard per plan entry.
 // planECDestinations ensures numTargets == totalShards.
-func createECTargets(multiPlan *topology.MultiDestinationPlan, dataShards, parityShards uint32) []*worker_pb.TaskTarget {
+func createECTargets(multiPlan *topology.MultiDestinationPlan, dataShards, parityShards int) []*worker_pb.TaskTarget {
 	var targets []*worker_pb.TaskTarget
 	numTargets := len(multiPlan.Plans)
 	totalShards := dataShards + parityShards
@@ -711,9 +713,9 @@ func createECTargets(multiPlan *topology.MultiDestinationPlan, dataShards, parit
 	for i := range targetShards {
 		targetShards[i] = make([]uint32, 0)
 	}
-	for shardId := uint32(0); shardId < totalShards; shardId++ {
-		targetIndex := int(shardId) % numTargets
-		targetShards[targetIndex] = append(targetShards[targetIndex], shardId)
+	for shardId := 0; shardId < totalShards; shardId++ {
+		targetIndex := shardId % numTargets
+		targetShards[targetIndex] = append(targetShards[targetIndex], uint32(shardId))
 	}
 
 	for i, plan := range multiPlan.Plans {
@@ -730,7 +732,7 @@ func createECTargets(multiPlan *topology.MultiDestinationPlan, dataShards, parit
 		assignedData := make([]uint32, 0)
 		assignedParity := make([]uint32, 0)
 		for _, shardId := range targetShards[i] {
-			if shardId < dataShards {
+			if int(shardId) < dataShards {
 				assignedData = append(assignedData, shardId)
 			} else {
 				assignedParity = append(assignedParity, shardId)
@@ -785,7 +787,7 @@ func convertTaskSourcesToProtobuf(sources []topology.TaskSourceSpec, volumeID ui
 }
 
 // createECTaskParams creates clean EC task parameters (destinations now in unified targets)
-func createECTaskParams(multiPlan *topology.MultiDestinationPlan, dataShards, parityShards uint32) *worker_pb.ErasureCodingTaskParams {
+func createECTaskParams(dataShards, parityShards int) *worker_pb.ErasureCodingTaskParams {
 	return &worker_pb.ErasureCodingTaskParams{
 		DataShards:   int32(dataShards),
 		ParityShards: int32(parityShards),

--- a/weed/worker/tasks/erasure_coding/detection_test.go
+++ b/weed/worker/tasks/erasure_coding/detection_test.go
@@ -57,7 +57,7 @@ func TestPlanECDestinationsUsesPlanner(t *testing.T) {
 		Collection: "",
 	}
 
-	plan, err := planECDestinations(planner, metric, NewDefaultConfig())
+	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 	assert.Equal(t, erasure_coding.TotalShardsCount, len(plan.Plans))
@@ -140,7 +140,9 @@ func TestDetectionContextCancellation(t *testing.T) {
 }
 
 func TestDetectionMaxResultsHonorsLimit(t *testing.T) {
-	activeTopology := buildActiveTopology(t, 4, []string{"hdd"}, 20, 0)
+	// Need at least TotalShardsCount distinct (server, disk_id) targets so each
+	// EC shard gets its own disk (#9369 placement invariant).
+	activeTopology := buildActiveTopology(t, erasure_coding.TotalShardsCount, []string{"hdd"}, 20, 0)
 	clusterInfo := &types.ClusterInfo{ActiveTopology: activeTopology}
 	metrics := buildVolumeMetricsForIDs(3)
 
@@ -148,6 +150,71 @@ func TestDetectionMaxResultsHonorsLimit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.True(t, hasMore)
+}
+
+// TestPlanECDestinationsSpreadsAcrossPhysicalDisks reproduces #9369: with 7
+// volume servers each owning 2 physical HDDs, the EC planner must produce 14
+// destinations on 14 distinct (server, disk_id) tuples — not 7 destinations
+// each receiving 2 shards on the same disk.
+func TestPlanECDestinationsSpreadsAcrossPhysicalDisks(t *testing.T) {
+	const numServers = 7
+	const disksPerServer = 2
+
+	activeTopology := topology.NewActiveTopology(10)
+	nodes := make([]*master_pb.DataNodeInfo, 0, numServers)
+	for i := 1; i <= numServers; i++ {
+		volumeInfos := make([]*master_pb.VolumeInformationMessage, 0, disksPerServer)
+		for d := uint32(0); d < disksPerServer; d++ {
+			volumeInfos = append(volumeInfos, &master_pb.VolumeInformationMessage{
+				Id:       uint32(i*100 + int(d)),
+				DiskId:   d,
+				DiskType: "hdd",
+			})
+		}
+		nodes = append(nodes, &master_pb.DataNodeInfo{
+			Id: fmt.Sprintf("127.0.0.1:%d", 8080+i),
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"hdd": {
+					DiskId:         0,
+					VolumeCount:    int64(disksPerServer),
+					MaxVolumeCount: 200,
+					VolumeInfos:    volumeInfos,
+				},
+			},
+		})
+	}
+	require.NoError(t, activeTopology.UpdateTopology(&master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id:            "rack1",
+				DataNodeInfos: nodes,
+			}},
+		}},
+	}))
+
+	planner := newECPlacementPlanner(activeTopology, nil)
+	require.NotNil(t, planner)
+
+	metric := &types.VolumeHealthMetrics{
+		VolumeID:   42,
+		Server:     "127.0.0.1:8081",
+		Size:       100 * 1024 * 1024,
+		Collection: "",
+	}
+
+	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.Equal(t, erasure_coding.TotalShardsCount, len(plan.Plans),
+		"need one destination per shard so #9185 disk_id routing is unambiguous")
+
+	seen := make(map[string]bool, len(plan.Plans))
+	for _, p := range plan.Plans {
+		key := fmt.Sprintf("%s:%d", p.TargetNode, p.TargetDisk)
+		assert.False(t, seen[key], "duplicate (server,disk_id) target %s — would race in ReceiveFile", key)
+		seen[key] = true
+	}
 }
 
 func TestPlanECDestinationsFailsWithInsufficientCapacity(t *testing.T) {
@@ -162,7 +229,7 @@ func TestPlanECDestinationsFailsWithInsufficientCapacity(t *testing.T) {
 		Collection: "",
 	}
 
-	_, err := planECDestinations(planner, metric, NewDefaultConfig())
+	_, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
 	require.Error(t, err)
 }
 

--- a/weed/worker/tasks/erasure_coding/detection_test.go
+++ b/weed/worker/tasks/erasure_coding/detection_test.go
@@ -140,8 +140,7 @@ func TestDetectionContextCancellation(t *testing.T) {
 }
 
 func TestDetectionMaxResultsHonorsLimit(t *testing.T) {
-	// Need at least TotalShardsCount distinct (server, disk_id) targets so each
-	// EC shard gets its own disk (#9369 placement invariant).
+	// One node per shard so each shard gets its own disk (#9369).
 	activeTopology := buildActiveTopology(t, erasure_coding.TotalShardsCount, []string{"hdd"}, 20, 0)
 	clusterInfo := &types.ClusterInfo{ActiveTopology: activeTopology}
 	metrics := buildVolumeMetricsForIDs(3)
@@ -152,10 +151,8 @@ func TestDetectionMaxResultsHonorsLimit(t *testing.T) {
 	assert.True(t, hasMore)
 }
 
-// TestPlanECDestinationsSpreadsAcrossPhysicalDisks reproduces #9369: with 7
-// volume servers each owning 2 physical HDDs, the EC planner must produce 14
-// destinations on 14 distinct (server, disk_id) tuples — not 7 destinations
-// each receiving 2 shards on the same disk.
+// #9369: 7 servers × 2 physical HDDs must yield 14 distinct (server, disk_id)
+// destinations, not 7 destinations doubled up on the same disk.
 func TestPlanECDestinationsSpreadsAcrossPhysicalDisks(t *testing.T) {
 	const numServers = 7
 	const disksPerServer = 2
@@ -206,13 +203,12 @@ func TestPlanECDestinationsSpreadsAcrossPhysicalDisks(t *testing.T) {
 	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
 	require.NoError(t, err)
 	require.NotNil(t, plan)
-	require.Equal(t, erasure_coding.TotalShardsCount, len(plan.Plans),
-		"need one destination per shard so #9185 disk_id routing is unambiguous")
+	require.Equal(t, erasure_coding.TotalShardsCount, len(plan.Plans))
 
 	seen := make(map[string]bool, len(plan.Plans))
 	for _, p := range plan.Plans {
 		key := fmt.Sprintf("%s:%d", p.TargetNode, p.TargetDisk)
-		assert.False(t, seen[key], "duplicate (server,disk_id) target %s — would race in ReceiveFile", key)
+		assert.False(t, seen[key], "duplicate (server,disk_id) target %s", key)
 		seen[key] = true
 	}
 }

--- a/weed/worker/tasks/erasure_coding/detection_test.go
+++ b/weed/worker/tasks/erasure_coding/detection_test.go
@@ -57,7 +57,7 @@ func TestPlanECDestinationsUsesPlanner(t *testing.T) {
 		Collection: "",
 	}
 
-	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
+	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), erasure_coding.DataShardsCount, erasure_coding.ParityShardsCount)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 	assert.Equal(t, erasure_coding.TotalShardsCount, len(plan.Plans))
@@ -200,7 +200,7 @@ func TestPlanECDestinationsSpreadsAcrossPhysicalDisks(t *testing.T) {
 		Collection: "",
 	}
 
-	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
+	plan, err := planECDestinations(planner, metric, NewDefaultConfig(), erasure_coding.DataShardsCount, erasure_coding.ParityShardsCount)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 	require.Equal(t, erasure_coding.TotalShardsCount, len(plan.Plans))
@@ -225,7 +225,7 @@ func TestPlanECDestinationsFailsWithInsufficientCapacity(t *testing.T) {
 		Collection: "",
 	}
 
-	_, err := planECDestinations(planner, metric, NewDefaultConfig(), uint32(erasure_coding.DataShardsCount), uint32(erasure_coding.ParityShardsCount))
+	_, err := planECDestinations(planner, metric, NewDefaultConfig(), erasure_coding.DataShardsCount, erasure_coding.ParityShardsCount)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary

Fixes #9369. On a volume server with multiple physical disks of the same type (e.g. `-dir=/d1,/d2`), the EC planner was placing multiple shards on the same `(server, disk_id)`, which collides with the disk_id-aware `ReceiveFile` introduced by #9185.

## Root cause

`master_pb.DataNodeInfo.DiskInfos` is a map keyed by disk type, so a server with N physical disks of the same type collapses into a single `DiskInfo`. Per-physical-disk attribution survives only inside `VolumeInfos[].DiskId` and `EcShardInfos[].DiskId`. The active topology never reconstructed this view, so the planner saw 7 candidates for a 7×2-disk lab cluster instead of 14, returned a 7-entry plan, and `createECTargets` round-robined the 14 shards across those 7 targets — putting two shards onto each `(server, disk_id)`.

## Changes

- `weed/admin/topology/topology_management.go`
  - New `splitDiskInfoByPhysicalDisk` rebuilds one `master_pb.DiskInfo` per disk_id observed in `VolumeInfos` / `EcShardInfos`. Capacity is split evenly across disks (the wire format doesn't carry per-disk capacity yet).
  - `UpdateTopology` registers one `activeDisk` per physical disk_id.
  - `rebuildIndexes` indexes volumes / EC shards by their own `DiskId` so `GetVolumeLocations` lines up with the per-physical-disk `activeDisk` entries.
- `weed/worker/tasks/erasure_coding/detection.go`
  - `planECDestinations`, `createECTargets`, `createECTaskParams` take `dataShards`/`parityShards` parameters instead of using `erasure_coding.DataShardsCount/ParityShardsCount/TotalShardsCount/MinTotalDisks` constants. Keeps the helpers free of the 10+4 hard-code so non-OSS forks can drive different ratios cleanly.
  - Refuse to plan when the planner returns fewer than `totalShards` distinct disks — better to fail loudly than write two shards to one disk and trip `ReceiveFile`.
- Tests
  - `TestECPlannerSeesEachPhysicalDisk` (topology layer) reproduces the 7×2 case at `GetDisksWithEffectiveCapacity` and asserts 14 distinct candidates.
  - `TestPlanECDestinationsSpreadsAcrossPhysicalDisks` (planner layer) asserts 14 distinct `(server, disk_id)` targets in the resulting plan.

## Test plan

- `go test ./weed/admin/topology/ ./weed/worker/tasks/erasure_coding/ ./weed/worker/tasks/balance/ ./weed/topology/ ./weed/storage/erasure_coding/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EC planner now treats each physical disk as its own placement target, preventing disk-collapsing and duplicate placements.

* **New Features**
  * EC planning and task generation honor configurable data/parity shard counts and compute shard distribution from those settings.

* **Tests**
  * Added regression tests verifying one destination per physical disk, correct distinct (server,disk) placement, and behavior with configured shard counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->