### PR TITLE
chore(weed/util/chunk_cache): remove unused functions

### DIFF
--- a/weed/util/chunk_cache/chunk_cache_in_memory.go
+++ b/weed/util/chunk_cache/chunk_cache_in_memory.go
@@ -51,20 +51,6 @@ func (c *ChunkCacheInMemory) GetChunk(fileId string) []byte {
 	return data
 }
 
-func (c *ChunkCacheInMemory) getChunkSlice(fileId string, offset, length uint64) ([]byte, error) {
-	item := c.cache.Get(fileId)
-	if item == nil {
-		return nil, nil
-	}
-	data := item.Value().([]byte)
-	item.Extend(time.Hour)
-	wanted := min(int(length), len(data)-int(offset))
-	if wanted < 0 {
-		return nil, ErrorOutOfBounds
-	}
-	return data[offset : int(offset)+wanted], nil
-}
-
 func (c *ChunkCacheInMemory) readChunkAt(buffer []byte, fileId string, offset uint64) (int, error) {
 	item := c.cache.Get(fileId)
 	if item == nil {

--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -165,39 +165,6 @@ func (v *ChunkCacheVolume) GetNeedle(key types.NeedleId) ([]byte, error) {
 	return data, nil
 }
 
-func (v *ChunkCacheVolume) getNeedleSlice(key types.NeedleId, offset, length uint64) ([]byte, error) {
-	nv, ok := v.nm.Get(key)
-	if !ok {
-		return nil, storage.ErrorNotFound
-	}
-	wanted := min(int(length), int(nv.Size)-int(offset))
-	if wanted < 0 {
-		// should never happen, but better than panicking
-		return nil, ErrorOutOfBounds
-	}
-	data := make([]byte, wanted)
-	readOffset := nv.Offset.ToActualOffset() + int64(offset)
-	var readSize int
-	var readErr error
-	if readSize, readErr = v.DataBackend.ReadAt(data, readOffset); readErr != nil {
-		if readSize != wanted {
-			return nil, fmt.Errorf("read %s.dat [%d,%d): %v",
-				v.fileName, readOffset, int64(readOffset)+int64(wanted), readErr)
-		}
-	} else {
-		if readSize != wanted {
-			return nil, fmt.Errorf("read %d, expected %d", readSize, wanted)
-		}
-	}
-	if readErr != nil && readSize == wanted {
-		readErr = nil
-	}
-	if readSize > 0 {
-		v.dropReadCache(readOffset, int64(readSize))
-	}
-	return data, readErr
-}
-
 func (v *ChunkCacheVolume) readNeedleSliceAt(data []byte, key types.NeedleId, offset uint64) (n int, err error) {
 	nv, ok := v.nm.Get(key)
 	if !ok {

--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -176,7 +176,7 @@ func (v *ChunkCacheVolume) readNeedleSliceAt(data []byte, key types.NeedleId, of
 		return 0, ErrorOutOfBounds
 	}
 	readOffset := nv.Offset.ToActualOffset() + int64(offset)
-	if n, err = v.DataBackend.ReadAt(data, readOffset); err != nil {
+	if n, err = v.DataBackend.ReadAt(data[:wanted], readOffset); err != nil {
 		if n != wanted {
 			return n, fmt.Errorf("read %s.dat [%d,%d): %v",
 				v.fileName, readOffset, int64(readOffset)+int64(wanted), err)

--- a/weed/util/chunk_cache/on_disk_cache_layer.go
+++ b/weed/util/chunk_cache/on_disk_cache_layer.go
@@ -63,50 +63,6 @@ func (c *OnDiskCacheLayer) setChunk(needleId types.NeedleId, data []byte) {
 
 }
 
-func (c *OnDiskCacheLayer) getChunk(needleId types.NeedleId) (data []byte) {
-
-	var err error
-
-	for _, diskCache := range c.diskCaches {
-		data, err = diskCache.GetNeedle(needleId)
-		if err == storage.ErrorNotFound {
-			continue
-		}
-		if err != nil {
-			glog.Errorf("failed to read cache file %s id %d", diskCache.fileName, needleId)
-			continue
-		}
-		if len(data) != 0 {
-			return
-		}
-	}
-
-	return nil
-
-}
-
-func (c *OnDiskCacheLayer) getChunkSlice(needleId types.NeedleId, offset, length uint64) (data []byte) {
-
-	var err error
-
-	for _, diskCache := range c.diskCaches {
-		data, err = diskCache.getNeedleSlice(needleId, offset, length)
-		if err == storage.ErrorNotFound {
-			continue
-		}
-		if err != nil {
-			glog.Warningf("failed to read cache file %s id %d: %v", diskCache.fileName, needleId, err)
-			continue
-		}
-		if len(data) != 0 {
-			return
-		}
-	}
-
-	return nil
-
-}
-
 func (c *OnDiskCacheLayer) readChunkAt(buffer []byte, needleId types.NeedleId, offset uint64) (n int, err error) {
 
 	for _, diskCache := range c.diskCaches {


### PR DESCRIPTION
This removes four unused functions from `weed/util/chunk_cache`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed internal helper methods to streamline caching internals.
  * Simplified on‑disk read logic to only read requested bytes while keeping cache TTL/eviction and best‑effort page‑cache dropping behavior intact.
  * Core in‑memory and on‑disk cache features (get/set, ranged reads, rotation/shutdown) remain fully operational.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->