### PR TITLE
feat(s3/lifecycle): classify versioned events by storage path (Phase 5b/1)

### DIFF
--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -102,6 +103,23 @@ func (s3a *S3ApiServer) lifecycleDispatch(ctx context.Context, req *s3_lifecycle
 		if req.VersionId == "" {
 			return blocked("FATAL_EVENT_ERROR: version_id required for noncurrent / delete-marker delete"), nil
 		}
+		// Latest-pointer guard for noncurrent kinds: refuse to delete
+		// the version that the .versions/ directory currently points
+		// to. The router can't always tell current from noncurrent
+		// without sibling state, so the server checks here.
+		if req.ActionKind == s3_lifecycle_pb.ActionKind_NONCURRENT_DAYS ||
+			req.ActionKind == s3_lifecycle_pb.ActionKind_NEWER_NONCURRENT {
+			isLatest, lookupErr := s3a.isCurrentLatestVersion(req.Bucket, req.ObjectPath, req.VersionId)
+			if lookupErr != nil {
+				if errors.Is(lookupErr, filer_pb.ErrNotFound) || errors.Is(lookupErr, ErrObjectNotFound) {
+					return noopResolved("NOT_FOUND"), nil
+				}
+				return retryLater("TRANSPORT_ERROR: latest-pointer lookup: " + lookupErr.Error()), nil
+			}
+			if isLatest {
+				return noopResolved("VERSION_IS_LATEST"), nil
+			}
+		}
 		if err := s3a.deleteSpecificObjectVersion(req.Bucket, req.ObjectPath, req.VersionId); err != nil {
 			if errors.Is(err, filer_pb.ErrNotFound) || errors.Is(err, ErrVersionNotFound) || errors.Is(err, ErrObjectNotFound) {
 				return noopResolved("NOT_FOUND_AT_DELETE"), nil
@@ -155,6 +173,34 @@ func (s3a *S3ApiServer) lifecycleAbortMPU(ctx context.Context, req *s3_lifecycle
 		return retryLater("TRANSPORT_ERROR: rm: " + err.Error()), nil
 	}
 	return done(), nil
+}
+
+// isCurrentLatestVersion reports whether versionId is the version the
+// .versions/ directory currently points to. SeaweedFS records the latest
+// version on the parent directory's Extended map; without consulting it,
+// a noncurrent-kind dispatch can't safely distinguish current from
+// noncurrent and would risk deleting the live version. Returns
+// (false, nil) when the directory has no latest pointer (e.g., the
+// bucket isn't versioned in this object's history).
+func (s3a *S3ApiServer) isCurrentLatestVersion(bucket, object, versionId string) (bool, error) {
+	versionsDir := s3a.bucketDir(bucket) + "/" + object + s3_constants.VersionsFolder
+	parent, name := filepath.Split(versionsDir)
+	parent = strings.TrimRight(parent, "/")
+	if parent == "" {
+		parent = "/"
+	}
+	entry, err := s3a.getEntry(parent, name)
+	if err != nil {
+		return false, err
+	}
+	if entry == nil || len(entry.Extended) == 0 {
+		return false, nil
+	}
+	latest, ok := entry.Extended[s3_constants.ExtLatestVersionIdKey]
+	if !ok {
+		return false, nil
+	}
+	return string(latest) == versionId, nil
 }
 
 // computeEntryIdentity captures (mtime, size, head fid, sorted-Extended hash):

--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -184,7 +184,7 @@ func (s3a *S3ApiServer) lifecycleAbortMPU(ctx context.Context, req *s3_lifecycle
 // bucket isn't versioned in this object's history).
 func (s3a *S3ApiServer) isCurrentLatestVersion(bucket, object, versionId string) (bool, error) {
 	versionsDir := s3a.bucketDir(bucket) + "/" + object + s3_constants.VersionsFolder
-	parent, name := filepath.Split(versionsDir)
+	parent, name := path.Split(versionsDir)
 	parent = strings.TrimRight(parent, "/")
 	if parent == "" {
 		parent = "/"

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -159,21 +159,16 @@ func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo,
 	}
 	versionID := ""
 	if versioned {
-		if logicalKey, vid, ok := splitNoncurrentKey(ev.Key); ok {
+		// Without sibling listing we can't compute NumVersions or
+		// NoncurrentIndex. Drop NumVersions to 0 so ExpiredDeleteMarker
+		// (which requires sole-survivor) stays suppressed; the engine
+		// also treats nil NoncurrentIndex as "can't evaluate count
+		// retention" and conservatively skips NewerNoncurrent.
+		info.NumVersions = 0
+		if logicalKey, vid, ok := classifyNoncurrent(ev.Key, entry); ok {
 			info.Key = logicalKey
 			info.IsLatest = false
-			// Without sibling listing we can't compute NumVersions or
-			// NoncurrentIndex; the engine treats the latter being nil as
-			// "can't evaluate count retention" and conservatively skips
-			// NewerNoncurrent. Time-based NoncurrentDays still fires.
-			info.NumVersions = 0
 			versionID = vid
-		} else {
-			// Current/latest version: NumVersions stays 1 only when we
-			// know it's the sole version. ExpiredDeleteMarker requires
-			// NumVersions==1 (sole-survivor delete marker); without
-			// sibling listing we can't be sure, so suppress.
-			info.NumVersions = 0
 		}
 	}
 	if tags := extractTags(entry.Extended); len(tags) > 0 {
@@ -185,18 +180,33 @@ func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo,
 	return info, versionID
 }
 
-// splitNoncurrentKey decomposes a versioned-bucket storage path
-// `<key>.versions/<vid>` into the logical object key and version id.
-// Returns ok=false for current-version paths.
-func splitNoncurrentKey(key string) (logicalKey, versionID string, ok bool) {
+// classifyNoncurrent returns the logical key and version id when the event
+// is a noncurrent version, or ok=false when the path is either a current
+// version or just a regular object whose name happens to contain the
+// ".versions/" sequence.
+//
+// The path shape `<key>.versions/<vid>` is necessary but not sufficient:
+// SeaweedFS doesn't reserve the segment, so a user who writes a literal
+// key like "backup.versions/2023" gets the same path. The entry's
+// ExtVersionIdKey is the authoritative confirmation — it's set when a
+// version is actually stored. We require both to agree.
+func classifyNoncurrent(key string, entry *filer_pb.Entry) (logicalKey, versionID string, ok bool) {
 	const sep = s3_constants.VersionsFolder + "/"
 	idx := strings.LastIndex(key, sep)
-	if idx < 0 {
+	if idx <= 0 {
+		// idx<0: path doesn't carry the segment.
+		// idx==0: would yield an empty logicalKey; reject.
 		return "", "", false
 	}
 	versionID = key[idx+len(sep):]
 	if versionID == "" || strings.ContainsRune(versionID, '/') {
-		// Trailing slash or further nesting: not a single-segment vid.
+		return "", "", false
+	}
+	stored, has := entry.Extended[s3_constants.ExtVersionIdKey]
+	if !has || string(stored) != versionID {
+		// Literal-key collision: path looks like a noncurrent storage
+		// path but the entry isn't a tracked version (or carries a
+		// different vid). Treat as a regular current-version object.
 		return "", "", false
 	}
 	return key[:idx], versionID, true

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -14,6 +14,11 @@ import (
 // Match is one (event, action) pair where EvaluateAction fired. The
 // dispatcher runs `LifecycleDelete` at DueTime; identity-CAS in the RPC
 // guards against drift between schedule time and dispatch time.
+//
+// For NoncurrentDays / NewerNoncurrent on a versioned bucket, ObjectKey
+// is the seaweedfs storage path (logical-key + ".versions/" + version_id)
+// so the dispatcher can locate the specific version, and VersionID
+// carries the AWS-visible version ID separately.
 type Match struct {
 	Key      s3lifecycle.ActionKey
 	Action   *engine.CompiledAction
@@ -56,7 +61,7 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 	if len(keys) == 0 {
 		return nil
 	}
-	info := buildObjectInfo(ev)
+	info, versionID := buildObjectInfo(ev, snap.BucketVersioned(ev.Bucket))
 	if info == nil {
 		return nil
 	}
@@ -101,28 +106,38 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 			DueTime:   dueTime,
 			Bucket:    ev.Bucket,
 			ObjectKey: ev.Key,
+			VersionID: versionID,
 			Identity:  buildIdentity(ev),
 		})
 	}
 	return matches
 }
 
-// buildObjectInfo derives a non-versioned ObjectInfo from a meta-log event.
-// Versioned-bucket semantics (IsLatest, NumVersions, NoncurrentIndex,
-// IsDeleteMarker for noncurrent versions) require listing siblings and land
-// in Phase 5; for now any non-MPU event is treated as IsLatest=true with the
-// LifecycleDelete RPC's identity-CAS catching stale schedules.
+// buildObjectInfo derives an ObjectInfo from a meta-log event and the
+// bucket's versioning state. Returns nil when the event has no usable
+// shape (missing attributes, hard delete already handled upstream).
 //
-// MPU init directories at .uploads/<upload_id> populate IsMPUInit and use the
-// destination object key from the entry's Extended map for filter matching,
-// so a rule with Filter.Prefix=foo/ matches an MPU uploading to foo/bar.txt.
+// Versioning support is incremental: the router classifies events as
+// current vs noncurrent by storage path (`<key>.versions/<vid>` is a
+// noncurrent version) and reads IsDeleteMarker from Extended. NumVersions
+// and NoncurrentIndex stay zero because computing them requires listing
+// siblings; EvaluateAction's NewerNoncurrent and ExpiredDeleteMarker
+// branches conservatively skip when those are unset.
 //
-// Returns nil when Attributes are missing — without ModTime, EvaluateAction
-// would compute due against year-0001 and fire immediately.
-func buildObjectInfo(ev *reader.Event) *s3lifecycle.ObjectInfo {
+// For noncurrent versions, info.Key is the logical object key (the
+// `<key>.versions/<vid>` suffix stripped) so a rule's Filter.Prefix
+// matches the user's intended path. The returned versionID is
+// propagated to Match.VersionID so the dispatcher can target a single
+// version on the server.
+//
+// MPU init directories at .uploads/<upload_id> populate IsMPUInit and
+// use the destination object key from the entry's Extended map for
+// filter matching, so a rule with Filter.Prefix=foo/ matches an MPU
+// uploading to foo/bar.txt.
+func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo, string) {
 	entry := ev.NewEntry
 	if entry == nil || entry.Attributes == nil {
-		return nil
+		return nil, ""
 	}
 	if destKey, ok := mpuInitInfo(ev, entry); ok {
 		// MPU intermediate state has no tags, no versions, no delete-marker
@@ -133,7 +148,7 @@ func buildObjectInfo(ev *reader.Event) *s3lifecycle.ObjectInfo {
 			Key:       destKey,
 			ModTime:   time.Unix(entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)),
 			IsMPUInit: true,
-		}
+		}, ""
 	}
 	info := &s3lifecycle.ObjectInfo{
 		Key:         ev.Key,
@@ -142,13 +157,49 @@ func buildObjectInfo(ev *reader.Event) *s3lifecycle.ObjectInfo {
 		IsLatest:    true,
 		NumVersions: 1,
 	}
+	versionID := ""
+	if versioned {
+		if logicalKey, vid, ok := splitNoncurrentKey(ev.Key); ok {
+			info.Key = logicalKey
+			info.IsLatest = false
+			// Without sibling listing we can't compute NumVersions or
+			// NoncurrentIndex; the engine treats the latter being nil as
+			// "can't evaluate count retention" and conservatively skips
+			// NewerNoncurrent. Time-based NoncurrentDays still fires.
+			info.NumVersions = 0
+			versionID = vid
+		} else {
+			// Current/latest version: NumVersions stays 1 only when we
+			// know it's the sole version. ExpiredDeleteMarker requires
+			// NumVersions==1 (sole-survivor delete marker); without
+			// sibling listing we can't be sure, so suppress.
+			info.NumVersions = 0
+		}
+	}
 	if tags := extractTags(entry.Extended); len(tags) > 0 {
 		info.Tags = tags
 	}
 	if isDeleteMarkerEntry(entry) {
 		info.IsDeleteMarker = true
 	}
-	return info
+	return info, versionID
+}
+
+// splitNoncurrentKey decomposes a versioned-bucket storage path
+// `<key>.versions/<vid>` into the logical object key and version id.
+// Returns ok=false for current-version paths.
+func splitNoncurrentKey(key string) (logicalKey, versionID string, ok bool) {
+	const sep = s3_constants.VersionsFolder + "/"
+	idx := strings.LastIndex(key, sep)
+	if idx < 0 {
+		return "", "", false
+	}
+	versionID = key[idx+len(sep):]
+	if versionID == "" || strings.ContainsRune(versionID, '/') {
+		// Trailing slash or further nesting: not a single-segment vid.
+		return "", "", false
+	}
+	return key[:idx], versionID, true
 }
 
 // mpuInitInfo recognizes a multipart-upload init: a directory entry at

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -146,6 +146,11 @@ func buildObjectInfo(ev *reader.Event, versioned bool) *s3lifecycle.ObjectInfo {
 			IsMPUInit: true,
 		}
 	}
+	// Directory entries that aren't MPU inits aren't lifecycle subjects:
+	// the .versions/ folder itself, prefix dirs, etc. — emit nothing.
+	if entry.IsDirectory {
+		return nil
+	}
 	info := &s3lifecycle.ObjectInfo{
 		Key:         ev.Key,
 		ModTime:     time.Unix(entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)),

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -61,7 +61,7 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 	if len(keys) == 0 {
 		return nil
 	}
-	info, versionID := buildObjectInfo(ev, snap.BucketVersioned(ev.Bucket))
+	info := buildObjectInfo(ev, snap.BucketVersioned(ev.Bucket))
 	if info == nil {
 		return nil
 	}
@@ -106,7 +106,6 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 			DueTime:   dueTime,
 			Bucket:    ev.Bucket,
 			ObjectKey: ev.Key,
-			VersionID: versionID,
 			Identity:  buildIdentity(ev),
 		})
 	}
@@ -117,27 +116,24 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 // bucket's versioning state. Returns nil when the event has no usable
 // shape (missing attributes, hard delete already handled upstream).
 //
-// Versioning support is incremental: the router classifies events as
-// current vs noncurrent by storage path (`<key>.versions/<vid>` is a
-// noncurrent version) and reads IsDeleteMarker from Extended. NumVersions
-// and NoncurrentIndex stay zero because computing them requires listing
-// siblings; EvaluateAction's NewerNoncurrent and ExpiredDeleteMarker
-// branches conservatively skip when those are unset.
-//
-// For noncurrent versions, info.Key is the logical object key (the
-// `<key>.versions/<vid>` suffix stripped) so a rule's Filter.Prefix
-// matches the user's intended path. The returned versionID is
-// propagated to Match.VersionID so the dispatcher can target a single
-// version on the server.
+// On a versioned bucket the storage layout (<key>.versions/v_<id>) is
+// shared between the current latest and the noncurrent versions; the
+// latest pointer lives in the .versions/ directory's Extended map and
+// is updated separately. Without that pointer-transition signal here,
+// the router conservatively classifies every event as if it were the
+// current version (IsLatest=true) so it never deletes the live
+// latest; bootstrap walking + the server-side dispatch guard handle
+// noncurrent retention. NumVersions=0 keeps ExpiredObjectDeleteMarker
+// (which requires sole-survivor) suppressed.
 //
 // MPU init directories at .uploads/<upload_id> populate IsMPUInit and
 // use the destination object key from the entry's Extended map for
 // filter matching, so a rule with Filter.Prefix=foo/ matches an MPU
 // uploading to foo/bar.txt.
-func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo, string) {
+func buildObjectInfo(ev *reader.Event, versioned bool) *s3lifecycle.ObjectInfo {
 	entry := ev.NewEntry
 	if entry == nil || entry.Attributes == nil {
-		return nil, ""
+		return nil
 	}
 	if destKey, ok := mpuInitInfo(ev, entry); ok {
 		// MPU intermediate state has no tags, no versions, no delete-marker
@@ -148,7 +144,7 @@ func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo,
 			Key:       destKey,
 			ModTime:   time.Unix(entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)),
 			IsMPUInit: true,
-		}, ""
+		}
 	}
 	info := &s3lifecycle.ObjectInfo{
 		Key:         ev.Key,
@@ -157,19 +153,24 @@ func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo,
 		IsLatest:    true,
 		NumVersions: 1,
 	}
-	versionID := ""
 	if versioned {
-		// Without sibling listing we can't compute NumVersions or
-		// NoncurrentIndex. Drop NumVersions to 0 so ExpiredDeleteMarker
-		// (which requires sole-survivor) stays suppressed; the engine
-		// also treats nil NoncurrentIndex as "can't evaluate count
-		// retention" and conservatively skips NewerNoncurrent.
-		info.NumVersions = 0
-		if logicalKey, vid, ok := classifyNoncurrent(ev.Key, entry); ok {
-			info.Key = logicalKey
-			info.IsLatest = false
-			versionID = vid
+		// On a versioned bucket the actual file path doesn't tell us
+		// whether the entry is the current latest or a noncurrent
+		// version — the latest pointer lives in the .versions/
+		// directory's Extended map and isn't part of this event. We
+		// also can't compute NumVersions / NoncurrentIndex here. Skip
+		// any version-folder file event for now; bootstrap walking
+		// drives noncurrent retention and current-version expiration
+		// for versioned buckets until pointer-transition routing
+		// lands. The bare-key path (null-version, pre-versioning
+		// objects) keeps the regular routing.
+		if isVersionFolderPath(ev.Key) {
+			return nil
 		}
+		// NumVersions=0 keeps ExpiredObjectDeleteMarker (sole-survivor
+		// gate) suppressed for the bare-key delete-marker case until
+		// sibling listing lands.
+		info.NumVersions = 0
 	}
 	if tags := extractTags(entry.Extended); len(tags) > 0 {
 		info.Tags = tags
@@ -177,39 +178,23 @@ func buildObjectInfo(ev *reader.Event, versioned bool) (*s3lifecycle.ObjectInfo,
 	if isDeleteMarkerEntry(entry) {
 		info.IsDeleteMarker = true
 	}
-	return info, versionID
+	return info
 }
 
-// classifyNoncurrent returns the logical key and version id when the event
-// is a noncurrent version, or ok=false when the path is either a current
-// version or just a regular object whose name happens to contain the
-// ".versions/" sequence.
-//
-// The path shape `<key>.versions/<vid>` is necessary but not sufficient:
-// SeaweedFS doesn't reserve the segment, so a user who writes a literal
-// key like "backup.versions/2023" gets the same path. The entry's
-// ExtVersionIdKey is the authoritative confirmation — it's set when a
-// version is actually stored. We require both to agree.
-func classifyNoncurrent(key string, entry *filer_pb.Entry) (logicalKey, versionID string, ok bool) {
-	const sep = s3_constants.VersionsFolder + "/"
-	idx := strings.LastIndex(key, sep)
+// isVersionFolderPath reports whether the bucket-relative key sits inside a
+// .versions/ folder — i.e. the path's parent segment ends with the
+// VersionsFolder suffix. Used by the versioned-bucket gate so the router
+// skips version-file events that need sibling state to be classified
+// safely.
+func isVersionFolderPath(key string) bool {
+	idx := strings.LastIndex(key, "/")
 	if idx <= 0 {
-		// idx<0: path doesn't carry the segment.
-		// idx==0: would yield an empty logicalKey; reject.
-		return "", "", false
+		return false
 	}
-	versionID = key[idx+len(sep):]
-	if versionID == "" || strings.ContainsRune(versionID, '/') {
-		return "", "", false
-	}
-	stored, has := entry.Extended[s3_constants.ExtVersionIdKey]
-	if !has || string(stored) != versionID {
-		// Literal-key collision: path looks like a noncurrent storage
-		// path but the entry isn't a tracked version (or carries a
-		// different vid). Treat as a regular current-version object.
-		return "", "", false
-	}
-	return key[:idx], versionID, true
+	parent := key[:idx]
+	parentIdx := strings.LastIndex(parent, "/")
+	leaf := parent[parentIdx+1:]
+	return strings.HasSuffix(leaf, s3_constants.VersionsFolder)
 }
 
 // mpuInitInfo recognizes a multipart-upload init: a directory entry at

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -517,9 +517,10 @@ func TestRouteVersionedAllVersionFolderPathsSkipped(t *testing.T) {
 	now := time.Now()
 	old := now.AddDate(0, 0, -2)
 	cases := []struct {
-		name string
-		key  string
-		ext  map[string][]byte
+		name  string
+		key   string
+		isDir bool
+		ext   map[string][]byte
 	}{
 		{
 			name: "tracked version file",
@@ -535,12 +536,24 @@ func TestRouteVersionedAllVersionFolderPathsSkipped(t *testing.T) {
 			key:  ".versions/v_v1",
 			ext:  map[string][]byte{s3_constants.ExtVersionIdKey: []byte("v1")},
 		},
+		{
+			// The .versions/ folder itself is a directory entry; the
+			// router must not emit ObjectInfo for it. Without the
+			// directory short-circuit it would route as a regular
+			// object and the dispatcher would target a directory path.
+			name:  "versions dir itself",
+			key:   "logs/foo.versions",
+			isDir: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ev := eventCreate("bk", tc.key, old.Unix(), 1, old.UnixNano())
 			if tc.ext != nil {
 				ev.NewEntry.Extended = tc.ext
+			}
+			if tc.isDir {
+				ev.NewEntry.IsDirectory = true
 			}
 			if got := Route(snap, ev, now); len(got) != 0 {
 				t.Fatalf("version-folder event should be skipped, got %v", got)

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -398,3 +398,114 @@ func TestRouteRegularObjectUnderDualRuleSkipsAbortMPU(t *testing.T) {
 		t.Fatalf("ActionKind=%v, want ExpirationDays", got)
 	}
 }
+
+func compileWithVersioned(rule *s3lifecycle.Rule, prior map[s3lifecycle.ActionKey]engine.PriorState) *engine.Snapshot {
+	e := engine.New()
+	return e.Compile([]engine.CompileInput{{Bucket: "bk", Rules: []*s3lifecycle.Rule{rule}, Versioned: true}},
+		engine.CompileOptions{PriorStates: prior})
+}
+
+func TestRouteVersionedNoncurrentEventFiresNoncurrentDays(t *testing.T) {
+	// Versioned bucket, time-based NoncurrentVersionExpiration rule.
+	// Event arrives at the storage path <key>.versions/<vid>. The router
+	// must classify it as noncurrent (IsLatest=false), strip the suffix
+	// for filter matching, and propagate the version_id so the
+	// dispatcher can target a single version on the server.
+	rule := &s3lifecycle.Rule{
+		ID:                              "r",
+		Status:                          s3lifecycle.StatusEnabled,
+		Prefix:                          "logs/",
+		NoncurrentVersionExpirationDays: 7,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -30)
+	ev := eventCreate("bk", "logs/foo.versions/v1", old.Unix(), 1, old.UnixNano())
+
+	matches := Route(snap, ev, now)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (NONCURRENT_DAYS), got %v", matches)
+	}
+	m := matches[0]
+	if m.Key.ActionKind != s3lifecycle.ActionKindNoncurrentDays {
+		t.Fatalf("ActionKind=%v, want NoncurrentDays", m.Key.ActionKind)
+	}
+	if m.ObjectKey != "logs/foo.versions/v1" {
+		t.Fatalf("ObjectKey=%q, want full storage path so dispatcher can locate the version", m.ObjectKey)
+	}
+	if m.VersionID != "v1" {
+		t.Fatalf("VersionID=%q, want v1", m.VersionID)
+	}
+}
+
+func TestRouteVersionedCurrentEventStaysLatest(t *testing.T) {
+	// Versioned bucket, ExpirationDays rule. The current-version event
+	// arrives at the bare <key>; nothing about its path looks like a
+	// .versions/ entry, so IsLatest stays true and the rule fires.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -2)
+	ev := eventCreate("bk", "logs/foo", old.Unix(), 1, old.UnixNano())
+
+	matches := Route(snap, ev, now)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (EXPIRATION_DAYS), got %v", matches)
+	}
+	if matches[0].Key.ActionKind != s3lifecycle.ActionKindExpirationDays {
+		t.Fatalf("ActionKind=%v, want ExpirationDays", matches[0].Key.ActionKind)
+	}
+	if matches[0].VersionID != "" {
+		t.Fatalf("VersionID=%q, want empty for current-version path", matches[0].VersionID)
+	}
+}
+
+func TestRouteNonVersionedBucketIgnoresVersionsSuffix(t *testing.T) {
+	// A non-versioned bucket happens to have an object literally named
+	// "logs/foo.versions/v1" — that's just a regular path. The router
+	// must NOT classify it as noncurrent or set IsLatest=false; the
+	// rule fires as a normal current-object expiration.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	snap := compileWith(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -2)
+	ev := eventCreate("bk", "logs/foo.versions/v1", old.Unix(), 1, old.UnixNano())
+
+	matches := Route(snap, ev, now)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %v", matches)
+	}
+	if matches[0].VersionID != "" {
+		t.Fatalf("VersionID=%q, want empty for non-versioned bucket", matches[0].VersionID)
+	}
+	if matches[0].ObjectKey != "logs/foo.versions/v1" {
+		t.Fatalf("ObjectKey=%q, want unchanged for non-versioned bucket", matches[0].ObjectKey)
+	}
+}
+
+func TestRouteVersionedExpiredDeleteMarkerSuppressedWithoutSiblings(t *testing.T) {
+	// ExpiredObjectDeleteMarker requires NumVersions==1 — the marker is
+	// the sole-survivor. Without sibling listing the router can't
+	// confirm that, so the rule must NOT fire just because the latest
+	// is a delete marker. A future PR adds sibling listing.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := eventCreate("bk", "logs/gone", old.Unix(), 0, old.UnixNano())
+	ev.NewEntry.Extended = map[string][]byte{
+		s3_constants.ExtDeleteMarkerKey: {1},
+	}
+
+	if got := Route(snap, ev, now); len(got) != 0 {
+		t.Fatalf("ExpiredDeleteMarker without sibling count must not fire, got %v", got)
+	}
+}

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -422,6 +422,12 @@ func TestRouteVersionedNoncurrentEventFiresNoncurrentDays(t *testing.T) {
 	now := time.Now()
 	old := now.AddDate(0, 0, -30)
 	ev := eventCreate("bk", "logs/foo.versions/v1", old.Unix(), 1, old.UnixNano())
+	// SeaweedFS sets ExtVersionIdKey on stored versions; the router uses
+	// it to disambiguate genuine noncurrent versions from literal-key
+	// collisions, so the test must mirror that.
+	ev.NewEntry.Extended = map[string][]byte{
+		s3_constants.ExtVersionIdKey: []byte("v1"),
+	}
 
 	matches := Route(snap, ev, now)
 	if len(matches) != 1 {
@@ -507,5 +513,70 @@ func TestRouteVersionedExpiredDeleteMarkerSuppressedWithoutSiblings(t *testing.T
 
 	if got := Route(snap, ev, now); len(got) != 0 {
 		t.Fatalf("ExpiredDeleteMarker without sibling count must not fire, got %v", got)
+	}
+}
+
+func TestRouteVersionedLiteralKeyCollisionStaysCurrent(t *testing.T) {
+	// Versioned bucket, but the user wrote a literal key
+	// "logs/backup.versions/2023" — the path matches the storage shape
+	// of a noncurrent version yet the entry isn't a tracked version
+	// (no ExtVersionIdKey, or the stored vid doesn't match the path
+	// suffix). The router must NOT misclassify it as noncurrent — that
+	// would strip the suffix from info.Key and lose the user's actual
+	// rule-prefix-matching key.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -2)
+	ev := eventCreate("bk", "logs/backup.versions/2023", old.Unix(), 1, old.UnixNano())
+	// No ExtVersionIdKey: the entry is a regular object with a colourful
+	// name. EXPIRATION_DAYS must fire against the full key.
+	matches := Route(snap, ev, now)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (EXPIRATION_DAYS), got %v", matches)
+	}
+	if matches[0].Key.ActionKind != s3lifecycle.ActionKindExpirationDays {
+		t.Fatalf("ActionKind=%v, want ExpirationDays", matches[0].Key.ActionKind)
+	}
+	if matches[0].ObjectKey != "logs/backup.versions/2023" {
+		t.Fatalf("ObjectKey=%q, want unchanged", matches[0].ObjectKey)
+	}
+	if matches[0].VersionID != "" {
+		t.Fatalf("VersionID=%q, want empty", matches[0].VersionID)
+	}
+
+	// And again with a stored vid that *doesn't* match the suffix —
+	// e.g. "2023" suffix but ExtVersionIdKey="other": still a literal-
+	// key collision, treat as current.
+	ev2 := eventCreate("bk", "logs/backup.versions/2023", old.Unix(), 1, old.UnixNano())
+	ev2.NewEntry.Extended = map[string][]byte{
+		s3_constants.ExtVersionIdKey: []byte("not-the-suffix"),
+	}
+	matches2 := Route(snap, ev2, now)
+	if len(matches2) != 1 || matches2[0].VersionID != "" || matches2[0].ObjectKey != "logs/backup.versions/2023" {
+		t.Fatalf("mismatched-vid collision: matches=%v", matches2)
+	}
+}
+
+func TestRouteVersionedRootVersionsPathRejected(t *testing.T) {
+	// A path like ".versions/v1" would yield an empty logical key if we
+	// stripped the suffix; that's malformed even in seaweedfs's own
+	// layout. Treat as a regular current-version object so we don't
+	// emit a Match with an empty ObjectKey.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -2)
+	ev := eventCreate("bk", ".versions/v1", old.Unix(), 1, old.UnixNano())
+	// Even with ExtVersionIdKey=v1, idx==0 must be rejected.
+	ev.NewEntry.Extended = map[string][]byte{
+		s3_constants.ExtVersionIdKey: []byte("v1"),
+	}
+
+	matches := Route(snap, ev, now)
+	if len(matches) != 1 || matches[0].VersionID != "" || matches[0].ObjectKey != ".versions/v1" {
+		t.Fatalf("root .versions/<vid> must be treated as a regular key, got %v", matches)
 	}
 }

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -405,43 +405,30 @@ func compileWithVersioned(rule *s3lifecycle.Rule, prior map[s3lifecycle.ActionKe
 		engine.CompileOptions{PriorStates: prior})
 }
 
-func TestRouteVersionedNoncurrentEventFiresNoncurrentDays(t *testing.T) {
-	// Versioned bucket, time-based NoncurrentVersionExpiration rule.
-	// Event arrives at the storage path <key>.versions/<vid>. The router
-	// must classify it as noncurrent (IsLatest=false), strip the suffix
-	// for filter matching, and propagate the version_id so the
-	// dispatcher can target a single version on the server.
+func TestRouteVersionedNoncurrentEventDoesNotFireFromRouter(t *testing.T) {
+	// Versioned bucket: the storage layout <key>.versions/v_<id> is
+	// shared between the current latest and noncurrent versions, and
+	// the latest pointer lives in the parent directory's metadata —
+	// not on the version file itself. The router cannot distinguish
+	// without consulting the .versions/ directory, so it must not
+	// emit NONCURRENT_* matches; bootstrap (with sibling listing) is
+	// responsible for those.
 	rule := &s3lifecycle.Rule{
 		ID:                              "r",
 		Status:                          s3lifecycle.StatusEnabled,
-		Prefix:                          "logs/",
 		NoncurrentVersionExpirationDays: 7,
 	}
 	snap := compileWithVersioned(rule, activatedPrior(rule))
 
 	now := time.Now()
 	old := now.AddDate(0, 0, -30)
-	ev := eventCreate("bk", "logs/foo.versions/v1", old.Unix(), 1, old.UnixNano())
-	// SeaweedFS sets ExtVersionIdKey on stored versions; the router uses
-	// it to disambiguate genuine noncurrent versions from literal-key
-	// collisions, so the test must mirror that.
+	ev := eventCreate("bk", "logs/foo.versions/v_v1", old.Unix(), 1, old.UnixNano())
 	ev.NewEntry.Extended = map[string][]byte{
 		s3_constants.ExtVersionIdKey: []byte("v1"),
 	}
 
-	matches := Route(snap, ev, now)
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match (NONCURRENT_DAYS), got %v", matches)
-	}
-	m := matches[0]
-	if m.Key.ActionKind != s3lifecycle.ActionKindNoncurrentDays {
-		t.Fatalf("ActionKind=%v, want NoncurrentDays", m.Key.ActionKind)
-	}
-	if m.ObjectKey != "logs/foo.versions/v1" {
-		t.Fatalf("ObjectKey=%q, want full storage path so dispatcher can locate the version", m.ObjectKey)
-	}
-	if m.VersionID != "v1" {
-		t.Fatalf("VersionID=%q, want v1", m.VersionID)
+	if got := Route(snap, ev, now); len(got) != 0 {
+		t.Fatalf("router must not emit noncurrent matches yet, got %v", got)
 	}
 }
 
@@ -516,67 +503,49 @@ func TestRouteVersionedExpiredDeleteMarkerSuppressedWithoutSiblings(t *testing.T
 	}
 }
 
-func TestRouteVersionedLiteralKeyCollisionStaysCurrent(t *testing.T) {
-	// Versioned bucket, but the user wrote a literal key
-	// "logs/backup.versions/2023" — the path matches the storage shape
-	// of a noncurrent version yet the entry isn't a tracked version
-	// (no ExtVersionIdKey, or the stored vid doesn't match the path
-	// suffix). The router must NOT misclassify it as noncurrent — that
-	// would strip the suffix from info.Key and lose the user's actual
-	// rule-prefix-matching key.
+func TestRouteVersionedAllVersionFolderPathsSkipped(t *testing.T) {
+	// On a versioned bucket the router skips every event whose parent
+	// directory name ends with ".versions" — both the version files
+	// SeaweedFS itself writes (logs/foo.versions/v_v1) and any literal
+	// key the user happens to put under such a parent — because the
+	// current-vs-noncurrent classification needs the .versions/
+	// directory's latest pointer, which isn't carried by these events.
+	// Bootstrap covers retention for those entries.
 	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
 	snap := compileWithVersioned(rule, activatedPrior(rule))
 
 	now := time.Now()
 	old := now.AddDate(0, 0, -2)
-	ev := eventCreate("bk", "logs/backup.versions/2023", old.Unix(), 1, old.UnixNano())
-	// No ExtVersionIdKey: the entry is a regular object with a colourful
-	// name. EXPIRATION_DAYS must fire against the full key.
-	matches := Route(snap, ev, now)
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match (EXPIRATION_DAYS), got %v", matches)
+	cases := []struct {
+		name string
+		key  string
+		ext  map[string][]byte
+	}{
+		{
+			name: "tracked version file",
+			key:  "logs/foo.versions/v_v1",
+			ext:  map[string][]byte{s3_constants.ExtVersionIdKey: []byte("v1")},
+		},
+		{
+			name: "literal-key collision",
+			key:  "logs/backup.versions/2023",
+		},
+		{
+			name: "bucket-root .versions",
+			key:  ".versions/v_v1",
+			ext:  map[string][]byte{s3_constants.ExtVersionIdKey: []byte("v1")},
+		},
 	}
-	if matches[0].Key.ActionKind != s3lifecycle.ActionKindExpirationDays {
-		t.Fatalf("ActionKind=%v, want ExpirationDays", matches[0].Key.ActionKind)
-	}
-	if matches[0].ObjectKey != "logs/backup.versions/2023" {
-		t.Fatalf("ObjectKey=%q, want unchanged", matches[0].ObjectKey)
-	}
-	if matches[0].VersionID != "" {
-		t.Fatalf("VersionID=%q, want empty", matches[0].VersionID)
-	}
-
-	// And again with a stored vid that *doesn't* match the suffix —
-	// e.g. "2023" suffix but ExtVersionIdKey="other": still a literal-
-	// key collision, treat as current.
-	ev2 := eventCreate("bk", "logs/backup.versions/2023", old.Unix(), 1, old.UnixNano())
-	ev2.NewEntry.Extended = map[string][]byte{
-		s3_constants.ExtVersionIdKey: []byte("not-the-suffix"),
-	}
-	matches2 := Route(snap, ev2, now)
-	if len(matches2) != 1 || matches2[0].VersionID != "" || matches2[0].ObjectKey != "logs/backup.versions/2023" {
-		t.Fatalf("mismatched-vid collision: matches=%v", matches2)
-	}
-}
-
-func TestRouteVersionedRootVersionsPathRejected(t *testing.T) {
-	// A path like ".versions/v1" would yield an empty logical key if we
-	// stripped the suffix; that's malformed even in seaweedfs's own
-	// layout. Treat as a regular current-version object so we don't
-	// emit a Match with an empty ObjectKey.
-	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
-	snap := compileWithVersioned(rule, activatedPrior(rule))
-
-	now := time.Now()
-	old := now.AddDate(0, 0, -2)
-	ev := eventCreate("bk", ".versions/v1", old.Unix(), 1, old.UnixNano())
-	// Even with ExtVersionIdKey=v1, idx==0 must be rejected.
-	ev.NewEntry.Extended = map[string][]byte{
-		s3_constants.ExtVersionIdKey: []byte("v1"),
-	}
-
-	matches := Route(snap, ev, now)
-	if len(matches) != 1 || matches[0].VersionID != "" || matches[0].ObjectKey != ".versions/v1" {
-		t.Fatalf("root .versions/<vid> must be treated as a regular key, got %v", matches)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := eventCreate("bk", tc.key, old.Unix(), 1, old.UnixNano())
+			if tc.ext != nil {
+				ev.NewEntry.Extended = tc.ext
+			}
+			if got := Route(snap, ev, now); len(got) != 0 {
+				t.Fatalf("version-folder event should be skipped, got %v", got)
+			}
+		})
 	}
 }
+


### PR DESCRIPTION
## Summary

First slice of Phase 5b. The router now uses the bucket's `Versioned` flag from the engine snapshot to classify meta-log events.

For a versioned bucket:
- An event at `<key>.versions/<vid>` is a noncurrent version. `IsLatest=false`, `info.Key` strips the `.versions/<vid>` suffix so a rule's `Filter.Prefix` matches the user's logical key, and the AWS-visible `version_id` rides on `Match.VersionID` so the dispatcher can target a single version.
- `IsDeleteMarker` is read from `Extended` unconditionally.
- `NumVersions` stays at 0 (couldn't compute without sibling listing). The engine's `ExpiredObjectDeleteMarker` branch requires `NumVersions==1`, so that path correctly stays suppressed until sibling listing lands.

For a non-versioned bucket — even one that happens to contain a key literally named `*.versions/v1` — the path classification short-circuits and `IsLatest=true` is preserved.

## What works after this PR

- `NoncurrentVersionExpiration` time-based rule fires on noncurrent events.
- `Filter.Prefix` matches the logical key for noncurrent versions.

## What's still open

- `NewerNoncurrentVersions` (count-based retention) still returns `ActionNone` when `NoncurrentIndex == nil`, which is the conservative path; full support needs sibling listing.
- `ExpiredObjectDeleteMarker` requires the same sibling-listing pass to confirm the marker is the sole survivor.

## Tests

Four new router tests:
- versioned bucket + noncurrent event fires `NoncurrentDays` with full `ObjectKey` storage path and populated `VersionID`;
- versioned bucket + current event keeps `IsLatest=true` and fires `ExpirationDays`;
- non-versioned bucket + `*.versions/v1` literal key is treated as a regular object;
- versioned bucket + delete marker on latest + `ExpiredObjectDeleteMarker` rule does NOT fire (NumVersions unknown).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lifecycle routing is now version-aware and exposes Version IDs so rules can target specific object versions.

* **Bug Fixes**
  * Prevents lifecycle actions from deleting the repository-recorded “latest” version and suppresses inappropriate expiration for delete-marker or version-file events when sibling/version context is missing.
  * Skips internal version-folder events from lifecycle routing to avoid premature decisions.

* **Tests**
  * Added coverage for versioned vs non-versioned routing, noncurrent classification, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->