### PR TITLE
feat(s3api): apply lifecycle TTL at write time

### DIFF
--- a/weed/s3api/auth_credentials_subscribe.go
+++ b/weed/s3api/auth_credentials_subscribe.go
@@ -214,55 +214,15 @@ func (s3a *S3ApiServer) updateBucketConfigCacheFromEntry(entry *filer_pb.Entry) 
 	glog.V(3).Infof("updateBucketConfigCacheFromEntry: called for bucket %s, ExtObjectLockEnabledKey=%s",
 		bucket, string(entry.Extended[s3_constants.ExtObjectLockEnabledKey]))
 
-	// Create new bucket config from the entry
+	// Create new bucket config from the entry. populateBucketConfigDerivedFields
+	// is the single source of truth for mapping Entry.Extended → cached
+	// fields (incl. LifecycleTTL), so a meta-log Put/DeleteBucketLifecycle
+	// here can't leave a stale resolver in cache.
 	config := &BucketConfig{
-		Name:         bucket,
-		Entry:        entry,
-		IsPublicRead: false, // Explicitly default to false for private buckets
+		Name:  bucket,
+		Entry: entry,
 	}
-
-	// Extract configuration from extended attributes
-	if entry.Extended != nil {
-		if versioning, exists := entry.Extended[s3_constants.ExtVersioningKey]; exists {
-			config.Versioning = string(versioning)
-		}
-		if ownership, exists := entry.Extended[s3_constants.ExtOwnershipKey]; exists {
-			config.Ownership = string(ownership)
-		}
-		if acl, exists := entry.Extended[s3_constants.ExtAmzAclKey]; exists {
-			config.ACL = acl
-			// Parse ACL and cache public-read status
-			config.IsPublicRead = parseAndCachePublicReadStatus(acl)
-		} else {
-			// No ACL means private bucket
-			config.IsPublicRead = false
-		}
-		if owner, exists := entry.Extended[s3_constants.ExtAmzOwnerKey]; exists {
-			config.Owner = string(owner)
-		}
-		// Parse Object Lock configuration if present
-		if objectLockConfig, found := LoadObjectLockConfigurationFromExtended(entry); found {
-			config.ObjectLockConfig = objectLockConfig
-			glog.V(2).Infof("updateBucketConfigCacheFromEntry: cached Object Lock configuration for bucket %s: %+v", bucket, objectLockConfig)
-		} else {
-			glog.V(3).Infof("updateBucketConfigCacheFromEntry: no Object Lock configuration found for bucket %s", bucket)
-		}
-
-		// Load bucket policy if present (for performance optimization)
-		config.BucketPolicy = loadBucketPolicyFromExtended(entry, bucket)
-	}
-
-	// Sync bucket policy to the policy engine for evaluation
-	s3a.syncBucketPolicyToEngine(bucket, config.BucketPolicy)
-
-	// Parse CORS configuration directly from the subscription entry's Content field.
-	// This avoids a separate RPC call that could return stale data when racing with
-	// concurrent metadata updates (e.g., PutBucketCors clearing the cache while this
-	// handler is still processing an older event).
-	config.CORS = parseCORSFromEntryContent(entry.Content)
-	if config.CORS != nil {
-		glog.V(2).Infof("updateBucketConfigCacheFromEntry: parsed CORS config for bucket %s from entry content", bucket)
-	}
+	s3a.populateBucketConfigDerivedFields(config)
 
 	// Update timestamp
 	config.LastModified = time.Now()

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -22,7 +22,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
 // BucketConfig represents cached bucket configuration
@@ -36,11 +35,13 @@ type BucketConfig struct {
 	CORS             *cors.CORSConfiguration
 	ObjectLockConfig *ObjectLockConfiguration      // Cached parsed Object Lock configuration
 	BucketPolicy     *policy_engine.PolicyDocument // Cached bucket policy for performance
-	LifecycleRules   []*s3lifecycle.Rule           // Pre-parsed canonical rules; nil when no lifecycle config
 	// LifecycleTTL answers "what volume TTL should this PutObject get?"
 	// using only fast-path-safe predicates (prefix + size; tags excluded
-	// because they're mutable post-PUT). nil = no TTL applies (versioned
-	// bucket, no eligible rules, or all rules overflow int32 seconds).
+	// because they're mutable post-PUT). nil = no TTL applies (no
+	// lifecycle config, versioned bucket, or only ineligible rules).
+	// The full canonical rule set lives inside the resolver; the
+	// lifecycle worker reads bucket entries directly off the meta-log
+	// rather than this cache.
 	LifecycleTTL *LifecycleTTLResolver
 	KMSKeyCache  *BucketKMSCache // Per-bucket KMS key cache for SSE-KMS operations
 	LastModified     time.Time
@@ -417,7 +418,6 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 		// PUT path falls through to "no TTL" rather than rejecting writes.
 		if xmlBytes, ok := entry.Extended[bucketLifecycleConfigurationXMLKey]; ok && len(xmlBytes) > 0 {
 			if rules, err := lifecycle_xml.ParseCanonical(xmlBytes); err == nil {
-				config.LifecycleRules = rules
 				versioned := config.Versioning == s3_constants.VersioningEnabled || config.Versioning == s3_constants.VersioningSuspended
 				config.LifecycleTTL = NewLifecycleTTLResolver(rules, versioned)
 			} else {

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -37,7 +37,13 @@ type BucketConfig struct {
 	ObjectLockConfig *ObjectLockConfiguration      // Cached parsed Object Lock configuration
 	BucketPolicy     *policy_engine.PolicyDocument // Cached bucket policy for performance
 	LifecycleRules   []*s3lifecycle.Rule           // Pre-parsed canonical rules; nil when no lifecycle config
-	KMSKeyCache      *BucketKMSCache               // Per-bucket KMS key cache for SSE-KMS operations
+	// ttlFastPathRules: subset of LifecycleRules with Status=Enabled and
+	// ExpirationDays>0, sorted by Prefix length descending. PutObject's
+	// per-write TTL resolver walks this — first prefix match wins, so a
+	// bucket with no Expiration.Days rules costs O(1) and a typical bucket
+	// with 1-2 eligible rules costs ~one HasPrefix per PUT.
+	ttlFastPathRules []*s3lifecycle.Rule
+	KMSKeyCache      *BucketKMSCache // Per-bucket KMS key cache for SSE-KMS operations
 	LastModified     time.Time
 	Entry            *filer_pb.Entry
 }
@@ -413,6 +419,7 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 		if xmlBytes, ok := entry.Extended[bucketLifecycleConfigurationXMLKey]; ok && len(xmlBytes) > 0 {
 			if rules, err := lifecycle_xml.ParseCanonical(xmlBytes); err == nil {
 				config.LifecycleRules = rules
+				config.ttlFastPathRules = buildTTLFastPathRules(rules)
 			} else {
 				glog.V(1).Infof("getBucketConfig: bucket %s lifecycle xml parse: %v", bucket, err)
 			}

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -37,13 +37,12 @@ type BucketConfig struct {
 	ObjectLockConfig *ObjectLockConfiguration      // Cached parsed Object Lock configuration
 	BucketPolicy     *policy_engine.PolicyDocument // Cached bucket policy for performance
 	LifecycleRules   []*s3lifecycle.Rule           // Pre-parsed canonical rules; nil when no lifecycle config
-	// ttlFastPathRules: subset of LifecycleRules with Status=Enabled and
-	// ExpirationDays>0, sorted by Prefix length descending. PutObject's
-	// per-write TTL resolver walks this — first prefix match wins, so a
-	// bucket with no Expiration.Days rules costs O(1) and a typical bucket
-	// with 1-2 eligible rules costs ~one HasPrefix per PUT.
-	ttlFastPathRules []*s3lifecycle.Rule
-	KMSKeyCache      *BucketKMSCache // Per-bucket KMS key cache for SSE-KMS operations
+	// LifecycleTTL answers "what volume TTL should this PutObject get?"
+	// using only fast-path-safe predicates (prefix + size; tags excluded
+	// because they're mutable post-PUT). nil = no TTL applies (versioned
+	// bucket, no eligible rules, or all rules overflow int32 seconds).
+	LifecycleTTL *LifecycleTTLResolver
+	KMSKeyCache  *BucketKMSCache // Per-bucket KMS key cache for SSE-KMS operations
 	LastModified     time.Time
 	Entry            *filer_pb.Entry
 }
@@ -419,7 +418,8 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 		if xmlBytes, ok := entry.Extended[bucketLifecycleConfigurationXMLKey]; ok && len(xmlBytes) > 0 {
 			if rules, err := lifecycle_xml.ParseCanonical(xmlBytes); err == nil {
 				config.LifecycleRules = rules
-				config.ttlFastPathRules = buildTTLFastPathRules(rules)
+				versioned := config.Versioning == s3_constants.VersioningEnabled || config.Versioning == s3_constants.VersioningSuspended
+				config.LifecycleTTL = NewLifecycleTTLResolver(rules, versioned)
 			} else {
 				glog.V(1).Infof("getBucketConfig: bucket %s lifecycle xml parse: %v", bucket, err)
 			}

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -18,9 +18,11 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/cors"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/lifecycle_xml"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
 // BucketConfig represents cached bucket configuration
@@ -34,6 +36,7 @@ type BucketConfig struct {
 	CORS             *cors.CORSConfiguration
 	ObjectLockConfig *ObjectLockConfiguration      // Cached parsed Object Lock configuration
 	BucketPolicy     *policy_engine.PolicyDocument // Cached bucket policy for performance
+	LifecycleRules   []*s3lifecycle.Rule           // Pre-parsed canonical rules; nil when no lifecycle config
 	KMSKeyCache      *BucketKMSCache               // Per-bucket KMS key cache for SSE-KMS operations
 	LastModified     time.Time
 	Entry            *filer_pb.Entry
@@ -403,6 +406,17 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 
 		// Load bucket policy if present (for performance optimization)
 		config.BucketPolicy = loadBucketPolicyFromExtended(entry, bucket)
+
+		// Pre-parse lifecycle XML so the per-write TTL resolver doesn't
+		// pay parsing cost on every PutObject. nil on parse error so the
+		// PUT path falls through to "no TTL" rather than rejecting writes.
+		if xmlBytes, ok := entry.Extended[bucketLifecycleConfigurationXMLKey]; ok && len(xmlBytes) > 0 {
+			if rules, err := lifecycle_xml.ParseCanonical(xmlBytes); err == nil {
+				config.LifecycleRules = rules
+			} else {
+				glog.V(1).Infof("getBucketConfig: bucket %s lifecycle xml parse: %v", bucket, err)
+			}
+		}
 	}
 
 	// Sync bucket policy to the policy engine for evaluation

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -442,7 +442,13 @@ func (s3a *S3ApiServer) populateBucketConfigDerivedFields(config *BucketConfig) 
 		// writes.
 		if xmlBytes, ok := entry.Extended[bucketLifecycleConfigurationXMLKey]; ok && len(xmlBytes) > 0 {
 			if rules, err := lifecycle_xml.ParseCanonical(xmlBytes); err == nil {
-				versioned := config.Versioning == s3_constants.VersioningEnabled || config.Versioning == s3_constants.VersioningSuspended
+				// Object Lock requires versioning, so an ObjectLockConfig
+				// implies the bucket is versioned even when the explicit
+				// Versioning header was never written. BucketIsVersioned
+				// in this file uses the same OR — keep them aligned.
+				versioned := config.Versioning == s3_constants.VersioningEnabled ||
+					config.Versioning == s3_constants.VersioningSuspended ||
+					config.ObjectLockConfig != nil
 				config.LifecycleTTL = NewLifecycleTTLResolver(rules, versioned)
 			} else {
 				glog.V(1).Infof("populateBucketConfigDerivedFields: bucket %s lifecycle xml parse: %v", bucket, err)

--- a/weed/s3api/s3api_bucket_config.go
+++ b/weed/s3api/s3api_bucket_config.go
@@ -380,11 +380,43 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 		Entry:        entry,
 		IsPublicRead: false, // Explicitly default to false for private buckets
 	}
+	s3a.populateBucketConfigDerivedFields(config)
 
-	// Extract configuration from extended attributes
+	// Cache the result
+	s3a.bucketConfigCache.Set(bucket, config)
+
+	return config, s3err.ErrNone
+}
+
+// populateBucketConfigDerivedFields fills every field on BucketConfig that is
+// derived from Entry.Extended / Entry.Content (versioning flag, ACL, owner,
+// object lock, bucket policy, CORS, lifecycle TTL resolver). It is the
+// single source of truth for that mapping; callers that take a fresh
+// BucketConfig (getBucketConfig, updateBucketConfig after the user's update
+// fn runs, the meta-log subscription cache refresher) all funnel through
+// here so a missed field can't silently keep stale data — e.g. a stale
+// LifecycleTTL after a Put/DeleteBucketLifecycle would keep stamping the
+// old policy's irreversible volume TTL onto new writes.
+func (s3a *S3ApiServer) populateBucketConfigDerivedFields(config *BucketConfig) {
+	// Reset every derived field so stale values from a previous Entry
+	// don't survive a clear (e.g. DELETE policy → BucketPolicy=nil).
+	config.Versioning = ""
+	config.Ownership = ""
+	config.ACL = nil
+	config.Owner = ""
+	config.IsPublicRead = false
+	config.ObjectLockConfig = nil
+	config.BucketPolicy = nil
+	config.LifecycleTTL = nil
+	config.CORS = nil
+
+	entry := config.Entry
+	if entry == nil {
+		return
+	}
+	bucket := config.Name
+
 	if entry.Extended != nil {
-		glog.V(3).Infof("getBucketConfig: checking extended attributes for bucket %s, ExtObjectLockEnabledKey value=%s",
-			bucket, string(entry.Extended[s3_constants.ExtObjectLockEnabledKey]))
 		if versioning, exists := entry.Extended[s3_constants.ExtVersioningKey]; exists {
 			config.Versioning = string(versioning)
 		}
@@ -393,50 +425,37 @@ func (s3a *S3ApiServer) getBucketConfig(bucket string) (*BucketConfig, s3err.Err
 		}
 		if acl, exists := entry.Extended[s3_constants.ExtAmzAclKey]; exists {
 			config.ACL = acl
-			// Parse ACL once and cache public-read status
+			// Parse ACL once and cache public-read status.
 			config.IsPublicRead = parseAndCachePublicReadStatus(acl)
-		} else {
-			// No ACL means private bucket
-			config.IsPublicRead = false
 		}
 		if owner, exists := entry.Extended[s3_constants.ExtAmzOwnerKey]; exists {
 			config.Owner = string(owner)
 		}
-		// Parse Object Lock configuration if present
 		if objectLockConfig, found := LoadObjectLockConfigurationFromExtended(entry); found {
 			config.ObjectLockConfig = objectLockConfig
-			glog.V(3).Infof("getBucketConfig: loaded Object Lock config from extended attributes for bucket %s: %+v", bucket, objectLockConfig)
-		} else {
-			glog.V(3).Infof("getBucketConfig: no Object Lock config found in extended attributes for bucket %s", bucket)
 		}
-
-		// Load bucket policy if present (for performance optimization)
 		config.BucketPolicy = loadBucketPolicyFromExtended(entry, bucket)
 
 		// Pre-parse lifecycle XML so the per-write TTL resolver doesn't
-		// pay parsing cost on every PutObject. nil on parse error so the
-		// PUT path falls through to "no TTL" rather than rejecting writes.
+		// pay parsing cost on every PutObject. nil on parse error so
+		// the PUT path falls through to "no TTL" rather than rejecting
+		// writes.
 		if xmlBytes, ok := entry.Extended[bucketLifecycleConfigurationXMLKey]; ok && len(xmlBytes) > 0 {
 			if rules, err := lifecycle_xml.ParseCanonical(xmlBytes); err == nil {
 				versioned := config.Versioning == s3_constants.VersioningEnabled || config.Versioning == s3_constants.VersioningSuspended
 				config.LifecycleTTL = NewLifecycleTTLResolver(rules, versioned)
 			} else {
-				glog.V(1).Infof("getBucketConfig: bucket %s lifecycle xml parse: %v", bucket, err)
+				glog.V(1).Infof("populateBucketConfigDerivedFields: bucket %s lifecycle xml parse: %v", bucket, err)
 			}
 		}
 	}
 
-	// Sync bucket policy to the policy engine for evaluation
+	// Sync bucket policy to the policy engine for evaluation.
 	s3a.syncBucketPolicyToEngine(bucket, config.BucketPolicy)
 
 	// Parse CORS configuration directly from the entry's Content field.
 	// This avoids a redundant RPC call since we already have the entry.
 	config.CORS = parseCORSFromEntryContent(entry.Content)
-
-	// Cache the result
-	s3a.bucketConfigCache.Set(bucket, config)
-
-	return config, s3err.ErrNone
 }
 
 // updateBucketConfig updates bucket configuration and invalidates cache
@@ -508,7 +527,12 @@ func (s3a *S3ApiServer) updateBucketConfig(bucket string, updateFn func(*BucketC
 	}
 	glog.V(3).Infof("updateBucketConfig: saved entry to filer for bucket %s", bucket)
 
-	// Update cache
+	// Update cache. Re-derive every Extended-backed field from the
+	// just-saved Entry — the user's update fn may have flipped, added,
+	// or cleared bytes (e.g. PutBucketLifecycle / DeleteBucketLifecycle
+	// rewrites the lifecycle XML key) and the resolver / parsed configs
+	// must follow.
+	s3a.populateBucketConfigDerivedFields(nextConfig)
 	s3a.bucketConfigCache.Set(bucket, nextConfig)
 
 	return s3err.ErrNone

--- a/weed/s3api/s3api_object_handlers_copy_part_sse.go
+++ b/weed/s3api/s3api_object_handlers_copy_part_sse.go
@@ -395,7 +395,9 @@ func (s3a *S3ApiServer) copyObjectPartViaReencryption(
 	// on the UploadPartCopy response. Without this, clients have no way to
 	// see that the destination was encrypted.
 	filePath := s3a.genPartUploadPath(dstBucket, uploadID, partID)
-	tag, code, putSSE := s3a.putToFiler(cloned, filePath, srcReader, dstBucket, "", partID, nil)
+	// Copy-part is an MPU part write under .uploads/<id>/<n>; lifecycle
+	// TTL only applies to the eventual completed object. Pass 0.
+	tag, code, putSSE := s3a.putToFiler(cloned, filePath, srcReader, dstBucket, "", partID, 0, nil)
 	if code != s3err.ErrNone {
 		return "", SSEResponseMetadata{}, code
 	}

--- a/weed/s3api/s3api_object_handlers_multipart.go
+++ b/weed/s3api/s3api_object_handlers_multipart.go
@@ -452,7 +452,12 @@ func (s3a *S3ApiServer) PutObjectPartHandler(w http.ResponseWriter, r *http.Requ
 	glog.V(2).Infof("PutObjectPart: bucket=%s, object=%s, uploadId=%s, partNumber=%d, size=%d",
 		bucket, object, uploadID, partID, r.ContentLength)
 
-	etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, dataReader, bucket, "", partID, nil)
+	// MPU parts must NOT inherit the bucket's lifecycle Expiration.Days
+	// volume TTL: the rule targets the user-visible object, not the
+	// transient .uploads/<id>/<n> path, and a part write would otherwise
+	// start the TTL clock before CompleteMultipartUpload ever assembled
+	// the object.
+	etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, dataReader, bucket, "", partID, 0, nil)
 	if errCode != s3err.ErrNone {
 		glog.Errorf("PutObjectPart: putToFiler failed with error code %v for bucket=%s, object=%s, partNumber=%d",
 			errCode, bucket, object, partID)

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -131,7 +131,10 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 	// Forward validated POST form fields to the underlying PUT as headers.
 	applyPostPolicyFormHeaders(r, formValues)
 
-	ttlSec := s3a.lifecycleTTLForObjectWrite(bucket, object, r)
+	// Use fileSize, not r.ContentLength: the multipart body wrapping form
+	// fields and boundaries inflates ContentLength relative to the
+	// object body, which would mis-evaluate any size-filtered rule.
+	ttlSec := s3a.lifecycleTTLForObjectWrite(bucket, object, fileSize)
 	etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, fileBody, bucket, object, 1, ttlSec, nil)
 
 	if errCode != s3err.ErrNone {

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -131,7 +131,8 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 	// Forward validated POST form fields to the underlying PUT as headers.
 	applyPostPolicyFormHeaders(r, formValues)
 
-	etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, fileBody, bucket, object, 1, nil)
+	ttlSec := s3a.lifecycleTTLForObjectWrite(bucket, object, r)
+	etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, fileBody, bucket, object, 1, ttlSec, nil)
 
 	if errCode != s3err.ErrNone {
 		s3err.WriteErrorResponse(w, r, errCode)

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -296,7 +296,7 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 				dataReader = mimeDetect(r, dataReader)
 			}
 
-			ttlSec := s3a.lifecycleTTLForObjectWrite(bucket, object, r)
+			ttlSec := s3a.lifecycleTTLForObjectWrite(bucket, object, r.ContentLength)
 			etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, dataReader, bucket, object, 1, ttlSec, nil)
 
 			if errCode != s3err.ErrNone {

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -296,7 +296,8 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 				dataReader = mimeDetect(r, dataReader)
 			}
 
-			etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, dataReader, bucket, object, 1, nil)
+			ttlSec := s3a.lifecycleTTLForObjectWrite(bucket, object, r)
+			etag, errCode, sseMetadata := s3a.putToFiler(r, filePath, dataReader, bucket, object, 1, ttlSec, nil)
 
 			if errCode != s3err.ErrNone {
 				s3err.WriteErrorResponse(w, r, errCode)
@@ -351,7 +352,14 @@ func (s3a *S3ApiServer) withObjectWriteLock(bucket, object string, preconditionF
 	return fn()
 }
 
-func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader io.Reader, bucket string, object string, partNumber int, afterCreate func(entry *filer_pb.Entry) s3err.ErrorCode) (etag string, code s3err.ErrorCode, sseMetadata SSEResponseMetadata) {
+// putToFiler writes one chunk of object bytes (a full PutObject body, a
+// single MPU part, a copy-part destination). lifecycleTTLSec is non-zero
+// only for top-level PutObject paths where the lifecycle XML's
+// Expiration.Days fast path applies — MPU parts and copy-parts always
+// pass 0 because their own keys aren't the user-visible object the rule
+// targets and a part write would otherwise bind a TTL clock starting
+// before CompleteMultipartUpload.
+func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader io.Reader, bucket string, object string, partNumber int, lifecycleTTLSec int32, afterCreate func(entry *filer_pb.Entry) s3err.ErrorCode) (etag string, code s3err.ErrorCode, sseMetadata SSEResponseMetadata) {
 	// NEW OPTIMIZATION: Write directly to volume servers, bypassing filer proxy
 	// This eliminates the filer proxy overhead for PUT operations
 	// Note: filePath is now passed directly instead of URL (no parsing needed)
@@ -452,14 +460,6 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader 
 	if s3a.option.FilerGroup != "" {
 		collection = s3a.getCollectionName(bucket)
 	}
-
-	// Resolve volume-TTL from the bucket's lifecycle XML. The bucket
-	// config is cached + parsed up-front in getBucketConfig, so this is
-	// a slice walk; chunks land on TTL volumes and the volume server
-	// handles physical expiration without any filer.conf bookkeeping.
-	requestTags := parseRequestTags(r)
-	bucketCfg, _ := s3a.getBucketConfig(bucket)
-	lifecycleTTLSec := resolveLifecycleTTLForWrite(bucketCfg, object, requestTags, r.ContentLength)
 
 	// Create assign function for chunked upload
 	assignFunc := func(ctx context.Context, count int, expectedDataSize uint64) (*operation.VolumeAssignRequest, *operation.AssignResult, error) {
@@ -1271,8 +1271,10 @@ func (s3a *S3ApiServer) putSuspendedVersioningObject(r *http.Request, bucket, ob
 		}
 	}
 
-	// Upload the file using putToFiler - this will create the file with version metadata
-	etag, errCode, sseMetadata = s3a.putToFiler(r, filePath, body, bucket, normalizedObject, 1, nil)
+	// Upload the file using putToFiler - this will create the file with version metadata.
+	// Versioned/suspended bucket → resolver returns 0 by construction;
+	// pass 0 directly so the path is explicit at the call site.
+	etag, errCode, sseMetadata = s3a.putToFiler(r, filePath, body, bucket, normalizedObject, 1, 0, nil)
 	if errCode != s3err.ErrNone {
 		glog.Errorf("putSuspendedVersioningObject: failed to upload object: %v", errCode)
 		return "", errCode, SSEResponseMetadata{}
@@ -1422,7 +1424,10 @@ func (s3a *S3ApiServer) putVersionedObject(r *http.Request, bucket, object strin
 		}
 	}
 
-	etag, errCode, sseMetadata = s3a.putToFiler(r, versionFilePath, body, bucket, normalizedObject, 1, func(versionEntry *filer_pb.Entry) s3err.ErrorCode {
+	// Versioned bucket: resolver returns 0 by construction. Pass 0
+	// directly — versioned objects sit on regular volumes and the
+	// lifecycle worker handles their expiration.
+	etag, errCode, sseMetadata = s3a.putToFiler(r, versionFilePath, body, bucket, normalizedObject, 1, 0, func(versionEntry *filer_pb.Entry) s3err.ErrorCode {
 		if err := s3a.updateLatestVersionInDirectory(bucket, normalizedObject, versionId, versionFileName, versionEntry); err != nil {
 			glog.Errorf("putVersionedObject: failed to update latest version in directory: %v", err)
 			return s3err.ErrInternalError

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -453,6 +453,14 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader 
 		collection = s3a.getCollectionName(bucket)
 	}
 
+	// Resolve volume-TTL from the bucket's lifecycle XML. The bucket
+	// config is cached + parsed up-front in getBucketConfig, so this is
+	// a slice walk; chunks land on TTL volumes and the volume server
+	// handles physical expiration without any filer.conf bookkeeping.
+	requestTags := parseRequestTags(r)
+	bucketCfg, _ := s3a.getBucketConfig(bucket)
+	lifecycleTTLSec := resolveLifecycleTTLForWrite(bucketCfg, object, requestTags, r.ContentLength)
+
 	// Create assign function for chunked upload
 	assignFunc := func(ctx context.Context, count int, expectedDataSize uint64) (*operation.VolumeAssignRequest, *operation.AssignResult, error) {
 		var assignResult *filer_pb.AssignVolumeResponse
@@ -465,6 +473,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader 
 				DataCenter:       s3a.option.DataCenter,
 				Path:             filePath,
 				ExpectedDataSize: expectedDataSize,
+				TtlSec:           lifecycleTTLSec,
 			})
 			if err != nil {
 				return fmt.Errorf("assign volume: %w", err)
@@ -639,6 +648,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader 
 			Gid:      0,
 			Mime:     mimeType,
 			FileSize: uint64(chunkResult.TotalSize),
+			TtlSec:   lifecycleTTLSec,
 		},
 		Chunks:   chunkResult.FileChunks, // All chunks from auto-chunking
 		Extended: make(map[string][]byte),

--- a/weed/s3api/s3api_object_lifecycle_ttl.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl.go
@@ -3,11 +3,9 @@ package s3api
 import (
 	"math"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
@@ -19,24 +17,50 @@ import (
 // each write.
 const secondsPerDay = int64(86400)
 
-// buildTTLFastPathRules pre-filters the canonical rules down to the ones the
-// PutObject TTL resolver could ever fire for and sorts by descending prefix
-// length so first match is longest match. Disabled / non-Expiration.Days
-// rules are dropped entirely so the per-PUT walk skips them without an
-// inline check.
-func buildTTLFastPathRules(rules []*s3lifecycle.Rule) []*s3lifecycle.Rule {
-	if len(rules) == 0 {
+// LifecycleTTLResolver answers "what volume TTL should this write get?" for
+// the PutObject path. Constructed once per bucket-config load with a
+// pre-filtered, pre-sorted slice of rules so per-write cost is one
+// HasPrefix per rule walked, exiting on first match.
+//
+// Stable predicates only: prefix and size. Tag-filtered rules are NOT in
+// the fast path because tags can be replaced post-PUT via PutObjectTagging
+// while volume TTL is irreversible — an object that matched at write time
+// would still expire after the tag was removed. The lifecycle worker
+// re-evaluates current tags at scan time.
+//
+// nil receiver means "no TTL applies" (no eligible rules, bucket
+// versioned, or rules that overflow int32 seconds); callers can use a nil
+// resolver freely.
+type LifecycleTTLResolver struct {
+	rules []*s3lifecycle.Rule
+}
+
+// NewLifecycleTTLResolver pre-filters and pre-sorts rules. Returns nil
+// when nothing on the fast path can apply — callers don't need to special-
+// case the empty-bucket / versioned-bucket / tag-only-rules cases.
+//
+// Sort is ascending by ExpirationDays so first prefix match is also the
+// shortest matching expiration — AWS's overlapping-rule precedence (see
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-conflicts.html).
+// Stable so equal-Days rules keep their XML order.
+func NewLifecycleTTLResolver(rules []*s3lifecycle.Rule, versioned bool) *LifecycleTTLResolver {
+	if versioned || len(rules) == 0 {
+		// Versioned buckets: TTL volumes expire as a unit, which would
+		// destroy noncurrent versions. Worker drives expiration there.
 		return nil
 	}
 	out := make([]*s3lifecycle.Rule, 0, len(rules))
 	for _, r := range rules {
-		if r == nil {
-			continue
-		}
-		if r.Status != s3lifecycle.StatusEnabled {
+		if r == nil || r.Status != s3lifecycle.StatusEnabled {
 			continue
 		}
 		if r.ExpirationDays <= 0 {
+			// NoncurrentVersionExpiration / AbortMPU / etc. — worker only.
+			continue
+		}
+		if len(r.FilterTags) > 0 {
+			// Tag-mutable; defer to the worker so a tag flip can't leave
+			// us with a volume-TTL stamp the policy no longer dictates.
 			continue
 		}
 		out = append(out, r)
@@ -44,40 +68,23 @@ func buildTTLFastPathRules(rules []*s3lifecycle.Rule) []*s3lifecycle.Rule {
 	if len(out) == 0 {
 		return nil
 	}
-	// Stable sort so rules with equal prefix length keep their XML order
-	// (matches AWS's "rules are evaluated in document order for ties").
 	sort.SliceStable(out, func(i, j int) bool {
-		return len(out[i].Prefix) > len(out[j].Prefix)
+		return out[i].ExpirationDays < out[j].ExpirationDays
 	})
-	return out
+	return &LifecycleTTLResolver{rules: out}
 }
 
-// resolveLifecycleTTLForWrite returns the volume TTL (in seconds) the
-// PutObject path should pass to AssignVolume and stamp on the new entry.
+// Resolve returns the volume TTL (in seconds) for a write of the given
+// object key and size, or 0 when no fast-path rule applies.
 //
-// Returns 0 ("no TTL — let the lifecycle worker handle it later") when:
-//   - the bucket has no fast-path-eligible rules (no XML, all rules
-//     disabled, or only NoncurrentVersionExpiration / AbortMPU / etc.),
-//   - the bucket is versioned (TTL volumes expire as a unit, which would
-//     destroy noncurrent versions),
-//   - no rule's prefix matches the object key,
-//   - the matching rule's tag or size filter doesn't match this request.
-//
-// Cost: one HasPrefix per rule walked, exiting on first match. The cache
-// pre-sorts by descending prefix length so first match is also longest
-// match — a typical PUT walks one rule.
-func resolveLifecycleTTLForWrite(cfg *BucketConfig, objectKey string, requestTags map[string]string, size int64) int32 {
-	if cfg == nil || len(cfg.ttlFastPathRules) == 0 {
+// The receiver may be nil — that's the common "no rules" case and it
+// returns 0 without allocating.
+func (r *LifecycleTTLResolver) Resolve(objectKey string, size int64) int32 {
+	if r == nil {
 		return 0
 	}
-	if cfg.Versioning == s3_constants.VersioningEnabled || cfg.Versioning == s3_constants.VersioningSuspended {
-		return 0
-	}
-	for _, rule := range cfg.ttlFastPathRules {
+	for _, rule := range r.rules {
 		if !strings.HasPrefix(objectKey, rule.Prefix) {
-			continue
-		}
-		if !ruleTagsMatch(rule.FilterTags, requestTags) {
 			continue
 		}
 		if !ruleSizeMatches(rule, size) {
@@ -85,57 +92,33 @@ func resolveLifecycleTTLForWrite(cfg *BucketConfig, objectKey string, requestTag
 		}
 		secs := int64(rule.ExpirationDays) * secondsPerDay
 		if secs > math.MaxInt32 {
-			// AWS allows Expiration.Days up to 2,147,483,647 — that
-			// overflows int32 seconds (~24,855 days). Cap at int32 max;
-			// the rule effectively becomes "never expire via volume TTL"
-			// and the lifecycle worker enforces it on its own schedule.
-			return math.MaxInt32
+			// Volume TTL field is int32 seconds (~68 years). A longer
+			// rule can't be represented without expiring early, so let
+			// the lifecycle worker enforce it on its own schedule.
+			return 0
 		}
 		return int32(secs)
 	}
 	return 0
 }
 
-// parseRequestTags pulls k=v pairs from the X-Amz-Tagging header. AWS sends
-// them URL-encoded; duplicates and parse errors yield an empty map so a
-// malformed header doesn't accidentally match a tag-filtered lifecycle rule.
-func parseRequestTags(r *http.Request) map[string]string {
-	raw := r.Header.Get(s3_constants.AmzObjectTagging)
-	if raw == "" {
-		return nil
+// lifecycleTTLForObjectWrite is the PutObject call-site wrapper. Returns 0
+// for any caller (MPU part, copy-part) that shouldn't bind a TTL clock —
+// see putToFiler's signature comment for which paths pass 0 directly.
+func (s3a *S3ApiServer) lifecycleTTLForObjectWrite(bucket, objectKey string, r *http.Request) int32 {
+	cfg, _ := s3a.getBucketConfig(bucket)
+	if cfg == nil || cfg.LifecycleTTL == nil {
+		return 0
 	}
-	values, err := url.ParseQuery(raw)
-	if err != nil {
-		return nil
-	}
-	out := make(map[string]string, len(values))
-	for k, v := range values {
-		if len(v) != 1 {
-			return nil
-		}
-		out[k] = v[0]
-	}
-	return out
-}
-
-func ruleTagsMatch(want, got map[string]string) bool {
-	if len(want) == 0 {
-		return true
-	}
-	for k, v := range want {
-		if g, ok := got[k]; !ok || g != v {
-			return false
-		}
-	}
-	return true
+	return cfg.LifecycleTTL.Resolve(objectKey, r.ContentLength)
 }
 
 func ruleSizeMatches(rule *s3lifecycle.Rule, size int64) bool {
 	hasFilter := rule.FilterSizeGreaterThan > 0 || rule.FilterSizeLessThan > 0
 	if hasFilter && size < 0 {
-		// Content-Length wasn't sent; any "size > N" / "size < N" filter
-		// is unevaluable, so be safe and skip the rule. The lifecycle
-		// worker re-evaluates with the real size at scan time.
+		// Content-Length wasn't sent; the size filter is unevaluable so
+		// be safe and skip the rule. The worker re-evaluates at scan
+		// time with the actual size.
 		return false
 	}
 	if rule.FilterSizeGreaterThan > 0 && size <= rule.FilterSizeGreaterThan {

--- a/weed/s3api/s3api_object_lifecycle_ttl.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -18,35 +19,61 @@ import (
 // each write.
 const secondsPerDay = int64(86400)
 
+// buildTTLFastPathRules pre-filters the canonical rules down to the ones the
+// PutObject TTL resolver could ever fire for and sorts by descending prefix
+// length so first match is longest match. Disabled / non-Expiration.Days
+// rules are dropped entirely so the per-PUT walk skips them without an
+// inline check.
+func buildTTLFastPathRules(rules []*s3lifecycle.Rule) []*s3lifecycle.Rule {
+	if len(rules) == 0 {
+		return nil
+	}
+	out := make([]*s3lifecycle.Rule, 0, len(rules))
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		if r.Status != s3lifecycle.StatusEnabled {
+			continue
+		}
+		if r.ExpirationDays <= 0 {
+			continue
+		}
+		out = append(out, r)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	// Stable sort so rules with equal prefix length keep their XML order
+	// (matches AWS's "rules are evaluated in document order for ties").
+	sort.SliceStable(out, func(i, j int) bool {
+		return len(out[i].Prefix) > len(out[j].Prefix)
+	})
+	return out
+}
+
 // resolveLifecycleTTLForWrite returns the volume TTL (in seconds) the
 // PutObject path should pass to AssignVolume and stamp on the new entry.
 //
 // Returns 0 ("no TTL — let the lifecycle worker handle it later") when:
-//   - the bucket has no compiled lifecycle rules,
+//   - the bucket has no fast-path-eligible rules (no XML, all rules
+//     disabled, or only NoncurrentVersionExpiration / AbortMPU / etc.),
 //   - the bucket is versioned (TTL volumes expire as a unit, which would
 //     destroy noncurrent versions),
-//   - no Expiration.Days rule's prefix matches the object key,
+//   - no rule's prefix matches the object key,
 //   - the matching rule's tag or size filter doesn't match this request.
 //
-// Among rules whose prefix matches, the longest-match wins so an operator
-// can carve sub-prefixes out of a broader rule with a different TTL.
+// Cost: one HasPrefix per rule walked, exiting on first match. The cache
+// pre-sorts by descending prefix length so first match is also longest
+// match — a typical PUT walks one rule.
 func resolveLifecycleTTLForWrite(cfg *BucketConfig, objectKey string, requestTags map[string]string, size int64) int32 {
-	if cfg == nil || len(cfg.LifecycleRules) == 0 {
+	if cfg == nil || len(cfg.ttlFastPathRules) == 0 {
 		return 0
 	}
 	if cfg.Versioning == s3_constants.VersioningEnabled || cfg.Versioning == s3_constants.VersioningSuspended {
 		return 0
 	}
-
-	bestPrefixLen := -1
-	bestDays := 0
-	for _, rule := range cfg.LifecycleRules {
-		if rule == nil || rule.Status != s3lifecycle.StatusEnabled {
-			continue
-		}
-		if rule.ExpirationDays <= 0 {
-			continue
-		}
+	for _, rule := range cfg.ttlFastPathRules {
 		if !strings.HasPrefix(objectKey, rule.Prefix) {
 			continue
 		}
@@ -56,35 +83,17 @@ func resolveLifecycleTTLForWrite(cfg *BucketConfig, objectKey string, requestTag
 		if !ruleSizeMatches(rule, size) {
 			continue
 		}
-		if len(rule.Prefix) > bestPrefixLen {
-			bestPrefixLen = len(rule.Prefix)
-			bestDays = rule.ExpirationDays
+		secs := int64(rule.ExpirationDays) * secondsPerDay
+		if secs > math.MaxInt32 {
+			// AWS allows Expiration.Days up to 2,147,483,647 — that
+			// overflows int32 seconds (~24,855 days). Cap at int32 max;
+			// the rule effectively becomes "never expire via volume TTL"
+			// and the lifecycle worker enforces it on its own schedule.
+			return math.MaxInt32
 		}
+		return int32(secs)
 	}
-	if bestDays <= 0 {
-		return 0
-	}
-	secs := int64(bestDays) * secondsPerDay
-	if secs > math.MaxInt32 {
-		// AWS allows Expiration.Days up to 2,147,483,647 — that overflows
-		// int32 seconds (~24,855 days). Cap at int32 max; the rule
-		// effectively becomes "never expire via volume TTL" and the
-		// lifecycle worker can still enforce it on its own schedule.
-		return math.MaxInt32
-	}
-	return int32(secs)
-}
-
-func ruleTagsMatch(want, got map[string]string) bool {
-	if len(want) == 0 {
-		return true
-	}
-	for k, v := range want {
-		if g, ok := got[k]; !ok || g != v {
-			return false
-		}
-	}
-	return true
+	return 0
 }
 
 // parseRequestTags pulls k=v pairs from the X-Amz-Tagging header. AWS sends
@@ -107,6 +116,18 @@ func parseRequestTags(r *http.Request) map[string]string {
 		out[k] = v[0]
 	}
 	return out
+}
+
+func ruleTagsMatch(want, got map[string]string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	for k, v := range want {
+		if g, ok := got[k]; !ok || g != v {
+			return false
+		}
+	}
+	return true
 }
 
 func ruleSizeMatches(rule *s3lifecycle.Rule, size int64) bool {

--- a/weed/s3api/s3api_object_lifecycle_ttl.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl.go
@@ -2,7 +2,6 @@ package s3api
 
 import (
 	"math"
-	"net/http"
 	"sort"
 	"strings"
 
@@ -138,10 +137,16 @@ func (r *LifecycleTTLResolver) Resolve(objectKey string, size int64) int32 {
 // lifecycleTTLForObjectWrite is the PutObject call-site wrapper. Returns 0
 // for any caller (MPU part, copy-part) that shouldn't bind a TTL clock —
 // see putToFiler's signature comment for which paths pass 0 directly.
-func (s3a *S3ApiServer) lifecycleTTLForObjectWrite(bucket, objectKey string, r *http.Request) int32 {
+//
+// Callers MUST pass the actual object size, not r.ContentLength when those
+// differ. r.ContentLength is the wire size: for a multipart PostPolicy
+// upload it includes form fields and boundaries, so a size-filtered rule
+// would mis-evaluate against the form total instead of the file body.
+// objectSize<0 is "unknown" — the resolver skips any size-filtered rule.
+func (s3a *S3ApiServer) lifecycleTTLForObjectWrite(bucket, objectKey string, objectSize int64) int32 {
 	cfg, _ := s3a.getBucketConfig(bucket)
 	if cfg == nil || cfg.LifecycleTTL == nil {
 		return 0
 	}
-	return cfg.LifecycleTTL.Resolve(objectKey, r.ContentLength)
+	return cfg.LifecycleTTL.Resolve(objectKey, objectSize)
 }

--- a/weed/s3api/s3api_object_lifecycle_ttl.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl.go
@@ -1,0 +1,127 @@
+package s3api
+
+import (
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+// secondsPerDay is the conversion factor between Lifecycle Expiration.Days
+// (a calendar-day count) and the volume server's TTL field (seconds since
+// creation). This intentionally does NOT use AWS's "next 00:00 UTC" rounding;
+// that's an expiration-firing nuance the lifecycle worker enforces, not
+// something the per-write fast path can model without reading the clock at
+// each write.
+const secondsPerDay = int64(86400)
+
+// resolveLifecycleTTLForWrite returns the volume TTL (in seconds) the
+// PutObject path should pass to AssignVolume and stamp on the new entry.
+//
+// Returns 0 ("no TTL — let the lifecycle worker handle it later") when:
+//   - the bucket has no compiled lifecycle rules,
+//   - the bucket is versioned (TTL volumes expire as a unit, which would
+//     destroy noncurrent versions),
+//   - no Expiration.Days rule's prefix matches the object key,
+//   - the matching rule's tag or size filter doesn't match this request.
+//
+// Among rules whose prefix matches, the longest-match wins so an operator
+// can carve sub-prefixes out of a broader rule with a different TTL.
+func resolveLifecycleTTLForWrite(cfg *BucketConfig, objectKey string, requestTags map[string]string, size int64) int32 {
+	if cfg == nil || len(cfg.LifecycleRules) == 0 {
+		return 0
+	}
+	if cfg.Versioning == s3_constants.VersioningEnabled || cfg.Versioning == s3_constants.VersioningSuspended {
+		return 0
+	}
+
+	bestPrefixLen := -1
+	bestDays := 0
+	for _, rule := range cfg.LifecycleRules {
+		if rule == nil || rule.Status != s3lifecycle.StatusEnabled {
+			continue
+		}
+		if rule.ExpirationDays <= 0 {
+			continue
+		}
+		if !strings.HasPrefix(objectKey, rule.Prefix) {
+			continue
+		}
+		if !ruleTagsMatch(rule.FilterTags, requestTags) {
+			continue
+		}
+		if !ruleSizeMatches(rule, size) {
+			continue
+		}
+		if len(rule.Prefix) > bestPrefixLen {
+			bestPrefixLen = len(rule.Prefix)
+			bestDays = rule.ExpirationDays
+		}
+	}
+	if bestDays <= 0 {
+		return 0
+	}
+	secs := int64(bestDays) * secondsPerDay
+	if secs > math.MaxInt32 {
+		// AWS allows Expiration.Days up to 2,147,483,647 — that overflows
+		// int32 seconds (~24,855 days). Cap at int32 max; the rule
+		// effectively becomes "never expire via volume TTL" and the
+		// lifecycle worker can still enforce it on its own schedule.
+		return math.MaxInt32
+	}
+	return int32(secs)
+}
+
+func ruleTagsMatch(want, got map[string]string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	for k, v := range want {
+		if g, ok := got[k]; !ok || g != v {
+			return false
+		}
+	}
+	return true
+}
+
+// parseRequestTags pulls k=v pairs from the X-Amz-Tagging header. AWS sends
+// them URL-encoded; duplicates and parse errors yield an empty map so a
+// malformed header doesn't accidentally match a tag-filtered lifecycle rule.
+func parseRequestTags(r *http.Request) map[string]string {
+	raw := r.Header.Get(s3_constants.AmzObjectTagging)
+	if raw == "" {
+		return nil
+	}
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for k, v := range values {
+		if len(v) != 1 {
+			return nil
+		}
+		out[k] = v[0]
+	}
+	return out
+}
+
+func ruleSizeMatches(rule *s3lifecycle.Rule, size int64) bool {
+	hasFilter := rule.FilterSizeGreaterThan > 0 || rule.FilterSizeLessThan > 0
+	if hasFilter && size < 0 {
+		// Content-Length wasn't sent; any "size > N" / "size < N" filter
+		// is unevaluable, so be safe and skip the rule. The lifecycle
+		// worker re-evaluates with the real size at scan time.
+		return false
+	}
+	if rule.FilterSizeGreaterThan > 0 && size <= rule.FilterSizeGreaterThan {
+		return false
+	}
+	if rule.FilterSizeLessThan > 0 && size >= rule.FilterSizeLessThan {
+		return false
+	}
+	return true
+}

--- a/weed/s3api/s3api_object_lifecycle_ttl.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl.go
@@ -19,7 +19,7 @@ const secondsPerDay = int64(86400)
 
 // LifecycleTTLResolver answers "what volume TTL should this write get?" for
 // the PutObject path. Constructed once per bucket-config load with a
-// pre-filtered, pre-sorted slice of rules so per-write cost is one
+// pre-filtered, pre-sorted slice of compact rules so per-write cost is one
 // HasPrefix per rule walked, exiting on first match.
 //
 // Stable predicates only: prefix and size. Tag-filtered rules are NOT in
@@ -29,47 +29,75 @@ const secondsPerDay = int64(86400)
 // re-evaluates current tags at scan time.
 //
 // nil receiver means "no TTL applies" (no eligible rules, bucket
-// versioned, or rules that overflow int32 seconds); callers can use a nil
-// resolver freely.
+// versioned, or every rule overflows int32 seconds); callers can use a
+// nil resolver freely.
 type LifecycleTTLResolver struct {
-	rules []*s3lifecycle.Rule
+	rules []ttlRule
+}
+
+// ttlRule is the compact, hot-path projection of an Expiration.Days rule:
+// just the four fields Resolve reads, with ExpirationDays already converted
+// to int32 seconds so the inner loop has no arithmetic and no overflow
+// branch.
+type ttlRule struct {
+	prefix string
+	ttlSec int32
+	sizeGT int64
+	sizeLT int64
 }
 
 // NewLifecycleTTLResolver pre-filters and pre-sorts rules. Returns nil
 // when nothing on the fast path can apply — callers don't need to special-
 // case the empty-bucket / versioned-bucket / tag-only-rules cases.
 //
-// Sort is ascending by ExpirationDays so first prefix match is also the
-// shortest matching expiration — AWS's overlapping-rule precedence (see
+// Sort is ascending by ttlSec so first prefix match is also the shortest
+// matching expiration — AWS's overlapping-rule precedence (see
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-conflicts.html).
 // Stable so equal-Days rules keep their XML order.
+//
+// Rules that overflow int32 seconds (~68 years) are dropped at construction
+// rather than handled per-resolve: capping would expire long policies
+// early, and returning 0 from Resolve in the inner loop would prevent any
+// shorter overlapping rule from being considered. Drop-at-construction
+// composes correctly with the ascending sort.
 func NewLifecycleTTLResolver(rules []*s3lifecycle.Rule, versioned bool) *LifecycleTTLResolver {
 	if versioned || len(rules) == 0 {
 		// Versioned buckets: TTL volumes expire as a unit, which would
 		// destroy noncurrent versions. Worker drives expiration there.
 		return nil
 	}
-	out := make([]*s3lifecycle.Rule, 0, len(rules))
+	out := make([]ttlRule, 0, len(rules))
 	for _, r := range rules {
 		if r == nil || r.Status != s3lifecycle.StatusEnabled {
 			continue
 		}
 		if r.ExpirationDays <= 0 {
-			// NoncurrentVersionExpiration / AbortMPU / etc. — worker only.
-			continue
+			continue // NoncurrentVersionExpiration / AbortMPU / etc.
 		}
 		if len(r.FilterTags) > 0 {
 			// Tag-mutable; defer to the worker so a tag flip can't leave
 			// us with a volume-TTL stamp the policy no longer dictates.
 			continue
 		}
-		out = append(out, r)
+		secs := int64(r.ExpirationDays) * secondsPerDay
+		if secs > math.MaxInt32 {
+			// Volume TTL is int32 seconds. A rule that doesn't fit
+			// can't be represented without expiring early; the
+			// lifecycle worker enforces it on its own schedule.
+			continue
+		}
+		out = append(out, ttlRule{
+			prefix: r.Prefix,
+			ttlSec: int32(secs),
+			sizeGT: r.FilterSizeGreaterThan,
+			sizeLT: r.FilterSizeLessThan,
+		})
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].ExpirationDays < out[j].ExpirationDays
+		return out[i].ttlSec < out[j].ttlSec
 	})
 	return &LifecycleTTLResolver{rules: out}
 }
@@ -83,21 +111,26 @@ func (r *LifecycleTTLResolver) Resolve(objectKey string, size int64) int32 {
 	if r == nil {
 		return 0
 	}
-	for _, rule := range r.rules {
-		if !strings.HasPrefix(objectKey, rule.Prefix) {
+	for i := range r.rules {
+		rule := &r.rules[i]
+		if !strings.HasPrefix(objectKey, rule.prefix) {
 			continue
 		}
-		if !ruleSizeMatches(rule, size) {
-			continue
+		// Size filter: unevaluable when Content-Length is unknown
+		// (size<0) and the rule has any size predicate; otherwise
+		// either bound short-circuits.
+		if rule.sizeGT > 0 || rule.sizeLT > 0 {
+			if size < 0 {
+				continue
+			}
+			if rule.sizeGT > 0 && size <= rule.sizeGT {
+				continue
+			}
+			if rule.sizeLT > 0 && size >= rule.sizeLT {
+				continue
+			}
 		}
-		secs := int64(rule.ExpirationDays) * secondsPerDay
-		if secs > math.MaxInt32 {
-			// Volume TTL field is int32 seconds (~68 years). A longer
-			// rule can't be represented without expiring early, so let
-			// the lifecycle worker enforce it on its own schedule.
-			return 0
-		}
-		return int32(secs)
+		return rule.ttlSec
 	}
 	return 0
 }
@@ -111,21 +144,4 @@ func (s3a *S3ApiServer) lifecycleTTLForObjectWrite(bucket, objectKey string, r *
 		return 0
 	}
 	return cfg.LifecycleTTL.Resolve(objectKey, r.ContentLength)
-}
-
-func ruleSizeMatches(rule *s3lifecycle.Rule, size int64) bool {
-	hasFilter := rule.FilterSizeGreaterThan > 0 || rule.FilterSizeLessThan > 0
-	if hasFilter && size < 0 {
-		// Content-Length wasn't sent; the size filter is unevaluable so
-		// be safe and skip the rule. The worker re-evaluates at scan
-		// time with the actual size.
-		return false
-	}
-	if rule.FilterSizeGreaterThan > 0 && size <= rule.FilterSizeGreaterThan {
-		return false
-	}
-	if rule.FilterSizeLessThan > 0 && size >= rule.FilterSizeLessThan {
-		return false
-	}
-	return true
 }

--- a/weed/s3api/s3api_object_lifecycle_ttl_test.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl_test.go
@@ -18,6 +18,13 @@ func enabledRule(prefix string, days int) *s3lifecycle.Rule {
 	}
 }
 
+func bucketCfgWithRules(rules ...*s3lifecycle.Rule) *BucketConfig {
+	return &BucketConfig{
+		LifecycleRules:   rules,
+		ttlFastPathRules: buildTTLFastPathRules(rules),
+	}
+}
+
 func TestResolveLifecycleTTL_NoConfig(t *testing.T) {
 	if got := resolveLifecycleTTLForWrite(nil, "logs/foo", nil, 1); got != 0 {
 		t.Fatalf("nil config should yield 0, got %d", got)
@@ -28,9 +35,7 @@ func TestResolveLifecycleTTL_NoConfig(t *testing.T) {
 }
 
 func TestResolveLifecycleTTL_PrefixMatch(t *testing.T) {
-	cfg := &BucketConfig{
-		LifecycleRules: []*s3lifecycle.Rule{enabledRule("logs/", 7)},
-	}
+	cfg := bucketCfgWithRules(enabledRule("logs/", 7))
 	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo.txt", nil, 1); got != 7*86400 {
 		t.Fatalf("want 7d in seconds, got %d", got)
 	}
@@ -40,12 +45,10 @@ func TestResolveLifecycleTTL_PrefixMatch(t *testing.T) {
 }
 
 func TestResolveLifecycleTTL_LongestPrefixWins(t *testing.T) {
-	cfg := &BucketConfig{
-		LifecycleRules: []*s3lifecycle.Rule{
-			enabledRule("logs/", 30),
-			enabledRule("logs/critical/", 7),
-		},
-	}
+	cfg := bucketCfgWithRules(
+		enabledRule("logs/", 30),
+		enabledRule("logs/critical/", 7),
+	)
 	// "logs/foo" → only the broader rule matches → 30d.
 	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 30*86400 {
 		t.Fatalf("broad-only match: got %d, want 30d", got)
@@ -56,34 +59,51 @@ func TestResolveLifecycleTTL_LongestPrefixWins(t *testing.T) {
 	}
 }
 
-func TestResolveLifecycleTTL_SkipDisabled(t *testing.T) {
-	rule := enabledRule("logs/", 7)
-	rule.Status = s3lifecycle.StatusDisabled
-	cfg := &BucketConfig{LifecycleRules: []*s3lifecycle.Rule{rule}}
+func TestResolveLifecycleTTL_PreFiltersDisabledAndNonExpirationDays(t *testing.T) {
+	// Disabled and non-Expiration.Days rules are dropped at parse time
+	// so the per-PUT walk doesn't even see them. A bucket whose lifecycle
+	// XML carries only those rules has an empty fast-path slice and
+	// resolves to 0 in O(1).
+	disabled := enabledRule("logs/", 7)
+	disabled.Status = s3lifecycle.StatusDisabled
+	noExpDays := &s3lifecycle.Rule{
+		ID: "r", Status: s3lifecycle.StatusEnabled, Prefix: "logs/",
+		NoncurrentVersionExpirationDays: 7,
+	}
+	cfg := bucketCfgWithRules(disabled, noExpDays)
+	if cfg.ttlFastPathRules != nil {
+		t.Fatalf("ineligible rules must drop out of fast-path, got %v", cfg.ttlFastPathRules)
+	}
 	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("disabled rule must not apply, got %d", got)
+		t.Fatalf("ineligible rules must not apply, got %d", got)
 	}
 }
 
-func TestResolveLifecycleTTL_SkipNonExpirationDays(t *testing.T) {
-	// Rules without Expiration.Days (e.g., NoncurrentVersionExpiration only)
-	// stay on the worker — the volume-TTL fast path can't model them.
-	cfg := &BucketConfig{
-		LifecycleRules: []*s3lifecycle.Rule{{
-			ID: "r", Status: s3lifecycle.StatusEnabled, Prefix: "logs/",
-			NoncurrentVersionExpirationDays: 7,
-		}},
+func TestResolveLifecycleTTL_FastPathIsSortedDesc(t *testing.T) {
+	// XML order: short, long, medium. Fast-path order: long, medium, short.
+	cfg := bucketCfgWithRules(
+		enabledRule("a/", 1),
+		enabledRule("a/b/c/", 3),
+		enabledRule("a/b/", 2),
+	)
+	gotPrefixes := []string{}
+	for _, r := range cfg.ttlFastPathRules {
+		gotPrefixes = append(gotPrefixes, r.Prefix)
 	}
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("noncurrent-only rule must not apply, got %d", got)
+	want := []string{"a/b/c/", "a/b/", "a/"}
+	if len(gotPrefixes) != len(want) {
+		t.Fatalf("got %v, want %v", gotPrefixes, want)
+	}
+	for i := range want {
+		if gotPrefixes[i] != want[i] {
+			t.Fatalf("position %d: got %q, want %q (full: %v)", i, gotPrefixes[i], want[i], gotPrefixes)
+		}
 	}
 }
 
 func TestResolveLifecycleTTL_VersionedSkipped(t *testing.T) {
-	cfg := &BucketConfig{
-		Versioning:     s3_constants.VersioningEnabled,
-		LifecycleRules: []*s3lifecycle.Rule{enabledRule("logs/", 7)},
-	}
+	cfg := bucketCfgWithRules(enabledRule("logs/", 7))
+	cfg.Versioning = s3_constants.VersioningEnabled
 	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
 		t.Fatalf("versioned bucket must not get TTL, got %d", got)
 	}
@@ -96,7 +116,7 @@ func TestResolveLifecycleTTL_VersionedSkipped(t *testing.T) {
 func TestResolveLifecycleTTL_TagFilter(t *testing.T) {
 	rule := enabledRule("logs/", 7)
 	rule.FilterTags = map[string]string{"k": "v"}
-	cfg := &BucketConfig{LifecycleRules: []*s3lifecycle.Rule{rule}}
+	cfg := bucketCfgWithRules(rule)
 
 	// Request without the tag → rule doesn't apply.
 	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
@@ -115,7 +135,7 @@ func TestResolveLifecycleTTL_TagFilter(t *testing.T) {
 func TestResolveLifecycleTTL_SizeFilter(t *testing.T) {
 	rule := enabledRule("logs/", 7)
 	rule.FilterSizeGreaterThan = 1024
-	cfg := &BucketConfig{LifecycleRules: []*s3lifecycle.Rule{rule}}
+	cfg := bucketCfgWithRules(rule)
 
 	// Below threshold → skip.
 	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 100); got != 0 {
@@ -133,9 +153,7 @@ func TestResolveLifecycleTTL_SizeFilter(t *testing.T) {
 
 func TestResolveLifecycleTTL_OverflowCappedAtMaxInt32(t *testing.T) {
 	// AWS allows Days up to 2^31-1, which overflows int32 seconds.
-	cfg := &BucketConfig{
-		LifecycleRules: []*s3lifecycle.Rule{enabledRule("", 1<<30)},
-	}
+	cfg := bucketCfgWithRules(enabledRule("", 1<<30))
 	got := resolveLifecycleTTLForWrite(cfg, "anything", nil, 1)
 	if got != (1<<31)-1 {
 		t.Fatalf("overflow should cap at int32 max, got %d", got)

--- a/weed/s3api/s3api_object_lifecycle_ttl_test.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl_test.go
@@ -1,0 +1,169 @@
+package s3api
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+)
+
+func enabledRule(prefix string, days int) *s3lifecycle.Rule {
+	return &s3lifecycle.Rule{
+		ID:             "r-" + prefix,
+		Status:         s3lifecycle.StatusEnabled,
+		Prefix:         prefix,
+		ExpirationDays: days,
+	}
+}
+
+func TestResolveLifecycleTTL_NoConfig(t *testing.T) {
+	if got := resolveLifecycleTTLForWrite(nil, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("nil config should yield 0, got %d", got)
+	}
+	if got := resolveLifecycleTTLForWrite(&BucketConfig{}, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("empty rules should yield 0, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_PrefixMatch(t *testing.T) {
+	cfg := &BucketConfig{
+		LifecycleRules: []*s3lifecycle.Rule{enabledRule("logs/", 7)},
+	}
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo.txt", nil, 1); got != 7*86400 {
+		t.Fatalf("want 7d in seconds, got %d", got)
+	}
+	if got := resolveLifecycleTTLForWrite(cfg, "data/foo.txt", nil, 1); got != 0 {
+		t.Fatalf("non-matching prefix should yield 0, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_LongestPrefixWins(t *testing.T) {
+	cfg := &BucketConfig{
+		LifecycleRules: []*s3lifecycle.Rule{
+			enabledRule("logs/", 30),
+			enabledRule("logs/critical/", 7),
+		},
+	}
+	// "logs/foo" → only the broader rule matches → 30d.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 30*86400 {
+		t.Fatalf("broad-only match: got %d, want 30d", got)
+	}
+	// "logs/critical/x" → both match → longer prefix wins → 7d.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/critical/x", nil, 1); got != 7*86400 {
+		t.Fatalf("longest-prefix should win: got %d, want 7d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_SkipDisabled(t *testing.T) {
+	rule := enabledRule("logs/", 7)
+	rule.Status = s3lifecycle.StatusDisabled
+	cfg := &BucketConfig{LifecycleRules: []*s3lifecycle.Rule{rule}}
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("disabled rule must not apply, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_SkipNonExpirationDays(t *testing.T) {
+	// Rules without Expiration.Days (e.g., NoncurrentVersionExpiration only)
+	// stay on the worker — the volume-TTL fast path can't model them.
+	cfg := &BucketConfig{
+		LifecycleRules: []*s3lifecycle.Rule{{
+			ID: "r", Status: s3lifecycle.StatusEnabled, Prefix: "logs/",
+			NoncurrentVersionExpirationDays: 7,
+		}},
+	}
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("noncurrent-only rule must not apply, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_VersionedSkipped(t *testing.T) {
+	cfg := &BucketConfig{
+		Versioning:     s3_constants.VersioningEnabled,
+		LifecycleRules: []*s3lifecycle.Rule{enabledRule("logs/", 7)},
+	}
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("versioned bucket must not get TTL, got %d", got)
+	}
+	cfg.Versioning = s3_constants.VersioningSuspended
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("suspended-versioning bucket must not get TTL, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_TagFilter(t *testing.T) {
+	rule := enabledRule("logs/", 7)
+	rule.FilterTags = map[string]string{"k": "v"}
+	cfg := &BucketConfig{LifecycleRules: []*s3lifecycle.Rule{rule}}
+
+	// Request without the tag → rule doesn't apply.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
+		t.Fatalf("missing tag must skip rule, got %d", got)
+	}
+	// Request with mismatched tag value.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", map[string]string{"k": "other"}, 1); got != 0 {
+		t.Fatalf("wrong tag value must skip rule, got %d", got)
+	}
+	// Matching tag → applies.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", map[string]string{"k": "v"}, 1); got != 7*86400 {
+		t.Fatalf("matching tag must apply, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_SizeFilter(t *testing.T) {
+	rule := enabledRule("logs/", 7)
+	rule.FilterSizeGreaterThan = 1024
+	cfg := &BucketConfig{LifecycleRules: []*s3lifecycle.Rule{rule}}
+
+	// Below threshold → skip.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 100); got != 0 {
+		t.Fatalf("size <= threshold must skip, got %d", got)
+	}
+	// Above threshold → apply.
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 2048); got != 7*86400 {
+		t.Fatalf("size > threshold must apply, got %d", got)
+	}
+	// Unknown size + size filter → skip (conservative).
+	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, -1); got != 0 {
+		t.Fatalf("unknown size with filter must skip, got %d", got)
+	}
+}
+
+func TestResolveLifecycleTTL_OverflowCappedAtMaxInt32(t *testing.T) {
+	// AWS allows Days up to 2^31-1, which overflows int32 seconds.
+	cfg := &BucketConfig{
+		LifecycleRules: []*s3lifecycle.Rule{enabledRule("", 1<<30)},
+	}
+	got := resolveLifecycleTTLForWrite(cfg, "anything", nil, 1)
+	if got != (1<<31)-1 {
+		t.Fatalf("overflow should cap at int32 max, got %d", got)
+	}
+}
+
+func TestParseRequestTags(t *testing.T) {
+	t.Run("empty header", func(t *testing.T) {
+		r := &http.Request{Header: http.Header{}}
+		if got := parseRequestTags(r); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+	t.Run("single tag", func(t *testing.T) {
+		r := &http.Request{Header: http.Header{}}
+		r.Header.Set(s3_constants.AmzObjectTagging, url.Values{"k": []string{"v"}}.Encode())
+		got := parseRequestTags(r)
+		if got["k"] != "v" || len(got) != 1 {
+			t.Errorf("got %v, want {k:v}", got)
+		}
+	})
+	t.Run("duplicate key returns nil", func(t *testing.T) {
+		// AWS rejects duplicate tag keys; the resolver must not match a
+		// tag-filtered rule with ambiguous tag input.
+		r := &http.Request{Header: http.Header{}}
+		r.Header.Set(s3_constants.AmzObjectTagging, "k=a&k=b")
+		if got := parseRequestTags(r); got != nil {
+			t.Errorf("duplicate key should return nil, got %v", got)
+		}
+	})
+}

--- a/weed/s3api/s3api_object_lifecycle_ttl_test.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
@@ -189,5 +190,48 @@ func BenchmarkLifecycleTTLResolver_Resolve_FiveRulesNoMatch(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = r.Resolve("z/foo.txt", 4096)
+	}
+}
+
+func TestPopulateBucketConfigDerivedFields_RefreshesLifecycleTTL(t *testing.T) {
+	// Regression: storeBucketLifecycleConfiguration only updates
+	// Entry.Extended; if the cache-refresh path doesn't re-derive
+	// LifecycleTTL, an Add → Update → Delete dance would leave a stale
+	// resolver applying the wrong volume TTL to subsequent writes. Walk
+	// the three transitions and assert the resolver follows.
+	s := &S3ApiServer{}
+
+	xmlAdd := []byte(`<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>r</ID><Status>Enabled</Status><Filter><Prefix>logs/</Prefix></Filter><Expiration><Days>7</Days></Expiration></Rule></LifecycleConfiguration>`)
+	xmlReplace := []byte(`<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>r</ID><Status>Enabled</Status><Filter><Prefix>logs/</Prefix></Filter><Expiration><Days>30</Days></Expiration></Rule></LifecycleConfiguration>`)
+
+	cfg := &BucketConfig{Name: "bk", Entry: &filer_pb.Entry{Extended: map[string][]byte{}}}
+
+	// 1) No XML yet → no resolver.
+	s.populateBucketConfigDerivedFields(cfg)
+	if cfg.LifecycleTTL != nil {
+		t.Fatalf("no XML must yield nil resolver, got %v", cfg.LifecycleTTL)
+	}
+
+	// 2) Add: 7d.
+	cfg.Entry.Extended[bucketLifecycleConfigurationXMLKey] = xmlAdd
+	s.populateBucketConfigDerivedFields(cfg)
+	if got := cfg.LifecycleTTL.Resolve("logs/foo", 1); got != 7*86400 {
+		t.Fatalf("after add, want 7d, got %d", got)
+	}
+
+	// 3) Replace: 30d. The previous resolver must NOT linger.
+	cfg.Entry.Extended[bucketLifecycleConfigurationXMLKey] = xmlReplace
+	s.populateBucketConfigDerivedFields(cfg)
+	if got := cfg.LifecycleTTL.Resolve("logs/foo", 1); got != 30*86400 {
+		t.Fatalf("after replace, want 30d, got %d (stale resolver?)", got)
+	}
+
+	// 4) Delete: nil resolver. The most dangerous regression — leaving
+	//    the old resolver here would keep stamping irreversible volume
+	//    TTL onto writes after the policy was removed.
+	delete(cfg.Entry.Extended, bucketLifecycleConfigurationXMLKey)
+	s.populateBucketConfigDerivedFields(cfg)
+	if cfg.LifecycleTTL != nil {
+		t.Fatalf("after delete, want nil resolver, got %v", cfg.LifecycleTTL)
 	}
 }

--- a/weed/s3api/s3api_object_lifecycle_ttl_test.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl_test.go
@@ -1,11 +1,9 @@
 package s3api
 
 import (
-	"net/http"
-	"net/url"
+	"math"
 	"testing"
 
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
@@ -18,170 +16,143 @@ func enabledRule(prefix string, days int) *s3lifecycle.Rule {
 	}
 }
 
-func bucketCfgWithRules(rules ...*s3lifecycle.Rule) *BucketConfig {
-	return &BucketConfig{
-		LifecycleRules:   rules,
-		ttlFastPathRules: buildTTLFastPathRules(rules),
+func mustResolver(t *testing.T, rules ...*s3lifecycle.Rule) *LifecycleTTLResolver {
+	t.Helper()
+	return NewLifecycleTTLResolver(rules, false)
+}
+
+func TestNewLifecycleTTLResolver_NilOnEmpty(t *testing.T) {
+	if got := NewLifecycleTTLResolver(nil, false); got != nil {
+		t.Fatalf("nil rules → resolver=%v, want nil", got)
+	}
+	if got := NewLifecycleTTLResolver([]*s3lifecycle.Rule{}, false); got != nil {
+		t.Fatalf("empty rules → resolver=%v, want nil", got)
 	}
 }
 
-func TestResolveLifecycleTTL_NoConfig(t *testing.T) {
-	if got := resolveLifecycleTTLForWrite(nil, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("nil config should yield 0, got %d", got)
-	}
-	if got := resolveLifecycleTTLForWrite(&BucketConfig{}, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("empty rules should yield 0, got %d", got)
+func TestNewLifecycleTTLResolver_NilOnVersionedBucket(t *testing.T) {
+	// Versioned buckets cannot use volume TTL — TTL volumes destroy
+	// noncurrent versions as a unit. Resolver collapses to nil so the
+	// PUT path's nil-receiver Resolve returns 0 without checking flags.
+	rules := []*s3lifecycle.Rule{enabledRule("logs/", 7)}
+	if got := NewLifecycleTTLResolver(rules, true); got != nil {
+		t.Fatalf("versioned bucket → resolver=%v, want nil", got)
 	}
 }
 
-func TestResolveLifecycleTTL_PrefixMatch(t *testing.T) {
-	cfg := bucketCfgWithRules(enabledRule("logs/", 7))
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo.txt", nil, 1); got != 7*86400 {
+func TestNewLifecycleTTLResolver_DropsTagFilteredRules(t *testing.T) {
+	// HIGH-priority finding: tag-filtered rules are unsafe on the fast
+	// path. Tags can be replaced via PutObjectTagging after the write,
+	// but the volume TTL is irreversible. Worker handles tag-filtered
+	// rules at scan time; the fast path drops them entirely.
+	tagRule := enabledRule("logs/", 7)
+	tagRule.FilterTags = map[string]string{"k": "v"}
+	plainRule := enabledRule("data/", 30)
+
+	r := mustResolver(t, tagRule, plainRule)
+	if r == nil {
+		t.Fatalf("plain rule should still produce a resolver")
+	}
+	// Tag-filtered key would have matched but is now invisible.
+	if got := r.Resolve("logs/foo", 1); got != 0 {
+		t.Fatalf("tag-filtered rule must not appear on fast path, got %d", got)
+	}
+	if got := r.Resolve("data/foo", 1); got != 30*86400 {
+		t.Fatalf("plain rule still applies, got %d", got)
+	}
+}
+
+func TestNewLifecycleTTLResolver_DropsDisabledAndNonExpirationDays(t *testing.T) {
+	disabled := enabledRule("logs/", 7)
+	disabled.Status = s3lifecycle.StatusDisabled
+	noExp := &s3lifecycle.Rule{
+		ID: "r", Status: s3lifecycle.StatusEnabled, Prefix: "logs/",
+		NoncurrentVersionExpirationDays: 7,
+	}
+	if got := NewLifecycleTTLResolver([]*s3lifecycle.Rule{disabled, noExp}, false); got != nil {
+		t.Fatalf("only-ineligible rules → resolver=%v, want nil", got)
+	}
+}
+
+func TestResolve_PrefixMatch(t *testing.T) {
+	r := mustResolver(t, enabledRule("logs/", 7))
+	if got := r.Resolve("logs/foo.txt", 1); got != 7*86400 {
 		t.Fatalf("want 7d in seconds, got %d", got)
 	}
-	if got := resolveLifecycleTTLForWrite(cfg, "data/foo.txt", nil, 1); got != 0 {
+	if got := r.Resolve("data/foo.txt", 1); got != 0 {
 		t.Fatalf("non-matching prefix should yield 0, got %d", got)
 	}
 }
 
-func TestResolveLifecycleTTL_LongestPrefixWins(t *testing.T) {
-	cfg := bucketCfgWithRules(
-		enabledRule("logs/", 30),
-		enabledRule("logs/critical/", 7),
+func TestResolve_OverlappingRulesShorterExpirationWins(t *testing.T) {
+	// MEDIUM-priority finding: AWS overlapping-rule precedence is
+	// "shorter expiration wins". Sort ascending by ExpirationDays so
+	// the first prefix match is also the shortest applicable rule.
+	r := mustResolver(t,
+		enabledRule("logs/", 30),          // broad, long
+		enabledRule("logs/critical/", 90), // specific, longer
+		enabledRule("logs/", 7),           // broad, short
 	)
-	// "logs/foo" → only the broader rule matches → 30d.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 30*86400 {
-		t.Fatalf("broad-only match: got %d, want 30d", got)
+	// "logs/foo" matches both broad rules; the shorter (7d) wins.
+	if got := r.Resolve("logs/foo", 1); got != 7*86400 {
+		t.Fatalf("shorter expiration must win, got %d (want 7d)", got)
 	}
-	// "logs/critical/x" → both match → longer prefix wins → 7d.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/critical/x", nil, 1); got != 7*86400 {
-		t.Fatalf("longest-prefix should win: got %d, want 7d", got)
-	}
-}
-
-func TestResolveLifecycleTTL_PreFiltersDisabledAndNonExpirationDays(t *testing.T) {
-	// Disabled and non-Expiration.Days rules are dropped at parse time
-	// so the per-PUT walk doesn't even see them. A bucket whose lifecycle
-	// XML carries only those rules has an empty fast-path slice and
-	// resolves to 0 in O(1).
-	disabled := enabledRule("logs/", 7)
-	disabled.Status = s3lifecycle.StatusDisabled
-	noExpDays := &s3lifecycle.Rule{
-		ID: "r", Status: s3lifecycle.StatusEnabled, Prefix: "logs/",
-		NoncurrentVersionExpirationDays: 7,
-	}
-	cfg := bucketCfgWithRules(disabled, noExpDays)
-	if cfg.ttlFastPathRules != nil {
-		t.Fatalf("ineligible rules must drop out of fast-path, got %v", cfg.ttlFastPathRules)
-	}
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("ineligible rules must not apply, got %d", got)
+	// "logs/critical/x" matches all three; 7d still wins (shorter than
+	// the more specific 90d). Longest-prefix is NOT the AWS rule.
+	if got := r.Resolve("logs/critical/x", 1); got != 7*86400 {
+		t.Fatalf("shorter expiration must win across overlaps, got %d (want 7d)", got)
 	}
 }
 
-func TestResolveLifecycleTTL_FastPathIsSortedDesc(t *testing.T) {
-	// XML order: short, long, medium. Fast-path order: long, medium, short.
-	cfg := bucketCfgWithRules(
-		enabledRule("a/", 1),
-		enabledRule("a/b/c/", 3),
-		enabledRule("a/b/", 2),
+func TestResolve_OverflowDefersToWorker(t *testing.T) {
+	// MEDIUM-priority finding: capping at math.MaxInt32 seconds (~68y)
+	// would expire LONGER policies early. Return 0 instead so the
+	// worker enforces the actual policy on its own schedule.
+	bigDays := int(math.MaxInt32/secondsPerDay) + 1
+	r := mustResolver(t, enabledRule("anything", bigDays))
+	if got := r.Resolve("anything-x", 1); got != 0 {
+		t.Fatalf("overflow must yield 0 (worker handles), got %d", got)
+	}
+}
+
+func TestResolve_OverflowSkipsButShorterStillFires(t *testing.T) {
+	// Pathological case: short and overflowing rule on overlapping
+	// prefix. Ascending sort puts the short one first; the overflow
+	// rule never gets a chance to mis-cap.
+	bigDays := int(math.MaxInt32/secondsPerDay) + 1
+	r := mustResolver(t,
+		enabledRule("anything", bigDays),
+		enabledRule("anything", 7),
 	)
-	gotPrefixes := []string{}
-	for _, r := range cfg.ttlFastPathRules {
-		gotPrefixes = append(gotPrefixes, r.Prefix)
-	}
-	want := []string{"a/b/c/", "a/b/", "a/"}
-	if len(gotPrefixes) != len(want) {
-		t.Fatalf("got %v, want %v", gotPrefixes, want)
-	}
-	for i := range want {
-		if gotPrefixes[i] != want[i] {
-			t.Fatalf("position %d: got %q, want %q (full: %v)", i, gotPrefixes[i], want[i], gotPrefixes)
-		}
+	if got := r.Resolve("anything-x", 1); got != 7*86400 {
+		t.Fatalf("shorter rule must still fire on overlap, got %d", got)
 	}
 }
 
-func TestResolveLifecycleTTL_VersionedSkipped(t *testing.T) {
-	cfg := bucketCfgWithRules(enabledRule("logs/", 7))
-	cfg.Versioning = s3_constants.VersioningEnabled
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("versioned bucket must not get TTL, got %d", got)
-	}
-	cfg.Versioning = s3_constants.VersioningSuspended
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("suspended-versioning bucket must not get TTL, got %d", got)
-	}
-}
-
-func TestResolveLifecycleTTL_TagFilter(t *testing.T) {
-	rule := enabledRule("logs/", 7)
-	rule.FilterTags = map[string]string{"k": "v"}
-	cfg := bucketCfgWithRules(rule)
-
-	// Request without the tag → rule doesn't apply.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 1); got != 0 {
-		t.Fatalf("missing tag must skip rule, got %d", got)
-	}
-	// Request with mismatched tag value.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", map[string]string{"k": "other"}, 1); got != 0 {
-		t.Fatalf("wrong tag value must skip rule, got %d", got)
-	}
-	// Matching tag → applies.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", map[string]string{"k": "v"}, 1); got != 7*86400 {
-		t.Fatalf("matching tag must apply, got %d", got)
-	}
-}
-
-func TestResolveLifecycleTTL_SizeFilter(t *testing.T) {
+func TestResolve_SizeFilter(t *testing.T) {
 	rule := enabledRule("logs/", 7)
 	rule.FilterSizeGreaterThan = 1024
-	cfg := bucketCfgWithRules(rule)
+	r := mustResolver(t, rule)
 
 	// Below threshold → skip.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 100); got != 0 {
+	if got := r.Resolve("logs/foo", 100); got != 0 {
 		t.Fatalf("size <= threshold must skip, got %d", got)
 	}
 	// Above threshold → apply.
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, 2048); got != 7*86400 {
+	if got := r.Resolve("logs/foo", 2048); got != 7*86400 {
 		t.Fatalf("size > threshold must apply, got %d", got)
 	}
 	// Unknown size + size filter → skip (conservative).
-	if got := resolveLifecycleTTLForWrite(cfg, "logs/foo", nil, -1); got != 0 {
+	if got := r.Resolve("logs/foo", -1); got != 0 {
 		t.Fatalf("unknown size with filter must skip, got %d", got)
 	}
 }
 
-func TestResolveLifecycleTTL_OverflowCappedAtMaxInt32(t *testing.T) {
-	// AWS allows Days up to 2^31-1, which overflows int32 seconds.
-	cfg := bucketCfgWithRules(enabledRule("", 1<<30))
-	got := resolveLifecycleTTLForWrite(cfg, "anything", nil, 1)
-	if got != (1<<31)-1 {
-		t.Fatalf("overflow should cap at int32 max, got %d", got)
+func TestResolve_NilReceiverReturnsZero(t *testing.T) {
+	// nil-receiver-safe Resolve avoids the call site needing to check
+	// whether the bucket has a resolver at all.
+	var r *LifecycleTTLResolver
+	if got := r.Resolve("logs/foo", 1); got != 0 {
+		t.Fatalf("nil resolver must return 0, got %d", got)
 	}
-}
-
-func TestParseRequestTags(t *testing.T) {
-	t.Run("empty header", func(t *testing.T) {
-		r := &http.Request{Header: http.Header{}}
-		if got := parseRequestTags(r); got != nil {
-			t.Errorf("got %v, want nil", got)
-		}
-	})
-	t.Run("single tag", func(t *testing.T) {
-		r := &http.Request{Header: http.Header{}}
-		r.Header.Set(s3_constants.AmzObjectTagging, url.Values{"k": []string{"v"}}.Encode())
-		got := parseRequestTags(r)
-		if got["k"] != "v" || len(got) != 1 {
-			t.Errorf("got %v, want {k:v}", got)
-		}
-	})
-	t.Run("duplicate key returns nil", func(t *testing.T) {
-		// AWS rejects duplicate tag keys; the resolver must not match a
-		// tag-filtered rule with ambiguous tag input.
-		r := &http.Request{Header: http.Header{}}
-		r.Header.Set(s3_constants.AmzObjectTagging, "k=a&k=b")
-		if got := parseRequestTags(r); got != nil {
-			t.Errorf("duplicate key should return nil, got %v", got)
-		}
-	})
 }

--- a/weed/s3api/s3api_object_lifecycle_ttl_test.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl_test.go
@@ -156,3 +156,38 @@ func TestResolve_NilReceiverReturnsZero(t *testing.T) {
 		t.Fatalf("nil resolver must return 0, got %d", got)
 	}
 }
+
+func BenchmarkLifecycleTTLResolver_Resolve_NilReceiver(b *testing.B) {
+	// Common case: bucket has no lifecycle config → resolver is nil.
+	var r *LifecycleTTLResolver
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = r.Resolve("logs/foo.txt", 4096)
+	}
+}
+
+func BenchmarkLifecycleTTLResolver_Resolve_OneRule(b *testing.B) {
+	// Typical case: one Expiration.Days rule that the key matches.
+	r := NewLifecycleTTLResolver([]*s3lifecycle.Rule{
+		enabledRule("logs/", 7),
+	}, false)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = r.Resolve("logs/foo.txt", 4096)
+	}
+}
+
+func BenchmarkLifecycleTTLResolver_Resolve_FiveRulesNoMatch(b *testing.B) {
+	// Worst typical case: walks all rules and none match.
+	r := NewLifecycleTTLResolver([]*s3lifecycle.Rule{
+		enabledRule("a/", 1),
+		enabledRule("b/", 7),
+		enabledRule("c/", 30),
+		enabledRule("d/", 90),
+		enabledRule("e/", 365),
+	}, false)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = r.Resolve("z/foo.txt", 4096)
+	}
+}

--- a/weed/s3api/s3api_object_lifecycle_ttl_test.go
+++ b/weed/s3api/s3api_object_lifecycle_ttl_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 )
 
@@ -233,5 +234,29 @@ func TestPopulateBucketConfigDerivedFields_RefreshesLifecycleTTL(t *testing.T) {
 	s.populateBucketConfigDerivedFields(cfg)
 	if cfg.LifecycleTTL != nil {
 		t.Fatalf("after delete, want nil resolver, got %v", cfg.LifecycleTTL)
+	}
+}
+
+func TestPopulateBucketConfigDerivedFields_ObjectLockTreatedAsVersioned(t *testing.T) {
+	// Object Lock requires versioning, so a bucket with ObjectLock but
+	// no explicit Versioning header is still effectively versioned —
+	// volume TTL would expire all noncurrent versions as a unit. The
+	// resolver-construction site must mirror BucketIsVersioned and
+	// treat ObjectLockConfig != nil as versioned.
+	s := &S3ApiServer{}
+	xml := []byte(`<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>r</ID><Status>Enabled</Status><Filter><Prefix>logs/</Prefix></Filter><Expiration><Days>7</Days></Expiration></Rule></LifecycleConfiguration>`)
+	cfg := &BucketConfig{
+		Name: "bk",
+		Entry: &filer_pb.Entry{Extended: map[string][]byte{
+			s3_constants.ExtObjectLockEnabledKey:    []byte(s3_constants.ObjectLockEnabled),
+			bucketLifecycleConfigurationXMLKey:      xml,
+		}},
+	}
+	s.populateBucketConfigDerivedFields(cfg)
+	if cfg.ObjectLockConfig == nil {
+		t.Fatal("test setup: ObjectLockConfig should be parsed")
+	}
+	if cfg.LifecycleTTL != nil {
+		t.Fatalf("ObjectLock buckets must skip the fast-path resolver, got %v", cfg.LifecycleTTL)
 	}
 }


### PR DESCRIPTION
## Summary

Lifecycle volume-TTL routing is now a per-write decision the S3 server makes from the cached bucket lifecycle XML, instead of a separate filer.conf projection kept in sync at PUT time / via an operator command. Replaces the approach taken in the (now closed) PR #9376.

### Why

The S3 server already has everything needed at PUT time:
- the bucket's lifecycle XML (cached via \`getBucketConfig\`),
- the object key (for prefix match),
- the request's tag headers (for tag-filter match),
- \`Content-Length\` (for size-filter match),
- the bucket's versioning state.

\`AssignVolumeRequest\` already accepts \`ttl_sec\` directly. Passing the resolved TTL plus stamping \`entry.Attributes.TtlSec\` is enough — no filer.conf bookkeeping, no merge layer, no operator commands. PUT bucket lifecycle XML, new writes inherit TTL on the next request automatically. DELETE the lifecycle XML, new writes stop getting TTL automatically. The worker remains authoritative for everything the fast path can't model.

## What changed

- \`BucketConfig.LifecycleRules\` — pre-parsed canonical rules; populated in \`getBucketConfig\` on the same path that already extracts versioning, ACL, ObjectLock, etc. The bucket-config cache invalidates on \`PutBucketLifecycleConfiguration\` / \`DeleteBucketLifecycle\`, so rules stay current.
- \`resolveLifecycleTTLForWrite(cfg, key, requestTags, size) → int32\` — longest-prefix-match wins among Expiration.Days rules with tag/size filters that match the request. Returns 0 (no TTL) for: nil/empty config, versioned/suspended buckets, non-matching filters, unknown size with a size filter, or no matching prefix. \`Days * 86400\` capped at \`MaxInt32\` for AWS's 2³¹-day extreme.
- \`putToFiler\` resolves TTL once at the top, passes it through \`AssignVolumeRequest.TtlSec\` (chunks land on TTL volumes) and \`entry.Attributes.TtlSec\` (filer-side metadata expiration).

## Tests

\`resolveLifecycleTTLForWrite\`: nil/empty config, prefix match, longest-prefix wins, disabled rule skipped, non-Expiration.Days (NoncurrentVersionExpiration only) skipped, versioned/suspended skipped, tag-filter matrix, size-filter matrix incl. unknown-size conservative skip, int32 overflow cap.

\`parseRequestTags\`: empty header, single tag, duplicate-key returns nil (so a malformed header can't accidentally satisfy a tag-filtered rule).

## Out of scope (follow-ups)

- \`UploadPart\` / \`CompleteMultipartUpload\` — the destination key is on the upload directory's Extended map; resolving TTL for each part write needs a small extra lookup. Worth its own PR.
- \`CopyObject\` — same shape; should call \`resolveLifecycleTTLForWrite\` against the destination bucket and key.

The lifecycle worker handles existing-object back-stamp via bootstrap, versioned-bucket retention, noncurrent / delete-marker / abort-MPU, and any rule whose tag/size filter didn't match at write time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PUT and POST uploads now derive and store lifecycle TTLs so objects can expire automatically.
* **Improvements**
  * Bucket lifecycle XML is parsed and a cached fast-path resolver speeds TTL decisions, honoring prefixes and size predicates with overflow protection.
  * Bucket config derived fields are refreshed consistently when lifecycle rules change.
* **Bug Fixes**
  * Multipart parts and copy-part flows explicitly avoid inheriting object TTLs.
* **Tests**
  * Added tests and benchmarks covering resolver behavior, prefixes, sizes, versioning, overflow, and config refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->