### PR TITLE
feat(s3/lifecycle): sole-survivor delete-marker routing (Phase 5b/2)

### DIFF
--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -120,6 +120,19 @@ func (s3a *S3ApiServer) lifecycleDispatch(ctx context.Context, req *s3_lifecycle
 				return noopResolved("VERSION_IS_LATEST"), nil
 			}
 		}
+		// Sole-survivor guard for EXPIRED_DELETE_MARKER: the router's
+		// schedule-time count is advisory — between schedule and dispatch
+		// a fresh PUT can land another version under .versions/<key>/, or
+		// the marker can be replaced by a new marker. Re-check here so
+		// the rule only fires when the marker is still the only entry.
+		// Identity-CAS upstream covers the marker entry's bytes; this
+		// covers the directory-shape invariant separately.
+		if req.ActionKind == s3_lifecycle_pb.ActionKind_EXPIRED_DELETE_MARKER {
+			outcome, err := s3a.checkSoleSurvivorMarker(req.Bucket, req.ObjectPath, req.VersionId)
+			if outcome != nil || err != nil {
+				return outcome, err
+			}
+		}
 		if err := s3a.deleteSpecificObjectVersion(req.Bucket, req.ObjectPath, req.VersionId); err != nil {
 			if errors.Is(err, filer_pb.ErrNotFound) || errors.Is(err, ErrVersionNotFound) || errors.Is(err, ErrObjectNotFound) {
 				return noopResolved("NOT_FOUND_AT_DELETE"), nil
@@ -173,6 +186,48 @@ func (s3a *S3ApiServer) lifecycleAbortMPU(ctx context.Context, req *s3_lifecycle
 		return retryLater("TRANSPORT_ERROR: rm: " + err.Error()), nil
 	}
 	return done(), nil
+}
+
+// checkSoleSurvivorMarker re-validates the EXPIRED_DELETE_MARKER invariant
+// at dispatch time: the marker must still be the only entry under
+// .versions/<object>/, and the directory's latest pointer (when set)
+// must still name versionId. Returns a non-nil response when the
+// dispatch should not delete (NOOP_RESOLVED for resolved drift, retry
+// for transient errors). Returns (nil, nil) when the delete should
+// proceed.
+func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string) (*s3_lifecycle_pb.LifecycleDeleteResponse, error) {
+	versionsDir := s3a.bucketDir(bucket) + "/" + object + s3_constants.VersionsFolder
+	count := 0
+	var firstName string
+	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+		return filer_pb.SeaweedList(context.Background(), client, versionsDir, "", func(entry *filer_pb.Entry, _ bool) error {
+			count++
+			if count == 1 && entry != nil {
+				firstName = entry.Name
+			}
+			return nil
+		}, "", false, 2)
+	})
+	if err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return noopResolved("NOT_FOUND"), nil
+		}
+		return retryLater("TRANSPORT_ERROR: sole-survivor list: " + err.Error()), nil
+	}
+	if count == 0 {
+		return noopResolved("NOT_FOUND"), nil
+	}
+	if count > 1 {
+		return noopResolved("NOT_SOLE_SURVIVOR"), nil
+	}
+	// One entry — confirm it's the same marker we scheduled, by file
+	// name. SeaweedFS stores each version as v_<versionId>; a mismatch
+	// means the marker was replaced (e.g. another DELETE landed) and
+	// the rule no longer applies to this dispatch.
+	if versionId != "" && firstName != "" && firstName != s3a.getVersionFileName(versionId) {
+		return noopResolved("MARKER_REPLACED"), nil
+	}
+	return nil, nil
 }
 
 // isCurrentLatestVersion reports whether versionId is the version the

--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -246,13 +246,19 @@ func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string
 		return noopResolved("MARKER_NOT_LATEST"), nil
 	}
 	// Null-version check: pre-versioning objects survive as the bare
-	// <bucket>/<key> entry. Deleting the marker while one exists would
-	// re-expose the older object.
-	bareExists, err := s3a.exists(bucketDir+"/"+path.Dir(object), path.Base(object), false)
+	// <bucket>/<key>. Both regular files and explicit S3 directory-key
+	// markers (object names ending in /) qualify; the listing path
+	// (s3api_object_versioning.go processExplicitDirectory) treats both
+	// as the null version. getEntry uses NewFullPath so a trailing slash
+	// in object splits the same as a regular key.
+	bareEntry, err := s3a.getEntry(bucketDir, object)
 	if err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return nil, nil
+		}
 		return retryLater("TRANSPORT_ERROR: null-version lookup: " + err.Error()), nil
 	}
-	if bareExists {
+	if bareEntry != nil && (!bareEntry.IsDirectory || bareEntry.IsDirectoryKeyObject()) {
 		return noopResolved("NULL_VERSION_PRESENT"), nil
 	}
 	return nil, nil

--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -120,13 +120,9 @@ func (s3a *S3ApiServer) lifecycleDispatch(ctx context.Context, req *s3_lifecycle
 				return noopResolved("VERSION_IS_LATEST"), nil
 			}
 		}
-		// Sole-survivor guard for EXPIRED_DELETE_MARKER: the router's
-		// schedule-time count is advisory — between schedule and dispatch
-		// a fresh PUT can land another version under .versions/<key>/, or
-		// the marker can be replaced by a new marker. Re-check here so
-		// the rule only fires when the marker is still the only entry.
-		// Identity-CAS upstream covers the marker entry's bytes; this
-		// covers the directory-shape invariant separately.
+		// Re-check sole-survivor: a fresh PUT can land between schedule
+		// and dispatch. Identity-CAS upstream covers the marker bytes;
+		// this covers the directory shape.
 		if req.ActionKind == s3_lifecycle_pb.ActionKind_EXPIRED_DELETE_MARKER {
 			outcome, err := s3a.checkSoleSurvivorMarker(req.Bucket, req.ObjectPath, req.VersionId)
 			if outcome != nil || err != nil {
@@ -188,13 +184,9 @@ func (s3a *S3ApiServer) lifecycleAbortMPU(ctx context.Context, req *s3_lifecycle
 	return done(), nil
 }
 
-// checkSoleSurvivorMarker re-validates the EXPIRED_DELETE_MARKER invariant
-// at dispatch time: the marker must still be the only entry under
-// .versions/<object>/, and the directory's latest pointer (when set)
-// must still name versionId. Returns a non-nil response when the
-// dispatch should not delete (NOOP_RESOLVED for resolved drift, retry
-// for transient errors). Returns (nil, nil) when the delete should
-// proceed.
+// checkSoleSurvivorMarker returns nil to proceed with the delete, or a
+// terminal response when state has drifted (count != 1, or the surviving
+// entry is a different version than the one scheduled).
 func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string) (*s3_lifecycle_pb.LifecycleDeleteResponse, error) {
 	versionsDir := s3a.bucketDir(bucket) + "/" + object + s3_constants.VersionsFolder
 	count := 0
@@ -220,10 +212,6 @@ func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string
 	if count > 1 {
 		return noopResolved("NOT_SOLE_SURVIVOR"), nil
 	}
-	// One entry — confirm it's the same marker we scheduled, by file
-	// name. SeaweedFS stores each version as v_<versionId>; a mismatch
-	// means the marker was replaced (e.g. another DELETE landed) and
-	// the rule no longer applies to this dispatch.
 	if versionId != "" && firstName != "" && firstName != s3a.getVersionFileName(versionId) {
 		return noopResolved("MARKER_REPLACED"), nil
 	}

--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -124,7 +124,7 @@ func (s3a *S3ApiServer) lifecycleDispatch(ctx context.Context, req *s3_lifecycle
 		// and dispatch. Identity-CAS upstream covers the marker bytes;
 		// this covers the directory shape.
 		if req.ActionKind == s3_lifecycle_pb.ActionKind_EXPIRED_DELETE_MARKER {
-			outcome, err := s3a.checkSoleSurvivorMarker(req.Bucket, req.ObjectPath, req.VersionId)
+			outcome, err := s3a.checkSoleSurvivorMarker(ctx, req.Bucket, req.ObjectPath, req.VersionId)
 			if outcome != nil || err != nil {
 				return outcome, err
 			}
@@ -190,13 +190,13 @@ func (s3a *S3ApiServer) lifecycleAbortMPU(ctx context.Context, req *s3_lifecycle
 // pointer doesn't name versionId, or a bare null-version exists outside
 // .versions/. Pointer missing while a marker is present is treated as
 // retry-later — the create races with the directory metadata update.
-func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string) (*s3_lifecycle_pb.LifecycleDeleteResponse, error) {
+func (s3a *S3ApiServer) checkSoleSurvivorMarker(ctx context.Context, bucket, object, versionId string) (*s3_lifecycle_pb.LifecycleDeleteResponse, error) {
 	bucketDir := s3a.bucketDir(bucket)
 	versionsDir := bucketDir + "/" + object + s3_constants.VersionsFolder
 	count := 0
 	var firstName string
 	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
-		return filer_pb.SeaweedList(context.Background(), client, versionsDir, "", func(entry *filer_pb.Entry, _ bool) error {
+		return filer_pb.SeaweedList(ctx, client, versionsDir, "", func(entry *filer_pb.Entry, _ bool) error {
 			count++
 			if count == 1 && entry != nil {
 				firstName = entry.Name
@@ -216,7 +216,13 @@ func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string
 	if count > 1 {
 		return noopResolved("NOT_SOLE_SURVIVOR"), nil
 	}
-	if versionId != "" && firstName != "" && firstName != s3a.getVersionFileName(versionId) {
+	// SeaweedList delivered a single callback but with a nil entry; we
+	// can't compare names so retry rather than silently bypass the
+	// marker-replaced check.
+	if firstName == "" {
+		return retryLater("PENDING_SURVIVOR_ENTRY"), nil
+	}
+	if versionId != "" && firstName != s3a.getVersionFileName(versionId) {
 		return noopResolved("MARKER_REPLACED"), nil
 	}
 	// Latest-pointer check: createDeleteMarker writes the marker file

--- a/weed/s3api/s3api_internal_lifecycle.go
+++ b/weed/s3api/s3api_internal_lifecycle.go
@@ -185,10 +185,14 @@ func (s3a *S3ApiServer) lifecycleAbortMPU(ctx context.Context, req *s3_lifecycle
 }
 
 // checkSoleSurvivorMarker returns nil to proceed with the delete, or a
-// terminal response when state has drifted (count != 1, or the surviving
-// entry is a different version than the one scheduled).
+// terminal response when state has drifted: count != 1, the surviving
+// entry is a different version, the .versions/ directory's latest
+// pointer doesn't name versionId, or a bare null-version exists outside
+// .versions/. Pointer missing while a marker is present is treated as
+// retry-later — the create races with the directory metadata update.
 func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string) (*s3_lifecycle_pb.LifecycleDeleteResponse, error) {
-	versionsDir := s3a.bucketDir(bucket) + "/" + object + s3_constants.VersionsFolder
+	bucketDir := s3a.bucketDir(bucket)
+	versionsDir := bucketDir + "/" + object + s3_constants.VersionsFolder
 	count := 0
 	var firstName string
 	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
@@ -214,6 +218,42 @@ func (s3a *S3ApiServer) checkSoleSurvivorMarker(bucket, object, versionId string
 	}
 	if versionId != "" && firstName != "" && firstName != s3a.getVersionFileName(versionId) {
 		return noopResolved("MARKER_REPLACED"), nil
+	}
+	// Latest-pointer check: createDeleteMarker writes the marker file
+	// and then updates the parent directory's Extended map. Reading
+	// before the second step lands would see count==1 but no pointer;
+	// retry-later rather than mistakenly delete.
+	parent, name := path.Split(versionsDir)
+	parent = strings.TrimRight(parent, "/")
+	if parent == "" {
+		parent = "/"
+	}
+	versionsEntry, err := s3a.getEntry(parent, name)
+	if err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return noopResolved("NOT_FOUND"), nil
+		}
+		return retryLater("TRANSPORT_ERROR: latest-pointer lookup: " + err.Error()), nil
+	}
+	if versionsEntry == nil {
+		return noopResolved("NOT_FOUND"), nil
+	}
+	latest, hasPointer := versionsEntry.Extended[s3_constants.ExtLatestVersionIdKey]
+	if !hasPointer || len(latest) == 0 {
+		return retryLater("PENDING_LATEST_POINTER"), nil
+	}
+	if string(latest) != versionId {
+		return noopResolved("MARKER_NOT_LATEST"), nil
+	}
+	// Null-version check: pre-versioning objects survive as the bare
+	// <bucket>/<key> entry. Deleting the marker while one exists would
+	// re-expose the older object.
+	bareExists, err := s3a.exists(bucketDir+"/"+path.Dir(object), path.Base(object), false)
+	if err != nil {
+		return retryLater("TRANSPORT_ERROR: null-version lookup: " + err.Error()), nil
+	}
+	if bareExists {
+		return noopResolved("NULL_VERSION_PRESENT"), nil
 	}
 	return nil, nil
 }

--- a/weed/s3api/s3lifecycle/dispatcher/pipeline.go
+++ b/weed/s3api/s3lifecycle/dispatcher/pipeline.go
@@ -205,6 +205,8 @@ func (p *Pipeline) Run(ctx context.Context) error {
 		cancel() // wake the dispatcher goroutine to drain & exit
 	}()
 
+	lister := &filerSiblingLister{client: p.FilerClient, bucketsPath: p.BucketsPath}
+
 	// Router/dispatcher goroutine: pulls events, routes them to per-shard
 	// schedules, ticks every shard's dispatcher on the same cadence, and
 	// checkpoints every shard's cursor on the checkpoint cadence. One
@@ -257,7 +259,7 @@ func (p *Pipeline) Run(ctx context.Context) error {
 				// against the prior (empty) snapshot would silently drop
 				// every match. Engine.Snapshot is an atomic Load.
 				snap := p.Engine.Snapshot()
-				for _, m := range router.Route(snap, ev, time.Now()) {
+				for _, m := range router.Route(runCtx, snap, ev, time.Now(), lister) {
 					st.dispatch.Schedule.Add(m)
 				}
 			case <-dt.C:

--- a/weed/s3api/s3lifecycle/dispatcher/pipeline_test.go
+++ b/weed/s3api/s3lifecycle/dispatcher/pipeline_test.go
@@ -48,7 +48,7 @@ func TestPipelineIntegrationInMemory(t *testing.T) {
 		},
 	}
 
-	matches := router.Route(snap, ev, now)
+	matches := router.Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %v", matches)
 	}

--- a/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
+++ b/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
@@ -8,16 +8,13 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 )
 
-// filerSiblingLister counts entries in <bucketsPath>/<bucket>/<key>.versions/
-// via the filer's existing list RPC; reused for every sole-survivor check.
+// filerSiblingLister counts entries under .versions/<key>/ via the
+// filer's list RPC. Caps at 2 — callers only distinguish 1 vs >=2.
 type filerSiblingLister struct {
 	client      filer_pb.SeaweedFilerClient
 	bucketsPath string
 }
 
-// Count caps at 2 — the caller only distinguishes "sole survivor" (1)
-// from "more than one" (>=2), so listing further siblings is wasted I/O
-// on hot keys with many versions.
 func (l *filerSiblingLister) Count(ctx context.Context, bucket, objectKey string) (int, error) {
 	dir := strings.TrimSuffix(l.bucketsPath, "/") + "/" + bucket + "/" + objectKey + s3_constants.VersionsFolder
 	count := 0

--- a/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
+++ b/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
@@ -2,28 +2,57 @@ package dispatcher
 
 import (
 	"context"
+	"errors"
+	"path"
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/router"
 )
 
-// filerSiblingLister counts entries under .versions/<key>/ via the
-// filer's list RPC. Caps at 2 — callers only distinguish 1 vs >=2.
+// filerSiblingLister inspects the .versions/<key>/ folder and the bare
+// null-version. Listing caps at 2 — callers only distinguish 1 vs >=2.
 type filerSiblingLister struct {
 	client      filer_pb.SeaweedFilerClient
 	bucketsPath string
 }
 
-func (l *filerSiblingLister) Count(ctx context.Context, bucket, objectKey string) (int, error) {
-	dir := strings.TrimSuffix(l.bucketsPath, "/") + "/" + bucket + "/" + objectKey + s3_constants.VersionsFolder
-	count := 0
-	err := filer_pb.SeaweedList(ctx, l.client, dir, "", func(_ *filer_pb.Entry, _ bool) error {
-		count++
+func (l *filerSiblingLister) Survivors(ctx context.Context, bucket, objectKey string) (router.Survivors, error) {
+	bucketPath := strings.TrimSuffix(l.bucketsPath, "/") + "/" + bucket
+	versionsDir := bucketPath + "/" + objectKey + s3_constants.VersionsFolder
+
+	var s router.Survivors
+	err := filer_pb.SeaweedList(ctx, l.client, versionsDir, "", func(entry *filer_pb.Entry, _ bool) error {
+		s.Count++
+		if s.Count == 1 && entry != nil {
+			s.LoneEntry = entry
+		} else if s.Count > 1 {
+			s.LoneEntry = nil
+		}
 		return nil
 	}, "", false, 2)
-	if err != nil {
-		return 0, err
+	if err != nil && !errors.Is(err, filer_pb.ErrNotFound) {
+		return router.Survivors{}, err
 	}
-	return count, nil
+
+	parent, name := path.Split(bucketPath + "/" + objectKey)
+	parent = strings.TrimRight(parent, "/")
+	if parent == "" {
+		parent = "/"
+	}
+	resp, err := l.client.LookupDirectoryEntry(ctx, &filer_pb.LookupDirectoryEntryRequest{
+		Directory: parent,
+		Name:      name,
+	})
+	if err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return s, nil
+		}
+		return router.Survivors{}, err
+	}
+	if resp.Entry != nil && !resp.Entry.IsDirectory {
+		s.HasNullVersion = true
+	}
+	return s, nil
 }

--- a/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
+++ b/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
@@ -1,0 +1,32 @@
+package dispatcher
+
+import (
+	"context"
+	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+)
+
+// filerSiblingLister counts entries in <bucketsPath>/<bucket>/<key>.versions/
+// via the filer's existing list RPC; reused for every sole-survivor check.
+type filerSiblingLister struct {
+	client      filer_pb.SeaweedFilerClient
+	bucketsPath string
+}
+
+// Count caps at 2 — the caller only distinguishes "sole survivor" (1)
+// from "more than one" (>=2), so listing further siblings is wasted I/O
+// on hot keys with many versions.
+func (l *filerSiblingLister) Count(ctx context.Context, bucket, objectKey string) (int, error) {
+	dir := strings.TrimSuffix(l.bucketsPath, "/") + "/" + bucket + "/" + objectKey + s3_constants.VersionsFolder
+	count := 0
+	err := filer_pb.SeaweedList(ctx, l.client, dir, "", func(_ *filer_pb.Entry, _ bool) error {
+		count++
+		return nil
+	}, "", false, 2)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
+++ b/weed/s3api/s3lifecycle/dispatcher/sibling_lister.go
@@ -3,12 +3,12 @@ package dispatcher
 import (
 	"context"
 	"errors"
-	"path"
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/router"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
 // filerSiblingLister inspects the .versions/<key>/ folder and the bare
@@ -36,12 +36,13 @@ func (l *filerSiblingLister) Survivors(ctx context.Context, bucket, objectKey st
 		return router.Survivors{}, err
 	}
 
-	parent, name := path.Split(bucketPath + "/" + objectKey)
-	parent = strings.TrimRight(parent, "/")
-	if parent == "" {
-		parent = "/"
-	}
-	resp, err := l.client.LookupDirectoryEntry(ctx, &filer_pb.LookupDirectoryEntryRequest{
+	// NewFullPath strips a trailing slash from objectKey so directory-key
+	// objects (foo/) split the same as regular keys. LookupEntry
+	// normalizes the gRPC string-mapped not-found into ErrNotFound; a
+	// raw client.LookupDirectoryEntry would return that as a generic
+	// error and suppress every otherwise-valid match.
+	parent, name := util.NewFullPath(bucketPath, objectKey).DirAndName()
+	resp, err := filer_pb.LookupEntry(ctx, l.client, &filer_pb.LookupDirectoryEntryRequest{
 		Directory: parent,
 		Name:      name,
 	})
@@ -51,7 +52,9 @@ func (l *filerSiblingLister) Survivors(ctx context.Context, bucket, objectKey st
 		}
 		return router.Survivors{}, err
 	}
-	if resp.Entry != nil && !resp.Entry.IsDirectory {
+	// Bare regular file or an explicit S3 directory-marker (an empty
+	// directory entry with Mime set) both count as the null version.
+	if resp.Entry != nil && (!resp.Entry.IsDirectory || resp.Entry.IsDirectoryKeyObject()) {
 		s.HasNullVersion = true
 	}
 	return s, nil

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -13,10 +13,20 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/reader"
 )
 
-// SiblingLister counts entries under .versions/<key>/. nil receiver or
-// an error means "unknown" — callers suppress rather than risk a wrong fire.
+// SiblingLister inspects the surviving versions of a versioned key.
+// nil receiver or an error means "unknown" — callers suppress.
 type SiblingLister interface {
-	Count(ctx context.Context, bucket, objectKey string) (int, error)
+	Survivors(ctx context.Context, bucket, objectKey string) (Survivors, error)
+}
+
+// Survivors describes the state under .versions/<key>/ plus the bare
+// null-version that exists when versioning was turned on after the
+// object was first PUT (s3api_object_versioning.go treats <bucket>/<key>
+// as a regular file, the null version, in that case).
+type Survivors struct {
+	Count          int             // entries under .versions/<key>/, capped at 2
+	LoneEntry      *filer_pb.Entry // populated when Count == 1
+	HasNullVersion bool            // bare <bucket>/<key> exists as a regular file
 }
 
 // Match is one (event, action) pair where EvaluateAction fired. The
@@ -52,13 +62,9 @@ type EntryIdentity struct {
 
 // Route returns the matches that fire for ev against snap. Only active
 // event-driven actions are considered; SCAN_AT_DATE and DISABLED bypass
-// this path. Hard deletes (NewEntry==nil) skip — Expiration would hit
-// NOOP_RESOLVED anyway and EXP_DM fires on the marker create.
+// this path.
 func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now time.Time, lister SiblingLister) []Match {
 	if snap == nil || ev == nil {
-		return nil
-	}
-	if ev.NewEntry == nil {
 		return nil
 	}
 	keys := snap.BucketActionKeys(ev.Bucket)
@@ -67,20 +73,19 @@ func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now tim
 	}
 	versioned := snap.BucketVersioned(ev.Bucket)
 
-	// EXP_DM is the only rule routable from a version-folder file event:
-	// when the marker is the sole entry under .versions/<key>/ it is
-	// necessarily the latest, no pointer lookup needed. buildObjectInfo
-	// can't see sibling state and skips these events outright.
+	// EXP_DM can fire on two version-folder events: the marker create
+	// (sole survivor immediately) and a noncurrent hard-delete that
+	// leaves only the marker behind. Both reach routeSoleSurvivorMarker.
 	if versioned && isVersionFolderPath(ev.Key) {
-		if !isDeleteMarkerEntry(ev.NewEntry) {
-			return nil
-		}
 		if !hasActiveEventDrivenAction(snap, keys, s3lifecycle.ActionKindExpiredDeleteMarker) {
 			return nil
 		}
 		return routeSoleSurvivorMarker(ctx, snap, ev, keys, lister)
 	}
 
+	if ev.NewEntry == nil {
+		return nil
+	}
 	info := buildObjectInfo(ev, versioned)
 	if info == nil {
 		return nil
@@ -134,30 +139,39 @@ func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now tim
 
 // routeSoleSurvivorMarker emits an EXP_DM Match against the LOGICAL key
 // (so the dispatcher can call deleteSpecificObjectVersion) with the
-// marker's version_id. Schedule-time count is advisory — the server
-// re-checks before deleting in case another version lands first.
+// marker's version_id. Handles two events: a marker create (the new
+// entry IS the marker) and a noncurrent hard-delete that leaves the
+// marker behind (the listing's lone entry IS the marker). The server
+// re-checks before deleting.
 func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, keys []s3lifecycle.ActionKey, lister SiblingLister) []Match {
+	if lister == nil {
+		return nil
+	}
 	logicalKey, ok := logicalKeyFromVersionPath(ev.Key)
 	if !ok {
 		return nil
 	}
-	// Empty version_id would BLOCK at dispatch and freeze the cursor.
-	versionID := string(ev.NewEntry.Extended[s3_constants.ExtVersionIdKey])
-	if versionID == "" {
-		return nil
-	}
-	if lister == nil {
-		return nil
-	}
-	n, err := lister.Count(ctx, ev.Bucket, logicalKey)
+	s, err := lister.Survivors(ctx, ev.Bucket, logicalKey)
 	if err != nil {
-		glog.V(2).Infof("lifecycle router: sibling count %s/%s: %v", ev.Bucket, logicalKey, err)
+		glog.V(2).Infof("lifecycle router: survivors %s/%s: %v", ev.Bucket, logicalKey, err)
 		return nil
 	}
-	if n != 1 {
+	// Pre-versioning bare-key objects (the "null" version) live outside
+	// .versions/. Treating count==1 as sole-survivor while a null
+	// version exists would let lifecycle delete the marker and re-expose
+	// the old object.
+	if s.Count != 1 || s.HasNullVersion || s.LoneEntry == nil {
 		return nil
 	}
-	entry := ev.NewEntry
+	if !isDeleteMarkerEntry(s.LoneEntry) {
+		return nil
+	}
+	versionID := string(s.LoneEntry.Extended[s3_constants.ExtVersionIdKey])
+	if versionID == "" {
+		// Empty version_id would BLOCK at dispatch and freeze the cursor.
+		return nil
+	}
+	entry := s.LoneEntry
 	info := &s3lifecycle.ObjectInfo{
 		Key:            logicalKey,
 		ModTime:        time.Unix(entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)),
@@ -170,6 +184,7 @@ func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *rea
 		info.Tags = tags
 	}
 	eventTime := time.Unix(0, ev.TsNs)
+	identity := buildIdentityFromEntry(entry)
 	var matches []Match
 	for _, key := range keys {
 		if key.ActionKind != s3lifecycle.ActionKindExpiredDeleteMarker {
@@ -193,7 +208,7 @@ func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *rea
 			Bucket:    ev.Bucket,
 			ObjectKey: logicalKey,
 			VersionID: versionID,
-			Identity:  buildIdentity(ev),
+			Identity:  identity,
 		})
 	}
 	return matches
@@ -299,7 +314,10 @@ func mpuInitInfo(ev *reader.Event, entry *filer_pb.Entry) (destKey string, ok bo
 // buildIdentity captures the entry's schedule-time fingerprint for the CAS
 // witness. Returns nil if the event has no entry to fingerprint (deletes).
 func buildIdentity(ev *reader.Event) *EntryIdentity {
-	entry := ev.NewEntry
+	return buildIdentityFromEntry(ev.NewEntry)
+}
+
+func buildIdentityFromEntry(entry *filer_pb.Entry) *EntryIdentity {
 	if entry == nil {
 		return nil
 	}

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -147,6 +147,12 @@ func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *rea
 	if lister == nil {
 		return nil
 	}
+	// Skip the listing RPC for events that can't possibly produce a
+	// sole-survivor marker: a regular non-marker version create/update
+	// always lands at Count >= 2.
+	if ev.NewEntry != nil && !isDeleteMarkerEntry(ev.NewEntry) {
+		return nil
+	}
 	logicalKey, ok := logicalKeyFromVersionPath(ev.Key)
 	if !ok {
 		return nil
@@ -214,6 +220,9 @@ func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *rea
 	return matches
 }
 
+// logicalKeyFromVersionPath extracts <logical> from <logical>.versions/<file>.
+// Returns false for a bucket-root marker (path = ".versions/<file>"), since
+// AWS S3 has no concept of an object at the bucket key itself.
 func logicalKeyFromVersionPath(versionPath string) (string, bool) {
 	lastSlash := strings.LastIndex(versionPath, "/")
 	if lastSlash <= 0 {

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -90,7 +90,7 @@ func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now tim
 		if !isDeleteMarkerEntry(ev.NewEntry) {
 			return nil
 		}
-		if !hasActionKind(keys, s3lifecycle.ActionKindExpiredDeleteMarker) {
+		if !hasActiveEventDrivenAction(snap, keys, s3lifecycle.ActionKindExpiredDeleteMarker) {
 			return nil
 		}
 		return routeSoleSurvivorMarker(ctx, snap, ev, keys, lister)
@@ -394,9 +394,22 @@ func extractTags(ext map[string][]byte) map[string]string {
 	return out
 }
 
-func hasActionKind(keys []s3lifecycle.ActionKey, kind s3lifecycle.ActionKind) bool {
+// hasActiveEventDrivenAction reports whether any key with the given kind
+// has an action that's active and event-driven — the same conditions
+// Route applies before emitting a match. Use this for I/O gates (e.g.
+// sibling listing) so the cost is paid only when a match could actually
+// fire; matching on key presence alone would still issue RPCs for keys
+// whose action is disabled or scan-only.
+func hasActiveEventDrivenAction(snap *engine.Snapshot, keys []s3lifecycle.ActionKey, kind s3lifecycle.ActionKind) bool {
 	for _, k := range keys {
-		if k.ActionKind == kind {
+		if k.ActionKind != kind {
+			continue
+		}
+		a := snap.Action(k)
+		if a == nil {
+			continue
+		}
+		if a.IsActive() && a.Mode == engine.ModeEventDriven {
 			return true
 		}
 	}

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -1,15 +1,26 @@
 package router
 
 import (
+	"context"
 	"strings"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/reader"
 )
+
+// SiblingLister counts the surviving versions of a versioned-bucket key.
+// Implementations must return the count of entries currently inside the
+// .versions/<key>/ folder. A nil lister or an error from Count means
+// "unknown" — callers must NOT mark the marker as sole survivor in that
+// case (suppress ExpiredObjectDeleteMarker rather than risk a wrong fire).
+type SiblingLister interface {
+	Count(ctx context.Context, bucket, objectKey string) (int, error)
+}
 
 // Match is one (event, action) pair where EvaluateAction fired. The
 // dispatcher runs `LifecycleDelete` at DueTime; identity-CAS in the RPC
@@ -46,7 +57,12 @@ type EntryIdentity struct {
 // actions on this bucket are considered; actions in SCAN_AT_DATE or DISABLED
 // modes are out-of-band of the event stream. Inactive actions
 // (BootstrapComplete=false) are also skipped.
-func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
+//
+// lister is consulted only for delete-marker version-folder events on a
+// versioned bucket when the bucket has an active ExpiredObjectDeleteMarker
+// rule; pass nil to suppress sole-survivor detection (no EXP_DM match
+// emitted rather than risk a wrong fire).
+func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now time.Time, lister SiblingLister) []Match {
 	if snap == nil || ev == nil {
 		return nil
 	}
@@ -61,7 +77,26 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 	if len(keys) == 0 {
 		return nil
 	}
-	info := buildObjectInfo(ev, snap.BucketVersioned(ev.Bucket))
+	versioned := snap.BucketVersioned(ev.Bucket)
+
+	// Production stores delete markers under <object>.versions/<version-file>;
+	// buildObjectInfo skips every version-folder event because it can't tell
+	// current from noncurrent without sibling state. EXP_DM is the one case
+	// we can route from the file path alone: if the marker is the only entry
+	// under .versions/<key>/ then it's necessarily the latest. Gate behind
+	// (versioned, version-folder path, marker entry, EXP_DM rule active,
+	// lister supplied) so non-marker version writes pay nothing.
+	if versioned && isVersionFolderPath(ev.Key) {
+		if !isDeleteMarkerEntry(ev.NewEntry) {
+			return nil
+		}
+		if !hasActionKind(keys, s3lifecycle.ActionKindExpiredDeleteMarker) {
+			return nil
+		}
+		return routeSoleSurvivorMarker(ctx, snap, ev, keys, lister)
+	}
+
+	info := buildObjectInfo(ev, versioned)
 	if info == nil {
 		return nil
 	}
@@ -112,19 +147,110 @@ func Route(snap *engine.Snapshot, ev *reader.Event, now time.Time) []Match {
 	return matches
 }
 
+// routeSoleSurvivorMarker handles the version-folder delete-marker case.
+// The Match's ObjectKey is the LOGICAL key (parent dir minus the .versions
+// suffix) and VersionID is the marker's stored version id; the dispatcher
+// uses both to reach deleteSpecificObjectVersion. The schedule-time count
+// is advisory — server-side re-checks the sole-survivor invariant before
+// actually deleting (another version may have landed between schedule and
+// dispatch).
+func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, keys []s3lifecycle.ActionKey, lister SiblingLister) []Match {
+	logicalKey, ok := logicalKeyFromVersionPath(ev.Key)
+	if !ok {
+		return nil
+	}
+	versionID := string(ev.NewEntry.Extended[s3_constants.ExtVersionIdKey])
+	if versionID == "" {
+		// Without a version_id the dispatcher can't target the marker;
+		// blocked dispatch would freeze the cursor.
+		return nil
+	}
+	if lister == nil {
+		return nil
+	}
+	n, err := lister.Count(ctx, ev.Bucket, logicalKey)
+	if err != nil {
+		glog.V(2).Infof("lifecycle router: sibling count %s/%s: %v", ev.Bucket, logicalKey, err)
+		return nil
+	}
+	if n != 1 {
+		return nil
+	}
+	entry := ev.NewEntry
+	info := &s3lifecycle.ObjectInfo{
+		Key:            logicalKey,
+		ModTime:        time.Unix(entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)),
+		Size:           int64(entry.Attributes.FileSize),
+		IsLatest:       true,
+		IsDeleteMarker: true,
+		NumVersions:    1,
+	}
+	if tags := extractTags(entry.Extended); len(tags) > 0 {
+		info.Tags = tags
+	}
+	eventTime := time.Unix(0, ev.TsNs)
+	var matches []Match
+	for _, key := range keys {
+		if key.ActionKind != s3lifecycle.ActionKindExpiredDeleteMarker {
+			continue
+		}
+		action := snap.Action(key)
+		if action == nil || !action.IsActive() || action.Mode != engine.ModeEventDriven {
+			continue
+		}
+		dueTime := info.ModTime.Add(action.Delay)
+		res := s3lifecycle.EvaluateAction(action.Rule, key.ActionKind, info, dueTime)
+		if res.Action == s3lifecycle.ActionNone {
+			continue
+		}
+		matches = append(matches, Match{
+			Key:       key,
+			Action:    action,
+			Result:    res,
+			EventTs:   eventTime,
+			DueTime:   dueTime,
+			Bucket:    ev.Bucket,
+			ObjectKey: logicalKey,
+			VersionID: versionID,
+			Identity:  buildIdentity(ev),
+		})
+	}
+	return matches
+}
+
+// logicalKeyFromVersionPath strips the trailing /<version-file> and the
+// .versions suffix from the parent. Returns false if the path doesn't
+// have the expected shape.
+func logicalKeyFromVersionPath(versionPath string) (string, bool) {
+	lastSlash := strings.LastIndex(versionPath, "/")
+	if lastSlash <= 0 {
+		return "", false
+	}
+	parent := versionPath[:lastSlash]
+	if !strings.HasSuffix(parent, s3_constants.VersionsFolder) {
+		return "", false
+	}
+	logical := strings.TrimSuffix(parent, s3_constants.VersionsFolder)
+	if logical == "" {
+		return "", false
+	}
+	return logical, true
+}
+
 // buildObjectInfo derives an ObjectInfo from a meta-log event and the
 // bucket's versioning state. Returns nil when the event has no usable
-// shape (missing attributes, hard delete already handled upstream).
+// shape (missing attributes, hard delete already handled upstream, or
+// version-folder file event — those are routed by routeSoleSurvivorMarker
+// upstream of this call when applicable).
 //
 // On a versioned bucket the storage layout (<key>.versions/v_<id>) is
 // shared between the current latest and the noncurrent versions; the
 // latest pointer lives in the .versions/ directory's Extended map and
 // is updated separately. Without that pointer-transition signal here,
-// the router conservatively classifies every event as if it were the
-// current version (IsLatest=true) so it never deletes the live
-// latest; bootstrap walking + the server-side dispatch guard handle
-// noncurrent retention. NumVersions=0 keeps ExpiredObjectDeleteMarker
-// (which requires sole-survivor) suppressed.
+// the router conservatively classifies every bare-key event as if it
+// were the current version (IsLatest=true) and leaves NumVersions=0 so
+// ExpiredObjectDeleteMarker stays suppressed by default — the worker's
+// bootstrap walk handles noncurrent retention.
 //
 // MPU init directories at .uploads/<upload_id> populate IsMPUInit and
 // use the destination object key from the entry's Extended map for
@@ -172,9 +298,11 @@ func buildObjectInfo(ev *reader.Event, versioned bool) *s3lifecycle.ObjectInfo {
 		if isVersionFolderPath(ev.Key) {
 			return nil
 		}
-		// NumVersions=0 keeps ExpiredObjectDeleteMarker (sole-survivor
-		// gate) suppressed for the bare-key delete-marker case until
-		// sibling listing lands.
+		// NumVersions=0 keeps ExpiredObjectDeleteMarker suppressed for
+		// the bare-key path; production never emits delete markers as
+		// bare keys (see routeSoleSurvivorMarker for the real path),
+		// but a defensive zero here means a misclassified event can't
+		// fire the rule.
 		info.NumVersions = 0
 	}
 	if tags := extractTags(entry.Extended); len(tags) > 0 {
@@ -266,10 +394,23 @@ func extractTags(ext map[string][]byte) map[string]string {
 	return out
 }
 
+func hasActionKind(keys []s3lifecycle.ActionKey, kind s3lifecycle.ActionKind) bool {
+	for _, k := range keys {
+		if k.ActionKind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// isDeleteMarkerEntry mirrors the production predicate: every site that
+// writes a delete marker stores []byte("true") (see
+// s3api_object_versioning.go createDeleteMarker), and every read site
+// compares string(v) == "true".
 func isDeleteMarkerEntry(entry *filer_pb.Entry) bool {
 	if entry == nil || len(entry.Extended) == 0 {
 		return false
 	}
 	v, ok := entry.Extended[s3_constants.ExtDeleteMarkerKey]
-	return ok && len(v) == 1 && v[0] == 1
+	return ok && string(v) == "true"
 }

--- a/weed/s3api/s3lifecycle/router/router.go
+++ b/weed/s3api/s3lifecycle/router/router.go
@@ -13,11 +13,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/reader"
 )
 
-// SiblingLister counts the surviving versions of a versioned-bucket key.
-// Implementations must return the count of entries currently inside the
-// .versions/<key>/ folder. A nil lister or an error from Count means
-// "unknown" — callers must NOT mark the marker as sole survivor in that
-// case (suppress ExpiredObjectDeleteMarker rather than risk a wrong fire).
+// SiblingLister counts entries under .versions/<key>/. nil receiver or
+// an error means "unknown" — callers suppress rather than risk a wrong fire.
 type SiblingLister interface {
 	Count(ctx context.Context, bucket, objectKey string) (int, error)
 }
@@ -53,23 +50,14 @@ type EntryIdentity struct {
 	ExtendedHash []byte
 }
 
-// Route returns the matches that fire for ev against snap. Only EVENT_DRIVEN
-// actions on this bucket are considered; actions in SCAN_AT_DATE or DISABLED
-// modes are out-of-band of the event stream. Inactive actions
-// (BootstrapComplete=false) are also skipped.
-//
-// lister is consulted only for delete-marker version-folder events on a
-// versioned bucket when the bucket has an active ExpiredObjectDeleteMarker
-// rule; pass nil to suppress sole-survivor detection (no EXP_DM match
-// emitted rather than risk a wrong fire).
+// Route returns the matches that fire for ev against snap. Only active
+// event-driven actions are considered; SCAN_AT_DATE and DISABLED bypass
+// this path. Hard deletes (NewEntry==nil) skip — Expiration would hit
+// NOOP_RESOLVED anyway and EXP_DM fires on the marker create.
 func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now time.Time, lister SiblingLister) []Match {
 	if snap == nil || ev == nil {
 		return nil
 	}
-	// Hard deletes carry no schedule-relevant state: an Expiration would
-	// hit NOOP_RESOLVED at dispatch time anyway, ExpiredObjectDeleteMarker
-	// only fires on the latest-version delete-marker which is a Create
-	// from the server's perspective. Skip rather than burn a schedule slot.
 	if ev.NewEntry == nil {
 		return nil
 	}
@@ -79,13 +67,10 @@ func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now tim
 	}
 	versioned := snap.BucketVersioned(ev.Bucket)
 
-	// Production stores delete markers under <object>.versions/<version-file>;
-	// buildObjectInfo skips every version-folder event because it can't tell
-	// current from noncurrent without sibling state. EXP_DM is the one case
-	// we can route from the file path alone: if the marker is the only entry
-	// under .versions/<key>/ then it's necessarily the latest. Gate behind
-	// (versioned, version-folder path, marker entry, EXP_DM rule active,
-	// lister supplied) so non-marker version writes pay nothing.
+	// EXP_DM is the only rule routable from a version-folder file event:
+	// when the marker is the sole entry under .versions/<key>/ it is
+	// necessarily the latest, no pointer lookup needed. buildObjectInfo
+	// can't see sibling state and skips these events outright.
 	if versioned && isVersionFolderPath(ev.Key) {
 		if !isDeleteMarkerEntry(ev.NewEntry) {
 			return nil
@@ -147,22 +132,18 @@ func Route(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, now tim
 	return matches
 }
 
-// routeSoleSurvivorMarker handles the version-folder delete-marker case.
-// The Match's ObjectKey is the LOGICAL key (parent dir minus the .versions
-// suffix) and VersionID is the marker's stored version id; the dispatcher
-// uses both to reach deleteSpecificObjectVersion. The schedule-time count
-// is advisory — server-side re-checks the sole-survivor invariant before
-// actually deleting (another version may have landed between schedule and
-// dispatch).
+// routeSoleSurvivorMarker emits an EXP_DM Match against the LOGICAL key
+// (so the dispatcher can call deleteSpecificObjectVersion) with the
+// marker's version_id. Schedule-time count is advisory — the server
+// re-checks before deleting in case another version lands first.
 func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *reader.Event, keys []s3lifecycle.ActionKey, lister SiblingLister) []Match {
 	logicalKey, ok := logicalKeyFromVersionPath(ev.Key)
 	if !ok {
 		return nil
 	}
+	// Empty version_id would BLOCK at dispatch and freeze the cursor.
 	versionID := string(ev.NewEntry.Extended[s3_constants.ExtVersionIdKey])
 	if versionID == "" {
-		// Without a version_id the dispatcher can't target the marker;
-		// blocked dispatch would freeze the cursor.
 		return nil
 	}
 	if lister == nil {
@@ -218,9 +199,6 @@ func routeSoleSurvivorMarker(ctx context.Context, snap *engine.Snapshot, ev *rea
 	return matches
 }
 
-// logicalKeyFromVersionPath strips the trailing /<version-file> and the
-// .versions suffix from the parent. Returns false if the path doesn't
-// have the expected shape.
 func logicalKeyFromVersionPath(versionPath string) (string, bool) {
 	lastSlash := strings.LastIndex(versionPath, "/")
 	if lastSlash <= 0 {
@@ -237,43 +215,25 @@ func logicalKeyFromVersionPath(versionPath string) (string, bool) {
 	return logical, true
 }
 
-// buildObjectInfo derives an ObjectInfo from a meta-log event and the
-// bucket's versioning state. Returns nil when the event has no usable
-// shape (missing attributes, hard delete already handled upstream, or
-// version-folder file event — those are routed by routeSoleSurvivorMarker
-// upstream of this call when applicable).
-//
-// On a versioned bucket the storage layout (<key>.versions/v_<id>) is
-// shared between the current latest and the noncurrent versions; the
-// latest pointer lives in the .versions/ directory's Extended map and
-// is updated separately. Without that pointer-transition signal here,
-// the router conservatively classifies every bare-key event as if it
-// were the current version (IsLatest=true) and leaves NumVersions=0 so
-// ExpiredObjectDeleteMarker stays suppressed by default — the worker's
-// bootstrap walk handles noncurrent retention.
-//
-// MPU init directories at .uploads/<upload_id> populate IsMPUInit and
-// use the destination object key from the entry's Extended map for
-// filter matching, so a rule with Filter.Prefix=foo/ matches an MPU
-// uploading to foo/bar.txt.
+// buildObjectInfo derives an ObjectInfo from a meta-log event. Returns
+// nil for shapes the router can't classify safely: missing attributes,
+// non-MPU directories, version-folder files (those route through
+// routeSoleSurvivorMarker upstream when EXP_DM applies). On a versioned
+// bucket the latest pointer lives in the .versions/ directory's
+// Extended map; without it we leave NumVersions=0 so the bootstrap walk
+// drives noncurrent retention.
 func buildObjectInfo(ev *reader.Event, versioned bool) *s3lifecycle.ObjectInfo {
 	entry := ev.NewEntry
 	if entry == nil || entry.Attributes == nil {
 		return nil
 	}
 	if destKey, ok := mpuInitInfo(ev, entry); ok {
-		// MPU intermediate state has no tags, no versions, no delete-marker
-		// semantics. info.Key is the user's destination key so a rule's
-		// Filter.Prefix matches the eventual object; the dispatcher already
-		// carries .uploads/<upload_id> in m.ObjectKey for ABORT_MPU.
 		return &s3lifecycle.ObjectInfo{
 			Key:       destKey,
 			ModTime:   time.Unix(entry.Attributes.Mtime, int64(entry.Attributes.MtimeNs)),
 			IsMPUInit: true,
 		}
 	}
-	// Directory entries that aren't MPU inits aren't lifecycle subjects:
-	// the .versions/ folder itself, prefix dirs, etc. — emit nothing.
 	if entry.IsDirectory {
 		return nil
 	}
@@ -285,24 +245,9 @@ func buildObjectInfo(ev *reader.Event, versioned bool) *s3lifecycle.ObjectInfo {
 		NumVersions: 1,
 	}
 	if versioned {
-		// On a versioned bucket the actual file path doesn't tell us
-		// whether the entry is the current latest or a noncurrent
-		// version — the latest pointer lives in the .versions/
-		// directory's Extended map and isn't part of this event. We
-		// also can't compute NumVersions / NoncurrentIndex here. Skip
-		// any version-folder file event for now; bootstrap walking
-		// drives noncurrent retention and current-version expiration
-		// for versioned buckets until pointer-transition routing
-		// lands. The bare-key path (null-version, pre-versioning
-		// objects) keeps the regular routing.
 		if isVersionFolderPath(ev.Key) {
 			return nil
 		}
-		// NumVersions=0 keeps ExpiredObjectDeleteMarker suppressed for
-		// the bare-key path; production never emits delete markers as
-		// bare keys (see routeSoleSurvivorMarker for the real path),
-		// but a defensive zero here means a misclassified event can't
-		// fire the rule.
 		info.NumVersions = 0
 	}
 	if tags := extractTags(entry.Extended); len(tags) > 0 {
@@ -394,12 +339,9 @@ func extractTags(ext map[string][]byte) map[string]string {
 	return out
 }
 
-// hasActiveEventDrivenAction reports whether any key with the given kind
-// has an action that's active and event-driven — the same conditions
-// Route applies before emitting a match. Use this for I/O gates (e.g.
-// sibling listing) so the cost is paid only when a match could actually
-// fire; matching on key presence alone would still issue RPCs for keys
-// whose action is disabled or scan-only.
+// hasActiveEventDrivenAction gates I/O (e.g. sibling listing) on whether
+// a match could actually fire. Mirrors the per-key filter in Route so
+// disabled or scan-only actions don't pay the RPC.
 func hasActiveEventDrivenAction(snap *engine.Snapshot, keys []s3lifecycle.ActionKey, kind s3lifecycle.ActionKind) bool {
 	for _, k := range keys {
 		if k.ActionKind != kind {
@@ -416,10 +358,8 @@ func hasActiveEventDrivenAction(snap *engine.Snapshot, keys []s3lifecycle.Action
 	return false
 }
 
-// isDeleteMarkerEntry mirrors the production predicate: every site that
-// writes a delete marker stores []byte("true") (see
-// s3api_object_versioning.go createDeleteMarker), and every read site
-// compares string(v) == "true".
+// isDeleteMarkerEntry mirrors every read site for ExtDeleteMarkerKey:
+// production writes []byte("true").
 func isDeleteMarkerEntry(entry *filer_pb.Entry) bool {
 	if entry == nil || len(entry.Extended) == 0 {
 		return false

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -726,6 +726,34 @@ func TestRouteVersionedExpiredDeleteMarkerInactiveActionSkipsListing(t *testing.
 	}
 }
 
+func TestRouteVersionedRegularVersionCreateSkipsListing(t *testing.T) {
+	// A non-marker version create under .versions/<key>/ can never be the
+	// sole survivor (Count >= 2 by definition), so the lister must NOT
+	// be consulted on every regular versioned PUT.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	versionPath := "logs/keep" + s3_constants.VersionsFolder + "/v_v1"
+	ev := eventCreate("bk", versionPath, old.Unix(), 100, old.UnixNano())
+	ev.NewEntry.Extended = map[string][]byte{
+		s3_constants.ExtVersionIdKey: []byte("v1"),
+	}
+
+	lister := &recordingLister{survivors: Survivors{Count: 1}}
+	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
+		t.Fatalf("regular version create must not fire EXP_DM, got %v", got)
+	}
+	if len(lister.calls) != 0 {
+		t.Fatalf("lister consulted for regular version create: calls=%v", lister.calls)
+	}
+}
+
 func TestRouteVersionedDeleteMarkerNoExpDMRuleSkipsListing(t *testing.T) {
 	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
 	snap := compileWithVersioned(rule, activatedPrior(rule))

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -495,22 +495,35 @@ func markerEvent(bucket, logicalKey, versionID string, mtimeUnix, mtimeNs int64)
 	return ev
 }
 
-// recordingLister captures Count calls so tests can assert the lister was
-// (or was NOT) consulted, and replay a configured count or error.
+// recordingLister captures Survivors calls. Configure with the exact
+// state to return; calls list is appended on each invocation so tests
+// can assert whether the lister was consulted at all.
 type recordingLister struct {
-	calls []string
-	count int
-	err   error
+	calls    []string
+	survivors Survivors
+	err      error
 }
 
-func (r *recordingLister) Count(_ context.Context, bucket, key string) (int, error) {
+func (r *recordingLister) Survivors(_ context.Context, bucket, key string) (Survivors, error) {
 	r.calls = append(r.calls, bucket+"/"+key)
-	return r.count, r.err
+	return r.survivors, r.err
+}
+
+func markerLoneEntry(versionID string, mtimeUnix, mtimeNs int64) *filer_pb.Entry {
+	return &filer_pb.Entry{
+		Name: "v_" + versionID,
+		Attributes: &filer_pb.FuseAttributes{
+			Mtime:   mtimeUnix,
+			MtimeNs: int32(mtimeNs - mtimeUnix*int64(1e9)),
+		},
+		Extended: map[string][]byte{
+			s3_constants.ExtDeleteMarkerKey: []byte("true"),
+			s3_constants.ExtVersionIdKey:    []byte(versionID),
+		},
+	}
 }
 
 func TestRouteVersionedExpiredDeleteMarkerNilListerSuppresses(t *testing.T) {
-	// Sole-survivor detection needs a sibling count; without a lister the
-	// router suppresses rather than risk a wrong fire.
 	rule := &s3lifecycle.Rule{
 		ID:                        "r",
 		Status:                    s3lifecycle.StatusEnabled,
@@ -528,10 +541,8 @@ func TestRouteVersionedExpiredDeleteMarkerNilListerSuppresses(t *testing.T) {
 }
 
 func TestRouteVersionedExpiredDeleteMarkerSoleSurvivorFires(t *testing.T) {
-	// Exactly one entry under .versions/<key>/ — the marker itself —
-	// fires ExpiredObjectDeleteMarker. Match must carry the LOGICAL key
-	// in ObjectKey and the version_id in VersionID so the dispatcher
-	// can call deleteSpecificObjectVersion(bucket, logical, version).
+	// Exactly one entry under .versions/<key>/ — the marker — and no
+	// bare null version: EXP_DM fires with the LOGICAL key + version_id.
 	rule := &s3lifecycle.Rule{
 		ID:                        "r",
 		Status:                    s3lifecycle.StatusEnabled,
@@ -543,7 +554,10 @@ func TestRouteVersionedExpiredDeleteMarkerSoleSurvivorFires(t *testing.T) {
 	old := now.AddDate(0, 0, -1)
 	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
 
-	lister := &recordingLister{count: 1}
+	lister := &recordingLister{survivors: Survivors{
+		Count:     1,
+		LoneEntry: markerLoneEntry("2026-05-09-abc", old.Unix(), old.UnixNano()),
+	}}
 	matches := Route(context.Background(), snap, ev, now, lister)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match (ExpiredDeleteMarker), got %v", matches)
@@ -564,8 +578,6 @@ func TestRouteVersionedExpiredDeleteMarkerSoleSurvivorFires(t *testing.T) {
 }
 
 func TestRouteVersionedExpiredDeleteMarkerSiblingsRemainSuppressed(t *testing.T) {
-	// More than one entry under .versions/<key>/ means other versions
-	// survive; the marker is not a sole survivor so the rule stays off.
 	rule := &s3lifecycle.Rule{
 		ID:                        "r",
 		Status:                    s3lifecycle.StatusEnabled,
@@ -577,14 +589,104 @@ func TestRouteVersionedExpiredDeleteMarkerSiblingsRemainSuppressed(t *testing.T)
 	old := now.AddDate(0, 0, -1)
 	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
 
-	lister := &recordingLister{count: 2}
+	lister := &recordingLister{survivors: Survivors{Count: 2}}
 	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
 		t.Fatalf("siblings present, must not fire, got %v", got)
 	}
 }
 
+func TestRouteVersionedExpiredDeleteMarkerNullVersionSuppresses(t *testing.T) {
+	// A pre-versioning bare-key object (HasNullVersion=true) still survives
+	// outside .versions/. Firing EXP_DM would re-expose it; suppress.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
+
+	lister := &recordingLister{survivors: Survivors{
+		Count:          1,
+		LoneEntry:      markerLoneEntry("2026-05-09-abc", old.Unix(), old.UnixNano()),
+		HasNullVersion: true,
+	}}
+	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
+		t.Fatalf("null-version present, must not fire, got %v", got)
+	}
+}
+
+func TestRouteVersionedExpiredDeleteMarkerHardDeleteLeavesLoneMarkerFires(t *testing.T) {
+	// Sequence: object had v1 + DM, hard-delete of v1 leaves DM as the
+	// sole survivor. The hard-delete event has NewEntry=nil; the router
+	// must still consult the lister, see the lone DM, and emit a match
+	// using the LoneEntry's version_id and identity.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	versionPath := "logs/gone" + s3_constants.VersionsFolder + "/v_2026-05-08-old"
+	ev := &reader.Event{
+		TsNs:     now.UnixNano(),
+		Bucket:   "bk",
+		Key:      versionPath,
+		OldEntry: &filer_pb.Entry{Name: "v_2026-05-08-old"},
+	}
+	lister := &recordingLister{survivors: Survivors{
+		Count:     1,
+		LoneEntry: markerLoneEntry("2026-05-09-abc", old.Unix(), old.UnixNano()),
+	}}
+	matches := Route(context.Background(), snap, ev, now, lister)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match after hard-delete, got %v", matches)
+	}
+	if matches[0].VersionID != "2026-05-09-abc" {
+		t.Fatalf("VersionID=%q, want lone-entry's version 2026-05-09-abc", matches[0].VersionID)
+	}
+	if matches[0].ObjectKey != "logs/gone" {
+		t.Fatalf("ObjectKey=%q, want logs/gone", matches[0].ObjectKey)
+	}
+}
+
+func TestRouteVersionedExpiredDeleteMarkerHardDeleteLoneNonMarkerNoFire(t *testing.T) {
+	// After a hard-delete the surviving entry is a regular version, not
+	// a marker. Nothing to expire.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	versionPath := "logs/gone" + s3_constants.VersionsFolder + "/v_2026-05-08-old"
+	ev := &reader.Event{
+		TsNs:     now.UnixNano(),
+		Bucket:   "bk",
+		Key:      versionPath,
+		OldEntry: &filer_pb.Entry{Name: "v_2026-05-08-old"},
+	}
+	regular := &filer_pb.Entry{
+		Name:       "v_v1",
+		Attributes: &filer_pb.FuseAttributes{Mtime: old.Unix()},
+		Extended:   map[string][]byte{s3_constants.ExtVersionIdKey: []byte("v1")},
+	}
+	lister := &recordingLister{survivors: Survivors{Count: 1, LoneEntry: regular}}
+	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
+		t.Fatalf("non-marker survivor must not fire, got %v", got)
+	}
+}
+
 func TestRouteVersionedExpiredDeleteMarkerListerErrorSuppressed(t *testing.T) {
-	// Lister error == unknown count; suppress rather than risk a wrong fire.
 	rule := &s3lifecycle.Rule{
 		ID:                        "r",
 		Status:                    s3lifecycle.StatusEnabled,
@@ -603,11 +705,6 @@ func TestRouteVersionedExpiredDeleteMarkerListerErrorSuppressed(t *testing.T) {
 }
 
 func TestRouteVersionedExpiredDeleteMarkerInactiveActionSkipsListing(t *testing.T) {
-	// EXP_DM rule exists but the action's BootstrapComplete=false leaves it
-	// inactive. The cost gate must not pay the listing for an action that
-	// can't fire — even if the per-key filter inside routeSoleSurvivorMarker
-	// would later drop the match, the gate runs first and would otherwise
-	// have already issued the RPC.
 	rule := &s3lifecycle.Rule{
 		ID:                        "r",
 		Status:                    s3lifecycle.StatusEnabled,
@@ -620,7 +717,7 @@ func TestRouteVersionedExpiredDeleteMarkerInactiveActionSkipsListing(t *testing.
 	old := now.AddDate(0, 0, -1)
 	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
 
-	lister := &recordingLister{count: 1}
+	lister := &recordingLister{survivors: Survivors{Count: 1}}
 	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
 		t.Fatalf("inactive action must not produce a match, got %v", got)
 	}
@@ -630,8 +727,6 @@ func TestRouteVersionedExpiredDeleteMarkerInactiveActionSkipsListing(t *testing.
 }
 
 func TestRouteVersionedDeleteMarkerNoExpDMRuleSkipsListing(t *testing.T) {
-	// Bucket has no ExpiredObjectDeleteMarker rule — the lister must NOT
-	// be consulted; that gate keeps the listing cost off most buckets.
 	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
 	snap := compileWithVersioned(rule, activatedPrior(rule))
 
@@ -639,7 +734,7 @@ func TestRouteVersionedDeleteMarkerNoExpDMRuleSkipsListing(t *testing.T) {
 	old := now.AddDate(0, 0, -1)
 	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
 
-	lister := &recordingLister{count: 1}
+	lister := &recordingLister{survivors: Survivors{Count: 1}}
 	Route(context.Background(), snap, ev, now, lister)
 	if len(lister.calls) != 0 {
 		t.Fatalf("lister consulted without EXP_DM rule: calls=%v", lister.calls)

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -45,7 +47,7 @@ func eventCreate(bucket, key string, modTimeS, size int64, ts int64) *reader.Eve
 }
 
 func TestRouteNoSnapshotNoMatches(t *testing.T) {
-	if got := Route(nil, eventCreate("bk", "k", 0, 1, 1), time.Now()); got != nil {
+	if got := Route(context.Background(), nil, eventCreate("bk", "k", 0, 1, 1), time.Now(), nil); got != nil {
 		t.Fatalf("nil snap should yield nil, got %v", got)
 	}
 }
@@ -54,7 +56,7 @@ func TestRouteMissingBucketNoMatches(t *testing.T) {
 	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
 	snap := compileWith(rule, activatedPrior(rule))
 	ev := eventCreate("other-bucket", "k", 0, 1, 1)
-	if got := Route(snap, ev, time.Now()); got != nil {
+	if got := Route(context.Background(), snap, ev, time.Now(), nil); got != nil {
 		t.Fatalf("foreign bucket should yield nil, got %v", got)
 	}
 }
@@ -68,7 +70,7 @@ func TestRouteInactiveSkipped(t *testing.T) {
 	old := now.Add(-48 * time.Hour) // past 1-day expiration
 	ev := eventCreate("bk", "k", old.Unix(), 1, old.UnixNano())
 
-	if got := Route(snap, ev, now); got != nil {
+	if got := Route(context.Background(), snap, ev, now, nil); got != nil {
 		t.Fatalf("inactive action should not match, got %v", got)
 	}
 }
@@ -81,7 +83,7 @@ func TestRouteExpirationDaysFires(t *testing.T) {
 	old := now.Add(-48 * time.Hour) // past 1-day expiration
 	ev := eventCreate("bk", "k", old.Unix(), 1, old.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %+v", matches)
 	}
@@ -107,7 +109,7 @@ func TestRouteFreshObjectSchedulesInFuture(t *testing.T) {
 	now := time.Now()
 	ev := eventCreate("bk", "k", now.Unix(), 1, now.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match (scheduled), got %v", matches)
 	}
@@ -127,13 +129,13 @@ func TestRouteRespectsPrefixFilter(t *testing.T) {
 
 	// Out of prefix: no match.
 	ev := eventCreate("bk", "data/file", old.Unix(), 1, old.UnixNano())
-	if got := Route(snap, ev, now); got != nil {
+	if got := Route(context.Background(), snap, ev, now, nil); got != nil {
 		t.Fatalf("out-of-prefix should not match, got %v", got)
 	}
 
 	// In prefix: matches.
 	ev = eventCreate("bk", "logs/file", old.Unix(), 1, old.UnixNano())
-	if got := Route(snap, ev, now); len(got) != 1 {
+	if got := Route(context.Background(), snap, ev, now, nil); len(got) != 1 {
 		t.Fatalf("in-prefix should match, got %v", got)
 	}
 }
@@ -153,7 +155,7 @@ func TestRouteSkipsHardDelete(t *testing.T) {
 			Attributes: &filer_pb.FuseAttributes{Mtime: old.Unix(), FileSize: 1},
 		},
 	}
-	if got := Route(snap, ev, now); got != nil {
+	if got := Route(context.Background(), snap, ev, now, nil); got != nil {
 		t.Fatalf("hard delete should not route, got %v", got)
 	}
 }
@@ -169,7 +171,7 @@ func TestRouteSkipsMissingAttributes(t *testing.T) {
 		Key:      "k",
 		NewEntry: &filer_pb.Entry{Name: "k"}, // no Attributes
 	}
-	if got := Route(snap, ev, time.Now()); got != nil {
+	if got := Route(context.Background(), snap, ev, time.Now(), nil); got != nil {
 		t.Fatalf("missing-Attributes event should not route, got %v", got)
 	}
 }
@@ -183,7 +185,7 @@ func TestRouteIdentityCapturedForNewEntry(t *testing.T) {
 	ev := eventCreate("bk", "k", old.Unix(), 42, old.UnixNano())
 	ev.NewEntry.Chunks = []*filer_pb.FileChunk{{FileId: "1,abc"}}
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %v", matches)
 	}
@@ -214,7 +216,7 @@ func TestRouteIdentityHashesExtended(t *testing.T) {
 		"Content-Type":    []byte("text/plain"),
 	}
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %v", matches)
 	}
@@ -259,7 +261,7 @@ func TestRouteMPUInitFiresAbortAfterDelay(t *testing.T) {
 	init := now.AddDate(0, 0, -8)
 	ev := mpuInitEvent("bk", "u1", "logs/foo.txt", init.Unix(), init.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %v", matches)
 	}
@@ -285,7 +287,7 @@ func TestRouteMPUInitFilteredOutByPrefix(t *testing.T) {
 	init := now.AddDate(0, 0, -8)
 	ev := mpuInitEvent("bk", "u2", "data/foo.txt", init.Unix(), init.UnixNano())
 
-	if got := Route(snap, ev, now); len(got) != 0 {
+	if got := Route(context.Background(), snap, ev, now, nil); len(got) != 0 {
 		t.Fatalf("expected 0 matches for foreign prefix, got %v", got)
 	}
 }
@@ -313,7 +315,7 @@ func TestRouteMPUInitMissingDestKeySkipped(t *testing.T) {
 		},
 	}
 
-	if got := Route(snap, ev, now); len(got) != 0 {
+	if got := Route(context.Background(), snap, ev, now, nil); len(got) != 0 {
 		t.Fatalf("expected 0 matches for missing destKey, got %v", got)
 	}
 }
@@ -341,7 +343,7 @@ func TestRouteMPUPartEventSkipped(t *testing.T) {
 		},
 	}
 
-	if got := Route(snap, ev, now); len(got) != 0 {
+	if got := Route(context.Background(), snap, ev, now, nil); len(got) != 0 {
 		t.Fatalf("expected 0 matches for part event, got %v", got)
 	}
 }
@@ -362,7 +364,7 @@ func TestRouteMPUInitDoesNotFireNoncurrent(t *testing.T) {
 	init := now.AddDate(0, 0, -30)
 	ev := mpuInitEvent("bk", "u1", "logs/foo.txt", init.Unix(), init.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected exactly 1 match (ABORT_MPU only), got %v", matches)
 	}
@@ -390,7 +392,7 @@ func TestRouteRegularObjectUnderDualRuleSkipsAbortMPU(t *testing.T) {
 	old := now.AddDate(0, 0, -2) // past the 1d expiration
 	ev := eventCreate("bk", "obj", old.Unix(), 1, old.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected exactly 1 match (EXPIRATION_DAYS only), got %v", matches)
 	}
@@ -427,7 +429,7 @@ func TestRouteVersionedNoncurrentEventDoesNotFireFromRouter(t *testing.T) {
 		s3_constants.ExtVersionIdKey: []byte("v1"),
 	}
 
-	if got := Route(snap, ev, now); len(got) != 0 {
+	if got := Route(context.Background(), snap, ev, now, nil); len(got) != 0 {
 		t.Fatalf("router must not emit noncurrent matches yet, got %v", got)
 	}
 }
@@ -443,7 +445,7 @@ func TestRouteVersionedCurrentEventStaysLatest(t *testing.T) {
 	old := now.AddDate(0, 0, -2)
 	ev := eventCreate("bk", "logs/foo", old.Unix(), 1, old.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match (EXPIRATION_DAYS), got %v", matches)
 	}
@@ -467,7 +469,7 @@ func TestRouteNonVersionedBucketIgnoresVersionsSuffix(t *testing.T) {
 	old := now.AddDate(0, 0, -2)
 	ev := eventCreate("bk", "logs/foo.versions/v1", old.Unix(), 1, old.UnixNano())
 
-	matches := Route(snap, ev, now)
+	matches := Route(context.Background(), snap, ev, now, nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %v", matches)
 	}
@@ -479,11 +481,36 @@ func TestRouteNonVersionedBucketIgnoresVersionsSuffix(t *testing.T) {
 	}
 }
 
-func TestRouteVersionedExpiredDeleteMarkerSuppressedWithoutSiblings(t *testing.T) {
-	// ExpiredObjectDeleteMarker requires NumVersions==1 — the marker is
-	// the sole-survivor. Without sibling listing the router can't
-	// confirm that, so the rule must NOT fire just because the latest
-	// is a delete marker. A future PR adds sibling listing.
+// markerEventBytes returns the production shape: a file event under
+// <key>.versions/v_<version-id>, with ExtDeleteMarkerKey="true" and
+// ExtVersionIdKey populated. Mirrors createDeleteMarker in
+// s3api_object_versioning.go.
+func markerEvent(bucket, logicalKey, versionID string, mtimeUnix, mtimeNs int64) *reader.Event {
+	versionPath := logicalKey + s3_constants.VersionsFolder + "/v_" + versionID
+	ev := eventCreate(bucket, versionPath, mtimeUnix, 0, mtimeNs)
+	ev.NewEntry.Extended = map[string][]byte{
+		s3_constants.ExtDeleteMarkerKey: []byte("true"),
+		s3_constants.ExtVersionIdKey:    []byte(versionID),
+	}
+	return ev
+}
+
+// recordingLister captures Count calls so tests can assert the lister was
+// (or was NOT) consulted, and replay a configured count or error.
+type recordingLister struct {
+	calls []string
+	count int
+	err   error
+}
+
+func (r *recordingLister) Count(_ context.Context, bucket, key string) (int, error) {
+	r.calls = append(r.calls, bucket+"/"+key)
+	return r.count, r.err
+}
+
+func TestRouteVersionedExpiredDeleteMarkerNilListerSuppresses(t *testing.T) {
+	// Sole-survivor detection needs a sibling count; without a lister the
+	// router suppresses rather than risk a wrong fire.
 	rule := &s3lifecycle.Rule{
 		ID:                        "r",
 		Status:                    s3lifecycle.StatusEnabled,
@@ -493,13 +520,102 @@ func TestRouteVersionedExpiredDeleteMarkerSuppressedWithoutSiblings(t *testing.T
 
 	now := time.Now()
 	old := now.AddDate(0, 0, -1)
-	ev := eventCreate("bk", "logs/gone", old.Unix(), 0, old.UnixNano())
-	ev.NewEntry.Extended = map[string][]byte{
-		s3_constants.ExtDeleteMarkerKey: {1},
-	}
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
 
-	if got := Route(snap, ev, now); len(got) != 0 {
-		t.Fatalf("ExpiredDeleteMarker without sibling count must not fire, got %v", got)
+	if got := Route(context.Background(), snap, ev, now, nil); len(got) != 0 {
+		t.Fatalf("nil lister must suppress, got %v", got)
+	}
+}
+
+func TestRouteVersionedExpiredDeleteMarkerSoleSurvivorFires(t *testing.T) {
+	// Exactly one entry under .versions/<key>/ — the marker itself —
+	// fires ExpiredObjectDeleteMarker. Match must carry the LOGICAL key
+	// in ObjectKey and the version_id in VersionID so the dispatcher
+	// can call deleteSpecificObjectVersion(bucket, logical, version).
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
+
+	lister := &recordingLister{count: 1}
+	matches := Route(context.Background(), snap, ev, now, lister)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (ExpiredDeleteMarker), got %v", matches)
+	}
+	m := matches[0]
+	if m.Result.Action != s3lifecycle.ActionExpireDeleteMarker {
+		t.Fatalf("Action=%v, want ExpireDeleteMarker", m.Result.Action)
+	}
+	if m.ObjectKey != "logs/gone" {
+		t.Fatalf("ObjectKey=%q, want logical key logs/gone", m.ObjectKey)
+	}
+	if m.VersionID != "2026-05-09-abc" {
+		t.Fatalf("VersionID=%q, want 2026-05-09-abc", m.VersionID)
+	}
+	if len(lister.calls) != 1 || lister.calls[0] != "bk/logs/gone" {
+		t.Fatalf("lister calls=%v, want [bk/logs/gone]", lister.calls)
+	}
+}
+
+func TestRouteVersionedExpiredDeleteMarkerSiblingsRemainSuppressed(t *testing.T) {
+	// More than one entry under .versions/<key>/ means other versions
+	// survive; the marker is not a sole survivor so the rule stays off.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
+
+	lister := &recordingLister{count: 2}
+	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
+		t.Fatalf("siblings present, must not fire, got %v", got)
+	}
+}
+
+func TestRouteVersionedExpiredDeleteMarkerListerErrorSuppressed(t *testing.T) {
+	// Lister error == unknown count; suppress rather than risk a wrong fire.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
+
+	lister := &recordingLister{err: errors.New("filer down")}
+	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
+		t.Fatalf("lister error must suppress, got %v", got)
+	}
+}
+
+func TestRouteVersionedDeleteMarkerNoExpDMRuleSkipsListing(t *testing.T) {
+	// Bucket has no ExpiredObjectDeleteMarker rule — the lister must NOT
+	// be consulted; that gate keeps the listing cost off most buckets.
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	snap := compileWithVersioned(rule, activatedPrior(rule))
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
+
+	lister := &recordingLister{count: 1}
+	Route(context.Background(), snap, ev, now, lister)
+	if len(lister.calls) != 0 {
+		t.Fatalf("lister consulted without EXP_DM rule: calls=%v", lister.calls)
 	}
 }
 
@@ -555,7 +671,7 @@ func TestRouteVersionedAllVersionFolderPathsSkipped(t *testing.T) {
 			if tc.isDir {
 				ev.NewEntry.IsDirectory = true
 			}
-			if got := Route(snap, ev, now); len(got) != 0 {
+			if got := Route(context.Background(), snap, ev, now, nil); len(got) != 0 {
 				t.Fatalf("version-folder event should be skipped, got %v", got)
 			}
 		})

--- a/weed/s3api/s3lifecycle/router/router_test.go
+++ b/weed/s3api/s3lifecycle/router/router_test.go
@@ -602,6 +602,33 @@ func TestRouteVersionedExpiredDeleteMarkerListerErrorSuppressed(t *testing.T) {
 	}
 }
 
+func TestRouteVersionedExpiredDeleteMarkerInactiveActionSkipsListing(t *testing.T) {
+	// EXP_DM rule exists but the action's BootstrapComplete=false leaves it
+	// inactive. The cost gate must not pay the listing for an action that
+	// can't fire — even if the per-key filter inside routeSoleSurvivorMarker
+	// would later drop the match, the gate runs first and would otherwise
+	// have already issued the RPC.
+	rule := &s3lifecycle.Rule{
+		ID:                        "r",
+		Status:                    s3lifecycle.StatusEnabled,
+		ExpiredObjectDeleteMarker: true,
+	}
+	// PriorStates omitted => BootstrapComplete=false => action stays inactive.
+	snap := compileWithVersioned(rule, nil)
+
+	now := time.Now()
+	old := now.AddDate(0, 0, -1)
+	ev := markerEvent("bk", "logs/gone", "2026-05-09-abc", old.Unix(), old.UnixNano())
+
+	lister := &recordingLister{count: 1}
+	if got := Route(context.Background(), snap, ev, now, lister); len(got) != 0 {
+		t.Fatalf("inactive action must not produce a match, got %v", got)
+	}
+	if len(lister.calls) != 0 {
+		t.Fatalf("inactive action must not consult lister, calls=%v", lister.calls)
+	}
+}
+
 func TestRouteVersionedDeleteMarkerNoExpDMRuleSkipsListing(t *testing.T) {
 	// Bucket has no ExpiredObjectDeleteMarker rule — the lister must NOT
 	// be consulted; that gate keeps the listing cost off most buckets.


### PR DESCRIPTION
Adds `router.SiblingLister` so the router can detect when a versioned-bucket delete marker is the only entry left under `.versions/<key>/` and promote `NumVersions` from 0 to 1, letting `ExpiredObjectDeleteMarker` fire.

The listing is gated on (versioned bucket, bare-key path, delete-marker entry, `EXP_DM` rule active for the bucket) so most buckets pay nothing. A nil lister or a `Count` error leaves `NumVersions=0` and suppresses the rule rather than risk a wrong fire.

`Route` now takes `(ctx, snap, ev, now, lister)`. `dispatcher.Pipeline` wires a filer-backed lister reusing the existing `FilerClient` and `BucketsPath`; tests pass `nil` where sole-survivor isn't exercised.

Follows #9373.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sibling-inspection to lifecycle routing so sole-survivor delete-marker cases are detected with contextual checks.

* **Bug Fixes**
  * More reliable handling of expired delete markers, including re-checks before final deletion and correct suppression when null-versions, multiple siblings, or lister errors are present.

* **Tests**
  * Expanded test coverage for sole-survivor scenarios, lister failures, suppression behavior, and routing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->