### PR TITLE
feat(s3/lifecycle): bootstrap re-walk cadence + operator hooks (Phase 8)

### DIFF
--- a/weed/s3api/s3lifecycle/scheduler/bootstrap.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap.go
@@ -78,27 +78,31 @@ func listAll(ctx context.Context, client filer_pb.SeaweedFilerClient, dir string
 // Synthesized events carry TsNs=0 so dispatcher.advance is a no-op for
 // them — the reader still resumes from its persisted cursor on restart.
 //
-// Walk completion is tracked in-memory per process. KickOffNew skips a
-// bucket whose last walk is younger than BootstrapInterval (or always,
-// when the interval is zero — the legacy "walk once per process"
-// behavior). Operators can force a re-walk via MarkDirty.
+// Walk state is tracked in-memory per process via two maps:
+//   - lastCompleted: time of the last successful walk, drives the
+//     BootstrapInterval cadence; zero interval means "walk once per
+//     process".
+//   - inFlight: buckets whose walk goroutines are still running.
+//     Skipped regardless of cadence so a walk that takes longer than
+//     BootstrapInterval can't trigger a duplicate goroutine on the
+//     next refresh.
 type BucketBootstrapper struct {
 	FilerClient filer_pb.SeaweedFilerClient
 	BucketsPath string
 	Injector    EventInjector
 
 	// BootstrapInterval gates re-walks. Zero means "walk once per
-	// process": after the initial walk the bucket stays known forever.
-	// Non-zero means "walk again once it's been at least this long
-	// since the last completed walk" — the cadence scan_only actions
-	// rely on, since they can only fire from bootstrap.
+	// process". Non-zero means "walk again once it's been at least
+	// this long since the last completed walk" — the cadence scan_only
+	// actions rely on, since they can only fire from bootstrap.
 	BootstrapInterval time.Duration
 
 	// Now overrides time.Now for tests.
 	Now func() time.Time
 
-	mu       sync.Mutex
-	lastWalk map[string]time.Time
+	mu            sync.Mutex
+	lastCompleted map[string]time.Time
+	inFlight      map[string]bool
 }
 
 func (b *BucketBootstrapper) now() time.Time {
@@ -109,27 +113,35 @@ func (b *BucketBootstrapper) now() time.Time {
 }
 
 // KickOffNew launches a one-shot walker goroutine for every bucket
-// that's either never been walked or whose last walk completed more
-// than BootstrapInterval ago.
+// that's not currently in flight and either has never completed a walk
+// or whose last successful walk finished more than BootstrapInterval ago.
 func (b *BucketBootstrapper) KickOffNew(ctx context.Context, buckets []string) {
 	if b.Injector == nil {
 		return
 	}
 	now := b.now()
 	b.mu.Lock()
-	if b.lastWalk == nil {
-		b.lastWalk = map[string]time.Time{}
+	if b.lastCompleted == nil {
+		b.lastCompleted = map[string]time.Time{}
+	}
+	if b.inFlight == nil {
+		b.inFlight = map[string]bool{}
 	}
 	fresh := make([]string, 0, len(buckets))
 	for _, bucket := range buckets {
-		last, seen := b.lastWalk[bucket]
-		if seen && (b.BootstrapInterval <= 0 || now.Sub(last) < b.BootstrapInterval) {
+		if b.inFlight[bucket] {
+			// Walk still running from an earlier KickOffNew — never
+			// double up regardless of cadence. A large bucket that
+			// takes longer than BootstrapInterval would otherwise
+			// have a fresh goroutine fire on every refresh tick.
 			continue
 		}
-		// Stamp now so a concurrent KickOffNew skips this bucket while
-		// the walk is in flight; walkBucket re-stamps with the actual
-		// completion time on success.
-		b.lastWalk[bucket] = now
+		if last, ok := b.lastCompleted[bucket]; ok {
+			if b.BootstrapInterval <= 0 || now.Sub(last) < b.BootstrapInterval {
+				continue
+			}
+		}
+		b.inFlight[bucket] = true
 		fresh = append(fresh, bucket)
 	}
 	b.mu.Unlock()
@@ -140,25 +152,24 @@ func (b *BucketBootstrapper) KickOffNew(ctx context.Context, buckets []string) {
 	}
 }
 
-// MarkDirty drops the in-memory record for the given buckets so the
-// next KickOffNew call walks them again. Operator hook for forcing a
-// re-bootstrap on a long-running worker — the standard knob is
-// BootstrapInterval, this is the manual override.
+// MarkDirty drops the completed-walk timestamp for the given buckets
+// so the next KickOffNew walks them again. In-flight walks are left
+// running; a re-walk fires after they finish.
 func (b *BucketBootstrapper) MarkDirty(buckets ...string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, bucket := range buckets {
-		delete(b.lastWalk, bucket)
+		delete(b.lastCompleted, bucket)
 	}
 }
 
-// MarkAllDirty drops every in-memory record. Equivalent to a process
-// restart for bootstrap purposes; useful when an operator wants to
-// reconcile every bucket immediately.
+// MarkAllDirty drops every completed-walk record. In-flight walks
+// continue. Useful when a worker config change should cause every
+// bucket to be re-bootstrapped on the next tick.
 func (b *BucketBootstrapper) MarkAllDirty() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.lastWalk = nil
+	b.lastCompleted = nil
 }
 
 func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
@@ -198,23 +209,25 @@ func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
 		count++
 		return b.Injector.InjectEvent(ctx, ev)
 	}
-	if err := walkBucketDir(ctx, b.FilerClient, root, root, cb); err != nil {
-		// Walk failed mid-way; drop the lastWalk stamp so the next
-		// KickOffNew picks this bucket up again. KickOffNew stamped
-		// the start time as a debounce.
+	walkErr := walkBucketDir(ctx, b.FilerClient, root, root, cb)
+	b.mu.Lock()
+	delete(b.inFlight, bucket)
+	if walkErr == nil {
+		// Stamp completion so BootstrapInterval cadence measures from
+		// end-of-walk. Failures leave lastCompleted alone, so the next
+		// KickOffNew sees no record and walks the bucket again.
+		if b.lastCompleted == nil {
+			b.lastCompleted = map[string]time.Time{}
+		}
+		b.lastCompleted[bucket] = b.now()
+	}
+	b.mu.Unlock()
+	if walkErr != nil {
 		if ctx.Err() == nil {
-			glog.V(0).Infof("lifecycle bootstrap %s: %v", bucket, err)
-			b.MarkDirty(bucket)
+			glog.V(0).Infof("lifecycle bootstrap %s: %v", bucket, walkErr)
 		}
 		return
 	}
-	// Re-stamp with the actual completion time so the BootstrapInterval
-	// cadence measures from end-of-walk, not start.
-	b.mu.Lock()
-	if b.lastWalk != nil {
-		b.lastWalk[bucket] = b.now()
-	}
-	b.mu.Unlock()
 	glog.V(0).Infof("lifecycle bootstrap: bucket %s injected %d entries", bucket, count)
 }
 

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap.go
@@ -103,13 +103,6 @@ type BucketBootstrapper struct {
 	mu            sync.Mutex
 	lastCompleted map[string]time.Time
 	inFlight      map[string]bool
-	// pendingDirty records MarkDirty calls that arrived while a bucket
-	// was in flight. The walk goroutine consumes the entry on
-	// completion and skips stamping lastCompleted, so the next
-	// KickOffNew picks the bucket up immediately rather than waiting
-	// for BootstrapInterval to elapse against the (now-stale) finish
-	// time of a walk the operator already invalidated.
-	pendingDirty map[string]bool
 }
 
 func (b *BucketBootstrapper) now() time.Time {
@@ -159,41 +152,6 @@ func (b *BucketBootstrapper) KickOffNew(ctx context.Context, buckets []string) {
 	}
 }
 
-// MarkDirty drops the completed-walk timestamp for the given buckets
-// so the next KickOffNew walks them again. For in-flight walks, the
-// dirty flag is recorded in pendingDirty; the walk goroutine reads it
-// on completion and skips stamping lastCompleted, so the next
-// KickOffNew picks up the bucket without waiting for the cadence.
-func (b *BucketBootstrapper) MarkDirty(buckets ...string) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.pendingDirty == nil {
-		b.pendingDirty = map[string]bool{}
-	}
-	for _, bucket := range buckets {
-		delete(b.lastCompleted, bucket)
-		if b.inFlight[bucket] {
-			b.pendingDirty[bucket] = true
-		}
-	}
-}
-
-// MarkAllDirty drops every completed-walk record. In-flight walks
-// stay scheduled to skip their completion stamp via pendingDirty so
-// the operator's "everything is dirty" intent isn't lost when the
-// in-flight walk finishes after this call.
-func (b *BucketBootstrapper) MarkAllDirty() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.lastCompleted = nil
-	if b.pendingDirty == nil {
-		b.pendingDirty = map[string]bool{}
-	}
-	for bucket := range b.inFlight {
-		b.pendingDirty[bucket] = true
-	}
-}
-
 func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
 	root := strings.TrimSuffix(b.BucketsPath, "/") + "/" + bucket
 	glog.V(0).Infof("lifecycle bootstrap: starting walk for bucket %s (root=%s)", bucket, root)
@@ -234,16 +192,10 @@ func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
 	walkErr := walkBucketDir(ctx, b.FilerClient, root, root, cb)
 	b.mu.Lock()
 	delete(b.inFlight, bucket)
-	wasDirty := b.pendingDirty[bucket]
-	delete(b.pendingDirty, bucket)
-	if walkErr == nil && !wasDirty {
+	if walkErr == nil {
 		// Stamp completion so BootstrapInterval cadence measures from
 		// end-of-walk. Failures leave lastCompleted alone, so the next
-		// KickOffNew sees no record and walks the bucket again. A
-		// MarkDirty arrived during the walk also leaves it alone so
-		// the next KickOffNew picks the bucket up immediately —
-		// otherwise stamping here would silently ignore the operator's
-		// invalidation request.
+		// KickOffNew sees no record and walks the bucket again.
 		if b.lastCompleted == nil {
 			b.lastCompleted = map[string]time.Time{}
 		}

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap.go
@@ -103,6 +103,13 @@ type BucketBootstrapper struct {
 	mu            sync.Mutex
 	lastCompleted map[string]time.Time
 	inFlight      map[string]bool
+	// pendingDirty records MarkDirty calls that arrived while a bucket
+	// was in flight. The walk goroutine consumes the entry on
+	// completion and skips stamping lastCompleted, so the next
+	// KickOffNew picks the bucket up immediately rather than waiting
+	// for BootstrapInterval to elapse against the (now-stale) finish
+	// time of a walk the operator already invalidated.
+	pendingDirty map[string]bool
 }
 
 func (b *BucketBootstrapper) now() time.Time {
@@ -153,23 +160,38 @@ func (b *BucketBootstrapper) KickOffNew(ctx context.Context, buckets []string) {
 }
 
 // MarkDirty drops the completed-walk timestamp for the given buckets
-// so the next KickOffNew walks them again. In-flight walks are left
-// running; a re-walk fires after they finish.
+// so the next KickOffNew walks them again. For in-flight walks, the
+// dirty flag is recorded in pendingDirty; the walk goroutine reads it
+// on completion and skips stamping lastCompleted, so the next
+// KickOffNew picks up the bucket without waiting for the cadence.
 func (b *BucketBootstrapper) MarkDirty(buckets ...string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.pendingDirty == nil {
+		b.pendingDirty = map[string]bool{}
+	}
 	for _, bucket := range buckets {
 		delete(b.lastCompleted, bucket)
+		if b.inFlight[bucket] {
+			b.pendingDirty[bucket] = true
+		}
 	}
 }
 
 // MarkAllDirty drops every completed-walk record. In-flight walks
-// continue. Useful when a worker config change should cause every
-// bucket to be re-bootstrapped on the next tick.
+// stay scheduled to skip their completion stamp via pendingDirty so
+// the operator's "everything is dirty" intent isn't lost when the
+// in-flight walk finishes after this call.
 func (b *BucketBootstrapper) MarkAllDirty() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.lastCompleted = nil
+	if b.pendingDirty == nil {
+		b.pendingDirty = map[string]bool{}
+	}
+	for bucket := range b.inFlight {
+		b.pendingDirty[bucket] = true
+	}
 }
 
 func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
@@ -212,10 +234,16 @@ func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
 	walkErr := walkBucketDir(ctx, b.FilerClient, root, root, cb)
 	b.mu.Lock()
 	delete(b.inFlight, bucket)
-	if walkErr == nil {
+	wasDirty := b.pendingDirty[bucket]
+	delete(b.pendingDirty, bucket)
+	if walkErr == nil && !wasDirty {
 		// Stamp completion so BootstrapInterval cadence measures from
 		// end-of-walk. Failures leave lastCompleted alone, so the next
-		// KickOffNew sees no record and walks the bucket again.
+		// KickOffNew sees no record and walks the bucket again. A
+		// MarkDirty arrived during the walk also leaves it alone so
+		// the next KickOffNew picks the bucket up immediately —
+		// otherwise stamping here would silently ignore the operator's
+		// invalidation request.
 		if b.lastCompleted == nil {
 			b.lastCompleted = map[string]time.Time{}
 		}

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap.go
@@ -78,33 +78,58 @@ func listAll(ctx context.Context, client filer_pb.SeaweedFilerClient, dir string
 // Synthesized events carry TsNs=0 so dispatcher.advance is a no-op for
 // them — the reader still resumes from its persisted cursor on restart.
 //
-// Bucket completion is in-memory per process; a fresh worker run walks
-// each bucket once on first refresh.
+// Walk completion is tracked in-memory per process. KickOffNew skips a
+// bucket whose last walk is younger than BootstrapInterval (or always,
+// when the interval is zero — the legacy "walk once per process"
+// behavior). Operators can force a re-walk via MarkDirty.
 type BucketBootstrapper struct {
 	FilerClient filer_pb.SeaweedFilerClient
 	BucketsPath string
 	Injector    EventInjector
 
-	mu    sync.Mutex
-	known map[string]bool
+	// BootstrapInterval gates re-walks. Zero means "walk once per
+	// process": after the initial walk the bucket stays known forever.
+	// Non-zero means "walk again once it's been at least this long
+	// since the last completed walk" — the cadence scan_only actions
+	// rely on, since they can only fire from bootstrap.
+	BootstrapInterval time.Duration
+
+	// Now overrides time.Now for tests.
+	Now func() time.Time
+
+	mu       sync.Mutex
+	lastWalk map[string]time.Time
+}
+
+func (b *BucketBootstrapper) now() time.Time {
+	if b.Now != nil {
+		return b.Now()
+	}
+	return time.Now()
 }
 
 // KickOffNew launches a one-shot walker goroutine for every bucket
-// in `buckets` that hasn't been seen before.
+// that's either never been walked or whose last walk completed more
+// than BootstrapInterval ago.
 func (b *BucketBootstrapper) KickOffNew(ctx context.Context, buckets []string) {
 	if b.Injector == nil {
 		return
 	}
+	now := b.now()
 	b.mu.Lock()
-	if b.known == nil {
-		b.known = map[string]bool{}
+	if b.lastWalk == nil {
+		b.lastWalk = map[string]time.Time{}
 	}
 	fresh := make([]string, 0, len(buckets))
 	for _, bucket := range buckets {
-		if b.known[bucket] {
+		last, seen := b.lastWalk[bucket]
+		if seen && (b.BootstrapInterval <= 0 || now.Sub(last) < b.BootstrapInterval) {
 			continue
 		}
-		b.known[bucket] = true
+		// Stamp now so a concurrent KickOffNew skips this bucket while
+		// the walk is in flight; walkBucket re-stamps with the actual
+		// completion time on success.
+		b.lastWalk[bucket] = now
 		fresh = append(fresh, bucket)
 	}
 	b.mu.Unlock()
@@ -113,6 +138,27 @@ func (b *BucketBootstrapper) KickOffNew(ctx context.Context, buckets []string) {
 		bucket := bucket
 		go b.walkBucket(ctx, bucket)
 	}
+}
+
+// MarkDirty drops the in-memory record for the given buckets so the
+// next KickOffNew call walks them again. Operator hook for forcing a
+// re-bootstrap on a long-running worker — the standard knob is
+// BootstrapInterval, this is the manual override.
+func (b *BucketBootstrapper) MarkDirty(buckets ...string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, bucket := range buckets {
+		delete(b.lastWalk, bucket)
+	}
+}
+
+// MarkAllDirty drops every in-memory record. Equivalent to a process
+// restart for bootstrap purposes; useful when an operator wants to
+// reconcile every bucket immediately.
+func (b *BucketBootstrapper) MarkAllDirty() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.lastWalk = nil
 }
 
 func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
@@ -153,11 +199,22 @@ func (b *BucketBootstrapper) walkBucket(ctx context.Context, bucket string) {
 		return b.Injector.InjectEvent(ctx, ev)
 	}
 	if err := walkBucketDir(ctx, b.FilerClient, root, root, cb); err != nil {
+		// Walk failed mid-way; drop the lastWalk stamp so the next
+		// KickOffNew picks this bucket up again. KickOffNew stamped
+		// the start time as a debounce.
 		if ctx.Err() == nil {
 			glog.V(0).Infof("lifecycle bootstrap %s: %v", bucket, err)
+			b.MarkDirty(bucket)
 		}
 		return
 	}
+	// Re-stamp with the actual completion time so the BootstrapInterval
+	// cadence measures from end-of-walk, not start.
+	b.mu.Lock()
+	if b.lastWalk != nil {
+		b.lastWalk[bucket] = b.now()
+	}
+	b.mu.Unlock()
 	glog.V(0).Infof("lifecycle bootstrap: bucket %s injected %d entries", bucket, count)
 }
 

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
@@ -1209,42 +1209,6 @@ func TestBucketBootstrapper_KickOffNew_ZeroIntervalLegacyOnceOnly(t *testing.T) 
 	}
 }
 
-func TestBucketBootstrapper_MarkDirtyForcesRewalk(t *testing.T) {
-	// Operator hook: MarkDirty drops the in-memory record so the next
-	// KickOffNew walks the bucket again, regardless of cadence.
-	client := newEmptyFilerClient()
-	inj := &recordingInjector{}
-	b := &BucketBootstrapper{
-		FilerClient:       client,
-		BucketsPath:       "/buckets",
-		Injector:          inj,
-		BootstrapInterval: 24 * time.Hour, // large interval that would otherwise skip
-	}
-	b.KickOffNew(context.Background(), []string{"bucketA"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 2 }, "first walk")
-	firstCount := atomic.LoadInt32(&client.listedN)
-
-	b.MarkDirty("bucketA")
-	b.KickOffNew(context.Background(), []string{"bucketA"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= firstCount+2 }, "re-walk after MarkDirty")
-}
-
-func TestBucketBootstrapper_MarkAllDirtyResets(t *testing.T) {
-	client := newEmptyFilerClient()
-	inj := &recordingInjector{}
-	b := &BucketBootstrapper{FilerClient: client, BucketsPath: "/buckets", Injector: inj}
-	b.KickOffNew(context.Background(), []string{"bucketA", "bucketB"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 4 }, "first wave")
-
-	b.MarkAllDirty()
-	b.mu.Lock()
-	empty := len(b.lastCompleted) == 0
-	b.mu.Unlock()
-	if !empty {
-		t.Fatalf("MarkAllDirty must clear the lastWalk map")
-	}
-}
-
 // blockingInjector lets the test pin a walk in progress until it
 // signals release. Useful for asserting in-flight debounce.
 type blockingInjector struct {
@@ -1330,55 +1294,3 @@ func TestBucketBootstrapper_KickOffNew_InFlightDebounceBlocksDuplicate(t *testin
 	}
 }
 
-func TestBucketBootstrapper_MarkDirtyDuringInFlightTakesEffectAfterCompletion(t *testing.T) {
-	// MarkDirty arriving while a walk is in progress used to be lost:
-	// the goroutine wrote a fresh lastCompleted on success, hiding
-	// the operator's invalidation. Verify the pending-dirty set
-	// suppresses the stamp so the next KickOffNew picks the bucket
-	// up without waiting for the cadence.
-	client := &fakeFilerClient{
-		tree: map[string][]*filer_pb.Entry{
-			"/buckets/bucketA": {fileEntry("a.txt")},
-		},
-	}
-	inj := newBlockingInjector()
-	clock := newFakeClock()
-	b := &BucketBootstrapper{
-		FilerClient:       client,
-		BucketsPath:       "/buckets",
-		Injector:          inj,
-		BootstrapInterval: time.Hour,
-		Now:               clock.Now,
-	}
-
-	b.KickOffNew(context.Background(), []string{"bucketA"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 1 }, "first walk to begin")
-
-	// MarkDirty before the walk completes: its effect must survive.
-	b.MarkDirty("bucketA")
-	inj.release()
-	// Wait for the walk goroutine to fully exit and clear inFlight.
-	waitFor(t, func() bool {
-		b.mu.Lock()
-		defer b.mu.Unlock()
-		return !b.inFlight["bucketA"]
-	}, "first walk to finish")
-
-	// lastCompleted must NOT have been stamped — the in-flight
-	// MarkDirty was honored.
-	b.mu.Lock()
-	_, hasCompleted := b.lastCompleted["bucketA"]
-	b.mu.Unlock()
-	if hasCompleted {
-		t.Fatalf("MarkDirty during walk must suppress the success stamp")
-	}
-
-	// Even within the BootstrapInterval, the next KickOffNew should
-	// re-walk the bucket because lastCompleted is empty.
-	listedBefore := atomic.LoadInt32(&client.listedN)
-	inj2 := newBlockingInjector()
-	b.Injector = inj2
-	b.KickOffNew(context.Background(), []string{"bucketA"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) > listedBefore }, "second walk to begin after MarkDirty")
-	inj2.release()
-}

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
@@ -1128,6 +1128,22 @@ func (c *fakeClock) Advance(d time.Duration) {
 	c.mu.Unlock()
 }
 
+// waitForCompleted blocks until the bootstrapper has stamped a
+// lastCompleted entry for the given bucket. Polling listedN is not
+// enough — that fires once both list passes have started, but
+// walkBucket stamps lastCompleted only after walkBucketDir returns,
+// so a clock.Advance between those events would record the stamp at
+// post-advance time and skew BootstrapInterval cadence assertions.
+func waitForCompleted(t *testing.T, b *BucketBootstrapper, bucket string) {
+	t.Helper()
+	waitFor(t, func() bool {
+		b.mu.Lock()
+		_, ok := b.lastCompleted[bucket]
+		b.mu.Unlock()
+		return ok
+	}, "lastCompleted stamp for "+bucket)
+}
+
 func TestBucketBootstrapper_KickOffNew_BootstrapIntervalRevisitsBucket(t *testing.T) {
 	// scan_only actions only fire from bootstrap, so a long-running
 	// worker has to revisit each bucket on a cadence. With
@@ -1144,9 +1160,12 @@ func TestBucketBootstrapper_KickOffNew_BootstrapIntervalRevisitsBucket(t *testin
 		Now:               clock.Now,
 	}
 
-	// First wave: walks once.
+	// First wave: walks once. Wait for the goroutine to actually stamp
+	// lastCompleted before advancing the clock — otherwise the stamp
+	// could land at clock+30m instead of T0 and the cadence assertion
+	// would race.
 	b.KickOffNew(context.Background(), []string{"bucketA"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 2 }, "first walk")
+	waitForCompleted(t, b, "bucketA")
 	firstCount := atomic.LoadInt32(&client.listedN)
 
 	// Inside the interval: skip.
@@ -1178,7 +1197,7 @@ func TestBucketBootstrapper_KickOffNew_ZeroIntervalLegacyOnceOnly(t *testing.T) 
 	}
 
 	b.KickOffNew(context.Background(), []string{"bucketA"})
-	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 2 }, "first walk")
+	waitForCompleted(t, b, "bucketA")
 	firstCount := atomic.LoadInt32(&client.listedN)
 
 	// Even after 100 hours, KickOffNew skips the bucket.

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
@@ -1329,3 +1329,56 @@ func TestBucketBootstrapper_KickOffNew_InFlightDebounceBlocksDuplicate(t *testin
 		t.Fatalf("post-release KickOffNew within interval must be a no-op; listedN=%d, want %d", got, prevListed)
 	}
 }
+
+func TestBucketBootstrapper_MarkDirtyDuringInFlightTakesEffectAfterCompletion(t *testing.T) {
+	// MarkDirty arriving while a walk is in progress used to be lost:
+	// the goroutine wrote a fresh lastCompleted on success, hiding
+	// the operator's invalidation. Verify the pending-dirty set
+	// suppresses the stamp so the next KickOffNew picks the bucket
+	// up without waiting for the cadence.
+	client := &fakeFilerClient{
+		tree: map[string][]*filer_pb.Entry{
+			"/buckets/bucketA": {fileEntry("a.txt")},
+		},
+	}
+	inj := newBlockingInjector()
+	clock := newFakeClock()
+	b := &BucketBootstrapper{
+		FilerClient:       client,
+		BucketsPath:       "/buckets",
+		Injector:          inj,
+		BootstrapInterval: time.Hour,
+		Now:               clock.Now,
+	}
+
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 1 }, "first walk to begin")
+
+	// MarkDirty before the walk completes: its effect must survive.
+	b.MarkDirty("bucketA")
+	inj.release()
+	// Wait for the walk goroutine to fully exit and clear inFlight.
+	waitFor(t, func() bool {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		return !b.inFlight["bucketA"]
+	}, "first walk to finish")
+
+	// lastCompleted must NOT have been stamped — the in-flight
+	// MarkDirty was honored.
+	b.mu.Lock()
+	_, hasCompleted := b.lastCompleted["bucketA"]
+	b.mu.Unlock()
+	if hasCompleted {
+		t.Fatalf("MarkDirty during walk must suppress the success stamp")
+	}
+
+	// Even within the BootstrapInterval, the next KickOffNew should
+	// re-walk the bucket because lastCompleted is empty.
+	listedBefore := atomic.LoadInt32(&client.listedN)
+	inj2 := newBlockingInjector()
+	b.Injector = inj2
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) > listedBefore }, "second walk to begin after MarkDirty")
+	inj2.release()
+}

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
@@ -396,9 +396,11 @@ func TestBucketBootstrapper_KickOffNew_LaunchesPerBucket(t *testing.T) {
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	assert.True(t, b.known["bucketA"])
-	assert.True(t, b.known["bucketB"])
-	assert.Len(t, b.known, 2)
+	_, hasA := b.lastWalk["bucketA"]
+	_, hasB := b.lastWalk["bucketB"]
+	assert.True(t, hasA)
+	assert.True(t, hasB)
+	assert.Len(t, b.lastWalk, 2)
 }
 
 func TestBucketBootstrapper_KickOffNew_SkipsAlreadyKnown(t *testing.T) {
@@ -442,8 +444,9 @@ func TestBucketBootstrapper_KickOffNew_SkipsAlreadyKnown(t *testing.T) {
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	assert.Len(t, b.known, 3)
-	assert.True(t, b.known["bucketC"])
+	assert.Len(t, b.lastWalk, 3)
+	_, hasC := b.lastWalk["bucketC"]
+	assert.True(t, hasC)
 }
 
 func TestBucketBootstrapper_KickOffNew_NilInjectorIsNoop(t *testing.T) {
@@ -456,12 +459,13 @@ func TestBucketBootstrapper_KickOffNew_NilInjectorIsNoop(t *testing.T) {
 	require.NotPanics(t, func() {
 		b.KickOffNew(context.Background(), []string{"bucketA"})
 	})
-	// No walks must have been kicked off, and known must remain empty.
+	// No walks must have been kicked off, and the lastWalk map must
+	// remain empty.
 	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&client.listedN))
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	assert.Empty(t, b.known)
+	assert.Empty(t, b.lastWalk)
 }
 
 func TestBucketBootstrapper_KickOffNew_EmptyBucketListIsNoop(t *testing.T) {
@@ -1099,4 +1103,125 @@ func TestWalkBucketDir_PaginatesBeyondListingLimit(t *testing.T) {
 	// everything else) to keep memory bounded on flat buckets. 5
 	// entries at page 2 = 3 paginated calls per pass = 6 total.
 	assert.Equal(t, 6, calls)
+}
+
+// fakeClock is a thread-safe time source for tests that need to fast-
+// forward across a BootstrapInterval boundary. Bootstrap goroutines
+// read it concurrently with the test advancing it, so a plain
+// `clock := time.Now()` plus closure write would race under -race.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Now()} }
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+func TestBucketBootstrapper_KickOffNew_BootstrapIntervalRevisitsBucket(t *testing.T) {
+	// scan_only actions only fire from bootstrap, so a long-running
+	// worker has to revisit each bucket on a cadence. With
+	// BootstrapInterval set, KickOffNew re-walks once enough wall-clock
+	// has passed since the last completed walk.
+	client := newEmptyFilerClient()
+	inj := &recordingInjector{}
+	clock := newFakeClock()
+	b := &BucketBootstrapper{
+		FilerClient:       client,
+		BucketsPath:       "/buckets",
+		Injector:          inj,
+		BootstrapInterval: time.Hour,
+		Now:               clock.Now,
+	}
+
+	// First wave: walks once.
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 2 }, "first walk")
+	firstCount := atomic.LoadInt32(&client.listedN)
+
+	// Inside the interval: skip.
+	clock.Advance(30 * time.Minute)
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	time.Sleep(20 * time.Millisecond)
+	if got := atomic.LoadInt32(&client.listedN); got != firstCount {
+		t.Fatalf("inside interval, must not re-walk; listedN=%d, want %d", got, firstCount)
+	}
+
+	// Past the interval: re-walk.
+	clock.Advance(45 * time.Minute) // total elapsed > 1h
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= firstCount+2 }, "re-walk after interval")
+}
+
+func TestBucketBootstrapper_KickOffNew_ZeroIntervalLegacyOnceOnly(t *testing.T) {
+	// BootstrapInterval == 0 preserves the original "walk once per
+	// process" behavior so existing deployments don't get a different
+	// cadence by default.
+	client := newEmptyFilerClient()
+	inj := &recordingInjector{}
+	clock := newFakeClock()
+	b := &BucketBootstrapper{
+		FilerClient: client,
+		BucketsPath: "/buckets",
+		Injector:    inj,
+		Now:         clock.Now,
+	}
+
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 2 }, "first walk")
+	firstCount := atomic.LoadInt32(&client.listedN)
+
+	// Even after 100 hours, KickOffNew skips the bucket.
+	clock.Advance(100 * time.Hour)
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	time.Sleep(20 * time.Millisecond)
+	if got := atomic.LoadInt32(&client.listedN); got != firstCount {
+		t.Fatalf("zero interval must keep the once-per-process behavior; listedN=%d, want %d", got, firstCount)
+	}
+}
+
+func TestBucketBootstrapper_MarkDirtyForcesRewalk(t *testing.T) {
+	// Operator hook: MarkDirty drops the in-memory record so the next
+	// KickOffNew walks the bucket again, regardless of cadence.
+	client := newEmptyFilerClient()
+	inj := &recordingInjector{}
+	b := &BucketBootstrapper{
+		FilerClient:       client,
+		BucketsPath:       "/buckets",
+		Injector:          inj,
+		BootstrapInterval: 24 * time.Hour, // large interval that would otherwise skip
+	}
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 2 }, "first walk")
+	firstCount := atomic.LoadInt32(&client.listedN)
+
+	b.MarkDirty("bucketA")
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= firstCount+2 }, "re-walk after MarkDirty")
+}
+
+func TestBucketBootstrapper_MarkAllDirtyResets(t *testing.T) {
+	client := newEmptyFilerClient()
+	inj := &recordingInjector{}
+	b := &BucketBootstrapper{FilerClient: client, BucketsPath: "/buckets", Injector: inj}
+	b.KickOffNew(context.Background(), []string{"bucketA", "bucketB"})
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 4 }, "first wave")
+
+	b.MarkAllDirty()
+	b.mu.Lock()
+	empty := len(b.lastWalk) == 0
+	b.mu.Unlock()
+	if !empty {
+		t.Fatalf("MarkAllDirty must clear the lastWalk map")
+	}
 }

--- a/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
+++ b/weed/s3api/s3lifecycle/scheduler/bootstrap_test.go
@@ -396,11 +396,11 @@ func TestBucketBootstrapper_KickOffNew_LaunchesPerBucket(t *testing.T) {
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	_, hasA := b.lastWalk["bucketA"]
-	_, hasB := b.lastWalk["bucketB"]
+	_, hasA := b.lastCompleted["bucketA"]
+	_, hasB := b.lastCompleted["bucketB"]
 	assert.True(t, hasA)
 	assert.True(t, hasB)
-	assert.Len(t, b.lastWalk, 2)
+	assert.Len(t, b.lastCompleted, 2)
 }
 
 func TestBucketBootstrapper_KickOffNew_SkipsAlreadyKnown(t *testing.T) {
@@ -444,8 +444,8 @@ func TestBucketBootstrapper_KickOffNew_SkipsAlreadyKnown(t *testing.T) {
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	assert.Len(t, b.lastWalk, 3)
-	_, hasC := b.lastWalk["bucketC"]
+	assert.Len(t, b.lastCompleted, 3)
+	_, hasC := b.lastCompleted["bucketC"]
 	assert.True(t, hasC)
 }
 
@@ -465,7 +465,7 @@ func TestBucketBootstrapper_KickOffNew_NilInjectorIsNoop(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&client.listedN))
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	assert.Empty(t, b.lastWalk)
+	assert.Empty(t, b.lastCompleted)
 }
 
 func TestBucketBootstrapper_KickOffNew_EmptyBucketListIsNoop(t *testing.T) {
@@ -1219,9 +1219,94 @@ func TestBucketBootstrapper_MarkAllDirtyResets(t *testing.T) {
 
 	b.MarkAllDirty()
 	b.mu.Lock()
-	empty := len(b.lastWalk) == 0
+	empty := len(b.lastCompleted) == 0
 	b.mu.Unlock()
 	if !empty {
 		t.Fatalf("MarkAllDirty must clear the lastWalk map")
+	}
+}
+
+// blockingInjector lets the test pin a walk in progress until it
+// signals release. Useful for asserting in-flight debounce.
+type blockingInjector struct {
+	mu       sync.Mutex
+	events   []*reader.Event
+	released chan struct{}
+}
+
+func newBlockingInjector() *blockingInjector {
+	return &blockingInjector{released: make(chan struct{})}
+}
+
+func (b *blockingInjector) InjectEvent(ctx context.Context, ev *reader.Event) error {
+	select {
+	case <-b.released:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	b.mu.Lock()
+	b.events = append(b.events, ev)
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *blockingInjector) release() { close(b.released) }
+
+func (b *blockingInjector) eventCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.events)
+}
+
+func TestBucketBootstrapper_KickOffNew_InFlightDebounceBlocksDuplicate(t *testing.T) {
+	// A walk that takes longer than BootstrapInterval would otherwise
+	// have a fresh KickOffNew start a duplicate goroutine on the next
+	// refresh tick. The inFlight set prevents that. Verify by:
+	//  1) Pinning a walk in progress via a blockingInjector,
+	//  2) Advancing the clock past BootstrapInterval,
+	//  3) Confirming the second KickOffNew is a no-op while the first
+	//     is still running,
+	//  4) Releasing the first walk and asserting only one walk
+	//     completed (one bucket-root listing pair).
+	client := &fakeFilerClient{
+		tree: map[string][]*filer_pb.Entry{
+			"/buckets/bucketA": {fileEntry("a.txt")},
+		},
+	}
+	inj := newBlockingInjector()
+	clock := newFakeClock()
+	b := &BucketBootstrapper{
+		FilerClient:       client,
+		BucketsPath:       "/buckets",
+		Injector:          inj,
+		BootstrapInterval: time.Hour,
+		Now:               clock.Now,
+	}
+
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	// Wait for the walk goroutine to actually start listing (pass 1
+	// fires a ListEntries before InjectEvent).
+	waitFor(t, func() bool { return atomic.LoadInt32(&client.listedN) >= 1 }, "first walk to begin listing")
+
+	// Advance past the interval — a stale-state KickOffNew would now
+	// see the lastCompleted as expired and try again.
+	clock.Advance(2 * time.Hour)
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	time.Sleep(20 * time.Millisecond)
+	if got := inj.eventCount(); got != 0 {
+		t.Fatalf("first walk still blocked, got %d injected events from a phantom second walk", got)
+	}
+
+	// Release: the first walk completes. eventCount goes to 1.
+	inj.release()
+	waitFor(t, func() bool { return inj.eventCount() == 1 }, "first walk to drain")
+	// Even after another KickOffNew at the same simulated time, the
+	// in-flight is now cleared and lastCompleted is fresh — second
+	// KickOffNew within interval is a no-op.
+	prevListed := atomic.LoadInt32(&client.listedN)
+	b.KickOffNew(context.Background(), []string{"bucketA"})
+	time.Sleep(20 * time.Millisecond)
+	if got := atomic.LoadInt32(&client.listedN); got != prevListed {
+		t.Fatalf("post-release KickOffNew within interval must be a no-op; listedN=%d, want %d", got, prevListed)
 	}
 }

--- a/weed/s3api/s3lifecycle/scheduler/scheduler.go
+++ b/weed/s3api/s3lifecycle/scheduler/scheduler.go
@@ -33,11 +33,12 @@ type Scheduler struct {
 	ClientID    int32
 	ClientName  string
 
-	Workers         int
-	DispatchTick    time.Duration
-	CheckpointTick  time.Duration
-	RefreshInterval time.Duration
-	RetryBackoff    time.Duration
+	Workers           int
+	DispatchTick      time.Duration
+	CheckpointTick    time.Duration
+	RefreshInterval   time.Duration
+	BootstrapInterval time.Duration
+	RetryBackoff      time.Duration
 }
 
 // Run blocks until ctx is canceled. Spawns Workers + 1 goroutines: one
@@ -100,9 +101,10 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	}
 
 	bs := &BucketBootstrapper{
-		FilerClient: s.FilerClient,
-		BucketsPath: s.BucketsPath,
-		Injector:    pipelineFanout(pipelinesByShard),
+		FilerClient:       s.FilerClient,
+		BucketsPath:       s.BucketsPath,
+		Injector:          pipelineFanout(pipelinesByShard),
+		BootstrapInterval: s.BootstrapInterval,
 	}
 
 	s.refreshEngine(ctx, bs)

--- a/weed/shell/command_s3_lifecycle_run_shard.go
+++ b/weed/shell/command_s3_lifecycle_run_shard.go
@@ -69,7 +69,6 @@ func (c *commandS3LifecycleRunShard) Do(args []string, env *CommandEnv, writer i
 	checkpointTick := fs.Duration("checkpoint", 30*time.Second, "cursor checkpoint cadence")
 	refreshInterval := fs.Duration("refresh", 5*time.Minute, "interval for rebuilding the engine snapshot from filer-backed bucket configs; 0 = compile once at startup")
 	bootstrapInterval := fs.Duration("bootstrap-interval", 0, "cadence for revisiting each bucket's bootstrap walk; 0 = walk once per process. scan_only actions only fire from bootstrap, so a long-running worker needs a non-zero value to handle their retention horizon")
-	forceBootstrap := fs.Bool("force-bootstrap", false, "drop in-memory bootstrap state on startup so every bucket walks again immediately; useful when a config change should take effect without a restart")
 	runtime := fs.Duration("runtime", 0, "wall-clock cap on the run; 0 = no timeout. -events alone can hang on quiet shards")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -125,9 +124,6 @@ func (c *commandS3LifecycleRunShard) Do(args []string, env *CommandEnv, writer i
 			BucketsPath:       bucketsPath,
 			Injector:          pipeline,
 			BootstrapInterval: *bootstrapInterval,
-		}
-		if *forceBootstrap {
-			bsr.MarkAllDirty()
 		}
 		bootstrapCtx, bootstrapCancel := context.WithCancel(context.Background())
 		defer bootstrapCancel()

--- a/weed/shell/command_s3_lifecycle_run_shard.go
+++ b/weed/shell/command_s3_lifecycle_run_shard.go
@@ -68,6 +68,8 @@ func (c *commandS3LifecycleRunShard) Do(args []string, env *CommandEnv, writer i
 	dispatchTick := fs.Duration("dispatch", 5*time.Second, "dispatcher tick cadence")
 	checkpointTick := fs.Duration("checkpoint", 30*time.Second, "cursor checkpoint cadence")
 	refreshInterval := fs.Duration("refresh", 5*time.Minute, "interval for rebuilding the engine snapshot from filer-backed bucket configs; 0 = compile once at startup")
+	bootstrapInterval := fs.Duration("bootstrap-interval", 0, "cadence for revisiting each bucket's bootstrap walk; 0 = walk once per process. scan_only actions only fire from bootstrap, so a long-running worker needs a non-zero value to handle their retention horizon")
+	forceBootstrap := fs.Bool("force-bootstrap", false, "drop in-memory bootstrap state on startup so every bucket walks again immediately; useful when a config change should take effect without a restart")
 	runtime := fs.Duration("runtime", 0, "wall-clock cap on the run; 0 = no timeout. -events alone can hang on quiet shards")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -119,9 +121,13 @@ func (c *commandS3LifecycleRunShard) Do(args []string, env *CommandEnv, writer i
 		}
 
 		bsr := &scheduler.BucketBootstrapper{
-			FilerClient: filerClient,
-			BucketsPath: bucketsPath,
-			Injector:    pipeline,
+			FilerClient:       filerClient,
+			BucketsPath:       bucketsPath,
+			Injector:          pipeline,
+			BootstrapInterval: *bootstrapInterval,
+		}
+		if *forceBootstrap {
+			bsr.MarkAllDirty()
 		}
 		bootstrapCtx, bootstrapCancel := context.WithCancel(context.Background())
 		defer bootstrapCancel()

--- a/weed/worker/tasks/s3_lifecycle/config.go
+++ b/weed/worker/tasks/s3_lifecycle/config.go
@@ -9,31 +9,34 @@ import (
 const (
 	jobType = "s3_lifecycle"
 
-	defaultWorkers                = 1
-	defaultDispatchTickMinutes    = int64(1)
-	defaultCheckpointTickSeconds  = int64(30)
-	defaultRefreshIntervalMinutes = int64(5)
-	defaultMaxRuntimeMinutes      = int64(60)
+	defaultWorkers                  = 1
+	defaultDispatchTickMinutes      = int64(1)
+	defaultCheckpointTickSeconds    = int64(30)
+	defaultRefreshIntervalMinutes   = int64(5)
+	defaultMaxRuntimeMinutes        = int64(60)
+	defaultBootstrapIntervalMinutes = int64(0) // 0 = walk once per process
 )
 
 // Config is the parsed AdminConfigForm + WorkerConfigForm view.
 type Config struct {
-	Workers         int
-	DispatchTick    time.Duration
-	CheckpointTick  time.Duration
-	RefreshInterval time.Duration
-	MaxRuntime      time.Duration
+	Workers           int
+	DispatchTick      time.Duration
+	CheckpointTick    time.Duration
+	RefreshInterval   time.Duration
+	BootstrapInterval time.Duration
+	MaxRuntime        time.Duration
 }
 
 // ParseConfig pulls the lifecycle Handler config from the merged
 // admin+worker config values. Missing fields fall back to defaults.
 func ParseConfig(adminValues, workerValues map[string]*plugin_pb.ConfigValue) Config {
 	cfg := Config{
-		Workers:         int(readInt64(adminValues, "workers", defaultWorkers)),
-		DispatchTick:    time.Duration(readInt64(workerValues, "dispatch_tick_minutes", defaultDispatchTickMinutes)) * time.Minute,
-		CheckpointTick:  time.Duration(readInt64(workerValues, "checkpoint_tick_seconds", defaultCheckpointTickSeconds)) * time.Second,
-		RefreshInterval: time.Duration(readInt64(workerValues, "refresh_interval_minutes", defaultRefreshIntervalMinutes)) * time.Minute,
-		MaxRuntime:      time.Duration(readInt64(workerValues, "max_runtime_minutes", defaultMaxRuntimeMinutes)) * time.Minute,
+		Workers:           int(readInt64(adminValues, "workers", defaultWorkers)),
+		DispatchTick:      time.Duration(readInt64(workerValues, "dispatch_tick_minutes", defaultDispatchTickMinutes)) * time.Minute,
+		CheckpointTick:    time.Duration(readInt64(workerValues, "checkpoint_tick_seconds", defaultCheckpointTickSeconds)) * time.Second,
+		RefreshInterval:   time.Duration(readInt64(workerValues, "refresh_interval_minutes", defaultRefreshIntervalMinutes)) * time.Minute,
+		BootstrapInterval: time.Duration(readInt64(workerValues, "bootstrap_interval_minutes", defaultBootstrapIntervalMinutes)) * time.Minute,
+		MaxRuntime:        time.Duration(readInt64(workerValues, "max_runtime_minutes", defaultMaxRuntimeMinutes)) * time.Minute,
 	}
 	if cfg.Workers <= 0 {
 		cfg.Workers = defaultWorkers
@@ -46,6 +49,13 @@ func ParseConfig(adminValues, workerValues map[string]*plugin_pb.ConfigValue) Co
 	}
 	if cfg.RefreshInterval <= 0 {
 		cfg.RefreshInterval = time.Duration(defaultRefreshIntervalMinutes) * time.Minute
+	}
+	// BootstrapInterval is intentionally NOT clamped — zero means
+	// "walk once per process", which is the legacy default for any
+	// deployment that hasn't opted into a cadence yet. Negative values
+	// fall back to zero.
+	if cfg.BootstrapInterval < 0 {
+		cfg.BootstrapInterval = 0
 	}
 	if cfg.MaxRuntime <= 0 {
 		cfg.MaxRuntime = time.Duration(defaultMaxRuntimeMinutes) * time.Minute

--- a/weed/worker/tasks/s3_lifecycle/config_test.go
+++ b/weed/worker/tasks/s3_lifecycle/config_test.go
@@ -24,6 +24,9 @@ func TestParseConfigDefaults(t *testing.T) {
 	if cfg.MaxRuntime != 60*time.Minute {
 		t.Errorf("MaxRuntime default=%v, want 60m", cfg.MaxRuntime)
 	}
+	if cfg.BootstrapInterval != 0 {
+		t.Errorf("BootstrapInterval default=%v, want 0 (walk-once-per-process)", cfg.BootstrapInterval)
+	}
 }
 
 func TestParseConfigOverrides(t *testing.T) {
@@ -31,10 +34,11 @@ func TestParseConfigOverrides(t *testing.T) {
 		"workers": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 4}},
 	}
 	worker := map[string]*plugin_pb.ConfigValue{
-		"dispatch_tick_minutes":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 2}},
-		"checkpoint_tick_seconds":  {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 15}},
-		"refresh_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 10}},
-		"max_runtime_minutes":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 120}},
+		"dispatch_tick_minutes":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 2}},
+		"checkpoint_tick_seconds":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 15}},
+		"refresh_interval_minutes":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 10}},
+		"bootstrap_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 120}},
+		"max_runtime_minutes":        {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 120}},
 	}
 	cfg := ParseConfig(admin, worker)
 	if cfg.Workers != 4 {
@@ -49,6 +53,9 @@ func TestParseConfigOverrides(t *testing.T) {
 	if cfg.RefreshInterval != 10*time.Minute {
 		t.Errorf("RefreshInterval=%v, want 10m", cfg.RefreshInterval)
 	}
+	if cfg.BootstrapInterval != 120*time.Minute {
+		t.Errorf("BootstrapInterval=%v, want 120m", cfg.BootstrapInterval)
+	}
 	if cfg.MaxRuntime != 120*time.Minute {
 		t.Errorf("MaxRuntime=%v, want 120m", cfg.MaxRuntime)
 	}
@@ -56,10 +63,11 @@ func TestParseConfigOverrides(t *testing.T) {
 
 func TestParseConfigClampsZeroAndNegative(t *testing.T) {
 	worker := map[string]*plugin_pb.ConfigValue{
-		"dispatch_tick_minutes":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
-		"checkpoint_tick_seconds":  {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
-		"refresh_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
-		"max_runtime_minutes":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: -5}},
+		"dispatch_tick_minutes":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
+		"checkpoint_tick_seconds":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
+		"refresh_interval_minutes":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
+		"bootstrap_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: -5}},
+		"max_runtime_minutes":        {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: -5}},
 	}
 	cfg := ParseConfig(nil, worker)
 	if cfg.DispatchTick != 1*time.Minute {
@@ -71,7 +79,23 @@ func TestParseConfigClampsZeroAndNegative(t *testing.T) {
 	if cfg.RefreshInterval != 5*time.Minute {
 		t.Errorf("zero RefreshInterval should clamp to default, got %v", cfg.RefreshInterval)
 	}
+	if cfg.BootstrapInterval != 0 {
+		t.Errorf("negative BootstrapInterval should clamp to 0, got %v", cfg.BootstrapInterval)
+	}
 	if cfg.MaxRuntime != 60*time.Minute {
 		t.Errorf("negative MaxRuntime should clamp to default, got %v", cfg.MaxRuntime)
+	}
+}
+
+func TestParseConfigBootstrapIntervalZeroIsLegacy(t *testing.T) {
+	// Explicit zero stays zero (walk-once-per-process). Existing
+	// deployments that don't set bootstrap_interval_minutes get the
+	// legacy behavior unchanged.
+	worker := map[string]*plugin_pb.ConfigValue{
+		"bootstrap_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
+	}
+	cfg := ParseConfig(nil, worker)
+	if cfg.BootstrapInterval != 0 {
+		t.Errorf("zero BootstrapInterval must stay zero, got %v", cfg.BootstrapInterval)
 	}
 }

--- a/weed/worker/tasks/s3_lifecycle/handler.go
+++ b/weed/worker/tasks/s3_lifecycle/handler.go
@@ -240,17 +240,18 @@ func (h *Handler) Execute(ctx context.Context, request *plugin_pb.ExecuteJobRequ
 	rpc := s3_lifecycle_pb.NewSeaweedS3LifecycleInternalClient(s3Conn)
 
 	sched := &scheduler.Scheduler{
-		BucketsPath:     bucketsPath,
-		Engine:          engine.New(),
-		Persister:       &dispatcher.FilerPersister{Store: dispatcher.NewFilerStoreClient(filerClient)},
-		Client:          lifecycleRPCAdapter{c: rpc},
-		FilerClient:     filerClient,
-		ClientID:        util.RandomInt32(),
-		ClientName:      "worker-s3-lifecycle",
-		Workers:         cfg.Workers,
-		DispatchTick:    cfg.DispatchTick,
-		CheckpointTick:  cfg.CheckpointTick,
-		RefreshInterval: cfg.RefreshInterval,
+		BucketsPath:       bucketsPath,
+		Engine:            engine.New(),
+		Persister:         &dispatcher.FilerPersister{Store: dispatcher.NewFilerStoreClient(filerClient)},
+		Client:            lifecycleRPCAdapter{c: rpc},
+		FilerClient:       filerClient,
+		ClientID:          util.RandomInt32(),
+		ClientName:        "worker-s3-lifecycle",
+		Workers:           cfg.Workers,
+		DispatchTick:      cfg.DispatchTick,
+		CheckpointTick:    cfg.CheckpointTick,
+		RefreshInterval:   cfg.RefreshInterval,
+		BootstrapInterval: cfg.BootstrapInterval,
 	}
 	if err := sched.Run(runCtx); err != nil {
 		glog.Warningf("s3 lifecycle execute: %v", err)

--- a/weed/worker/tasks/s3_lifecycle/handler.go
+++ b/weed/worker/tasks/s3_lifecycle/handler.go
@@ -123,6 +123,14 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 							MinValue:    &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 1}},
 						},
 						{
+							Name:        "bootstrap_interval_minutes",
+							Label:       "Bootstrap Re-walk Interval (minutes)",
+							Description: "How often each bucket is re-walked. scan_only rules — those whose retention horizon exceeds meta-log retention — only fire from the bootstrap walk, so a non-zero value is required to enforce them on a long-running worker. 0 keeps the legacy walk-once-per-process behavior.",
+							FieldType:   plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_INT64,
+							Widget:      plugin_pb.ConfigWidget_CONFIG_WIDGET_NUMBER,
+							MinValue:    &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: 0}},
+						},
+						{
 							Name:        "max_runtime_minutes",
 							Label:       "Max Runtime (minutes)",
 							Description: "Wall-clock cap on each run. Each daily run processes events for one day; the cursor persists across runs.",
@@ -134,10 +142,11 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 				},
 			},
 			DefaultValues: map[string]*plugin_pb.ConfigValue{
-				"dispatch_tick_minutes":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultDispatchTickMinutes}},
-				"checkpoint_tick_seconds":  {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultCheckpointTickSeconds}},
-				"refresh_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultRefreshIntervalMinutes}},
-				"max_runtime_minutes":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMaxRuntimeMinutes}},
+				"dispatch_tick_minutes":      {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultDispatchTickMinutes}},
+				"checkpoint_tick_seconds":    {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultCheckpointTickSeconds}},
+				"refresh_interval_minutes":   {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultRefreshIntervalMinutes}},
+				"bootstrap_interval_minutes": {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultBootstrapIntervalMinutes}},
+				"max_runtime_minutes":        {Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: defaultMaxRuntimeMinutes}},
 			},
 		},
 		AdminRuntimeDefaults: &plugin_pb.AdminRuntimeDefaults{


### PR DESCRIPTION
`scan_only` actions only fire from the bootstrap walk: the engine flags a rule as `scan_only` when its retention horizon exceeds meta-log retention, so event-driven routing can't be trusted. Today each bucket walks once per process — a long-running worker never revisits, and `scan_only` retention only catches up when the worker restarts.

## What changes

`BucketBootstrapper`'s `known` set becomes `lastWalk` (bucket → completion time). `KickOffNew` now re-walks a bucket once its `lastWalk` is older than `BootstrapInterval`. Zero interval preserves the legacy walk-once-per-process behavior. `walkBucket` re-stamps on success and `MarkDirty`'s the bucket on failure, so the next call picks up failed walks.

Two operator hooks:
- `MarkDirty(buckets...)` / `MarkAllDirty()` — force a re-walk on demand.
- `--force-bootstrap` flag at startup → calls `MarkAllDirty` so every bucket walks again immediately.

`weed shell s3.lifecycle.run-shard` grows `--bootstrap-interval` (cadence knob) and `--force-bootstrap` (drop in-memory state on startup).

## Tests

- `BootstrapIntervalRevisitsBucket`: walks, skip inside interval, re-walk past it.
- `ZeroIntervalLegacyOnceOnly`: zero keeps once-per-process even after 100h advance.
- `MarkDirtyForcesRewalk`: under a 24h interval, `MarkDirty` lets the next `KickOffNew` walk again.
- `MarkAllDirtyResets`: clears every record.
- `fakeClock` helper guards the test time source with a mutex so `-race` is clean.

Follows #9385.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a configurable bootstrap interval (CLI flag and worker config) to control how often each bucket is re-scanned. A value of 0 preserves “walk once per process”; negative values are clamped to 0.

* **Bug Fixes**
  - Prevents duplicate concurrent bucket scans by avoiding overlapping bootstrap walks.

* **Tests**
  - Expanded tests for interval cadence, zero/negative handling, and in-flight/debounce behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9386)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->