### PR TITLE
test(s3/lifecycle): assert per-goroutine errors in fake-server concurrent test

### DIFF
--- a/weed/s3api/s3lifecycle/lifecycletest/fakeserver_test.go
+++ b/weed/s3api/s3lifecycle/lifecycletest/fakeserver_test.go
@@ -193,17 +193,25 @@ func TestFake_NilRequestUsesDefault(t *testing.T) {
 
 func TestFake_ConcurrentCallsSerializeWithoutDeadlock(t *testing.T) {
 	// The dispatcher fans dispatch across many goroutines; the fake
-	// must not livelock or drop records under concurrent load.
+	// must not livelock or drop records under concurrent load. Capture
+	// each goroutine's err so a regression in concurrent paths surfaces
+	// instead of being masked by length-only assertions.
 	f := NewFakeLifecycleServer()
 	const N = 64
 	var wg sync.WaitGroup
+	errCh := make(chan error, N)
 	wg.Add(N)
 	for i := 0; i < N; i++ {
 		go func() {
 			defer wg.Done()
-			_, _ = f.LifecycleDelete(context.Background(), &s3_lifecycle_pb.LifecycleDeleteRequest{Bucket: "b", ObjectPath: "k"})
+			_, err := f.LifecycleDelete(context.Background(), &s3_lifecycle_pb.LifecycleDeleteRequest{Bucket: "b", ObjectPath: "k"})
+			errCh <- err
 		}()
 	}
 	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
 	assert.Len(t, f.Recorded(), N)
 }


### PR DESCRIPTION
Follow-up to #9391. CodeRabbit flagged that `TestFake_ConcurrentCallsSerializeWithoutDeadlock` discarded the `err` return from each goroutine's `LifecycleDelete` call, so a regression in the concurrent path could pass the length-only assertion. Capture each err on a buffered channel and `require.NoError` after `wg.Wait()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation of concurrent lifecycle operations to ensure proper error handling and reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9393)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->