### PR TITLE
test(s3/lifecycle): pin Descriptor structural invariants

### DIFF
--- a/weed/worker/tasks/s3_lifecycle/handler_test.go
+++ b/weed/worker/tasks/s3_lifecycle/handler_test.go
@@ -335,15 +335,20 @@ func TestDescriptor_WorkerConfigFormCadenceDefaultsMatchParseConfig(t *testing.T
 		})
 	}
 	// And the form fields themselves: every default must be paired with
-	// a field of matching name so the admin can render and edit it.
-	declared := map[string]bool{}
+	// a field of matching name AND INT64 type so the admin can render +
+	// edit it and ParseConfig's readInt64 reads it correctly. Drift to
+	// e.g. STRING here would silently make the worker fall back to the
+	// hardcoded default and ignore admin edits.
+	declared := map[string]plugin_pb.ConfigFieldType{}
 	for _, sec := range d.WorkerConfigForm.Sections {
 		for _, f := range sec.Fields {
-			declared[f.Name] = true
+			declared[f.Name] = f.FieldType
 		}
 	}
 	for name := range wantDefaults {
-		assert.True(t, declared[name], "WorkerConfigForm has no field named %q", name)
+		ft, ok := declared[name]
+		assert.True(t, ok, "WorkerConfigForm has no field named %q", name)
+		assert.Equal(t, plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_INT64, ft, "field %q must be INT64 to match readInt64", name)
 	}
 }
 
@@ -356,7 +361,7 @@ func TestDescriptor_AdminRuntimeDefaultsDailyCadence(t *testing.T) {
 	d := h.Descriptor()
 	require.NotNil(t, d.AdminRuntimeDefaults)
 	assert.Equal(t, int32(24*60), d.AdminRuntimeDefaults.DetectionIntervalMinutes)
-	assert.Greater(t, d.AdminRuntimeDefaults.DetectionTimeoutSeconds, int32(0))
+	assert.Equal(t, int32(60), d.AdminRuntimeDefaults.DetectionTimeoutSeconds, "60s timeout caps a stuck detect at one minute")
 	assert.Equal(t, int32(1), d.AdminRuntimeDefaults.MaxJobsPerDetection)
 }
 

--- a/weed/worker/tasks/s3_lifecycle/handler_test.go
+++ b/weed/worker/tasks/s3_lifecycle/handler_test.go
@@ -267,6 +267,99 @@ func TestDetect_PropagatesCompleteSendError(t *testing.T) {
 	assert.Empty(t, r.completes)
 }
 
+// ---------- Descriptor ----------
+
+func TestDescriptor_BasicShape(t *testing.T) {
+	// Sanity-check the Descriptor's public-facing identifiers so a
+	// rename in handler.go doesn't silently break the admin UI without
+	// an admin-side change too.
+	h := NewHandler(nil)
+	d := h.Descriptor()
+	require.NotNil(t, d)
+	assert.Equal(t, jobType, d.JobType)
+	assert.NotEmpty(t, d.DisplayName)
+	assert.NotEmpty(t, d.Description)
+	assert.Greater(t, d.DescriptorVersion, uint32(0), "descriptor version must be positive (admins use it for compat)")
+}
+
+func TestDescriptor_AdminConfigFormHasWorkersField(t *testing.T) {
+	// Workers is the only admin-side knob today; if it disappears, the
+	// admin form would render empty and operators couldn't tune
+	// concurrency.
+	h := NewHandler(nil)
+	d := h.Descriptor()
+	require.NotNil(t, d.AdminConfigForm)
+	assert.Equal(t, "s3-lifecycle-admin", d.AdminConfigForm.FormId)
+
+	// Walk every section's fields and find "workers".
+	var found bool
+	for _, sec := range d.AdminConfigForm.Sections {
+		for _, f := range sec.Fields {
+			if f.Name == "workers" {
+				found = true
+				assert.Equal(t, plugin_pb.ConfigFieldType_CONFIG_FIELD_TYPE_INT64, f.FieldType)
+			}
+		}
+	}
+	assert.True(t, found, "admin form must expose 'workers' field")
+
+	// Default value matches the constant used by ParseConfig.
+	dv, ok := d.AdminConfigForm.DefaultValues["workers"]
+	require.True(t, ok, "workers must have a default in AdminConfigForm")
+	assert.Equal(t, int64(defaultWorkers), dv.GetInt64Value())
+}
+
+func TestDescriptor_WorkerConfigFormCadenceDefaultsMatchParseConfig(t *testing.T) {
+	// Every default the parser reads must be exposed in the descriptor's
+	// DefaultValues; otherwise the admin UI would seed the form with a
+	// blank or zero value and the worker would silently clamp to the
+	// hardcoded fallback. Drift between the two is the bug this test
+	// catches.
+	h := NewHandler(nil)
+	d := h.Descriptor()
+	require.NotNil(t, d.WorkerConfigForm)
+	assert.Equal(t, "s3-lifecycle-worker", d.WorkerConfigForm.FormId)
+
+	wantDefaults := map[string]int64{
+		"dispatch_tick_minutes":      defaultDispatchTickMinutes,
+		"checkpoint_tick_seconds":    defaultCheckpointTickSeconds,
+		"refresh_interval_minutes":   defaultRefreshIntervalMinutes,
+		"bootstrap_interval_minutes": defaultBootstrapIntervalMinutes,
+		"max_runtime_minutes":        defaultMaxRuntimeMinutes,
+	}
+	for name, want := range wantDefaults {
+		t.Run(name, func(t *testing.T) {
+			dv, ok := d.WorkerConfigForm.DefaultValues[name]
+			require.True(t, ok, "WorkerConfigForm.DefaultValues missing %q", name)
+			assert.Equal(t, want, dv.GetInt64Value(), "default mismatch for %q", name)
+		})
+	}
+	// And the form fields themselves: every default must be paired with
+	// a field of matching name so the admin can render and edit it.
+	declared := map[string]bool{}
+	for _, sec := range d.WorkerConfigForm.Sections {
+		for _, f := range sec.Fields {
+			declared[f.Name] = true
+		}
+	}
+	for name := range wantDefaults {
+		assert.True(t, declared[name], "WorkerConfigForm has no field named %q", name)
+	}
+}
+
+func TestDescriptor_AdminRuntimeDefaultsDailyCadence(t *testing.T) {
+	// Lifecycle is a daily batch; the admin must default to a 24-hour
+	// detection interval so cron pressure doesn't escalate. Bound the
+	// detection timeout so a stuck detect can't pin a worker slot
+	// indefinitely. Max 1 job per detection = scheduler runs alone.
+	h := NewHandler(nil)
+	d := h.Descriptor()
+	require.NotNil(t, d.AdminRuntimeDefaults)
+	assert.Equal(t, int32(24*60), d.AdminRuntimeDefaults.DetectionIntervalMinutes)
+	assert.Greater(t, d.AdminRuntimeDefaults.DetectionTimeoutSeconds, int32(0))
+	assert.Equal(t, int32(1), d.AdminRuntimeDefaults.MaxJobsPerDetection)
+}
+
 // ---------- Execute ----------
 
 // recordingExecSender captures Execute-side messages. The Execute path


### PR DESCRIPTION
Follow-up to #9396 / #9398, which covered Capability + Detect + Execute. \`Descriptor()\` was previously untested.

Drift between the descriptor's form fields and the defaults \`ParseConfig\` reads silently breaks the admin UI in two ways:
1. The form renders blank → admin can't tune the knob from the UI
2. The worker clamps to a hardcoded fallback → admin edits are silently ignored

Pinned (4 tests):
- **basic shape**: \`jobType\`, non-empty \`DisplayName\` / \`Description\`, positive \`DescriptorVersion\` (used by admin for compat)
- **AdminConfigForm**: \`s3-lifecycle-admin\` form exposes a \`workers\` int64 field whose default value matches \`defaultWorkers\` from \`config.go\`
- **WorkerConfigForm**: every default \`ParseConfig\` reads has a paired \`DefaultValues\` entry AND a form field of the same name (\`dispatch_tick_minutes\`, \`checkpoint_tick_seconds\`, \`refresh_interval_minutes\`, \`bootstrap_interval_minutes\`, \`max_runtime_minutes\`)
- **AdminRuntimeDefaults**: daily detection cadence (24*60 minutes), bounded detection timeout, max 1 job per detection so the scheduler runs alone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for S3 lifecycle handler descriptors, verifying descriptor metadata, admin and worker configuration forms, cadence/default interval values, and daily runtime defaults (detection interval, timeout, and max jobs).
  * Improved coverage around configuration validation and default-value alignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9401)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->