### PR TITLE
test(s3/lifecycle): pin Pipeline.Run dependency + shard validation (Phase 15 slice)

### DIFF
--- a/weed/s3api/s3lifecycle/dispatcher/pipeline_test.go
+++ b/weed/s3api/s3lifecycle/dispatcher/pipeline_test.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -80,5 +81,107 @@ func TestPipelineRunRequiresDependencies(t *testing.T) {
 	err := p.Run(context.Background())
 	if err == nil {
 		t.Fatal("expected error for empty Pipeline")
+	}
+}
+
+// stubFilerClient satisfies filer_pb.SeaweedFilerClient just enough to
+// pass the nil-check in Pipeline.Run; methods would panic if called,
+// but the validation tests below all return before any RPC.
+type stubFilerClient struct {
+	filer_pb.SeaweedFilerClient
+}
+
+// fullPipeline assembles a Pipeline whose dependencies all pass the
+// nil-check, so individual tests can knock out one piece at a time
+// to exercise specific validation branches.
+func fullPipeline() *Pipeline {
+	return &Pipeline{
+		Engine:      engine.New(),
+		Persister:   reader.NewInMemoryPersister(),
+		Client:      &fakeClient{},
+		FilerClient: &stubFilerClient{},
+		BucketsPath: "/buckets",
+		ShardID:     0,
+	}
+}
+
+func TestPipelineRunMissingEngine(t *testing.T) {
+	p := fullPipeline()
+	p.Engine = nil
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
+		t.Fatalf("expected dependency error, got %v", err)
+	}
+}
+
+func TestPipelineRunMissingPersister(t *testing.T) {
+	p := fullPipeline()
+	p.Persister = nil
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
+		t.Fatalf("expected dependency error, got %v", err)
+	}
+}
+
+func TestPipelineRunMissingClient(t *testing.T) {
+	p := fullPipeline()
+	p.Client = nil
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
+		t.Fatalf("expected dependency error, got %v", err)
+	}
+}
+
+func TestPipelineRunMissingFilerClient(t *testing.T) {
+	p := fullPipeline()
+	p.FilerClient = nil
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
+		t.Fatalf("expected dependency error, got %v", err)
+	}
+}
+
+func TestPipelineRunMissingBucketsPath(t *testing.T) {
+	// BucketsPath has its own error message so operators can spot the
+	// missing wiring (the dependency check runs first and would mask it).
+	p := fullPipeline()
+	p.BucketsPath = ""
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "BucketsPath required") {
+		t.Fatalf("expected BucketsPath error, got %v", err)
+	}
+}
+
+func TestPipelineRunRejectsNegativeShard(t *testing.T) {
+	p := fullPipeline()
+	p.ShardID = -1
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "out of") {
+		t.Fatalf("expected shard-range error, got %v", err)
+	}
+}
+
+func TestPipelineRunRejectsShardAtBoundary(t *testing.T) {
+	// The range is half-open [0, ShardCount); ShardCount itself is
+	// out-of-range. Catch this so a refactor that flips < to <= can't
+	// introduce a one-past-the-end shard.
+	p := fullPipeline()
+	p.ShardID = s3lifecycle.ShardCount
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "out of") {
+		t.Fatalf("expected shard-range error, got %v", err)
+	}
+}
+
+func TestPipelineRunRejectsAnyShardOutOfRange(t *testing.T) {
+	// Multi-shard configs use Shards rather than ShardID; if any one
+	// of them is out of range the whole run must refuse, otherwise a
+	// single bad entry could silently disable the rest.
+	p := fullPipeline()
+	p.ShardID = 0
+	p.Shards = []int{0, 1, s3lifecycle.ShardCount + 1}
+	err := p.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "out of") {
+		t.Fatalf("expected shard-range error for multi-shard config, got %v", err)
 	}
 }

--- a/weed/s3api/s3lifecycle/dispatcher/pipeline_test.go
+++ b/weed/s3api/s3lifecycle/dispatcher/pipeline_test.go
@@ -105,83 +105,37 @@ func fullPipeline() *Pipeline {
 	}
 }
 
-func TestPipelineRunMissingEngine(t *testing.T) {
-	p := fullPipeline()
-	p.Engine = nil
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
-		t.Fatalf("expected dependency error, got %v", err)
+func TestPipelineRunValidation(t *testing.T) {
+	// Each case mutates one piece of a fullPipeline() and asserts the
+	// expected error fragment. Per-dependency cases pin that the nil
+	// check exercises every required field individually; the Buckets-
+	// Path case asserts the distinct error message; the shard cases
+	// pin the half-open [0, ShardCount) range and that any one bad
+	// entry refuses the whole multi-shard run.
+	cases := []struct {
+		name    string
+		mutate  func(*Pipeline)
+		wantErr string
+	}{
+		{"missing Engine", func(p *Pipeline) { p.Engine = nil }, "missing required dependency"},
+		{"missing Persister", func(p *Pipeline) { p.Persister = nil }, "missing required dependency"},
+		{"missing Client", func(p *Pipeline) { p.Client = nil }, "missing required dependency"},
+		{"missing FilerClient", func(p *Pipeline) { p.FilerClient = nil }, "missing required dependency"},
+		{"missing BucketsPath", func(p *Pipeline) { p.BucketsPath = "" }, "BucketsPath required"},
+		{"negative ShardID", func(p *Pipeline) { p.ShardID = -1 }, "out of"},
+		{"ShardID at boundary", func(p *Pipeline) { p.ShardID = s3lifecycle.ShardCount }, "out of"},
+		{"multi-shard out of range", func(p *Pipeline) {
+			p.Shards = []int{0, 1, s3lifecycle.ShardCount + 1}
+		}, "out of"},
 	}
-}
-
-func TestPipelineRunMissingPersister(t *testing.T) {
-	p := fullPipeline()
-	p.Persister = nil
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
-		t.Fatalf("expected dependency error, got %v", err)
-	}
-}
-
-func TestPipelineRunMissingClient(t *testing.T) {
-	p := fullPipeline()
-	p.Client = nil
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
-		t.Fatalf("expected dependency error, got %v", err)
-	}
-}
-
-func TestPipelineRunMissingFilerClient(t *testing.T) {
-	p := fullPipeline()
-	p.FilerClient = nil
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "missing required dependency") {
-		t.Fatalf("expected dependency error, got %v", err)
-	}
-}
-
-func TestPipelineRunMissingBucketsPath(t *testing.T) {
-	// BucketsPath has its own error message so operators can spot the
-	// missing wiring (the dependency check runs first and would mask it).
-	p := fullPipeline()
-	p.BucketsPath = ""
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "BucketsPath required") {
-		t.Fatalf("expected BucketsPath error, got %v", err)
-	}
-}
-
-func TestPipelineRunRejectsNegativeShard(t *testing.T) {
-	p := fullPipeline()
-	p.ShardID = -1
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "out of") {
-		t.Fatalf("expected shard-range error, got %v", err)
-	}
-}
-
-func TestPipelineRunRejectsShardAtBoundary(t *testing.T) {
-	// The range is half-open [0, ShardCount); ShardCount itself is
-	// out-of-range. Catch this so a refactor that flips < to <= can't
-	// introduce a one-past-the-end shard.
-	p := fullPipeline()
-	p.ShardID = s3lifecycle.ShardCount
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "out of") {
-		t.Fatalf("expected shard-range error, got %v", err)
-	}
-}
-
-func TestPipelineRunRejectsAnyShardOutOfRange(t *testing.T) {
-	// Multi-shard configs use Shards rather than ShardID; if any one
-	// of them is out of range the whole run must refuse, otherwise a
-	// single bad entry could silently disable the rest.
-	p := fullPipeline()
-	p.ShardID = 0
-	p.Shards = []int{0, 1, s3lifecycle.ShardCount + 1}
-	err := p.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "out of") {
-		t.Fatalf("expected shard-range error for multi-shard config, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := fullPipeline()
+			tc.mutate(p)
+			err := p.Run(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
\`Pipeline.Run\` is the central event-driven orchestrator for Phase 3 (event-driven trigger + pending drain). The pre-existing \`TestPipelineRunRequiresDependencies\` only checked that an empty Pipeline errors; it didn't pin which specific dependency must be present. A refactor that makes one nilable accidentally would slip through.

8 new tests pin every validation branch:
- **Per-dependency nil check**: \`Engine\` / \`Persister\` / \`Client\` / \`FilerClient\` each error individually with "missing required dependency" so a refactor that nils any one of them is caught
- **Empty BucketsPath**: errors with its own distinct message ("BucketsPath required") so operators can spot the missing wiring (the dependency check would otherwise mask it)
- **Negative ShardID**: errors with a range message
- **ShardID at the boundary**: \`ShardCount\` itself is out of range. Catches a regression that flips \`<\` to \`<=\` and introduces a one-past-the-end shard
- **Multi-shard config with one bad entry**: refuses the whole run rather than silently disabling the rest

\`stubFilerClient\` and \`fullPipeline()\` helpers let each test knock out a single piece. None of these reach a real RPC, so the tests are fast and don't need an in-process gRPC server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for pipeline validation, adding helper stubs and constructing a minimally valid pipeline for tests.
  * New cases assert errors for missing dependencies (engine, persister, client, filer client, path) and invalid shard configurations (negative, out-of-range, boundary conditions).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9402)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->