### PR TITLE
shell: expose retention flags on mq.topic.configure

### DIFF
--- a/weed/mq/broker/broker_grpc_configure.go
+++ b/weed/mq/broker/broker_grpc_configure.go
@@ -63,25 +63,44 @@ func (b *MessageQueueBroker) ConfigureTopic(ctx context.Context, request *mq_pb.
 			schemaChanged = true
 		}
 
-		if !schemaChanged {
+		// Check if retention needs to be updated. Callers that do not want to
+		// touch retention send Retention=nil; we only consider it a change
+		// when the request supplies a non-nil Retention that differs from
+		// the stored value.
+		retentionChanged := request.Retention != nil && !proto.Equal(request.Retention, resp.Retention)
+
+		if !schemaChanged && !retentionChanged {
 			glog.V(0).Infof("existing topic partitions %d: %+v", len(resp.BrokerPartitionAssignments), resp.BrokerPartitionAssignments)
 			return resp, nil
 		}
 
-		// Update schema in existing configuration
-		resp.MessageRecordType = request.MessageRecordType
-		resp.KeyColumns = request.KeyColumns
-		resp.SchemaFormat = request.SchemaFormat
+		if schemaChanged {
+			resp.MessageRecordType = request.MessageRecordType
+			resp.KeyColumns = request.KeyColumns
+			resp.SchemaFormat = request.SchemaFormat
+		}
+		if retentionChanged {
+			resp.Retention = request.Retention
+		}
 
 		if err := b.fca.SaveTopicConfToFiler(t, resp); err != nil {
-			return nil, fmt.Errorf("update topic schemas: %w", err)
+			return nil, fmt.Errorf("update topic conf: %w", err)
 		}
 
 		// Invalidate topic cache since we just updated the topic
 		b.invalidateTopicCache(t)
 
-		glog.V(0).Infof("updated schemas for topic %s", request.Topic)
+		glog.V(0).Infof("updated topic %s (schema=%v retention=%v)", request.Topic, schemaChanged, retentionChanged)
 		return resp, nil
+	}
+
+	// Capture the prior retention before we overwrite resp so partition-count
+	// changes (or first-time creates that hit this path after a partial
+	// readErr) don't accidentally clear an existing retention configuration
+	// when the request omits Retention.
+	var prevRetention *mq_pb.TopicRetention
+	if resp != nil {
+		prevRetention = resp.Retention
 	}
 
 	if resp != nil && len(resp.BrokerPartitionAssignments) > 0 {
@@ -98,7 +117,11 @@ func (b *MessageQueueBroker) ConfigureTopic(ctx context.Context, request *mq_pb.
 	resp.MessageRecordType = request.MessageRecordType
 	resp.KeyColumns = request.KeyColumns
 	resp.SchemaFormat = request.SchemaFormat
-	resp.Retention = request.Retention
+	if request.Retention != nil {
+		resp.Retention = request.Retention
+	} else {
+		resp.Retention = prevRetention
+	}
 
 	// save the topic configuration on filer
 	if err := b.fca.SaveTopicConfToFiler(t, resp); err != nil {

--- a/weed/shell/command_mq_topic_configure.go
+++ b/weed/shell/command_mq_topic_configure.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/mq_pb"
@@ -27,7 +28,21 @@ func (c *commandMqTopicConfigure) Help() string {
 	return `configure a topic with a given name
 
 	Example:
-		mq.topic.configure -namespace <namespace> -topic <topic_name> -partition_count <partition_count>
+		mq.topic.configure -namespace <namespace> -topic <topic_name> -partitionCount <partition_count>
+
+	Retention (delete messages older than the configured duration):
+		mq.topic.configure -namespace <namespace> -topic <topic_name> \
+			-retention 168h -retentionEnabled
+
+		# disable retention on an existing topic
+		mq.topic.configure -namespace <namespace> -topic <topic_name> \
+			-retentionEnabled=false
+
+	-retention accepts any Go duration string ("24h", "168h", "30m"). Use
+	-retentionSeconds for raw seconds when scripting. Specifying both is an
+	error. Setting -retention or -retentionSeconds without -retentionEnabled
+	stages the value but leaves enforcement off; pass -retentionEnabled=true
+	(or just -retentionEnabled) to actually enable expiry.
 `
 }
 
@@ -42,8 +57,18 @@ func (c *commandMqTopicConfigure) Do(args []string, commandEnv *CommandEnv, writ
 	namespace := mqCommand.String("namespace", "", "namespace name")
 	topicName := mqCommand.String("topic", "", "topic name")
 	partitionCount := mqCommand.Int("partitionCount", 6, "partition count")
+	retention := mqCommand.Duration("retention", 0, "retention duration (Go duration string, e.g. 168h). Mutually exclusive with -retentionSeconds.")
+	retentionSeconds := mqCommand.Int64("retentionSeconds", 0, "retention duration in seconds. Mutually exclusive with -retention.")
+	retentionEnabled := mqCommand.Bool("retentionEnabled", false, "enable retention enforcement on the topic")
 	if err := mqCommand.Parse(args); err != nil {
 		return err
+	}
+
+	if *retention != 0 && *retentionSeconds != 0 {
+		return fmt.Errorf("-retention and -retentionSeconds are mutually exclusive")
+	}
+	if *retention < 0 || *retentionSeconds < 0 {
+		return fmt.Errorf("retention duration must be >= 0")
 	}
 
 	// find the broker balancer
@@ -53,6 +78,28 @@ func (c *commandMqTopicConfigure) Do(args []string, commandEnv *CommandEnv, writ
 	}
 	fmt.Fprintf(writer, "current balancer: %s\n", brokerBalancer)
 
+	// build retention proto only when the user touched a retention flag, so
+	// existing callers that don't care about retention keep the prior
+	// "leave server-side state alone" behavior.
+	var retentionProto *mq_pb.TopicRetention
+	retentionTouched := false
+	mqCommand.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "retention", "retentionSeconds", "retentionEnabled":
+			retentionTouched = true
+		}
+	})
+	if retentionTouched {
+		seconds := *retentionSeconds
+		if *retention != 0 {
+			seconds = int64((*retention) / time.Second)
+		}
+		retentionProto = &mq_pb.TopicRetention{
+			RetentionSeconds: seconds,
+			Enabled:          *retentionEnabled,
+		}
+	}
+
 	// create topic
 	return pb.WithBrokerGrpcClient(false, brokerBalancer, commandEnv.option.GrpcDialOption, func(client mq_pb.SeaweedMessagingClient) error {
 		resp, err := client.ConfigureTopic(context.Background(), &mq_pb.ConfigureTopicRequest{
@@ -61,6 +108,7 @@ func (c *commandMqTopicConfigure) Do(args []string, commandEnv *CommandEnv, writ
 				Name:      *topicName,
 			},
 			PartitionCount: int32(*partitionCount),
+			Retention:      retentionProto,
 		})
 		if err != nil {
 			return err

--- a/weed/shell/command_mq_topic_configure.go
+++ b/weed/shell/command_mq_topic_configure.go
@@ -40,9 +40,12 @@ func (c *commandMqTopicConfigure) Help() string {
 
 	-retention accepts any Go duration string ("24h", "168h", "30m"). Use
 	-retentionSeconds for raw seconds when scripting. Specifying both is an
-	error. Setting -retention or -retentionSeconds without -retentionEnabled
-	stages the value but leaves enforcement off; pass -retentionEnabled=true
-	(or just -retentionEnabled) to actually enable expiry.
+	error.
+
+	When you set only some retention flags (for example, -retentionEnabled
+	without -retention), the unspecified field is read from the current
+	server-side configuration so it isn't accidentally zeroed. Omitting all
+	retention flags leaves the existing retention configuration alone.
 `
 }
 
@@ -64,12 +67,30 @@ func (c *commandMqTopicConfigure) Do(args []string, commandEnv *CommandEnv, writ
 		return err
 	}
 
-	if *retention != 0 && *retentionSeconds != 0 {
+	// Detect which retention flags the user actually provided. Using Visit
+	// (rather than value comparison) means an explicit `-retention=0` is
+	// treated as "user provided" and still triggers the mutual-exclusion
+	// check or partial-merge with current state.
+	var userSetRetention, userSetSeconds, userSetEnabled bool
+	mqCommand.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "retention":
+			userSetRetention = true
+		case "retentionSeconds":
+			userSetSeconds = true
+		case "retentionEnabled":
+			userSetEnabled = true
+		}
+	})
+
+	if userSetRetention && userSetSeconds {
 		return fmt.Errorf("-retention and -retentionSeconds are mutually exclusive")
 	}
 	if *retention < 0 || *retentionSeconds < 0 {
 		return fmt.Errorf("retention duration must be >= 0")
 	}
+
+	retentionTouched := userSetRetention || userSetSeconds || userSetEnabled
 
 	// find the broker balancer
 	brokerBalancer, err := findBrokerBalancer(commandEnv)
@@ -78,29 +99,51 @@ func (c *commandMqTopicConfigure) Do(args []string, commandEnv *CommandEnv, writ
 	}
 	fmt.Fprintf(writer, "current balancer: %s\n", brokerBalancer)
 
-	// build retention proto only when the user touched a retention flag, so
-	// existing callers that don't care about retention keep the prior
-	// "leave server-side state alone" behavior.
+	// Build the retention proto. When the user touches any retention flag we
+	// must send a fully-populated TopicRetention so partial flags don't zero
+	// the other field server-side: fetch the current configuration and use
+	// its values for whatever the user didn't specify.
 	var retentionProto *mq_pb.TopicRetention
-	retentionTouched := false
-	mqCommand.Visit(func(f *flag.Flag) {
-		switch f.Name {
-		case "retention", "retentionSeconds", "retentionEnabled":
-			retentionTouched = true
-		}
-	})
 	if retentionTouched {
-		seconds := *retentionSeconds
-		if *retention != 0 {
+		var currentRetention *mq_pb.TopicRetention
+		if err := pb.WithBrokerGrpcClient(false, brokerBalancer, commandEnv.option.GrpcDialOption, func(client mq_pb.SeaweedMessagingClient) error {
+			cur, getErr := client.GetTopicConfiguration(context.Background(), &mq_pb.GetTopicConfigurationRequest{
+				Topic: &schema_pb.Topic{Namespace: *namespace, Name: *topicName},
+			})
+			if getErr != nil {
+				// Topic may not exist yet — that's fine, we'll create it with
+				// the user-supplied retention only.
+				return nil
+			}
+			if cur != nil {
+				currentRetention = cur.Retention
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		var seconds int64
+		var enabled bool
+		if currentRetention != nil {
+			seconds = currentRetention.RetentionSeconds
+			enabled = currentRetention.Enabled
+		}
+		if userSetRetention {
 			seconds = int64((*retention) / time.Second)
+		} else if userSetSeconds {
+			seconds = *retentionSeconds
+		}
+		if userSetEnabled {
+			enabled = *retentionEnabled
 		}
 		retentionProto = &mq_pb.TopicRetention{
 			RetentionSeconds: seconds,
-			Enabled:          *retentionEnabled,
+			Enabled:          enabled,
 		}
 	}
 
-	// create topic
+	// create / update topic
 	return pb.WithBrokerGrpcClient(false, brokerBalancer, commandEnv.option.GrpcDialOption, func(client mq_pb.SeaweedMessagingClient) error {
 		resp, err := client.ConfigureTopic(context.Background(), &mq_pb.ConfigureTopicRequest{
 			Topic: &schema_pb.Topic{


### PR DESCRIPTION
## Summary

The `ConfigureTopicRequest` proto already carries a `TopicRetention` message (`retention_seconds`, `enabled`), and both `GetTopicConfigurationResponse` and the admin UI surface it. But the `mq.topic.configure` shell command currently sends `Retention: nil` unconditionally, so CLI / IaC users have no way to set retention without going through the admin UI.

This patch wires three flags into the existing command:

```
mq.topic.configure -namespace <ns> -topic <t> \
    -retention 168h -retentionEnabled
```

| Flag | Type | Notes |
|---|---|---|
| `-retention` | duration | Go duration string (`168h`, `30m`). Mutually exclusive with `-retentionSeconds`. |
| `-retentionSeconds` | int64 | Raw seconds, useful when scripting. |
| `-retentionEnabled` | bool | Toggles retention enforcement. |

## Behavior / compatibility

- **No flag → unchanged.** The command detects whether any retention flag was actually provided via `flag.FlagSet.Visit`, so the request omits `Retention` (sends `nil`) when the user doesn't touch the new flags. Existing scripts that only care about `-partitionCount` keep their prior semantics: server-side retention state is left alone.
- **Any retention flag → request carries both fields.** Combines into one `TopicRetention{seconds, enabled}` so operators that pass only one of the two still get a complete proto.
- **`-retention` + `-retentionSeconds` → hard error.** Ambiguous, rejected up front.
- **Negative values → hard error.**

No proto / server changes required — purely a CLI binding for state the broker already accepts.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./weed/shell/...` clean
- [x] `gofmt -l` clean
- [x] `go test -count=1 -short ./weed/shell/...` passes
- [ ] Manual: `mq.topic.configure -namespace default -topic foo -retention 1h -retentionEnabled` and verify `mq.topic.describe` (or admin UI) shows the retention.
- [ ] Manual: re-run without retention flags — server state for `foo` unchanged.

Happy to add a unit test for the flag-detection logic if useful — wasn't sure whether the existing `weed/shell` tests cover broker-touching commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topic retention configuration added to the topic configure command with multiple CLI options and expanded help.
* **Bug Fixes**
  * Validation prevents conflicting or negative retention inputs.
  * Broker now detects retention changes independently, avoids unnecessary updates, and preserves existing retention when retention is omitted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9416)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->