### PR TITLE
fix(s3api): cap copy-chunk receive buffer to avoid append-grow blowup

### DIFF
--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1434,7 +1434,13 @@ func (s3a *S3ApiServer) downloadChunkData(srcUrl, fileId string, offset, size in
 		return nil, fmt.Errorf("chunk size %d exceeds maximum int32 size", size)
 	}
 	sizeInt := int(size)
-	var chunkData []byte
+	// Pre-size the receive buffer to the known chunk size so the streaming
+	// callback below does not trigger geometric `append`-grow on a nil slice.
+	// Receiving a 64 MiB chunk through 256 KiB callback ticks would otherwise
+	// allocate ~2x the chunk size, and with concurrent UploadPartCopy requests
+	// (Harbor-style assemble loops) this caused the runaway-RSS pattern in
+	// https://github.com/seaweedfs/seaweedfs/issues/6541.
+	chunkData := make([]byte, 0, sizeInt)
 	shouldRetry, err := util_http.ReadUrlAsStream(context.Background(), srcUrl, jwt, nil, false, false, offset, sizeInt, func(data []byte) {
 		chunkData = append(chunkData, data...)
 	})

--- a/weed/s3api/s3api_object_handlers_copy_alloc_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_alloc_test.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -79,12 +80,17 @@ func TestDownloadChunkData_AllocationBound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("downloadChunkData: %v", err)
 	}
-	if len(data) != chunkSize {
-		t.Fatalf("got %d bytes, want %d", len(data), chunkSize)
-	}
 
 	runtime.ReadMemStats(&after)
 	allocated := after.TotalAlloc - before.TotalAlloc
+
+	// Correctness check happens after the alloc measurement so bytes.Equal
+	// doesn't pollute the window. A pre-sized buffer that silently truncates
+	// or corrupts the chunk would still pass the bound — assert content too.
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("downloaded data does not match payload (len got=%d want=%d)",
+			len(data), len(payload))
+	}
 
 	// The output slice itself is chunkSize bytes; the streaming pump uses a
 	// pooled 256 KiB read buffer and doesn't otherwise accumulate. A 1.5x

--- a/weed/s3api/s3api_object_handlers_copy_alloc_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_alloc_test.go
@@ -1,0 +1,100 @@
+package s3api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"testing"
+
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+// TestDownloadChunkData_AllocationBound is a regression guard for
+// https://github.com/seaweedfs/seaweedfs/issues/6541.
+//
+// downloadChunkData previously accumulated streamed bytes via
+//
+//	var chunkData []byte
+//	... fn := func(data []byte) { chunkData = append(chunkData, data...) }
+//
+// The callback fires once per ReadUrlAsStream pump (256 KiB), so a 16 MiB
+// chunk grew the slice geometrically (256K -> 512K -> 1M -> ... -> 32M),
+// allocating ~2x the chunk size for every transferred byte. Combined with
+// the 4-way per-request concurrency in copyChunks/copyChunksForRange and
+// any number of in-flight UploadPartCopy calls (Harbor multipart assemble),
+// this produced the runaway RSS reported in the issue.
+//
+// We assert that downloading a chunkSize-byte chunk allocates at most
+// 1.5 * chunkSize bytes on the heap. The pre-fix nil-append pattern blows
+// past that bound; the fixed (`make([]byte, 0, sizeInt)`) version stays
+// well under it.
+func TestDownloadChunkData_AllocationBound(t *testing.T) {
+	// downloadChunkData drives the package-level global HTTP client. Tests
+	// don't go through the normal `weed` startup that does this, so call it
+	// here. Idempotent on subsequent test runs.
+	util_http.InitGlobalHttpClient()
+
+	const chunkSize = 16 << 20 // 16 MiB
+	payload := make([]byte, chunkSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		// Write in 64 KiB increments so the body is delivered to the client
+		// reader in many small reads, mirroring real volume-server streaming
+		// behavior. The exact step does not matter as long as the body comes
+		// through the client in multiple Read() calls.
+		const step = 64 * 1024
+		for i := 0; i < len(payload); i += step {
+			end := i + step
+			if end > len(payload) {
+				end = len(payload)
+			}
+			if _, err := w.Write(payload[i:end]); err != nil {
+				return
+			}
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	s3a := &S3ApiServer{}
+
+	// Warm up the global HTTP client and any package-level pools so they
+	// don't show up in the measured allocation window.
+	if _, err := s3a.downloadChunkData(srv.URL, "1,0", 0, int64(chunkSize), nil); err != nil {
+		t.Fatalf("warm-up downloadChunkData: %v", err)
+	}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	data, err := s3a.downloadChunkData(srv.URL, "1,0", 0, int64(chunkSize), nil)
+	if err != nil {
+		t.Fatalf("downloadChunkData: %v", err)
+	}
+	if len(data) != chunkSize {
+		t.Fatalf("got %d bytes, want %d", len(data), chunkSize)
+	}
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	// The output slice itself is chunkSize bytes; the streaming pump uses a
+	// pooled 256 KiB read buffer and doesn't otherwise accumulate. A 1.5x
+	// bound is comfortably above the steady-state cost and well below the
+	// pre-fix geometric-grow cost (~2x).
+	maxAllowed := uint64(chunkSize) * 3 / 2
+	if allocated > maxAllowed {
+		t.Fatalf("downloadChunkData allocated %d bytes for a %d-byte chunk; bound is %d "+
+			"(regression: unbounded append in callback?)",
+			allocated, chunkSize, maxAllowed)
+	}
+	t.Logf("allocated=%d bytes, bound=%d, output=%d", allocated, maxAllowed, chunkSize)
+}


### PR DESCRIPTION
Refs #6541 ([EpochBoy comment](https://github.com/seaweedfs/seaweedfs/issues/6541#issuecomment-4414927382) — runaway RSS on Harbor still seen on v4.06 and v4.23, even after #6665).

## What

`downloadChunkData` accumulated the streamed chunk into a nil `[]byte`:

```go
var chunkData []byte
shouldRetry, err := util_http.ReadUrlAsStream(..., sizeInt, func(data []byte) {
    chunkData = append(chunkData, data...)
})
```

`ReadUrlAsStream` pumps in 256 KiB ticks, so a 64 MiB chunk grew the slice geometrically (256K → 512K → 1M → … → 64M), allocating ~2× the chunk size for every transferred byte. Combined with the 4-way `defaultChunkCopyConcurrency` per request and any number of concurrent `UploadPartCopy` calls (Harbor multipart-assemble), that produces the runaway-RSS pattern in the issue.

Pre-size the receive slice to `sizeInt` so the callback fills it in place.

## Repro (weed 4.23, 6 parallel UploadPartCopy on a 512 MiB source)

| stage              | RSS      |
| ------------------ | -------- |
| baseline           | 96 MiB   |
| after src upload   | 642 MiB  |
| after round 1      | 2693 MiB |
| after round 2      | 3134 MiB |

Heap profile at peak:
```
inuse_space  650 MiB  bytes.growSlice
inuse_space  461 MiB  s3api.downloadChunkData.func1
inuse_space  248 MiB  bytebufferpool.ByteBuffer.Write   (volume PostHandler)
alloc_space 14.6 GiB cumulative (>14× amplification)
```

## Test

`TestDownloadChunkData_AllocationBound` downloads a 16 MiB chunk through `httptest` and asserts `TotalAlloc` stays ≤ 1.5× chunk size:

- pre-fix:  allocates 90 MiB → fails (`bound is 25165824`)
- post-fix: allocates 17 MiB → passes

## Follow-ups (not in this PR)

The volume server's GET (`bytes.Buffer.ReadFrom`, ~184 MiB inuse) and `bytebufferpool` retention on the upload side are independent contributors that could each be addressed similarly. They should be separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocations during S3 copy/encrypt/decrypt chunk downloads for more efficient transfers.

* **Tests**
  * Added a regression test ensuring chunk download memory usage stays within expected bounds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9420)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->