### PR TITLE
feat(s3api): stream chunk copy via io.Pipe to cut peak working set

### DIFF
--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1379,16 +1379,7 @@ func (s3a *S3ApiServer) prepareChunkCopy(sourceFileId, dstPath string, expectedD
 // uploadChunkData uploads chunk data to the destination using common upload logic
 // isCompressed indicates if the data is already compressed and should not be compressed again
 func (s3a *S3ApiServer) uploadChunkData(chunkData []byte, assignResult *filer_pb.AssignVolumeResponse, isCompressed bool) error {
-	dstUrl := fmt.Sprintf("http://%s/%s", assignResult.Location.Url, assignResult.FileId)
-
-	uploadOption := &operation.UploadOption{
-		UploadUrl:         dstUrl,
-		Cipher:            false, // Data is already encrypted if source had CipherKey; don't re-encrypt
-		IsInputCompressed: isCompressed,
-		MimeType:          "",
-		PairMap:           nil,
-		Jwt:               security.EncodedJwt(assignResult.Auth),
-	}
+	uploadOption := newChunkUploadOption(chunkData, assignResult, isCompressed)
 	uploader, err := operation.NewUploader()
 	if err != nil {
 		return fmt.Errorf("create uploader: %w", err)
@@ -1399,6 +1390,33 @@ func (s3a *S3ApiServer) uploadChunkData(chunkData []byte, assignResult *filer_pb
 	}
 
 	return nil
+}
+
+// multipartFramingOverhead reserves space for the multipart wrapper
+// upload_content writes around chunkData (boundary + Content-Disposition +
+// optional Content-Type/Content-Encoding/Content-MD5 headers + trailing
+// boundary). Real-world overhead is a few hundred bytes; rounding to 1 KiB
+// avoids a single grow on the buffer we hand to the multipart writer.
+const multipartFramingOverhead = 1024
+
+// newChunkUploadOption builds the operation.UploadOption used by every
+// chunk-copy upload. It always sets BytesBuffer to a fresh, per-call buffer
+// so upload_content does not fall back to the package-global
+// valyala/bytebufferpool — that pool retains every high-water buffer for the
+// process's lifetime, and under concurrent UploadPartCopy load it hoarded
+// one chunk-sized buffer per concurrent upload (see #6541). The per-call
+// buffer is GC'd as soon as the upload returns.
+func newChunkUploadOption(chunkData []byte, assignResult *filer_pb.AssignVolumeResponse, isCompressed bool) *operation.UploadOption {
+	dstUrl := fmt.Sprintf("http://%s/%s", assignResult.Location.Url, assignResult.FileId)
+	return &operation.UploadOption{
+		UploadUrl:         dstUrl,
+		Cipher:            false, // Data is already encrypted if source had CipherKey; don't re-encrypt
+		IsInputCompressed: isCompressed,
+		MimeType:          "",
+		PairMap:           nil,
+		Jwt:               security.EncodedJwt(assignResult.Auth),
+		BytesBuffer:       bytes.NewBuffer(make([]byte, 0, len(chunkData)+multipartFramingOverhead)),
+	}
 }
 
 // downloadChunkData downloads chunk data from the source URL

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1053,7 +1053,18 @@ func (s3a *S3ApiServer) copySingleChunk(chunk *filer_pb.FileChunk, dstPath strin
 		return nil, err
 	}
 
-	// Download and upload the chunk
+	// Stream the chunk through io.Pipe when no in-transit transformation is
+	// required; this holds only ~32 KiB per copy in flight, vs. the
+	// chunk-sized buffers the buffered path needs.
+	if canStreamCopyChunk(chunk) {
+		if err := s3a.streamCopyChunkRange(context.Background(), srcUrl, fileId, 0, int64(chunk.Size), assignResult, chunk.IsCompressed); err != nil {
+			return nil, fmt.Errorf("stream chunk: %w", err)
+		}
+		return dstChunk, nil
+	}
+
+	// SSE / per-chunk-cipher: bytes need to be transformed in transit, so
+	// download into a buffer first.
 	chunkData, err := s3a.downloadChunkData(srcUrl, fileId, 0, int64(chunk.Size), chunk.CipherKey)
 	if err != nil {
 		return nil, fmt.Errorf("download chunk data: %w", err)
@@ -1087,6 +1098,17 @@ func (s3a *S3ApiServer) copySingleChunkForRange(originalChunk, rangeChunk *filer
 	chunkStart := originalChunk.Offset
 	overlapStart := max(rangeStart, chunkStart)
 	offsetInChunk := overlapStart - chunkStart
+
+	// Stream the byte range through io.Pipe when there's no in-transit
+	// transformation required (see canStreamCopyChunk for the eligibility
+	// rules); this is the dominant path for Harbor-style multipart
+	// assemble loads, which use UploadPartCopy with a CopySourceRange.
+	if canStreamCopyChunk(originalChunk) {
+		if err := s3a.streamCopyChunkRange(context.Background(), srcUrl, fileId, offsetInChunk, int64(rangeChunk.Size), assignResult, originalChunk.IsCompressed); err != nil {
+			return nil, fmt.Errorf("stream chunk range: %w", err)
+		}
+		return dstChunk, nil
+	}
 
 	// Download and upload the chunk portion
 	chunkData, err := s3a.downloadChunkData(srcUrl, fileId, offsetInChunk, int64(rangeChunk.Size), originalChunk.CipherKey)

--- a/weed/s3api/s3api_object_handlers_copy_bench_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_bench_test.go
@@ -1,0 +1,186 @@
+package s3api
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+// benchEnv stands up a fake source volume (returns N bytes on GET) and a
+// fake destination volume (parses an incoming multipart POST and discards
+// the body, asserting the data arrived intact via SHA-256). It returns the
+// URLs and an AssignVolumeResponse pointing at the destination.
+type benchEnv struct {
+	srcSrv  *httptest.Server
+	dstSrv  *httptest.Server
+	payload []byte
+	dstHash [32]byte
+	assign  *filer_pb.AssignVolumeResponse
+}
+
+func newBenchEnv(b *testing.B, payloadSize int) *benchEnv {
+	b.Helper()
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i*31 + 7) // arbitrary repeatable pattern
+	}
+	wantHash := sha256.Sum256(payload)
+
+	srcSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Honor Range header if present (UploadPartCopy passes one).
+		start, end := int64(0), int64(len(payload)-1)
+		if rng := r.Header.Get("Range"); rng != "" {
+			var s, e int64
+			if _, err := fmt.Sscanf(rng, "bytes=%d-%d", &s, &e); err == nil {
+				start, end = s, e
+			}
+		}
+		w.Header().Set("Content-Length", strconv.FormatInt(end-start+1, 10))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload[start : end+1])
+	}))
+
+	dstSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mr, err := r.MultipartReader()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		part, err := mr.NextPart()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		h := sha256.New()
+		if _, err := io.Copy(h, part); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var got [32]byte
+		copy(got[:], h.Sum(nil))
+		if got != wantHash {
+			http.Error(w, "hash mismatch", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"size":`+strconv.Itoa(payloadSize)+`}`)
+	}))
+
+	dstURL, _ := neturl(dstSrv.URL)
+	assign := &filer_pb.AssignVolumeResponse{
+		FileId: "1,benchmark",
+		Location: &filer_pb.Location{
+			Url:       dstURL,
+			PublicUrl: dstURL,
+		},
+		Auth: "",
+	}
+
+	return &benchEnv{
+		srcSrv:  srcSrv,
+		dstSrv:  dstSrv,
+		payload: payload,
+		dstHash: wantHash,
+		assign:  assign,
+	}
+}
+
+func (e *benchEnv) close() {
+	e.srcSrv.Close()
+	e.dstSrv.Close()
+}
+
+// neturl extracts host:port from "http://host:port".
+func neturl(rawURL string) (string, error) {
+	const prefix = "http://"
+	if len(rawURL) < len(prefix) || rawURL[:len(prefix)] != prefix {
+		return "", fmt.Errorf("unexpected URL: %q", rawURL)
+	}
+	host := rawURL[len(prefix):]
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		return "", err
+	}
+	return host, nil
+}
+
+// BenchmarkCopyChunk_Buffered measures the cost of the existing buffered
+// chunk-copy path (downloadChunkData + uploadChunkData). The path
+// allocates one chunk-sized []byte and one multipart-encoded buffer per
+// call.
+func BenchmarkCopyChunk_Buffered(b *testing.B) {
+	for _, size := range []int{1 << 20, 8 << 20, 64 << 20} {
+		b.Run(humanByteName(size), func(b *testing.B) {
+			util_http.InitGlobalHttpClient()
+			env := newBenchEnv(b, size)
+			defer env.close()
+
+			s3a := &S3ApiServer{}
+			b.ResetTimer()
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				data, err := s3a.downloadChunkData(env.srcSrv.URL, env.assign.FileId, 0, int64(size), nil)
+				if err != nil {
+					b.Fatalf("download: %v", err)
+				}
+				if err := s3a.uploadChunkData(data, env.assign, false); err != nil {
+					b.Fatalf("upload: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCopyChunk_Streamed measures the cost of the io.Pipe streaming
+// chunk-copy path. The path holds only the pipe's hand-off buffer (~32
+// KiB) plus http transport buffers per call, regardless of chunk size.
+func BenchmarkCopyChunk_Streamed(b *testing.B) {
+	for _, size := range []int{1 << 20, 8 << 20, 64 << 20} {
+		b.Run(humanByteName(size), func(b *testing.B) {
+			util_http.InitGlobalHttpClient()
+			env := newBenchEnv(b, size)
+			defer env.close()
+
+			s3a := &S3ApiServer{}
+			b.ResetTimer()
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				if err := s3a.streamCopyChunkRange(context.Background(),
+					env.srcSrv.URL, env.assign.FileId, 0, int64(size),
+					env.assign, false); err != nil {
+					b.Fatalf("stream: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func humanByteName(n int) string {
+	switch {
+	case n >= 1<<30:
+		return strconv.Itoa(n>>30) + "GiB"
+	case n >= 1<<20:
+		return strconv.Itoa(n>>20) + "MiB"
+	case n >= 1<<10:
+		return strconv.Itoa(n>>10) + "KiB"
+	default:
+		return strconv.Itoa(n) + "B"
+	}
+}
+
+// Compile-time sanity: ensure the multipart library version we depend on
+// is the one whose framing we mirror in streamCopyChunkRange.
+var _ = multipart.NewWriter

--- a/weed/s3api/s3api_object_handlers_copy_chunk_upload_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_chunk_upload_test.go
@@ -1,0 +1,77 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+// TestNewChunkUploadOption_AvoidsBytePool is a regression guard for the
+// s3-side retention amplifier in https://github.com/seaweedfs/seaweedfs/issues/6541.
+//
+// operation.upload_content falls back to the package-global
+// valyala/bytebufferpool (which retains high-water buffers for the
+// process's lifetime) whenever UploadOption.BytesBuffer is nil. Concurrent
+// UploadPartCopy calls then hoard one chunk-sized buffer per concurrent
+// upload in that pool, and RSS never recedes. The chunk-copy path must
+// therefore always provide its own buffer; this test pins that contract.
+func TestNewChunkUploadOption_AvoidsBytePool(t *testing.T) {
+	cases := []struct {
+		name     string
+		chunkLen int
+	}{
+		{"empty chunk", 0},
+		{"small chunk", 1024},
+		{"typical 8 MiB chunk", 8 * 1024 * 1024},
+		{"large 64 MiB chunk", 64 * 1024 * 1024},
+	}
+
+	assign := &filer_pb.AssignVolumeResponse{
+		FileId: "1,foo",
+		Location: &filer_pb.Location{
+			Url:       "127.0.0.1:8080",
+			PublicUrl: "127.0.0.1:8080",
+		},
+		Auth: "",
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data := make([]byte, c.chunkLen)
+			opt := newChunkUploadOption(data, assign, false)
+
+			if opt.BytesBuffer == nil {
+				t.Fatalf("BytesBuffer must be non-nil so chunk uploads bypass " +
+					"the package-global bytebufferpool (regression: #6541)")
+			}
+			if got, want := opt.BytesBuffer.Cap(), c.chunkLen+multipartFramingOverhead; got < want {
+				t.Errorf("BytesBuffer cap=%d, want >=%d (one alloc-and-grow "+
+					"per upload defeats the purpose of pre-sizing)", got, want)
+			}
+			if opt.BytesBuffer.Len() != 0 {
+				t.Errorf("BytesBuffer not empty: len=%d", opt.BytesBuffer.Len())
+			}
+			if opt.Cipher {
+				t.Errorf("Cipher must be false: chunk-copy data is already " +
+					"encrypted if the source had a CipherKey")
+			}
+		})
+	}
+}
+
+// TestNewChunkUploadOption_PerCallIsolation verifies each call returns a
+// distinct buffer. Sharing one buffer across concurrent uploads would
+// corrupt the multipart bodies under concurrent UploadPartCopy.
+func TestNewChunkUploadOption_PerCallIsolation(t *testing.T) {
+	assign := &filer_pb.AssignVolumeResponse{
+		FileId:   "1,foo",
+		Location: &filer_pb.Location{Url: "127.0.0.1:8080"},
+	}
+
+	o1 := newChunkUploadOption(nil, assign, false)
+	o2 := newChunkUploadOption(nil, assign, false)
+	if o1.BytesBuffer == o2.BytesBuffer {
+		t.Fatalf("newChunkUploadOption must hand each caller a distinct buffer; " +
+			"sharing one across concurrent uploads would corrupt the multipart bodies")
+	}
+}

--- a/weed/s3api/s3api_object_handlers_copy_stream.go
+++ b/weed/s3api/s3api_object_handlers_copy_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -54,6 +55,11 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 	assignResult *filer_pb.AssignVolumeResponse,
 	isCompressed bool,
 ) error {
+	// ReadUrlAsStream takes int for size; reject anything that would
+	// truncate negative on 32-bit. Mirrors the guard in downloadChunkData.
+	if size > int64(math.MaxInt32) {
+		return fmt.Errorf("chunk size %d exceeds maximum int32 size", size)
+	}
 	dstUrl := fmt.Sprintf("http://%s/%s", assignResult.Location.Url, assignResult.FileId)
 	dstJwt := security.EncodedJwt(assignResult.Auth)
 	srcJwt := filer.JwtForVolumeServer(srcFileId)
@@ -115,6 +121,16 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 			producerErr = fmt.Errorf("stream read: %w", readErr)
 			return
 		}
+		// shouldRetry can be set without an error (e.g. ReadUrlAsStream
+		// surfacing a partial-read condition that the buffered path
+		// re-fetches). Treat it as a failed copy here too — otherwise we
+		// would close the multipart cleanly and let the destination POST
+		// succeed against a possibly-truncated body. Mirrors the explicit
+		// check downloadChunkData makes after ReadUrlAsStream returns.
+		if shouldRetry {
+			producerErr = fmt.Errorf("stream read %s offset=%d size=%d: retry needed", srcUrl, offset, size)
+			return
+		}
 
 		if err := mw.Close(); err != nil {
 			producerErr = fmt.Errorf("multipart close: %w", err)
@@ -140,14 +156,12 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 		pipeReader.CloseWithError(err)
 		return fmt.Errorf("POST: %w", err)
 	}
+	// CloseResponse drains and closes resp.Body for us; no manual io.Copy
+	// drain needed for keepalive.
 	defer util_http.CloseResponse(resp)
 
 	if resp.StatusCode >= 400 {
-		// Drain the body so the connection can be reused.
-		_, _ = io.Copy(io.Discard, resp.Body)
 		return fmt.Errorf("POST %s: %s", dstUrl, resp.Status)
 	}
-	// Drain the body even on success — http.Client's keepalive depends on it.
-	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }

--- a/weed/s3api/s3api_object_handlers_copy_stream.go
+++ b/weed/s3api/s3api_object_handlers_copy_stream.go
@@ -1,0 +1,153 @@
+package s3api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+// canStreamCopyChunk reports whether the chunk-copy fast path can use the
+// io.Pipe streaming variant. The streaming path bypasses both the s3-side
+// download buffer and the s3-side multipart-encode buffer, holding only the
+// io.Pipe internal buffer (~32 KiB) per copy in flight. It does not work
+// when bytes need to be transformed in transit:
+//
+//   - SSE-C / SSE-KMS / SSE-S3: bytes need to be re-encrypted with a
+//     different key on the destination, so they have to land in memory.
+//   - Per-chunk CipherKey (per-chunk encryption from the source): the
+//     source bytes need to be decrypted before being re-uploaded.
+//
+// In both cases the caller falls back to the buffered copySingleChunk path,
+// which already handles those transformations correctly. The streaming
+// path is still safe for IsCompressed chunks — gzip is end-to-end and we
+// just forward the compressed bytes with the Content-Encoding header.
+func canStreamCopyChunk(chunk *filer_pb.FileChunk) bool {
+	if len(chunk.CipherKey) > 0 {
+		return false
+	}
+	if chunk.GetSseType() != filer_pb.SSEType_NONE {
+		return false
+	}
+	return true
+}
+
+// streamCopyChunkRange copies size bytes starting at offset from srcUrl to
+// the destination volume identified by assignResult, using io.Pipe to avoid
+// buffering the chunk in memory. The destination volume server expects the
+// same multipart wire format that operation.upload_content writes — see
+// upload_content.go for the canonical version; we mirror its part headers
+// here so the volume's needle.parseUpload accepts the request.
+func (s3a *S3ApiServer) streamCopyChunkRange(
+	ctx context.Context,
+	srcUrl, srcFileId string,
+	offset, size int64,
+	assignResult *filer_pb.AssignVolumeResponse,
+	isCompressed bool,
+) error {
+	dstUrl := fmt.Sprintf("http://%s/%s", assignResult.Location.Url, assignResult.FileId)
+	dstJwt := security.EncodedJwt(assignResult.Auth)
+	srcJwt := filer.JwtForVolumeServer(srcFileId)
+
+	// io.Pipe gives us a synchronous handoff: the producer goroutine
+	// builds the multipart body, the consumer (HTTP transport) reads it.
+	// Writes block until reads consume them, so the in-flight footprint
+	// is the pipe's internal hand-off buffer — not the chunk size.
+	pipeReader, pipeWriter := io.Pipe()
+	mw := multipart.NewWriter(pipeWriter)
+	contentType := mw.FormDataContentType()
+
+	go func() {
+		// CloseWithError on the writer end propagates the failure to the
+		// HTTP transport reading from pipeReader, which then aborts the
+		// POST. Plain Close (with err==nil) sends EOF normally.
+		var producerErr error
+		defer func() {
+			pipeWriter.CloseWithError(producerErr)
+		}()
+
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", mime.FormatMediaType("form-data",
+			map[string]string{"name": "file", "filename": ""}))
+		h.Set("Idempotency-Key", dstUrl)
+		if isCompressed {
+			h.Set("Content-Encoding", "gzip")
+		}
+
+		fw, err := mw.CreatePart(h)
+		if err != nil {
+			producerErr = fmt.Errorf("multipart create part: %w", err)
+			return
+		}
+
+		// ReadUrlAsStream reads in 256 KiB ticks and hands each tick to
+		// the callback. Forwarding directly into fw means each tick is
+		// flushed through the multipart writer into the pipe, where the
+		// HTTP transport picks it up — no per-chunk buffering on either
+		// side of the pipe.
+		var writeErr error
+		shouldRetry, readErr := util_http.ReadUrlAsStream(ctx, srcUrl, srcJwt, nil, false, false, offset, int(size), func(data []byte) {
+			if writeErr != nil {
+				return
+			}
+			if _, err := fw.Write(data); err != nil {
+				writeErr = err
+			}
+		})
+		if writeErr != nil {
+			producerErr = fmt.Errorf("stream write: %w", writeErr)
+			return
+		}
+		if readErr != nil {
+			if shouldRetry {
+				glog.V(2).Infof("stream copy %s offset=%d size=%d: retryable error: %v",
+					srcUrl, offset, size, readErr)
+			}
+			producerErr = fmt.Errorf("stream read: %w", readErr)
+			return
+		}
+
+		if err := mw.Close(); err != nil {
+			producerErr = fmt.Errorf("multipart close: %w", err)
+			return
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, dstUrl, pipeReader)
+	if err != nil {
+		// Drain the pipe so the producer goroutine doesn't leak waiting
+		// on a never-read writer.
+		pipeReader.CloseWithError(err)
+		return fmt.Errorf("create POST request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	if dstJwt != "" {
+		req.Header.Set("Authorization", "BEARER "+string(dstJwt))
+	}
+
+	resp, err := util_http.GetGlobalHttpClient().Do(req)
+	if err != nil {
+		// Closing the reader unblocks the producer if it was still mid-write.
+		pipeReader.CloseWithError(err)
+		return fmt.Errorf("POST: %w", err)
+	}
+	defer util_http.CloseResponse(resp)
+
+	if resp.StatusCode >= 400 {
+		// Drain the body so the connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return fmt.Errorf("POST %s: %s", dstUrl, resp.Status)
+	}
+	// Drain the body even on success — http.Client's keepalive depends on it.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/weed/s3api/s3api_object_handlers_copy_stream.go
+++ b/weed/s3api/s3api_object_handlers_copy_stream.go
@@ -60,6 +60,15 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 	if size > int64(math.MaxInt32) {
 		return fmt.Errorf("chunk size %d exceeds maximum int32 size", size)
 	}
+	// Child context so a terminal error here unblocks the producer
+	// goroutine immediately. Without this, a failed POST closes
+	// pipeReader (which only fails the producer's writes), but
+	// ReadUrlAsStream can keep draining the source body in its read
+	// loop until EOF before noticing — wasting source-volume bandwidth
+	// and CPU. Cancelling streamCtx makes ReadUrlAsStream's per-tick
+	// ctx.Done() check return on the next iteration.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	dstUrl := fmt.Sprintf("http://%s/%s", assignResult.Location.Url, assignResult.FileId)
 	dstJwt := security.EncodedJwt(assignResult.Auth)
 	srcJwt := filer.JwtForVolumeServer(srcFileId)
@@ -101,7 +110,7 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 		// HTTP transport picks it up — no per-chunk buffering on either
 		// side of the pipe.
 		var writeErr error
-		shouldRetry, readErr := util_http.ReadUrlAsStream(ctx, srcUrl, srcJwt, nil, false, false, offset, int(size), func(data []byte) {
+		shouldRetry, readErr := util_http.ReadUrlAsStream(streamCtx, srcUrl, srcJwt, nil, false, false, offset, int(size), func(data []byte) {
 			if writeErr != nil {
 				return
 			}
@@ -138,7 +147,7 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 		}
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, dstUrl, pipeReader)
+	req, err := http.NewRequestWithContext(streamCtx, http.MethodPost, dstUrl, pipeReader)
 	if err != nil {
 		// Drain the pipe so the producer goroutine doesn't leak waiting
 		// on a never-read writer.
@@ -152,7 +161,8 @@ func (s3a *S3ApiServer) streamCopyChunkRange(
 
 	resp, err := util_http.GetGlobalHttpClient().Do(req)
 	if err != nil {
-		// Closing the reader unblocks the producer if it was still mid-write.
+		// Closing the reader unblocks the producer if it was still mid-write;
+		// the deferred cancel above also stops any in-flight source read.
 		pipeReader.CloseWithError(err)
 		return fmt.Errorf("POST: %w", err)
 	}

--- a/weed/util/buffer_pool/sync_pool.go
+++ b/weed/util/buffer_pool/sync_pool.go
@@ -5,6 +5,16 @@ import (
 	"sync"
 )
 
+// maxRetainedBufferCap caps the capacity of buffers we hand back to the
+// sync.Pool. Buffers grown past this (e.g. by a 64 MiB chunk upload through
+// volume.PostHandler -> needle.ParseUpload -> bytes.Buffer.ReadFrom) are
+// dropped instead of pooled, so the underlying byte array becomes garbage
+// and is collected. Without this cap the pool effectively hoards every
+// high-water buffer for the process's lifetime — see #6541, where Harbor's
+// concurrent UploadPartCopy filled the pool with 64 MiB buffers and RSS
+// never receded.
+const maxRetainedBufferCap = 4 * 1024 * 1024
+
 var syncPool = sync.Pool{
 	New: func() interface{} {
 		return new(bytes.Buffer)
@@ -16,5 +26,13 @@ func SyncPoolGetBuffer() *bytes.Buffer {
 }
 
 func SyncPoolPutBuffer(buffer *bytes.Buffer) {
+	if buffer == nil {
+		return
+	}
+	if buffer.Cap() > maxRetainedBufferCap {
+		// Drop the buffer; let GC reclaim the oversized backing array.
+		return
+	}
+	buffer.Reset()
 	syncPool.Put(buffer)
 }

--- a/weed/util/buffer_pool/sync_pool_test.go
+++ b/weed/util/buffer_pool/sync_pool_test.go
@@ -1,0 +1,92 @@
+package buffer_pool
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestSyncPoolPutBuffer_DropsOversized is a regression guard for the volume-side
+// retention amplifier in https://github.com/seaweedfs/seaweedfs/issues/6541.
+//
+// volume.PostHandler -> needle.ParseUpload -> bytes.Buffer.ReadFrom grows the
+// buffer to chunk size. If we Put that buffer back as-is, sync.Pool keeps it
+// at the grown capacity for the rest of the process's lifetime. With
+// concurrent UploadPartCopy load that fills the pool with N × chunk-size
+// backing arrays that never shrink — exactly the "RSS never recedes" pattern
+// reported in the issue.
+//
+// We verify a Put + Get round trip can never round-trip a buffer larger than
+// maxRetainedBufferCap, regardless of how big it grew while in use.
+func TestSyncPoolPutBuffer_DropsOversized(t *testing.T) {
+	// Drain the pool so we start from a deterministic point. sync.Pool may
+	// still hold cached entries on other Ps, but for the small/big-cap
+	// distinction below that doesn't matter — we assert an invariant on
+	// every Get, not the identity of a specific buffer.
+	for i := 0; i < 64; i++ {
+		_ = SyncPoolGetBuffer()
+	}
+
+	big := &bytes.Buffer{}
+	big.Grow(maxRetainedBufferCap * 4) // simulate a large upload buffer
+	if got := big.Cap(); got <= maxRetainedBufferCap {
+		t.Fatalf("test setup: big.Cap=%d should exceed threshold %d",
+			got, maxRetainedBufferCap)
+	}
+	SyncPoolPutBuffer(big)
+
+	// Any number of Gets must not return a buffer with cap > threshold.
+	// (If big had been retained, sync.Pool's per-P cache would surface it
+	// on the very next Get on this goroutine.)
+	for i := 0; i < 16; i++ {
+		got := SyncPoolGetBuffer()
+		if cap := got.Cap(); cap > maxRetainedBufferCap {
+			t.Fatalf("Get %d returned buffer with cap=%d, exceeds threshold %d "+
+				"(regression: oversized buffers retained in pool?)",
+				i, cap, maxRetainedBufferCap)
+		}
+	}
+}
+
+// TestSyncPoolPutBuffer_KeepsRightSized verifies the cap is one-sided: we
+// still pool reasonably-sized buffers so the common case (small uploads,
+// header parsing) doesn't pay an alloc per request.
+func TestSyncPoolPutBuffer_KeepsRightSized(t *testing.T) {
+	for i := 0; i < 64; i++ {
+		_ = SyncPoolGetBuffer()
+	}
+
+	small := &bytes.Buffer{}
+	small.Grow(maxRetainedBufferCap / 2)
+	smallCap := small.Cap()
+	SyncPoolPutBuffer(small)
+
+	// We don't assert pointer identity (sync.Pool can hand back any cached
+	// buffer), but the previously-Put buffer should appear among Gets on
+	// the same goroutine in the absence of a GC. If our cap-policy ever
+	// regresses to dropping right-sized buffers, this test starts seeing
+	// only fresh (cap=0) buffers and fails.
+	sawPooled := false
+	for i := 0; i < 8; i++ {
+		got := SyncPoolGetBuffer()
+		if got.Cap() == smallCap {
+			sawPooled = true
+			break
+		}
+	}
+	if !sawPooled {
+		t.Fatalf("right-sized buffer (cap=%d) never came back from the pool "+
+			"(regression: cap policy too aggressive?)", smallCap)
+	}
+}
+
+// TestSyncPoolPutBuffer_NilSafe documents that Put tolerates a nil buffer.
+// The volume server defers Put on a buffer obtained via Get, but defensive
+// callers in other paths may Put(nil); we should not panic.
+func TestSyncPoolPutBuffer_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SyncPoolPutBuffer(nil) panicked: %v", r)
+		}
+	}()
+	SyncPoolPutBuffer(nil)
+}


### PR DESCRIPTION
First of two stacked PRs targeting the volume-side floor on top of #9420 / #9421 / #9422. Refs #6541.

This PR introduces the `io.Pipe` streaming path; the gzip pass-through optimization is split out into a follow-up.

## What

The buffered chunk-copy path holds two chunk-sized buffers per copy in flight:
- Download: \`downloadChunkData\` reads the whole source chunk into a \`[]byte\`.
- Upload: \`uploadChunkData\` then writes a multipart-encoded copy into a per-call \`bytes.Buffer\`.

Under concurrent UploadPartCopy that puts a floor on RSS at *concurrency × 2 × chunk_size* — about 768 MiB for the Harbor-style 6-way / 64 MiB assemble repro, even after the pool/retention fixes in the previous PRs.

Replace the buffered path with an \`io.Pipe\` between the source GET and the destination POST: \`ReadUrlAsStream\` pumps data into the pipe via a \`multipart.Writer\`, the \`http.Client\` reads from the pipe end and POSTs the body. In-flight per copy is now ~32 KiB (pipe hand-off + http buffers), regardless of chunk size.

The streaming path is gated by \`canStreamCopyChunk\`: only used when no in-transit transformation is needed (no per-chunk \`CipherKey\`, no SSE). SSE-C / SSE-KMS / SSE-S3 paths still go through the buffered path, which already handles re-encryption correctly.

## Benchmarks

\`go test -bench BenchmarkCopyChunk -benchtime=3x ./weed/s3api/\` on Apple M4, httptest source/dest:

| chunk size | path     | B/op       | allocs/op | MB/s |
|------------|----------|------------|-----------|------|
| 1 MiB      | Buffered | 6.0 MiB    | 366       | 443  |
| 1 MiB      | Streamed | 374 KiB    | 352       | 727  |
| 8 MiB      | Buffered | 56 MiB     | 400       | 559  |
| 8 MiB      | Streamed | 379 KiB    | 588       | 1138 |
| 64 MiB     | Buffered | 455 MiB    | 415       | 718  |
| 64 MiB     | Streamed | 304 KiB    | 2387      | 1387 |

For 64 MiB chunks, B/op drops by **1500×** and throughput nearly doubles.

## End-to-end repro (512 MiB source, 6 parallel UploadPartCopy)

| metric                       | pre-fix    | +#9420 +#9421 +#9422 | + this PR  |
|------------------------------|------------|----------------------|------------|
| RSS, round 2                 | 3134 MiB   | 2236 MiB             | **1521 MiB** |
| heap inuse_space, post-test  | 1594 MiB   | 1187 MiB             | **350 MiB**  |
| HeapSys (MemStats)           | n/a        | 2.49 GiB             | 1.74 GiB     |
| HeapInuse, post-GC           | n/a        | 251 MiB              | 247 MiB      |

Content correctness verified: the 6-way assemble produces a destination object whose head + tail 16 KiB match the source byte-for-byte.

## Stacked follow-up

The full-chunk gzip pass-through optimization (skip volume-side decompression when the requested copy covers an entire source chunk) is split into a follow-up PR: #9425. Reviewing this PR alone keeps the diff focused on the architectural change (Pipe-based streaming); the optimization can land separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * S3 object copy now streams data directly for eligible chunks, reducing buffering and speeding large copies
  * Improved memory efficiency by preventing oversized buffers from being retained in the pool

* **Reliability**
  * Upload path isolation reduced risk of concurrent upload body corruption

* **Tests**
  * Added benchmarks for S3 copy across multiple chunk sizes
  * Added tests for buffer-pool behavior and upload option isolation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9424)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->