### PR TITLE
fix(pb): skip Unix-socket gRPC registration on Windows (#9430)

### DIFF
--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,7 +82,15 @@ func init() {
 // GrpcDial to host:grpcPort (or to a loopback alias of host on the same
 // port) is routed through the Unix socket. Dials to any other host on the
 // same port still go over TCP.
+//
+// No-op on Windows: the /tmp/...sock paths callers pass are POSIX-only and
+// the listen/dial would fail at runtime, taking gRPC down with it (#9430).
+// Skipping registration leaves the maps empty, so ServeGrpcOnLocalSocket
+// and resolveLocalGrpcSocket short-circuit and same-host RPCs go over TCP.
 func RegisterLocalGrpcSocket(host string, grpcPort int, socketPath string) {
+	if runtime.GOOS == "windows" {
+		return
+	}
 	localGrpcSocketsLock.Lock()
 	defer localGrpcSocketsLock.Unlock()
 	localGrpcSockets[grpcPort] = socketPath

--- a/weed/pb/grpc_client_server_test.go
+++ b/weed/pb/grpc_client_server_test.go
@@ -2,6 +2,7 @@ package pb
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -74,6 +75,9 @@ func TestIsClientSideMarshalError_RequiresGrpcStatus(t *testing.T) {
 // continue out over TCP — they must NOT be hijacked into host A's local
 // socket on the basis of port match alone.
 func TestResolveLocalGrpcSocket_RemotePortCollision(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-socket routing is disabled on Windows (#9430)")
+	}
 	// Snapshot and restore global state so the test does not leak into others.
 	localGrpcSocketsLock.Lock()
 	prevSockets := localGrpcSockets


### PR DESCRIPTION
## Summary
- Fixes #9430. The same-host gRPC fast path registered `/tmp/...sock` paths and dialed them with `net.Listen("unix", ...)` — POSIX-only, so on Windows the listener failed at startup and every local gRPC call routed through the registered port lost its transport.
- Gate `RegisterLocalGrpcSocket` to return early on Windows. `ServeGrpcOnLocalSocket` and `resolveLocalGrpcSocket` already short-circuit when nothing is registered, so all same-host RPCs fall back to TCP without touching any callsite.
- Skip the port-collision regression test on Windows, where registration is now intentionally a no-op.

## Test plan
- [x] `go test ./weed/pb/...` on darwin
- [x] `GOOS=windows GOARCH=amd64 go build ./weed/pb/... ./weed/command/...`
- [ ] Verified by Windows user that `weed server` starts and serves gRPC over TCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gRPC socket registration on Windows by properly skipping Unix-socket operations that are not natively supported on this platform. This prevents errors that could occur during socket registration attempts and improves overall Windows platform compatibility. Test suites have been updated to reflect the new platform-specific behavior by appropriately skipping affected tests on Windows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->