### PR TITLE
fix(master): route ec shard vids to NewEcVids on initial subscribe

### DIFF
--- a/weed/topology/topology_info.go
+++ b/weed/topology/topology_info.go
@@ -102,8 +102,17 @@ func (t *Topology) ToVolumeLocations() (volumeLocations []*master_pb.VolumeLocat
 				for _, v := range dn.GetVolumes() {
 					volumeLocation.NewVids = append(volumeLocation.NewVids, uint32(v.Id))
 				}
+				// A single EC volume's shards can live on multiple disks of
+				// one DataNode, so GetEcShards returns per-(vid,disk) entries.
+				// Dedupe so the snapshot carries each vid once.
+				seenEcVids := make(map[uint32]struct{})
 				for _, s := range dn.GetEcShards() {
-					volumeLocation.NewEcVids = append(volumeLocation.NewEcVids, uint32(s.VolumeId))
+					vid := uint32(s.VolumeId)
+					if _, ok := seenEcVids[vid]; ok {
+						continue
+					}
+					seenEcVids[vid] = struct{}{}
+					volumeLocation.NewEcVids = append(volumeLocation.NewEcVids, vid)
 				}
 				volumeLocations = append(volumeLocations, volumeLocation)
 			}

--- a/weed/topology/topology_info.go
+++ b/weed/topology/topology_info.go
@@ -103,7 +103,7 @@ func (t *Topology) ToVolumeLocations() (volumeLocations []*master_pb.VolumeLocat
 					volumeLocation.NewVids = append(volumeLocation.NewVids, uint32(v.Id))
 				}
 				for _, s := range dn.GetEcShards() {
-					volumeLocation.NewVids = append(volumeLocation.NewVids, uint32(s.VolumeId))
+					volumeLocation.NewEcVids = append(volumeLocation.NewEcVids, uint32(s.VolumeId))
 				}
 				volumeLocations = append(volumeLocations, volumeLocation)
 			}


### PR DESCRIPTION
Fixes #9429.

`Topology.ToVolumeLocations` is the snapshot sent to a master client right after it subscribes via `KeepConnected`. It was appending EC shard volume IDs to `NewVids` (regular volumes) instead of `NewEcVids`. As a result, a freshly-subscribed filer/client registered EC shards in the regular-volume map (`addLocation`) instead of the EC location map (`addEcLocation`) until the next heartbeat-driven incremental update reconciled state.

The incremental path in `master_grpc_server.go` already routes EC shards to `NewEcVids`; this aligns the initial-sync path with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected volume location tracking to keep erasure-coded shard IDs separate from standard volume IDs and to avoid duplicate entries.
  * Result: more accurate topology information and cleaner volume listings, reducing confusion in volume discovery and reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9435)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->