### PR TITLE
fix(mount): fall through to filer when cached dir misses a tracked inode

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -583,16 +583,15 @@ func (wfs *WFS) lookupEntry(fullpath util.FullPath) (*filer.Entry, fuse.Status) 
 		// our IsDirectoryCached check and FindEntry (e.g. markDirectoryReadThrough).
 		// If it's no longer cached, fall through to the filer lookup below.
 		if wfs.metaCache.IsDirectoryCached(dirPath) {
-			// If the kernel is still tracking this path's inode, the entry
-			// was known to exist recently; a cached-dir miss here suggests
-			// metaCache/parent-cache coherence drift. Log visibly so the
-			// next occurrence shows up in mount.log without -v=4.
-			if _, inodeFound := wfs.inodeToPath.GetInode(fullpath); inodeFound {
-				glog.Warningf("lookupEntry: %s missing from cache while parent %s is cached; inode still tracked (possible coherence bug)", fullpath, dirPath)
-			} else {
+			// Authoritative ENOENT only if inodeToPath also has no record.
+			// If the kernel still tracks this inode, the three layers
+			// disagree; trust the filer over the local cache (the
+			// filer-ErrNotFound branch below logs the confirmed drift).
+			if _, inodeFound := wfs.inodeToPath.GetInode(fullpath); !inodeFound {
 				glog.V(4).Infof("lookupEntry cache miss (dir cached) %s", fullpath)
+				return nil, fuse.ENOENT
 			}
-			return nil, fuse.ENOENT
+			glog.V(2).Infof("lookupEntry: %s missing from cache while parent %s is cached; inode tracked, consulting filer", fullpath, dirPath)
 		}
 	}
 


### PR DESCRIPTION
## Summary

`lookupEntry` returned `ENOENT` whenever the parent dir was marked cached in `metaCache` but the child entry was absent. That is only authoritative when `inodeToPath` also has no record of the path; when the kernel still tracks the inode, the three layers disagree and the live entry on the filer is the source of truth.

This fires noisily in #9139: under 16 concurrent rclone imports the diagnostic `Warningf` added in b94ad824 (originally a smoking-gun signal for the lock-contention flake) prints thousands of times, and worse, the matching `fuse.ENOENT` response makes existing paths look gone to userspace.

Fix: when `inodeToPath` still has the path, fall through to the existing `filer_pb.GetEntry` path. That path already serves the live entry on success, and on a genuine miss logs at `Warningf` with full layer state (the line right below at `weedfs.go:637`). Drop the now-redundant warning at the cached-dir branch.

## Test plan

- `go test ./weed/mount/... -count=1` (mount, meta_cache, page_writer all pass)
- The `ConcurrentLockContention` subtest that motivated b94ad824 keeps its master-fd workaround in place but no longer needs it once this lands — leaving that cleanup for a follow-up to keep this PR small.

Refs #9139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where file lookups could incorrectly report files as missing in certain cached directory scenarios. The system now verifies file existence with the filer service before returning a "not found" error, improving accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9436)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->