### PR TITLE
volume: require admin auth on ReadAllNeedles and VolumeNeedleStatus

### DIFF
--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -398,6 +398,10 @@ func (vs *VolumeServer) VolumeNeedleStatus(ctx context.Context, req *volume_serv
 
 	resp := &volume_server_pb.VolumeNeedleStatusResponse{}
 
+	if err := vs.checkGrpcAdminAuth(ctx); err != nil {
+		return resp, err
+	}
+
 	volumeId := needle.VolumeId(req.VolumeId)
 
 	n := &needle.Needle{

--- a/weed/server/volume_grpc_read_all.go
+++ b/weed/server/volume_grpc_read_all.go
@@ -11,6 +11,10 @@ import (
 
 func (vs *VolumeServer) ReadAllNeedles(req *volume_server_pb.ReadAllNeedlesRequest, stream volume_server_pb.VolumeServer_ReadAllNeedlesServer) (err error) {
 
+	if err := vs.checkGrpcAdminAuth(stream.Context()); err != nil {
+		return err
+	}
+
 	for _, vid := range req.VolumeIds {
 		if err := vs.streamReadOneVolume(needle.VolumeId(vid), stream); err != nil {
 			stats.VolumeServerFileReadFailures.Inc()


### PR DESCRIPTION
These RPCs return raw needle bytes and cookies, but neither was running through `checkGrpcAdminAuth`. Add the gate so they behave like the other destructive/admin RPCs on the volume server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added authorization verification to admin volume operations. Needle status requests and volume read operations now require proper authentication before executing, preventing unauthorized access to sensitive volume data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9437)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->