### PR TITLE
volume: require admin auth on BatchDelete

### DIFF
--- a/weed/server/volume_grpc_batch_delete.go
+++ b/weed/server/volume_grpc_batch_delete.go
@@ -13,6 +13,10 @@ import (
 func (vs *VolumeServer) BatchDelete(ctx context.Context, req *volume_server_pb.BatchDeleteRequest) (*volume_server_pb.BatchDeleteResponse, error) {
 	resp := &volume_server_pb.BatchDeleteResponse{}
 
+	if err := vs.checkGrpcAdminAuth(ctx); err != nil {
+		return resp, err
+	}
+
 	if err := vs.CheckMaintenanceMode(); err != nil {
 		return resp, err
 	}

--- a/weed/server/volume_grpc_batch_delete_test.go
+++ b/weed/server/volume_grpc_batch_delete_test.go
@@ -1,0 +1,44 @@
+package weed_server
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+)
+
+// TestBatchDelete_DeniesNonWhitelistedPeer verifies that BatchDelete refuses
+// callers that fall outside the configured admin whitelist, matching the
+// behaviour of the other destructive volume-server RPCs.
+func TestBatchDelete_DeniesNonWhitelistedPeer(t *testing.T) {
+	vs := &VolumeServer{
+		guard: security.NewGuard([]string{"10.0.0.1"}, "", 0, "", 0),
+	}
+
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345},
+	})
+
+	resp, err := vs.BatchDelete(ctx, &volume_server_pb.BatchDeleteRequest{
+		FileIds:         []string{"1,deadbeef"},
+		SkipCookieCheck: true,
+	})
+	if err == nil {
+		t.Fatalf("expected PermissionDenied, got nil error (resp=%+v)", resp)
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("expected codes.PermissionDenied, got %v (err=%v)", got, err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response even on auth failure")
+	}
+	if len(resp.Results) != 0 {
+		t.Fatalf("expected no per-file results on auth failure, got %d", len(resp.Results))
+	}
+}


### PR DESCRIPTION
`BatchDelete` mutates needle state and accepts `SkipCookieCheck=true`, yet was not running through `checkGrpcAdminAuth` like the other destructive volume-server RPCs. Add the gate for parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added authorization checks to batch delete operations to enforce peer whitelist validation, preventing non-whitelisted network addresses from executing delete operations while ensuring appropriate permission-denied error responses are returned to unauthorized clients

* **Tests**
  * Added comprehensive test coverage verifying batch delete correctly denies requests from non-whitelisted peer addresses and validates error response structures on authorization failures

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->