### PR TITLE
fix(storage): refuse to load .vif-only entry as regular volume when .ecx exists (#9448)

### DIFF
--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -152,6 +152,19 @@ func getValidVolumeName(basename string) string {
 	return ""
 }
 
+// hasEcxFile reports whether an .ecx for volumeName exists on this disk.
+// Checks IdxDirectory first, then falls back to Directory (the .ecx may
+// have been created before -dir.idx was configured).
+func (l *DiskLocation) hasEcxFile(volumeName string) bool {
+	if util.FileExists(filepath.Join(l.IdxDirectory, volumeName+".ecx")) {
+		return true
+	}
+	if l.IdxDirectory != l.Directory {
+		return util.FileExists(filepath.Join(l.Directory, volumeName+".ecx"))
+	}
+	return false
+}
+
 func (l *DiskLocation) loadExistingVolume(dirEntry os.DirEntry, needleMapKind NeedleMapKind, skipIfEcVolumesExists bool, ldbTimeout int64, diskId uint32) bool {
 	basename := dirEntry.Name()
 	if dirEntry.IsDir() {
@@ -169,14 +182,16 @@ func (l *DiskLocation) loadExistingVolume(dirEntry os.DirEntry, needleMapKind Ne
 		return false
 	}
 
+	// .vif next to .ecx is EC shard metadata, not a regular volume.
+	// Without this guard NewVolume below would create a phantom empty .dat.
+	if strings.HasSuffix(basename, ".vif") && l.hasEcxFile(volumeName) {
+		glog.V(1).Infof("loadExistingVolume: skipping .vif-only entry for volume %d (collection=%q); .ecx present", vid, collection)
+		return false
+	}
+
 	// skip if ec volumes exists, but validate EC files first
 	if skipIfEcVolumesExists {
-		ecxFilePath := filepath.Join(l.IdxDirectory, volumeName+".ecx")
-		if !util.FileExists(ecxFilePath) && l.IdxDirectory != l.Directory {
-			// .ecx may have been created before -dir.idx was configured
-			ecxFilePath = filepath.Join(l.Directory, volumeName+".ecx")
-		}
-		if util.FileExists(ecxFilePath) {
+		if l.hasEcxFile(volumeName) {
 			// Validate EC volume: shard count, size consistency, and expected size vs .dat file
 			if !l.validateEcVolume(collection, vid) {
 				glog.Warningf("EC volume %d validation failed, removing incomplete EC files to allow .dat file loading", vid)

--- a/weed/storage/disk_location_ec_test.go
+++ b/weed/storage/disk_location_ec_test.go
@@ -661,3 +661,78 @@ func TestDistributedEcVolumeNoFileDeletion(t *testing.T) {
 
 	t.Logf("SUCCESS: Distributed EC volume files preserved (not deleted)")
 }
+
+// TestLoadExistingVolumeSkipsVifWhenEcxPresent pins the skip behavior on
+// the LoadVolume / MountVolume path (skipIfEcVolumesExists=false) for the
+// .vif + .ecx disk layout without .dat. Two variants cover both
+// IdxDirectory==Directory and the split-idx-dir fallback.
+func TestLoadExistingVolumeSkipsVifWhenEcxPresent(t *testing.T) {
+	const vid needle.VolumeId = 42
+
+	cases := []struct {
+		name      string
+		splitDirs bool
+	}{
+		{name: "same-idx-dir", splitDirs: false},
+		{name: "split-idx-dir", splitDirs: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			idxDir := dataDir
+			if tc.splitDirs {
+				idxDir = t.TempDir()
+			}
+
+			minFreeSpace := util.MinFreeSpace{Type: util.AsPercent, Percent: 1, Raw: "1"}
+			diskLocation := &DiskLocation{
+				Directory:              dataDir,
+				DirectoryUuid:          "test-uuid",
+				IdxDirectory:           idxDir,
+				DiskType:               types.HddType,
+				MaxVolumeCount:         100,
+				OriginalMaxVolumeCount: 100,
+				MinFreeSpace:           minFreeSpace,
+			}
+			diskLocation.volumes = make(map[needle.VolumeId]*Volume)
+			diskLocation.ecVolumes = make(map[needle.VolumeId]*erasure_coding.EcVolume)
+
+			vifPath := erasure_coding.EcShardFileName("", dataDir, int(vid)) + ".vif"
+			ecxPath := erasure_coding.EcShardFileName("", idxDir, int(vid)) + ".ecx"
+			if err := os.WriteFile(vifPath, []byte{}, 0644); err != nil {
+				t.Fatalf("write .vif: %v", err)
+			}
+			if err := os.WriteFile(ecxPath, []byte{}, 0644); err != nil {
+				t.Fatalf("write .ecx: %v", err)
+			}
+
+			entries, err := os.ReadDir(dataDir)
+			if err != nil {
+				t.Fatalf("read dir: %v", err)
+			}
+			var vifEntry os.DirEntry
+			for _, e := range entries {
+				if filepath.Ext(e.Name()) == ".vif" {
+					vifEntry = e
+					break
+				}
+			}
+			if vifEntry == nil {
+				t.Fatalf(".vif entry missing from dir listing")
+			}
+
+			loaded := diskLocation.loadExistingVolume(vifEntry, NeedleMapInMemory, false, 0, 0)
+			if loaded {
+				t.Fatalf("loadExistingVolume should refuse to load a .vif-only entry when .ecx is present (volume %d)", vid)
+			}
+			if _, exists := diskLocation.volumes[vid]; exists {
+				t.Fatalf("volume %d should not be registered in l.volumes (would create phantom regular volume)", vid)
+			}
+			datPath := erasure_coding.EcShardFileName("", dataDir, int(vid)) + ".dat"
+			if util.FileExists(datPath) {
+				t.Fatalf("guard must not create a placeholder .dat for volume %d", vid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Defensive root-cause follow-up to #9458. That PR fixed the detection-side loop by skipping re-encode when EC shards already exist for the volume — and by auto-cleaning the orphaned regular replica via a targeted `VolumeDelete` RPC. This PR closes the only remaining re-entry path I can find for the same bug.

The post-#9448 disk state is:
- `.vif` preserved (because EC shards live on the same disk and need it for metadata)
- `.ecx` present (EC index)
- no `.dat`, no `.idx`

`loadExistingVolume`'s existing `.ecx`-present check is gated on the caller passing `skipIfEcVolumesExists=true`. The startup-scan path (`concurrentLoadingVolumes`) does pass that flag and correctly skips the `.vif`. The `LoadVolume → loadExistingVolume(…, false, …)` path used by `VolumeMount` does **not**, so it falls through to `NewVolume`, which calls `v.load` with `createDatIfMissing=true` and creates a phantom empty `.dat`. The master then reports the volume as regular and EC detection re-proposes it — the exact loop #9448 reports.

The change: hoist the `.ecx`-present check so it runs **unconditionally** for `.vif` entries. If the EC index is on the disk, the `.vif` belongs to those EC shards, never to a regular volume to be resurrected.

Pure OSS clusters never reach this exact state today — OSS deletes `.vif` unconditionally during `Destroy`. The enterprise branch preserves it (commit `da272b721` "fix: preserve .vif file when deleting EC-encoded volumes"), so this guard is more directly load-bearing there. Landing it on OSS hardens the load path against any future change that leaves the same state, and keeps the two branches symmetric.

## Test plan

- [x] New `TestLoadExistingVolumeSkipsVifWhenEcxPresent` builds the exact post-#9448 disk layout (`.vif` + `.ecx`, no `.dat`) and asserts `loadExistingVolume(skipIfEcVolumesExists=false)` returns `false`, does not create a placeholder `.dat`, and does not register a phantom volume in `l.volumes`.
- [x] `go test ./weed/storage/...` and `go test ./weed/worker/tasks/erasure_coding/...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented erasure-coded shard metadata from being misidentified and loaded as regular volume files when corresponding EC index data exists.

* **Tests**
  * Added a test ensuring the system skips loading standalone shard marker files when matching EC index data is present, and no placeholder volume is created.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9461)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9461)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->