### PR TITLE
fix(s3/lifecycle): align walker dispatch error label to RPC_ERROR

### DIFF
--- a/weed/s3api/s3lifecycle/dailyrun/walker_dispatcher.go
+++ b/weed/s3api/s3lifecycle/dailyrun/walker_dispatcher.go
@@ -59,14 +59,16 @@ func (d *WalkerDispatcher) Delete(ctx context.Context, action *engine.CompiledAc
 	kindLabel := action.Key.ActionKind.String()
 	resp, err := d.Client.LifecycleDelete(ctx, req)
 	if err != nil {
-		stats.S3LifecycleDispatchCounter.WithLabelValues(action.Bucket, kindLabel, "TRANSPORT_ERROR").Inc()
+		// "RPC_ERROR" matches the streaming dispatcher and processMatches
+		// labels so transport-class failures aggregate under one key.
+		stats.S3LifecycleDispatchCounter.WithLabelValues(action.Bucket, kindLabel, "RPC_ERROR").Inc()
 		return fmt.Errorf("walker dispatch %s/%s %s: %w", action.Bucket, objectPath, action.Key.ActionKind, err)
 	}
 	if resp == nil {
 		// A misbehaving server stub returning (nil, nil) would panic on
-		// the switch below. Surface as an error so the walk halts at
-		// this entry, preserving the in-flight cursor's correctness.
-		stats.S3LifecycleDispatchCounter.WithLabelValues(action.Bucket, kindLabel, "NIL_RESPONSE").Inc()
+		// the switch below. Bucket under RPC_ERROR rather than a new
+		// label — operationally it's the same class of failure.
+		stats.S3LifecycleDispatchCounter.WithLabelValues(action.Bucket, kindLabel, "RPC_ERROR").Inc()
 		return fmt.Errorf("walker dispatch %s/%s %s: nil response", action.Bucket, objectPath, action.Key.ActionKind)
 	}
 	stats.S3LifecycleDispatchCounter.WithLabelValues(action.Bucket, kindLabel, resp.Outcome.String()).Inc()


### PR DESCRIPTION
Follow-up to PR #9459 (which merged before the alignment fix landed on that branch).

The Phase 4b walker dispatcher labels RPC failure paths as \`TRANSPORT_ERROR\` and \`NIL_RESPONSE\`. Streaming (\`dispatcher/dispatcher.go\`) and the replay drain (\`processMatches\` in \`run.go\` via #9462) both use \`RPC_ERROR\` for the same condition. This PR aligns the walker so a single Prometheus query covers all three delete paths.

Folds the nil-response edge case under \`RPC_ERROR\` rather than a separate label — operationally it's the same class of failure.

## Test plan

- \`go test ./weed/s3api/s3lifecycle/...\` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification and tracking for S3 lifecycle operations, providing more accurate failure reporting and enhanced diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9464)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->