### PR TITLE
test(s3/audit): track() audit fallback coverage + stale comment cleanup

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -772,7 +772,6 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 				return
 			}
 			if objectEntryForSSE == nil {
-				// Not found, return error early to avoid another lookup in proxyToFiler
 				s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 				return
 			}
@@ -2274,7 +2273,6 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 				return
 			}
 			if objectEntryForSSE == nil {
-				// Not found, return error early to avoid another lookup in proxyToFiler
 				s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 				return
 			}

--- a/weed/s3api/s3err/audit_fluent.go
+++ b/weed/s3api/s3err/audit_fluent.go
@@ -183,10 +183,17 @@ func GetAccessLog(r *http.Request, HTTPStatusCode int, s3errCode ErrorCode) *Acc
 }
 
 func PostLog(r *http.Request, HTTPStatusCode int, errorCode ErrorCode) {
-	if r == nil || Logger == nil {
+	if r == nil {
 		return
 	}
+	// Mark before the Logger nil-check so the middleware fallback in track()
+	// still sees that audit was handled by the caller in deployments that
+	// haven't configured fluent — keeps the flag behavior consistent and
+	// makes wiring testable without standing up a fluent server.
 	markAuditLogged(r)
+	if Logger == nil {
+		return
+	}
 	if err := Logger.Post(tag, *GetAccessLog(r, HTTPStatusCode, errorCode)); err != nil {
 		glog.Warning("Error while posting log: ", err)
 	}

--- a/weed/s3api/stats_test.go
+++ b/weed/s3api/stats_test.go
@@ -1,0 +1,51 @@
+package s3api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTrackAuditFallbackForDirectWriteHeader covers the regression behind
+// issue #9463: handlers that bypass writeSuccessResponse helpers and call
+// w.WriteHeader directly (GetObjectHandler stream path, HeadObjectHandler,
+// GetBucketEncryption, GetObjectLockConfiguration, etc.) used to drop their
+// audit entry. track() must mark the request as audited via a fallback
+// PostLog after the handler returns.
+func TestTrackAuditFallbackForDirectWriteHeader(t *testing.T) {
+	var captured *http.Request
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+	}
+	wrapped := track(handler, "GET")
+	wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
+
+	if assert.NotNil(t, captured, "handler must have been invoked") {
+		assert.True(t, s3err.AuditAlreadyLogged(captured),
+			"track must emit fallback audit when handler writes response directly")
+	}
+}
+
+// TestTrackAuditSkipsFallbackWhenHandlerEmits guards against double logging:
+// handlers that already call PostLog (e.g. via writeSuccessResponseXML or
+// WriteErrorResponse) flip the audit flag, and track must observe that and
+// not re-emit.
+func TestTrackAuditSkipsFallbackWhenHandlerEmits(t *testing.T) {
+	var captured *http.Request
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		s3err.PostLog(r, http.StatusOK, s3err.ErrNone)
+		w.WriteHeader(http.StatusOK)
+	}
+	wrapped := track(handler, "PUT")
+	wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/bucket/object", nil))
+
+	if assert.NotNil(t, captured) {
+		assert.True(t, s3err.AuditAlreadyLogged(captured),
+			"flag must be set after handler PostLog")
+	}
+}


### PR DESCRIPTION
Stacks on #9467. Will rebase to master once that merges.

## Summary

- Adds two regression tests in `weed/s3api/stats_test.go` covering `track()`'s audit-tracking wiring: the fallback fires for handlers that write directly (the GET/HEAD object case behind #9463), and is skipped when the handler emits its own PostLog.
- Moves `markAuditLogged` ahead of the `Logger == nil` short-circuit in `PostLog`, so the flag is observable without standing up a fluent server (production unchanged — no logger, no posting).
- Removes two stale `proxyToFiler` comments in `s3api_object_handlers.go`; the helper itself was removed when GET/HEAD switched to streaming from volume servers, which is exactly how the audit gap got introduced.

## Test plan

- [x] `go test ./weed/s3api/... -count=1`
- [x] New tests: `TestTrackAuditFallbackForDirectWriteHeader`, `TestTrackAuditSkipsFallbackWhenHandlerEmits`