### PR TITLE
master: drop racy explicit TakeSnapshot after TopologyId generation

### DIFF
--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -302,28 +302,17 @@ func (ms *MasterServer) ensureTopologyId() {
 	currentId := ms.Topo.GetTopologyId()
 	glog.V(1).Infof("ensureTopologyId: current TopologyId after barrier: %s", currentId)
 
-	prevId := ms.Topo.GetTopologyId()
-
 	EnsureTopologyId(ms.Topo, func() bool {
 		return ms.Topo.IsLeader()
 	}, func(topologyId string) error {
 		return ms.syncRaftForTopologyId(topologyId)
 	})
 
-	// If a new TopologyId was generated, take a snapshot so it survives
-	// raft state cleanup on future non-resume restarts.
-	if prevId == "" && ms.Topo.GetTopologyId() != "" {
-		ms.Topo.RaftServerAccessLock.RLock()
-		if ms.Topo.RaftServer != nil {
-			if err := ms.Topo.RaftServer.TakeSnapshot(); err != nil {
-				glog.Warningf("snapshot after TopologyId generation: %v", err)
-			} else {
-				glog.V(0).Infof("snapshot taken to persist TopologyId %s", ms.Topo.GetTopologyId())
-			}
-		}
-		// Hashicorp raft snapshots are handled automatically.
-		ms.Topo.RaftServerAccessLock.RUnlock()
-	}
+	// The TopologyId is preserved by the committed raft log entry from
+	// syncRaftForTopologyId; raft's own periodic auto-snapshot picks it up.
+	// A previous synchronous TakeSnapshot call here was removed to avoid a
+	// race in github.com/seaweedfs/raft@v1.1.8's snapshot machinery, where
+	// TakeSnapshot and maybeTakeSnapshot share pendingSnapshot without locking.
 }
 
 func (ms *MasterServer) proxyToLeader(f http.HandlerFunc) http.HandlerFunc {


### PR DESCRIPTION
The TopologyId is committed to the raft log via syncRaftForTopologyId before this snapshot call. seaweedfs/raft's own periodic auto-snapshot picks it up. The explicit synchronous TakeSnapshot here is purely an optimization, and it races with raft's internal maybeTakeSnapshot over the unsynchronised pendingSnapshot field — the race detector keeps catching this in the FUSE Mount integration test.

The raft library has a TODO at the top of TakeSnapshot acknowledging this needs proper locking. Until that lands upstream, drop the redundant explicit snapshot call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of topology ID persistence by refactoring the synchronization mechanism to leverage raft's committed log entries and periodic auto-snapshots.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->