### PR TITLE
feat(s3/lifecycle): enable scheduler by default

### DIFF
--- a/weed/worker/tasks/s3_lifecycle/handler.go
+++ b/weed/worker/tasks/s3_lifecycle/handler.go
@@ -143,6 +143,15 @@ func (h *Handler) Descriptor() *plugin_pb.JobTypeDescriptor {
 			},
 		},
 		AdminRuntimeDefaults: &plugin_pb.AdminRuntimeDefaults{
+			// On by default: S3 lifecycle is a standard bucket feature
+			// (PutBucketLifecycleConfiguration is part of the S3 API),
+			// and a bucket with rules set but no worker running silently
+			// retains data past its declared expiration. Operators who
+			// want the worker off can still disable it in the admin UI;
+			// the default error is "data lingers" not "worker burns CPU
+			// on empty rule sets" (the worker fast-exits with no
+			// configured rules).
+			Enabled:                  true,
 			DetectionIntervalMinutes: 24 * 60, // daily
 			DetectionTimeoutSeconds:  60,
 			MaxJobsPerDetection:      1,

--- a/weed/worker/tasks/s3_lifecycle/handler_test.go
+++ b/weed/worker/tasks/s3_lifecycle/handler_test.go
@@ -348,6 +348,20 @@ func TestDescriptor_AdminRuntimeDefaultsDailyCadence(t *testing.T) {
 	assert.Equal(t, int32(1), d.AdminRuntimeDefaults.MaxJobsPerDetection)
 }
 
+func TestDescriptor_AdminRuntimeDefaultsEnabledByDefault(t *testing.T) {
+	// S3 lifecycle is a standard bucket feature — operators set
+	// PutBucketLifecycleConfiguration expecting it to actually fire.
+	// Default-off would silently retain data past declared expiration
+	// until an operator notices and flips it on. Document the choice
+	// here so a future change to disabled-by-default fails the test
+	// and surfaces a conscious revisit.
+	h := NewHandler(nil)
+	d := h.Descriptor()
+	require.NotNil(t, d.AdminRuntimeDefaults)
+	assert.True(t, d.AdminRuntimeDefaults.Enabled,
+		"s3_lifecycle defaults must enable the scheduler so configured rules fire without operator opt-in")
+}
+
 // ---------- Execute ----------
 
 // recordingExecSender captures Execute-side messages. The Execute path


### PR DESCRIPTION
## Summary

Set \`AdminRuntimeDefaults.Enabled = true\` in the s3_lifecycle handler descriptor so a fresh install runs configured lifecycle rules without operator opt-in.

## Why

S3 lifecycle is a standard bucket feature — operators set \`PutBucketLifecycleConfiguration\` through the S3 API expecting the rules to fire. With the prior default (\`Enabled = false\`), buckets configured with lifecycle XML silently retained data past their declared expiration until an operator turned the scheduler on in the admin UI. AWS S3 doesn't have this discoverability gap; SeaweedFS shouldn't either.

| Failure mode | Cost |
|---|---|
| Default-off, operator missed it | Data lingers past expiration, looks broken |
| Default-on, no rules configured | Worker fast-exits each day (\`rsh == [32]byte{}\` skips subscription entirely) |

Default-on is the cheaper failure.

## Compatibility

Persisted configs (deployments that have already touched the lifecycle scheduler config in the admin UI) win over the descriptor default — \`deriveSchedulerAdminRuntime\` reads \`AdminRuntime.Enabled\` from the persisted config when present, and only falls back to the descriptor default when no persisted config exists. So:

- **Fresh installs**: scheduler comes up enabled.
- **Existing deployments with operator-disabled scheduler**: stays disabled. No surprise.
- **Existing deployments that never touched the config**: scheduler flips to enabled on next admin restart. This matches the bucket owners' expectation that PutBucketLifecycle works.

## Test plan

- [x] \`go test ./weed/worker/tasks/s3_lifecycle/ -run TestDescriptor\` — new \`TestDescriptor_AdminRuntimeDefaultsEnabledByDefault\` pins the choice
- [x] \`go build ./...\` clean
- [ ] On a fresh \`weed mini\` instance, set a lifecycle rule on a bucket, wait one detection cycle, confirm the worker fires without manual scheduler enable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 lifecycle expiration is now enabled by default, automatically processing any configured lifecycle rules without manual operator intervention.

* **Tests**
  * Added unit test to validate the default-enabled state of the S3 lifecycle scheduler.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->