### PR TITLE
fix(ec): verify full shard set before deleting source volume (#9490)

### DIFF
--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -3203,11 +3203,17 @@ fn get_append_at_ns(last: u64) -> u64 {
 }
 
 /// Remove all files associated with a volume.
+/// .dat/.idx removals log at info level so destructive calls are traceable.
 pub(crate) fn remove_volume_files(base: &str) {
     for ext in &[
         ".dat", ".idx", ".vif", ".sdx", ".cpd", ".cpx", ".note", ".rdb",
     ] {
-        let _ = fs::remove_file(format!("{}{}", base, ext));
+        let path = format!("{}{}", base, ext);
+        let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let existed = fs::remove_file(&path).is_ok();
+        if existed && (*ext == ".dat" || *ext == ".idx") {
+            tracing::info!("removed volume file {} (size={})", path, size);
+        }
     }
     // leveldb uses a directory
     let _ = fs::remove_dir_all(format!("{}.ldb", base));

--- a/test/plugin_workers/fake_volume_server.go
+++ b/test/plugin_workers/fake_volume_server.go
@@ -293,6 +293,9 @@ func (v *VolumeServer) VolumeEcShardsMount(ctx context.Context, req *volume_serv
 }
 
 func (v *VolumeServer) VolumeEcShardsInfo(ctx context.Context, req *volume_server_pb.VolumeEcShardsInfoRequest) (*volume_server_pb.VolumeEcShardsInfoResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("VolumeEcShardsInfo request is nil")
+	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
@@ -300,7 +303,7 @@ func (v *VolumeServer) VolumeEcShardsInfo(ctx context.Context, req *volume_serve
 	// comes from the matching mount request when one exists.
 	collectionByShard := make(map[uint32]string)
 	for _, mr := range v.mountRequests {
-		if mr.VolumeId != req.VolumeId {
+		if mr == nil || mr.VolumeId != req.VolumeId {
 			continue
 		}
 		for _, shardId := range mr.ShardIds {

--- a/test/plugin_workers/fake_volume_server.go
+++ b/test/plugin_workers/fake_volume_server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -295,23 +296,49 @@ func (v *VolumeServer) VolumeEcShardsInfo(ctx context.Context, req *volume_serve
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	resp := &volume_server_pb.VolumeEcShardsInfoResponse{}
+	// Report whichever shards exist on disk: seeded or mounted. Collection
+	// comes from the matching mount request when one exists.
+	collectionByShard := make(map[uint32]string)
 	for _, mr := range v.mountRequests {
 		if mr.VolumeId != req.VolumeId {
 			continue
 		}
 		for _, shardId := range mr.ShardIds {
-			var size int64
-			if info, err := os.Stat(v.filePath(mr.VolumeId, fmt.Sprintf(".ec%02d", shardId))); err == nil {
-				size = info.Size()
+			if _, ok := collectionByShard[shardId]; !ok {
+				collectionByShard[shardId] = mr.Collection
 			}
-			resp.EcShardInfos = append(resp.EcShardInfos, &volume_server_pb.EcShardInfo{
-				ShardId:    shardId,
-				Size:       size,
-				Collection: mr.Collection,
-				VolumeId:   mr.VolumeId,
-			})
 		}
+	}
+
+	resp := &volume_server_pb.VolumeEcShardsInfoResponse{}
+	prefix := fmt.Sprintf("%d.ec", req.VolumeId)
+	entries, _ := os.ReadDir(v.baseDir)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(name, prefix)
+		if len(suffix) < 2 {
+			continue
+		}
+		var shardId uint32
+		if _, err := fmt.Sscanf(suffix[:2], "%d", &shardId); err != nil {
+			continue
+		}
+		var size int64
+		if info, err := entry.Info(); err == nil {
+			size = info.Size()
+		}
+		resp.EcShardInfos = append(resp.EcShardInfos, &volume_server_pb.EcShardInfo{
+			ShardId:    shardId,
+			Size:       size,
+			Collection: collectionByShard[shardId],
+			VolumeId:   req.VolumeId,
+		})
 	}
 	return resp, nil
 }

--- a/test/plugin_workers/fake_volume_server.go
+++ b/test/plugin_workers/fake_volume_server.go
@@ -291,6 +291,31 @@ func (v *VolumeServer) VolumeEcShardsMount(ctx context.Context, req *volume_serv
 	return &volume_server_pb.VolumeEcShardsMountResponse{}, nil
 }
 
+func (v *VolumeServer) VolumeEcShardsInfo(ctx context.Context, req *volume_server_pb.VolumeEcShardsInfoRequest) (*volume_server_pb.VolumeEcShardsInfoResponse, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	resp := &volume_server_pb.VolumeEcShardsInfoResponse{}
+	for _, mr := range v.mountRequests {
+		if mr.VolumeId != req.VolumeId {
+			continue
+		}
+		for _, shardId := range mr.ShardIds {
+			var size int64
+			if info, err := os.Stat(v.filePath(mr.VolumeId, fmt.Sprintf(".ec%02d", shardId))); err == nil {
+				size = info.Size()
+			}
+			resp.EcShardInfos = append(resp.EcShardInfos, &volume_server_pb.EcShardInfo{
+				ShardId:    shardId,
+				Size:       size,
+				Collection: mr.Collection,
+				VolumeId:   mr.VolumeId,
+			})
+		}
+	}
+	return resp, nil
+}
+
 func (v *VolumeServer) VolumeDelete(ctx context.Context, req *volume_server_pb.VolumeDeleteRequest) (*volume_server_pb.VolumeDeleteResponse, error) {
 	v.mu.Lock()
 	v.deleteRequests = append(v.deleteRequests, req)

--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -176,7 +176,7 @@ func (vs *VolumeServer) VolumeDelete(ctx context.Context, req *volume_server_pb.
 	if err != nil {
 		glog.Errorf("volume delete %v: %v", req, err)
 	} else {
-		// V(0) so destructive RPCs are always traceable (#9490).
+		// V(0) so destructive RPCs are always traceable.
 		glog.Infof("volume delete %v", req)
 	}
 

--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -176,9 +176,7 @@ func (vs *VolumeServer) VolumeDelete(ctx context.Context, req *volume_server_pb.
 	if err != nil {
 		glog.Errorf("volume delete %v: %v", req, err)
 	} else {
-		// Log at V(0) so a destructive RPC is always traceable in production
-		// logs (#9490: a silent source delete after a partial EC encode
-		// destroyed the only intact replica).
+		// V(0) so destructive RPCs are always traceable (#9490).
 		glog.Infof("volume delete %v", req)
 	}
 

--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -176,7 +176,10 @@ func (vs *VolumeServer) VolumeDelete(ctx context.Context, req *volume_server_pb.
 	if err != nil {
 		glog.Errorf("volume delete %v: %v", req, err)
 	} else {
-		glog.V(2).Infof("volume delete %v", req)
+		// Log at V(0) so a destructive RPC is always traceable in production
+		// logs (#9490: a silent source delete after a partial EC encode
+		// destroyed the only intact replica).
+		glog.Infof("volume delete %v", req)
 	}
 
 	return resp, err

--- a/weed/shell/command_ec_decode.go
+++ b/weed/shell/command_ec_decode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 
@@ -175,6 +176,13 @@ func doEcDecode(commandEnv *CommandEnv, topoInfo *master_pb.TopologyInfo, collec
 		return fmt.Errorf("mount decoded volume %d on %s: %v", vid, targetNodeLocation, err)
 	}
 
+	// Confirm the regenerated .dat is present and non-empty before destroying
+	// the shards. Without this gate, a silent failure in generate/mount could
+	// leave the cluster with neither shards nor volume.
+	if err := verifyDecodedVolumeBeforeDelete(commandEnv.option.GrpcDialOption, targetNodeLocation, vid); err != nil {
+		return fmt.Errorf("verify decoded volume %d on %s before deleting shards: %w", vid, targetNodeLocation, err)
+	}
+
 	// delete the previous ec shards
 	err = unmountAndDeleteEcShardsWithPrefix("deleteDecodedEcShards", commandEnv.option.GrpcDialOption, collection, nodeToEcShardsInfo, vid)
 	if err != nil {
@@ -223,6 +231,30 @@ func unmountAndDeleteEcShardsWithPrefix(prefix string, grpcDialOption grpc.DialO
 		})
 	}
 	return ewg.Wait()
+}
+
+func verifyDecodedVolumeBeforeDelete(grpcDialOption grpc.DialOption, target pb.ServerAddress, vid needle.VolumeId) error {
+	var resp *volume_server_pb.ReadVolumeFileStatusResponse
+	if err := operation.WithVolumeServerClient(false, target, grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
+		r, e := client.ReadVolumeFileStatus(context.Background(), &volume_server_pb.ReadVolumeFileStatusRequest{
+			VolumeId: uint32(vid),
+		})
+		if e != nil {
+			return e
+		}
+		resp = r
+		return nil
+	}); err != nil {
+		return fmt.Errorf("read volume file status: %w", err)
+	}
+	if resp.DatFileSize == 0 {
+		return fmt.Errorf("decoded .dat is 0 bytes")
+	}
+	if resp.IdxFileSize == 0 {
+		return fmt.Errorf("decoded .idx is 0 bytes")
+	}
+	glog.V(0).Infof("ec decode verification ok for volume %d on %s: dat=%d idx=%d", vid, target, resp.DatFileSize, resp.IdxFileSize)
+	return nil
 }
 
 func mountDecodedVolume(grpcDialOption grpc.DialOption, targetNodeLocation pb.ServerAddress, vid needle.VolumeId) error {

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -199,6 +199,12 @@ func (c *commandEcEncode) Do(args []string, commandEnv *CommandEnv, writer io.Wr
 	if err := EcBalance(commandEnv, balanceCollections, "", rp, diskType, *maxParallelization, *applyBalancing); err != nil {
 		return fmt.Errorf("re-balance ec shards for collection(s) %v: %w", balanceCollections, err)
 	}
+	// ...verify every encoded volume has the full shard set across the
+	// cluster before destroying any source. See #9490: a partial encode
+	// followed by source deletion is unrecoverable.
+	if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
+		return fmt.Errorf("verify EC shards before deleting originals: %w", err)
+	}
 	// ...then delete original volumes using pre-collected locations.
 	fmt.Printf("Deleting original volumes after EC encoding...\n")
 	if err := doDeleteVolumesWithLocations(commandEnv, volumeIds, volumeLocationsMap, *maxParallelization); err != nil {
@@ -330,6 +336,42 @@ func doEcEncode(commandEnv *CommandEnv, writer io.Writer, volumeIdToCollection m
 	}
 	if err := ewg.Wait(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// verifyEcShardsBeforeDelete walks the master topology and refuses to proceed
+// unless every volume in volumeIds has all TotalShardsCount EC shards present
+// across the cluster on the target diskType. Issue #9490: a partial encode
+// must not be followed by source deletion.
+func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType) error {
+	topoInfo, _, err := collectTopologyInfo(commandEnv, 0)
+	if err != nil {
+		return fmt.Errorf("fetch topology for shard verification: %w", err)
+	}
+
+	for _, vid := range volumeIds {
+		nodeShards := collectEcNodeShardsInfo(topoInfo, vid, diskType)
+
+		var union erasure_coding.ShardBits
+		for _, info := range nodeShards {
+			union = erasure_coding.ShardBits(uint32(union) | info.Bitmap())
+		}
+
+		if err := erasure_coding.RequireFullShardSet(uint32(vid), union); err != nil {
+			summary := make([]string, 0, len(nodeShards))
+			for node, info := range nodeShards {
+				summary = append(summary, fmt.Sprintf("%s=%s", node, info.String()))
+			}
+			sort.Strings(summary)
+			glog.Errorf("EC shard verification failed for volume %d on diskType %q: %v; observed: %v",
+				vid, diskType.ReadableString(), err, summary)
+			return fmt.Errorf("volume %d: %w (observed: %v)", vid, err, summary)
+		}
+
+		glog.V(0).Infof("EC shard verification ok for volume %d on diskType %q: %d/%d shards present across %d nodes",
+			vid, diskType.ReadableString(), union.Count(), erasure_coding.TotalShardsCount, len(nodeShards))
 	}
 
 	return nil

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -199,7 +199,7 @@ func (c *commandEcEncode) Do(args []string, commandEnv *CommandEnv, writer io.Wr
 	if err := EcBalance(commandEnv, balanceCollections, "", rp, diskType, *maxParallelization, *applyBalancing); err != nil {
 		return fmt.Errorf("re-balance ec shards for collection(s) %v: %w", balanceCollections, err)
 	}
-	// #9490: a partial encode followed by source deletion is unrecoverable.
+	// A partial encode followed by source deletion is unrecoverable.
 	if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
 		return fmt.Errorf("verify EC shards before deleting originals: %w", err)
 	}

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -353,7 +353,8 @@ func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.Volum
 			union = erasure_coding.ShardBits(uint32(union) | info.Bitmap())
 		}
 
-		if err := erasure_coding.RequireFullShardSet(uint32(vid), union); err != nil {
+		totalShards := erasure_coding.TotalShardsCount
+		if err := erasure_coding.RequireFullShardSet(uint32(vid), union, totalShards); err != nil {
 			summary := make([]string, 0, len(nodeShards))
 			for node, info := range nodeShards {
 				summary = append(summary, fmt.Sprintf("%s=%s", node, info.String()))
@@ -365,7 +366,7 @@ func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.Volum
 		}
 
 		glog.V(0).Infof("EC shard verification ok for volume %d on diskType %q: %d/%d shards present across %d nodes",
-			vid, diskType.ReadableString(), union.Count(), erasure_coding.TotalShardsCount, len(nodeShards))
+			vid, diskType.ReadableString(), union.Count(), totalShards, len(nodeShards))
 	}
 
 	return nil

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -199,9 +199,7 @@ func (c *commandEcEncode) Do(args []string, commandEnv *CommandEnv, writer io.Wr
 	if err := EcBalance(commandEnv, balanceCollections, "", rp, diskType, *maxParallelization, *applyBalancing); err != nil {
 		return fmt.Errorf("re-balance ec shards for collection(s) %v: %w", balanceCollections, err)
 	}
-	// ...verify every encoded volume has the full shard set across the
-	// cluster before destroying any source. See #9490: a partial encode
-	// followed by source deletion is unrecoverable.
+	// #9490: a partial encode followed by source deletion is unrecoverable.
 	if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
 		return fmt.Errorf("verify EC shards before deleting originals: %w", err)
 	}
@@ -341,10 +339,6 @@ func doEcEncode(commandEnv *CommandEnv, writer io.Writer, volumeIdToCollection m
 	return nil
 }
 
-// verifyEcShardsBeforeDelete walks the master topology and refuses to proceed
-// unless every volume in volumeIds has all TotalShardsCount EC shards present
-// across the cluster on the target diskType. Issue #9490: a partial encode
-// must not be followed by source deletion.
 func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType) error {
 	topoInfo, _, err := collectTopologyInfo(commandEnv, 0)
 	if err != nil {

--- a/weed/storage/erasure_coding/verification.go
+++ b/weed/storage/erasure_coding/verification.go
@@ -1,0 +1,135 @@
+package erasure_coding
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"google.golang.org/grpc"
+)
+
+// ServerShardInventory is the per-shard view of one server's EC shards for a
+// volume, as reported by VolumeEcShardsInfo. Size is the raw shard file size
+// in bytes — callers compare sizes across servers to spot truncated shards.
+type ServerShardInventory struct {
+	Bits       ShardBits
+	Sizes      map[ShardId]int64
+	QueryError error
+}
+
+// VerifyShardsAcrossServers polls each server's VolumeEcShardsInfo and returns
+// the union of shard ids observed plus a per-server breakdown. Query errors
+// (including the volume server's "EC volume not found" reply) are recorded on
+// the per-server entry and treated as zero shards — they do not abort the
+// scan, so the caller can still see partial coverage from healthy peers.
+//
+// Callers gate destructive actions on RequireFullShardSet(...) against the
+// returned union bitmap.
+func VerifyShardsAcrossServers(ctx context.Context, volumeID uint32,
+	servers []string, dialOption grpc.DialOption) (
+	union ShardBits, perServer map[string]ServerShardInventory) {
+
+	perServer = make(map[string]ServerShardInventory, len(servers))
+
+	for _, server := range servers {
+		if server == "" {
+			continue
+		}
+		if _, seen := perServer[server]; seen {
+			continue
+		}
+
+		inv := ServerShardInventory{Sizes: make(map[ShardId]int64)}
+
+		callErr := operation.WithVolumeServerClient(false, pb.ServerAddress(server), dialOption,
+			func(client volume_server_pb.VolumeServerClient) error {
+				resp, e := client.VolumeEcShardsInfo(ctx, &volume_server_pb.VolumeEcShardsInfoRequest{
+					VolumeId: volumeID,
+				})
+				if e != nil {
+					return e
+				}
+				for _, s := range resp.EcShardInfos {
+					if s.VolumeId != volumeID {
+						continue
+					}
+					sid := ShardId(s.ShardId)
+					inv.Bits = inv.Bits.Set(sid)
+					inv.Sizes[sid] = s.Size
+				}
+				return nil
+			})
+		if callErr != nil {
+			inv.QueryError = callErr
+		}
+
+		perServer[server] = inv
+		union = ShardBits(uint32(union) | uint32(inv.Bits))
+	}
+
+	return union, perServer
+}
+
+// RequireFullShardSet returns nil if shardsPresent covers every shard id in
+// [0, TotalShardsCount); otherwise it returns an error naming the missing
+// ids. This is the gate erasure-coding callers use before destroying the
+// source replica.
+func RequireFullShardSet(volumeID uint32, shardsPresent ShardBits) error {
+	var missing []int
+	for id := 0; id < TotalShardsCount; id++ {
+		if !shardsPresent.Has(ShardId(id)) {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Ints(missing)
+	return fmt.Errorf("EC shard set incomplete for volume %d: %d/%d shards present, missing shard ids %v",
+		volumeID, shardsPresent.Count(), TotalShardsCount, missing)
+}
+
+// SummarizeShardInventory returns a string like
+// "10.0.0.1:8081=[0 1 2 3] 10.0.0.2:8081=[4 5 6 ERR:not found]" suitable for
+// logging the verification result.
+func SummarizeShardInventory(perServer map[string]ServerShardInventory) string {
+	servers := make([]string, 0, len(perServer))
+	for s := range perServer {
+		servers = append(servers, s)
+	}
+	sort.Strings(servers)
+
+	var b []byte
+	for i, s := range servers {
+		if i > 0 {
+			b = append(b, ' ')
+		}
+		inv := perServer[s]
+		b = append(b, s...)
+		b = append(b, '=')
+		b = append(b, '[')
+		ids := make([]int, 0)
+		for id := 0; id < MaxShardCount; id++ {
+			if inv.Bits.Has(ShardId(id)) {
+				ids = append(ids, id)
+			}
+		}
+		for j, id := range ids {
+			if j > 0 {
+				b = append(b, ' ')
+			}
+			b = append(b, []byte(fmt.Sprintf("%d", id))...)
+		}
+		if inv.QueryError != nil {
+			if len(ids) > 0 {
+				b = append(b, ' ')
+			}
+			b = append(b, []byte("ERR:"+inv.QueryError.Error())...)
+		}
+		b = append(b, ']')
+	}
+	return string(b)
+}

--- a/weed/storage/erasure_coding/verification.go
+++ b/weed/storage/erasure_coding/verification.go
@@ -13,7 +13,6 @@ import (
 
 type ServerShardInventory struct {
 	Bits       ShardBits
-	Sizes      map[ShardId]int64
 	QueryError error
 }
 
@@ -35,7 +34,7 @@ func VerifyShardsAcrossServers(ctx context.Context, volumeID uint32,
 			continue
 		}
 
-		inv := ServerShardInventory{Sizes: make(map[ShardId]int64)}
+		var inv ServerShardInventory
 
 		callErr := operation.WithVolumeServerClient(false, pb.ServerAddress(server), dialOption,
 			func(client volume_server_pb.VolumeServerClient) error {
@@ -46,12 +45,10 @@ func VerifyShardsAcrossServers(ctx context.Context, volumeID uint32,
 					return e
 				}
 				for _, s := range resp.EcShardInfos {
-					if s.VolumeId != volumeID {
+					if s.VolumeId != volumeID || s.ShardId >= MaxShardCount {
 						continue
 					}
-					sid := ShardId(s.ShardId)
-					inv.Bits = inv.Bits.Set(sid)
-					inv.Sizes[sid] = s.Size
+					inv.Bits = inv.Bits.Set(ShardId(s.ShardId))
 				}
 				return nil
 			})

--- a/weed/storage/erasure_coding/verification.go
+++ b/weed/storage/erasure_coding/verification.go
@@ -66,9 +66,16 @@ func VerifyShardsAcrossServers(ctx context.Context, volumeID uint32,
 	return union, perServer
 }
 
-func RequireFullShardSet(volumeID uint32, shardsPresent ShardBits) error {
+// totalShards is the configured DataShards+ParityShards for this volume.
+// Passed as a parameter (not derived from TotalShardsCount) so enterprise
+// builds with custom EC ratios share this helper verbatim.
+func RequireFullShardSet(volumeID uint32, shardsPresent ShardBits, totalShards int) error {
+	if totalShards <= 0 || totalShards > MaxShardCount {
+		return fmt.Errorf("invalid totalShards %d for volume %d (must be in [1, %d])",
+			totalShards, volumeID, MaxShardCount)
+	}
 	var missing []int
-	for id := 0; id < TotalShardsCount; id++ {
+	for id := 0; id < totalShards; id++ {
 		if !shardsPresent.Has(ShardId(id)) {
 			missing = append(missing, id)
 		}
@@ -78,7 +85,7 @@ func RequireFullShardSet(volumeID uint32, shardsPresent ShardBits) error {
 	}
 	sort.Ints(missing)
 	return fmt.Errorf("EC shard set incomplete for volume %d: %d/%d shards present, missing shard ids %v",
-		volumeID, shardsPresent.Count(), TotalShardsCount, missing)
+		volumeID, shardsPresent.Count(), totalShards, missing)
 }
 
 func SummarizeShardInventory(perServer map[string]ServerShardInventory) string {

--- a/weed/storage/erasure_coding/verification.go
+++ b/weed/storage/erasure_coding/verification.go
@@ -11,23 +11,16 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ServerShardInventory is the per-shard view of one server's EC shards for a
-// volume, as reported by VolumeEcShardsInfo. Size is the raw shard file size
-// in bytes — callers compare sizes across servers to spot truncated shards.
 type ServerShardInventory struct {
 	Bits       ShardBits
 	Sizes      map[ShardId]int64
 	QueryError error
 }
 
-// VerifyShardsAcrossServers polls each server's VolumeEcShardsInfo and returns
-// the union of shard ids observed plus a per-server breakdown. Query errors
-// (including the volume server's "EC volume not found" reply) are recorded on
-// the per-server entry and treated as zero shards — they do not abort the
-// scan, so the caller can still see partial coverage from healthy peers.
-//
-// Callers gate destructive actions on RequireFullShardSet(...) against the
-// returned union bitmap.
+// Query errors are recorded per-server and treated as zero shards rather
+// than aborting the scan, so the caller still sees partial coverage from
+// healthy peers when one server is down. The caller gates destructive
+// actions on RequireFullShardSet against the returned union.
 func VerifyShardsAcrossServers(ctx context.Context, volumeID uint32,
 	servers []string, dialOption grpc.DialOption) (
 	union ShardBits, perServer map[string]ServerShardInventory) {
@@ -73,10 +66,6 @@ func VerifyShardsAcrossServers(ctx context.Context, volumeID uint32,
 	return union, perServer
 }
 
-// RequireFullShardSet returns nil if shardsPresent covers every shard id in
-// [0, TotalShardsCount); otherwise it returns an error naming the missing
-// ids. This is the gate erasure-coding callers use before destroying the
-// source replica.
 func RequireFullShardSet(volumeID uint32, shardsPresent ShardBits) error {
 	var missing []int
 	for id := 0; id < TotalShardsCount; id++ {
@@ -92,9 +81,6 @@ func RequireFullShardSet(volumeID uint32, shardsPresent ShardBits) error {
 		volumeID, shardsPresent.Count(), TotalShardsCount, missing)
 }
 
-// SummarizeShardInventory returns a string like
-// "10.0.0.1:8081=[0 1 2 3] 10.0.0.2:8081=[4 5 6 ERR:not found]" suitable for
-// logging the verification result.
 func SummarizeShardInventory(perServer map[string]ServerShardInventory) string {
 	servers := make([]string, 0, len(perServer))
 	for s := range perServer {

--- a/weed/storage/erasure_coding/verification_test.go
+++ b/weed/storage/erasure_coding/verification_test.go
@@ -10,7 +10,7 @@ func TestRequireFullShardSet_AllPresent(t *testing.T) {
 	for id := 0; id < TotalShardsCount; id++ {
 		bits = bits.Set(ShardId(id))
 	}
-	if err := RequireFullShardSet(42, bits); err != nil {
+	if err := RequireFullShardSet(42, bits, TotalShardsCount); err != nil {
 		t.Fatalf("unexpected error for full set: %v", err)
 	}
 }
@@ -23,7 +23,7 @@ func TestRequireFullShardSet_ReportsMissingIds(t *testing.T) {
 		}
 		bits = bits.Set(ShardId(id))
 	}
-	err := RequireFullShardSet(42, bits)
+	err := RequireFullShardSet(42, bits, TotalShardsCount)
 	if err == nil {
 		t.Fatal("expected error for incomplete set, got nil")
 	}
@@ -40,12 +40,45 @@ func TestRequireFullShardSet_ReportsMissingIds(t *testing.T) {
 }
 
 func TestRequireFullShardSet_EmptyBitmap(t *testing.T) {
-	err := RequireFullShardSet(1, 0)
+	err := RequireFullShardSet(1, 0, TotalShardsCount)
 	if err == nil {
 		t.Fatal("expected error for empty bitmap")
 	}
 	if !strings.Contains(err.Error(), "0/14") {
 		t.Errorf("error should report 0/14 shards: %s", err.Error())
+	}
+}
+
+func TestRequireFullShardSet_CustomRatio(t *testing.T) {
+	// 6+3 ratio: total=9, all present
+	var bits ShardBits
+	for id := 0; id < 9; id++ {
+		bits = bits.Set(ShardId(id))
+	}
+	if err := RequireFullShardSet(7, bits, 9); err != nil {
+		t.Fatalf("unexpected error for full 6+3 set: %v", err)
+	}
+
+	// 6+3, missing shard 5
+	bits = bits.Clear(5)
+	err := RequireFullShardSet(7, bits, 9)
+	if err == nil {
+		t.Fatal("expected error when shard 5 is missing in 6+3 ratio")
+	}
+	if !strings.Contains(err.Error(), "8/9") {
+		t.Errorf("error should report 8/9: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "[5]") {
+		t.Errorf("error should list missing id 5: %s", err.Error())
+	}
+}
+
+func TestRequireFullShardSet_RejectsInvalidTotal(t *testing.T) {
+	if err := RequireFullShardSet(1, 0, 0); err == nil {
+		t.Error("expected error for totalShards=0")
+	}
+	if err := RequireFullShardSet(1, 0, MaxShardCount+1); err == nil {
+		t.Errorf("expected error for totalShards > MaxShardCount")
 	}
 }
 

--- a/weed/storage/erasure_coding/verification_test.go
+++ b/weed/storage/erasure_coding/verification_test.go
@@ -1,0 +1,78 @@
+package erasure_coding
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRequireFullShardSet_AllPresent(t *testing.T) {
+	var bits ShardBits
+	for id := 0; id < TotalShardsCount; id++ {
+		bits = bits.Set(ShardId(id))
+	}
+	if err := RequireFullShardSet(42, bits); err != nil {
+		t.Fatalf("unexpected error for full set: %v", err)
+	}
+}
+
+func TestRequireFullShardSet_ReportsMissingIds(t *testing.T) {
+	var bits ShardBits
+	for id := 0; id < TotalShardsCount; id++ {
+		if id == 3 || id == 7 {
+			continue
+		}
+		bits = bits.Set(ShardId(id))
+	}
+	err := RequireFullShardSet(42, bits)
+	if err == nil {
+		t.Fatal("expected error for incomplete set, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "volume 42") {
+		t.Errorf("error should name the volume id: %s", msg)
+	}
+	if !strings.Contains(msg, "[3 7]") {
+		t.Errorf("error should list missing ids 3 and 7: %s", msg)
+	}
+	if !strings.Contains(msg, "12/14") {
+		t.Errorf("error should report 12/14 shards present: %s", msg)
+	}
+}
+
+func TestRequireFullShardSet_EmptyBitmap(t *testing.T) {
+	err := RequireFullShardSet(1, 0)
+	if err == nil {
+		t.Fatal("expected error for empty bitmap")
+	}
+	if !strings.Contains(err.Error(), "0/14") {
+		t.Errorf("error should report 0/14 shards: %s", err.Error())
+	}
+}
+
+func TestSummarizeShardInventory_Deterministic(t *testing.T) {
+	perServer := map[string]ServerShardInventory{
+		"10.0.0.2:8080": {Bits: ShardBits(0).Set(4).Set(5).Set(6)},
+		"10.0.0.1:8080": {Bits: ShardBits(0).Set(0).Set(1).Set(2).Set(3)},
+	}
+	got := SummarizeShardInventory(perServer)
+	want := "10.0.0.1:8080=[0 1 2 3] 10.0.0.2:8080=[4 5 6]"
+	if got != want {
+		t.Errorf("summary mismatch\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestSummarizeShardInventory_IncludesError(t *testing.T) {
+	perServer := map[string]ServerShardInventory{
+		"10.0.0.1:8080": {Bits: ShardBits(0).Set(0).Set(1), QueryError: errStr("dial timeout")},
+	}
+	got := SummarizeShardInventory(perServer)
+	if !strings.Contains(got, "ERR:dial timeout") {
+		t.Errorf("expected error tag in summary, got %q", got)
+	}
+}
+
+// errStr is a tiny helper so test data can attach an error without pulling in
+// errors.New everywhere.
+type errStr string
+
+func (e errStr) Error() string { return string(e) }

--- a/weed/storage/erasure_coding/verification_test.go
+++ b/weed/storage/erasure_coding/verification_test.go
@@ -71,8 +71,6 @@ func TestSummarizeShardInventory_IncludesError(t *testing.T) {
 	}
 }
 
-// errStr is a tiny helper so test data can attach an error without pulling in
-// errors.New everywhere.
 type errStr string
 
 func (e errStr) Error() string { return string(e) }

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -104,8 +104,17 @@ func removeVolumeFiles(filename string) {
 	// basic
 	deleteAndLog := func(ext string) {
 		fullFilename := filename + "." + ext
-		if err := os.RemoveAll(fullFilename); err != nil {
+		// Log existence + size before removal so a destructive call is
+		// always traceable in production logs (#9490). Successful removal
+		// is logged for .dat/.idx; failures are logged for all extensions.
+		st, statErr := os.Stat(fullFilename)
+		err := os.RemoveAll(fullFilename)
+		if err != nil {
 			glog.V(0).Infof("failed to remove volume file %s: %s", fullFilename, err)
+			return
+		}
+		if statErr == nil && (ext == "dat" || ext == "idx") {
+			glog.Infof("removed volume file %s (size=%d)", fullFilename, st.Size())
 		}
 	}
 	deleteAndLog("dat")

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -101,7 +101,7 @@ func (v *Volume) Destroy(onlyEmpty bool, keepRemoteData bool) (err error) {
 }
 
 func removeVolumeFiles(filename string) {
-	// .dat/.idx removals log at V(0) so destructive calls are traceable (#9490).
+	// .dat/.idx removals log at V(0) so destructive calls are traceable.
 	deleteAndLog := func(ext string) {
 		fullFilename := filename + "." + ext
 		st, statErr := os.Stat(fullFilename)

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -101,12 +101,9 @@ func (v *Volume) Destroy(onlyEmpty bool, keepRemoteData bool) (err error) {
 }
 
 func removeVolumeFiles(filename string) {
-	// basic
+	// .dat/.idx removals log at V(0) so destructive calls are traceable (#9490).
 	deleteAndLog := func(ext string) {
 		fullFilename := filename + "." + ext
-		// Log existence + size before removal so a destructive call is
-		// always traceable in production logs (#9490). Successful removal
-		// is logged for .dat/.idx; failures are logged for all extensions.
 		st, statErr := os.Stat(fullFilename)
 		err := os.RemoveAll(fullFilename)
 		if err != nil {

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -190,10 +190,8 @@ func (t *ErasureCodingTask) Execute(ctx context.Context, params *worker_pb.TaskP
 		return fmt.Errorf("failed to mount EC shards: %v", err)
 	}
 
-	// Step 6: Verify all shards landed before destroying the source.
-	// Without this, a partial distribute/mount failure (see #9490) lets the
-	// next step zero the only intact .dat while the cluster is missing one
-	// or more shards — unrecoverable.
+	// Without this gate, a partial distribute/mount lets Step 7 zero the
+	// only intact .dat while the cluster is missing shards (#9490).
 	t.ReportProgressWithStage(85.0, "Verifying EC shards across destinations")
 	t.GetLogger().Info("Verifying EC shards across destinations")
 	if err := t.verifyEcShardsBeforeDelete(ctx); err != nil {
@@ -555,12 +553,6 @@ func (t *ErasureCodingTask) mountEcShards() error {
 	return erasure_coding.MountEcShards(t.volumeID, t.collection, t.shardAssignment, t.sourceDiskType, t.grpcDialOption, t.GetLogger())
 }
 
-// verifyEcShardsBeforeDelete queries every destination server for its EC
-// shard inventory and refuses to proceed unless the full shard set
-// (DataShardsCount + ParityShardsCount distinct ids) is observed.
-//
-// This is the safety gate that issue #9490 was asking for: a half-failed
-// distribute/mount must not be followed by source deletion.
 func (t *ErasureCodingTask) verifyEcShardsBeforeDelete(ctx context.Context) error {
 	servers := make([]string, 0, len(t.shardAssignment))
 	for node := range t.shardAssignment {

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -190,7 +190,17 @@ func (t *ErasureCodingTask) Execute(ctx context.Context, params *worker_pb.TaskP
 		return fmt.Errorf("failed to mount EC shards: %v", err)
 	}
 
-	// Step 6: Delete original volume
+	// Step 6: Verify all shards landed before destroying the source.
+	// Without this, a partial distribute/mount failure (see #9490) lets the
+	// next step zero the only intact .dat while the cluster is missing one
+	// or more shards — unrecoverable.
+	t.ReportProgressWithStage(85.0, "Verifying EC shards across destinations")
+	t.GetLogger().Info("Verifying EC shards across destinations")
+	if err := t.verifyEcShardsBeforeDelete(ctx); err != nil {
+		return fmt.Errorf("EC shard verification failed; refusing to delete source volume %d: %w", t.volumeID, err)
+	}
+
+	// Step 7: Delete original volume
 	t.ReportProgressWithStage(90.0, "Deleting original volume")
 	t.GetLogger().Info("Deleting original volume")
 	if err := t.deleteOriginalVolume(ctx); err != nil {
@@ -543,6 +553,42 @@ func (t *ErasureCodingTask) distributeEcShards(shardFiles map[string]string) err
 // mountEcShards mounts EC shards on destination servers
 func (t *ErasureCodingTask) mountEcShards() error {
 	return erasure_coding.MountEcShards(t.volumeID, t.collection, t.shardAssignment, t.sourceDiskType, t.grpcDialOption, t.GetLogger())
+}
+
+// verifyEcShardsBeforeDelete queries every destination server for its EC
+// shard inventory and refuses to proceed unless the full shard set
+// (DataShardsCount + ParityShardsCount distinct ids) is observed.
+//
+// This is the safety gate that issue #9490 was asking for: a half-failed
+// distribute/mount must not be followed by source deletion.
+func (t *ErasureCodingTask) verifyEcShardsBeforeDelete(ctx context.Context) error {
+	servers := make([]string, 0, len(t.shardAssignment))
+	for node := range t.shardAssignment {
+		servers = append(servers, node)
+	}
+	if len(servers) == 0 {
+		return fmt.Errorf("no destinations to verify; shardAssignment is empty")
+	}
+
+	union, perServer := erasure_coding.VerifyShardsAcrossServers(ctx, t.volumeID, servers, t.grpcDialOption)
+
+	summary := erasure_coding.SummarizeShardInventory(perServer)
+	t.GetLogger().WithFields(map[string]interface{}{
+		"volume_id":     t.volumeID,
+		"shards_seen":   union.Count(),
+		"shards_needed": erasure_coding.TotalShardsCount,
+		"per_server":    summary,
+	}).Info("EC shard inventory before source deletion")
+
+	if err := erasure_coding.RequireFullShardSet(t.volumeID, union); err != nil {
+		t.GetLogger().WithFields(map[string]interface{}{
+			"volume_id":  t.volumeID,
+			"per_server": summary,
+			"error":      err.Error(),
+		}).Error("EC shard verification failed — source volume will be kept")
+		return err
+	}
+	return nil
 }
 
 // deleteOriginalVolume deletes the original volume and all its replicas from all servers

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -562,17 +562,18 @@ func (t *ErasureCodingTask) verifyEcShardsBeforeDelete(ctx context.Context) erro
 		return fmt.Errorf("no destinations to verify; shardAssignment is empty")
 	}
 
+	totalShards := int(t.dataShards + t.parityShards)
 	union, perServer := erasure_coding.VerifyShardsAcrossServers(ctx, t.volumeID, servers, t.grpcDialOption)
 
 	summary := erasure_coding.SummarizeShardInventory(perServer)
 	t.GetLogger().WithFields(map[string]interface{}{
 		"volume_id":     t.volumeID,
 		"shards_seen":   union.Count(),
-		"shards_needed": erasure_coding.TotalShardsCount,
+		"shards_needed": totalShards,
 		"per_server":    summary,
 	}).Info("EC shard inventory before source deletion")
 
-	if err := erasure_coding.RequireFullShardSet(t.volumeID, union); err != nil {
+	if err := erasure_coding.RequireFullShardSet(t.volumeID, union, totalShards); err != nil {
 		t.GetLogger().WithFields(map[string]interface{}{
 			"volume_id":  t.volumeID,
 			"per_server": summary,

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -190,8 +190,8 @@ func (t *ErasureCodingTask) Execute(ctx context.Context, params *worker_pb.TaskP
 		return fmt.Errorf("failed to mount EC shards: %v", err)
 	}
 
-	// Without this gate, a partial distribute/mount lets Step 7 zero the
-	// only intact .dat while the cluster is missing shards (#9490).
+	// Without this gate, a partial distribute/mount lets the next step
+	// zero the only intact .dat while the cluster is missing shards.
 	t.ReportProgressWithStage(85.0, "Verifying EC shards across destinations")
 	t.GetLogger().Info("Verifying EC shards across destinations")
 	if err := t.verifyEcShardsBeforeDelete(ctx); err != nil {


### PR DESCRIPTION
Fixes #9490.

When EC encoding finishes mounting shards on destinations, the worker and the `ec.encode` shell command both delete the original `.dat` immediately. If distribute or mount failed for any shard, the cluster ends up with fewer than 14 shards and the only intact copy is gone. The deletion logs were at `V(2)`, so production logs showed nothing — just a synthesized 0-byte `.dat` at the next restart.

This change adds a pre-delete gate that polls `VolumeEcShardsInfo` (worker) or walks the master topology (shell), unions the shard bitmaps, and refuses to proceed unless all `TotalShardsCount` distinct shard ids are observed. A failed gate leaves the source readonly so the next detection scan can retry.

`VolumeDelete` RPC success and `.dat`/`.idx` unlinks now log at `V(0)` so any source destruction is traceable at default verbosity.

The EC-balance-vs-in-flight-encode race seen in the report (balance moving shards out of a half-encoded volume) is a separate, larger change and left as a follow-up: balance should refuse to touch volumes whose encode job is not `Completed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic verification of erasure-coded shard integrity across destination servers before permanently deleting original volumes; deletion is blocked if verification fails.
  * Verification that regenerated decoded volumes have non-empty data/index files on the target node before removing source shards.

* **Bug Fixes**
  * Successful volume deletions now always emit an info-level log.
  * Removed volume data/index files now log removed file sizes.

* **Tests**
  * Added tests for shard-set validation and deterministic per-server inventory summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9493)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->