### PR TITLE
fix(ec): clear cross-server stale EC shards before re-distribute (#9478)

### DIFF
--- a/weed/admin/topology/structs.go
+++ b/weed/admin/topology/structs.go
@@ -113,10 +113,14 @@ type MultiDestinationPlan struct {
 	SuccessfulDCs  int                `json:"successful_dcs"`
 }
 
-// VolumeReplica represents a replica location with server and disk information
+// VolumeReplica represents a replica location with server and disk information.
+// For EC shard locations (returned by GetECShardLocations), ShardIds carries
+// the shard ids present on the disk so callers can drive shard-targeted RPCs
+// such as VolumeEcShardsUnmount / VolumeEcShardsDelete without re-querying.
 type VolumeReplica struct {
-	ServerID   string `json:"server_id"`
-	DiskID     uint32 `json:"disk_id"`
-	DataCenter string `json:"data_center"`
-	Rack       string `json:"rack"`
+	ServerID   string   `json:"server_id"`
+	DiskID     uint32   `json:"disk_id"`
+	DataCenter string   `json:"data_center"`
+	Rack       string   `json:"rack"`
+	ShardIds   []uint32 `json:"shard_ids,omitempty"`
 }

--- a/weed/admin/topology/structs.go
+++ b/weed/admin/topology/structs.go
@@ -114,9 +114,8 @@ type MultiDestinationPlan struct {
 }
 
 // VolumeReplica represents a replica location with server and disk information.
-// For EC shard locations (returned by GetECShardLocations), ShardIds carries
-// the shard ids present on the disk so callers can drive shard-targeted RPCs
-// such as VolumeEcShardsUnmount / VolumeEcShardsDelete without re-querying.
+// ShardIds is populated only by GetECShardLocations — it lists the EC shards
+// the disk holds for the volume.
 type VolumeReplica struct {
 	ServerID   string   `json:"server_id"`
 	DiskID     uint32   `json:"disk_id"`

--- a/weed/admin/topology/task_management.go
+++ b/weed/admin/topology/task_management.go
@@ -341,6 +341,7 @@ type TaskSourceSpec struct {
 	DataCenter    string             // Data center of the source server
 	Rack          string             // Rack of the source server
 	CleanupType   SourceCleanupType  // For EC: volume replica vs existing shards
+	ShardIds      []uint32           // For CleanupECShards: shard ids on the source disk to clear before re-distributing
 	StorageImpact *StorageSlotChange // Optional: manual override
 	EstimatedSize *int64             // Optional: manual override
 }

--- a/weed/admin/topology/topology_management.go
+++ b/weed/admin/topology/topology_management.go
@@ -354,6 +354,13 @@ func (at *ActiveTopology) GetECShardLocations(volumeID uint32, collection string
 			continue
 		}
 		shardIds := collectShardIdsForDisk(disk, volumeID, collection)
+		if len(shardIds) == 0 {
+			// ecShardMatchesCollection saw an info entry but every
+			// EcIndexBits is zero — phantom shard record; emitting it
+			// would feed an EC-cleanup source with no shard ids and
+			// confuse the len(ShardIds) discriminator downstream.
+			continue
+		}
 		ecShards = append(ecShards, VolumeReplica{
 			ServerID:   disk.NodeID,
 			DiskID:     disk.DiskID,

--- a/weed/admin/topology/topology_management.go
+++ b/weed/admin/topology/topology_management.go
@@ -334,10 +334,7 @@ func (at *ActiveTopology) GetVolumeLocations(volumeID uint32, collection string)
 }
 
 // GetECShardLocations returns the disk locations for EC shards using O(1) lookup.
-// ShardIds on each returned VolumeReplica enumerates the shard ids present on
-// that disk for the volume — fed by the EC worker into VolumeEcShardsUnmount /
-// VolumeEcShardsDelete to clear stale shards from cross-server destinations
-// before a re-encode distributes fresh ones (#9478 follow-up).
+// Each VolumeReplica.ShardIds lists the shard ids on that disk.
 func (at *ActiveTopology) GetECShardLocations(volumeID uint32, collection string) []VolumeReplica {
 	at.mutex.RLock()
 	defer at.mutex.RUnlock()
@@ -369,12 +366,9 @@ func (at *ActiveTopology) GetECShardLocations(volumeID uint32, collection string
 	return ecShards
 }
 
-// collectShardIdsForDisk walks the disk's EcShardInfos for the given
-// (volumeID, collection) and expands each EcIndexBits bitmap into the
-// concrete shard ids present on the disk. A single info entry can carry
-// multiple shards, and the same volume can have several info entries (one
-// per DiskId on cross-disk layouts), so we union into a single bitmap
-// before expanding to avoid duplicates.
+// collectShardIdsForDisk unions every matching EcIndexBits on the disk and
+// expands the bitmap into shard ids, so multiple info entries for the same
+// volume don't produce duplicates.
 func collectShardIdsForDisk(disk *activeDisk, volumeID uint32, collection string) []uint32 {
 	if disk == nil || disk.DiskInfo == nil || disk.DiskInfo.DiskInfo == nil {
 		return nil

--- a/weed/admin/topology/topology_management.go
+++ b/weed/admin/topology/topology_management.go
@@ -333,7 +333,11 @@ func (at *ActiveTopology) GetVolumeLocations(volumeID uint32, collection string)
 	return replicas
 }
 
-// GetECShardLocations returns the disk locations for EC shards using O(1) lookup
+// GetECShardLocations returns the disk locations for EC shards using O(1) lookup.
+// ShardIds on each returned VolumeReplica enumerates the shard ids present on
+// that disk for the volume — fed by the EC worker into VolumeEcShardsUnmount /
+// VolumeEcShardsDelete to clear stale shards from cross-server destinations
+// before a re-encode distributes fresh ones (#9478 follow-up).
 func (at *ActiveTopology) GetECShardLocations(volumeID uint32, collection string) []VolumeReplica {
 	at.mutex.RLock()
 	defer at.mutex.RUnlock()
@@ -345,20 +349,53 @@ func (at *ActiveTopology) GetECShardLocations(volumeID uint32, collection string
 
 	var ecShards []VolumeReplica
 	for _, diskKey := range diskKeys {
-		if disk, diskExists := at.disks[diskKey]; diskExists {
-			// Verify collection matches (since index doesn't include collection)
-			if at.ecShardMatchesCollection(disk, volumeID, collection) {
-				ecShards = append(ecShards, VolumeReplica{
-					ServerID:   disk.NodeID,
-					DiskID:     disk.DiskID,
-					DataCenter: disk.DataCenter,
-					Rack:       disk.Rack,
-				})
-			}
+		disk, diskExists := at.disks[diskKey]
+		if !diskExists {
+			continue
 		}
+		if !at.ecShardMatchesCollection(disk, volumeID, collection) {
+			continue
+		}
+		shardIds := collectShardIdsForDisk(disk, volumeID, collection)
+		ecShards = append(ecShards, VolumeReplica{
+			ServerID:   disk.NodeID,
+			DiskID:     disk.DiskID,
+			DataCenter: disk.DataCenter,
+			Rack:       disk.Rack,
+			ShardIds:   shardIds,
+		})
 	}
 
 	return ecShards
+}
+
+// collectShardIdsForDisk walks the disk's EcShardInfos for the given
+// (volumeID, collection) and expands each EcIndexBits bitmap into the
+// concrete shard ids present on the disk. A single info entry can carry
+// multiple shards, and the same volume can have several info entries (one
+// per DiskId on cross-disk layouts), so we union into a single bitmap
+// before expanding to avoid duplicates.
+func collectShardIdsForDisk(disk *activeDisk, volumeID uint32, collection string) []uint32 {
+	if disk == nil || disk.DiskInfo == nil || disk.DiskInfo.DiskInfo == nil {
+		return nil
+	}
+	var bits uint32
+	for _, ecShardInfo := range disk.DiskInfo.DiskInfo.EcShardInfos {
+		if ecShardInfo.Id != volumeID || ecShardInfo.Collection != collection {
+			continue
+		}
+		bits |= ecShardInfo.EcIndexBits
+	}
+	if bits == 0 {
+		return nil
+	}
+	var ids []uint32
+	for i := uint32(0); i < 32; i++ {
+		if bits&(1<<i) != 0 {
+			ids = append(ids, i)
+		}
+	}
+	return ids
 }
 
 // volumeMatchesCollection checks if a volume on a disk matches the given collection

--- a/weed/admin/topology/topology_management.go
+++ b/weed/admin/topology/topology_management.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 )
 
 // splitDiskInfoByPhysicalDisk returns one master_pb.DiskInfo per physical
@@ -380,20 +381,20 @@ func collectShardIdsForDisk(disk *activeDisk, volumeID uint32, collection string
 	if disk == nil || disk.DiskInfo == nil || disk.DiskInfo.DiskInfo == nil {
 		return nil
 	}
-	var bits uint32
+	var bits erasure_coding.ShardBits
 	for _, ecShardInfo := range disk.DiskInfo.DiskInfo.EcShardInfos {
 		if ecShardInfo.Id != volumeID || ecShardInfo.Collection != collection {
 			continue
 		}
-		bits |= ecShardInfo.EcIndexBits
+		bits |= erasure_coding.ShardBits(ecShardInfo.EcIndexBits)
 	}
 	if bits == 0 {
 		return nil
 	}
-	var ids []uint32
-	for i := uint32(0); i < 32; i++ {
-		if bits&(1<<i) != 0 {
-			ids = append(ids, i)
+	ids := make([]uint32, 0, bits.Count())
+	for id := uint32(0); id < erasure_coding.MaxShardCount; id++ {
+		if uint32(bits)&(1<<id) != 0 {
+			ids = append(ids, id)
 		}
 	}
 	return ids

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -273,6 +273,7 @@ func Detection(ctx context.Context, metrics []*types.VolumeHealthMetrics, cluste
 							DataCenter:  shard.DataCenter,
 							Rack:        shard.Rack,
 							CleanupType: topology.CleanupECShards,
+							ShardIds:    append([]uint32(nil), shard.ShardIds...),
 						})
 						duplicateCheck[key] = true
 					}
@@ -827,15 +828,18 @@ func convertTaskSourcesToProtobuf(sources []topology.TaskSourceSpec, volumeID ui
 			pbSource.EstimatedSize = uint64(*source.EstimatedSize)
 		}
 
-		// Set appropriate volume ID or shard IDs based on cleanup type
+		// Set appropriate volume ID or shard IDs based on cleanup type.
+		// EC-shard sources carry the shard ids the worker must unmount + delete
+		// on the destination before re-distributing (#9478 follow-up); presence
+		// of ShardIds is the on-the-wire discriminator the worker uses to
+		// route a source to cleanupStaleEcShards rather than treat it as a
+		// regular volume replica to delete.
 		switch source.CleanupType {
 		case topology.CleanupVolumeReplica:
-			// This is a volume replica, use the actual volume ID
 			pbSource.VolumeId = volumeID
 		case topology.CleanupECShards:
-			// This is EC shards, also use the volume ID for consistency
 			pbSource.VolumeId = volumeID
-			// Note: ShardIds would need to be passed separately if we need specific shard info
+			pbSource.ShardIds = append([]uint32(nil), source.ShardIds...)
 		}
 
 		protobufSources = append(protobufSources, pbSource)

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -828,12 +828,9 @@ func convertTaskSourcesToProtobuf(sources []topology.TaskSourceSpec, volumeID ui
 			pbSource.EstimatedSize = uint64(*source.EstimatedSize)
 		}
 
-		// Set appropriate volume ID or shard IDs based on cleanup type.
-		// EC-shard sources carry the shard ids the worker must unmount + delete
-		// on the destination before re-distributing (#9478 follow-up); presence
-		// of ShardIds is the on-the-wire discriminator the worker uses to
-		// route a source to cleanupStaleEcShards rather than treat it as a
-		// regular volume replica to delete.
+		// Populated ShardIds is the wire-level marker that flags an
+		// EC-shard cleanup source; the worker routes it through
+		// cleanupStaleEcShards and skips it in getReplicas.
 		switch source.CleanupType {
 		case topology.CleanupVolumeReplica:
 			pbSource.VolumeId = volumeID

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -673,15 +673,19 @@ func (t *ErasureCodingTask) deleteOriginalVolume(ctx context.Context) error {
 
 // getReplicas extracts regular .dat replica servers from unified sources.
 // Sources with ShardIds set are EC-shard cleanup targets and must be skipped.
+// Per-disk source rows are deduped to one server entry — VolumeDelete is a
+// server-wide call.
 func (t *ErasureCodingTask) getReplicas() []string {
 	var replicas []string
+	seen := make(map[string]struct{})
 	for _, source := range t.sources {
-		if source.VolumeId == 0 {
+		if source.VolumeId == 0 || len(source.ShardIds) > 0 {
 			continue
 		}
-		if len(source.ShardIds) > 0 {
+		if _, ok := seen[source.Node]; ok {
 			continue
 		}
+		seen[source.Node] = struct{}{}
 		replicas = append(replicas, source.Node)
 	}
 	return replicas

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -176,13 +176,9 @@ func (t *ErasureCodingTask) Execute(ctx context.Context, params *worker_pb.TaskP
 		return fmt.Errorf("failed to generate EC shards: %v", err)
 	}
 
-	// Step 3b: Clear partial EC shards left over on destinations from a prior
-	// failed encode. Without this, ReceiveFile in distributeEcShards trips on
-	// volume_grpc_copy.go's mounted-volume guard ("ec volume %d is mounted;
-	// refusing overwrite for %s") and the scheduler retries forever. The
-	// same-store prune from #9480 only handles the .dat-and-partial-EC-on-
-	// sibling-disks layout; cross-server stale shards have to be cleaned by
-	// the worker driving the encode (#9478 follow-up).
+	// Clear partial EC shards left over on destinations from a prior failed
+	// encode so distributeEcShards' ReceiveFile is not refused by the
+	// mounted-volume guard.
 	t.ReportProgressWithStage(55.0, "Clearing stale EC shards on destinations")
 	t.GetLogger().Info("Clearing stale EC shards on destinations")
 	if err := t.cleanupStaleEcShards(ctx); err != nil {
@@ -676,10 +672,7 @@ func (t *ErasureCodingTask) deleteOriginalVolume(ctx context.Context) error {
 }
 
 // getReplicas extracts regular .dat replica servers from unified sources.
-// Sources with ShardIds populated are EC-shard cleanup targets (see
-// cleanupStaleEcShards) and must be skipped — running VolumeDelete against a
-// destination that only holds stale EC shards would be a no-op at best and a
-// misleading log line at worst.
+// Sources with ShardIds set are EC-shard cleanup targets and must be skipped.
 func (t *ErasureCodingTask) getReplicas() []string {
 	var replicas []string
 	for _, source := range t.sources {
@@ -694,42 +687,17 @@ func (t *ErasureCodingTask) getReplicas() []string {
 	return replicas
 }
 
-// cleanupStaleEcShards unmounts and deletes partial EC shards left over on
-// destinations from a previous failed encode of the same volume. The shard
-// ids come from detection, populated from the topology's mounted view of
-// the cluster (TaskSource.ShardIds; collected in
-// ActiveTopology.GetECShardLocations and threaded through
-// convertTaskSourcesToProtobuf).
-//
-// The shape of the bug: an interrupted encode lands a handful of .ec?? files
-// on a destination volume server with no .dat on the same node. PR #9480's
-// pruneIncompleteEcWithSiblingDat only clears the partial EC when the .dat
-// is on a sibling disk of the SAME store; cross-server, those leftovers
-// stay mounted forever. The next encode attempt tries to ReceiveFile a
-// fresh shard to that destination and trips on volume_grpc_copy.go's "ec
-// volume %d is mounted; refusing overwrite" guard. Detection re-fires every
-// cycle and the cluster loops.
-//
-// Unmount + delete are safe here: this method runs after the worker has
-// already copied the .dat off the source and generated a full local shard
-// set, so the bytes being cleared on the destination are strictly redundant
-// — either they're stale duplicates of what's about to be re-distributed,
-// or they're remnants the cluster can't reconstruct without the source
-// (which the worker still has in workDir).
-//
-// Errors per destination are aggregated and returned together; we don't
-// short-circuit on the first failure because operators want to see the
-// full picture of which destinations are stuck.
+// cleanupStaleEcShards unmounts and deletes partial EC shards still mounted
+// on destinations from a previous failed encode. Safe by ordering: runs
+// after the source .dat is in the worker's workdir and a full local shard
+// set is generated. Per-destination errors are aggregated, not short-circuited.
 func (t *ErasureCodingTask) cleanupStaleEcShards(ctx context.Context) error {
 	if len(t.sources) == 0 {
 		return nil
 	}
 
-	// Group shard ids per destination node. Detection may emit one source
-	// row per (node, disk); volume server-side cleanup is keyed by node
-	// (deleteEcShardIdsForEachLocation walks every DiskLocation), so the
-	// per-disk granularity isn't useful here. Union to avoid duplicate
-	// shard ids in the RPC.
+	// Union shard ids per destination node — volume-server cleanup walks
+	// every DiskLocation, so per-disk source rows collapse to one RPC.
 	perNode := make(map[string]map[uint32]struct{})
 	for _, source := range t.sources {
 		if source == nil || len(source.ShardIds) == 0 {
@@ -779,13 +747,9 @@ func (t *ErasureCodingTask) cleanupStaleEcShards(ctx context.Context) error {
 	return nil
 }
 
-// unmountAndDeleteEcShards sends VolumeEcShardsUnmount followed by
-// VolumeEcShardsDelete on a single destination. Both RPCs are idempotent
-// against missing shards (UnmountEcShards in store_ec.go returns nil if the
-// shard isn't loaded; deleteEcShardIdsForEachLocation skips files that don't
-// exist), so passing shard ids that have already been cleaned is harmless.
-// The unmount has to land first — VolumeEcShardsDelete's contract is "the
-// shard should not be mounted before calling this".
+// unmountAndDeleteEcShards unmounts then deletes the named shards on one
+// destination. Unmount must precede delete (delete requires the shard be
+// unmounted); both RPCs are idempotent against missing shards.
 func unmountAndDeleteEcShards(
 	ctx context.Context,
 	dialOption grpc.DialOption,

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -176,6 +176,20 @@ func (t *ErasureCodingTask) Execute(ctx context.Context, params *worker_pb.TaskP
 		return fmt.Errorf("failed to generate EC shards: %v", err)
 	}
 
+	// Step 3b: Clear partial EC shards left over on destinations from a prior
+	// failed encode. Without this, ReceiveFile in distributeEcShards trips on
+	// volume_grpc_copy.go's mounted-volume guard ("ec volume %d is mounted;
+	// refusing overwrite for %s") and the scheduler retries forever. The
+	// same-store prune from #9480 only handles the .dat-and-partial-EC-on-
+	// sibling-disks layout; cross-server stale shards have to be cleaned by
+	// the worker driving the encode (#9478 follow-up).
+	t.ReportProgressWithStage(55.0, "Clearing stale EC shards on destinations")
+	t.GetLogger().Info("Clearing stale EC shards on destinations")
+	if err := t.cleanupStaleEcShards(ctx); err != nil {
+		t.rollbackReadonly(ctx)
+		return fmt.Errorf("failed to clear stale EC shards on destinations: %v", err)
+	}
+
 	// Step 4: Distribute shards to destinations
 	t.ReportProgressWithStage(60.0, "Distributing EC shards to destinations")
 	t.GetLogger().Info("Distributing EC shards to destinations")
@@ -661,18 +675,142 @@ func (t *ErasureCodingTask) deleteOriginalVolume(ctx context.Context) error {
 	return nil
 }
 
-// getReplicas extracts replica servers from unified sources
+// getReplicas extracts regular .dat replica servers from unified sources.
+// Sources with ShardIds populated are EC-shard cleanup targets (see
+// cleanupStaleEcShards) and must be skipped — running VolumeDelete against a
+// destination that only holds stale EC shards would be a no-op at best and a
+// misleading log line at worst.
 func (t *ErasureCodingTask) getReplicas() []string {
 	var replicas []string
 	for _, source := range t.sources {
-		// Only include volume replica sources (not EC shard sources)
-		// Assumption: VolumeId == 0 is considered invalid and should be excluded.
-		// If volume ID 0 is valid in some contexts, update this check accordingly.
-		if source.VolumeId > 0 {
-			replicas = append(replicas, source.Node)
+		if source.VolumeId == 0 {
+			continue
 		}
+		if len(source.ShardIds) > 0 {
+			continue
+		}
+		replicas = append(replicas, source.Node)
 	}
 	return replicas
+}
+
+// cleanupStaleEcShards unmounts and deletes partial EC shards left over on
+// destinations from a previous failed encode of the same volume. The shard
+// ids come from detection, populated from the topology's mounted view of
+// the cluster (TaskSource.ShardIds; collected in
+// ActiveTopology.GetECShardLocations and threaded through
+// convertTaskSourcesToProtobuf).
+//
+// The shape of the bug: an interrupted encode lands a handful of .ec?? files
+// on a destination volume server with no .dat on the same node. PR #9480's
+// pruneIncompleteEcWithSiblingDat only clears the partial EC when the .dat
+// is on a sibling disk of the SAME store; cross-server, those leftovers
+// stay mounted forever. The next encode attempt tries to ReceiveFile a
+// fresh shard to that destination and trips on volume_grpc_copy.go's "ec
+// volume %d is mounted; refusing overwrite" guard. Detection re-fires every
+// cycle and the cluster loops.
+//
+// Unmount + delete are safe here: this method runs after the worker has
+// already copied the .dat off the source and generated a full local shard
+// set, so the bytes being cleared on the destination are strictly redundant
+// — either they're stale duplicates of what's about to be re-distributed,
+// or they're remnants the cluster can't reconstruct without the source
+// (which the worker still has in workDir).
+//
+// Errors per destination are aggregated and returned together; we don't
+// short-circuit on the first failure because operators want to see the
+// full picture of which destinations are stuck.
+func (t *ErasureCodingTask) cleanupStaleEcShards(ctx context.Context) error {
+	if len(t.sources) == 0 {
+		return nil
+	}
+
+	// Group shard ids per destination node. Detection may emit one source
+	// row per (node, disk); volume server-side cleanup is keyed by node
+	// (deleteEcShardIdsForEachLocation walks every DiskLocation), so the
+	// per-disk granularity isn't useful here. Union to avoid duplicate
+	// shard ids in the RPC.
+	perNode := make(map[string]map[uint32]struct{})
+	for _, source := range t.sources {
+		if source == nil || len(source.ShardIds) == 0 {
+			continue
+		}
+		shardSet, ok := perNode[source.Node]
+		if !ok {
+			shardSet = make(map[uint32]struct{})
+			perNode[source.Node] = shardSet
+		}
+		for _, shardID := range source.ShardIds {
+			shardSet[shardID] = struct{}{}
+		}
+	}
+	if len(perNode) == 0 {
+		return nil
+	}
+
+	var cleanupErrors []string
+	for node, shardSet := range perNode {
+		shardIds := make([]uint32, 0, len(shardSet))
+		for id := range shardSet {
+			shardIds = append(shardIds, id)
+		}
+
+		t.GetLogger().WithFields(map[string]interface{}{
+			"volume_id":   t.volumeID,
+			"destination": node,
+			"shard_ids":   shardIds,
+		}).Info("Clearing stale EC shards on destination before re-distribute")
+
+		if err := unmountAndDeleteEcShards(ctx, t.grpcDialOption, node, t.volumeID, t.collection, shardIds); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Sprintf("%s: %v", node, err))
+			t.GetLogger().WithFields(map[string]interface{}{
+				"volume_id":   t.volumeID,
+				"destination": node,
+				"shard_ids":   shardIds,
+				"error":       err.Error(),
+			}).Error("Failed to clear stale EC shards on destination")
+		}
+	}
+
+	if len(cleanupErrors) > 0 {
+		return fmt.Errorf("stale EC shard cleanup failed on %d destination(s): %s",
+			len(cleanupErrors), strings.Join(cleanupErrors, "; "))
+	}
+	return nil
+}
+
+// unmountAndDeleteEcShards sends VolumeEcShardsUnmount followed by
+// VolumeEcShardsDelete on a single destination. Both RPCs are idempotent
+// against missing shards (UnmountEcShards in store_ec.go returns nil if the
+// shard isn't loaded; deleteEcShardIdsForEachLocation skips files that don't
+// exist), so passing shard ids that have already been cleaned is harmless.
+// The unmount has to land first — VolumeEcShardsDelete's contract is "the
+// shard should not be mounted before calling this".
+func unmountAndDeleteEcShards(
+	ctx context.Context,
+	dialOption grpc.DialOption,
+	destination string,
+	volumeID uint32,
+	collection string,
+	shardIds []uint32,
+) error {
+	return operation.WithVolumeServerClient(false, pb.ServerAddress(destination), dialOption,
+		func(client volume_server_pb.VolumeServerClient) error {
+			if _, err := client.VolumeEcShardsUnmount(ctx, &volume_server_pb.VolumeEcShardsUnmountRequest{
+				VolumeId: volumeID,
+				ShardIds: shardIds,
+			}); err != nil {
+				return fmt.Errorf("unmount: %w", err)
+			}
+			if _, err := client.VolumeEcShardsDelete(ctx, &volume_server_pb.VolumeEcShardsDeleteRequest{
+				VolumeId:   volumeID,
+				Collection: collection,
+				ShardIds:   shardIds,
+			}); err != nil {
+				return fmt.Errorf("delete: %w", err)
+			}
+			return nil
+		})
 }
 
 // verifyDatIdxConsistency checks that all .idx entries reference data within the

--- a/weed/worker/tasks/erasure_coding/ec_task_stale_shard_cleanup_test.go
+++ b/weed/worker/tasks/erasure_coding/ec_task_stale_shard_cleanup_test.go
@@ -1,0 +1,246 @@
+package erasure_coding
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/test/volume_server/framework"
+	"github.com/seaweedfs/seaweedfs/test/volume_server/matrix"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Reproduces the cross-server stale-EC-shard collision reported as a 4.24
+// recurrence of #9478: a previous EC encode left partial shards mounted on
+// destination servers that are NOT the .dat owner, so PR #9480's same-store
+// prune doesn't fire. The EC scheduler keeps re-proposing, and every retry
+// hits ReceiveFile's "ec volume %d is mounted; refusing overwrite" guard on
+// those destinations. Worker must clear stale shards from each destination
+// before distributing.
+//
+// The test sets up the post-failure state on a single volume server,
+// confirms the refusal, then drives the new cleanupStaleEcShards helper
+// and asserts the next ReceiveFile attempt succeeds.
+func TestCleanupStaleEcShardsBeforeDistribute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	clusterHarness := framework.StartVolumeCluster(t, matrix.P1())
+	conn, grpcClient := framework.DialVolumeServer(t, clusterHarness.VolumeGRPCAddress())
+	defer conn.Close()
+
+	const (
+		volumeID   = uint32(9478)
+		collection = "ec-9478-xserver"
+	)
+
+	framework.AllocateVolume(t, grpcClient, volumeID, collection)
+
+	httpClient := framework.NewHTTPClient()
+	fid := framework.NewFileID(volumeID, 947800, 0x9478CAFE)
+	upResp := framework.UploadBytes(t, httpClient, clusterHarness.VolumeAdminURL(), fid,
+		[]byte("payload-for-cross-server-stale-ec-cleanup"))
+	_ = framework.ReadAllAndClose(t, upResp)
+	require.Equal(t, http.StatusCreated, upResp.StatusCode)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	_, err := grpcClient.VolumeEcShardsGenerate(ctx, &volume_server_pb.VolumeEcShardsGenerateRequest{
+		VolumeId: volumeID, Collection: collection,
+	})
+	require.NoError(t, err)
+
+	// Mount a partial subset to mimic the half-done previous distribute that
+	// the user reported on 10.0.14.12 / .13 / .9: 1-3 shards mounted per node,
+	// no .dat on the destination, nothing left to trigger #9480's prune.
+	staleShards := []uint32{0, 1, 2}
+	_, err = grpcClient.VolumeEcShardsMount(ctx, &volume_server_pb.VolumeEcShardsMountRequest{
+		VolumeId: volumeID, Collection: collection,
+		ShardIds: staleShards,
+	})
+	require.NoError(t, err)
+
+	shardPath := makeTinyEcShardFile(t)
+
+	// Pre-fix state: ReceiveFile against the mounted EC volume is refused.
+	// This is the exact symptom 4.24 keeps logging in the user's cluster.
+	err = sendShardViaReceiveFile(ctx, grpcClient, volumeID, collection, 0, shardPath)
+	require.Error(t, err, "expected ReceiveFile to be refused while EC volume is mounted")
+	require.True(t,
+		strings.Contains(err.Error(), "is mounted") ||
+			strings.Contains(err.Error(), "unmount before ReceiveFile"),
+		"expected refusal to name the mounted-volume guard, got: %v", err)
+
+	// Drive the worker-side cleanup we expect ec_task to perform before
+	// distributing. The source is keyed by len(ShardIds)>0; getReplicas
+	// must NOT treat this as a regular volume replica to delete.
+	task := NewErasureCodingTask(
+		"9478-xserver",
+		clusterHarness.VolumeServerAddress(),
+		volumeID,
+		collection,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	task.dataShards = erasure_coding.DataShardsCount
+	task.parityShards = erasure_coding.ParityShardsCount
+	task.sources = []*worker_pb.TaskSource{
+		{
+			Node:     clusterHarness.VolumeServerAddress(),
+			VolumeId: volumeID,
+			ShardIds: staleShards,
+		},
+	}
+
+	require.NoError(t, task.cleanupStaleEcShards(ctx))
+
+	// EC volume should no longer be mounted on the destination.
+	_, infoErr := grpcClient.VolumeEcShardsInfo(ctx, &volume_server_pb.VolumeEcShardsInfoRequest{VolumeId: volumeID})
+	require.Error(t, infoErr, "EC volume should be gone from server after cleanupStaleEcShards")
+
+	// The new shard transfer that previously collided now goes through.
+	require.NoError(t,
+		sendShardViaReceiveFile(ctx, grpcClient, volumeID, collection, 0, shardPath),
+		"ReceiveFile must succeed after stale shards are cleaned up")
+
+	// getReplicas must skip EC-shard sources so the post-encode VolumeDelete
+	// step does not run against destination-only nodes.
+	require.Empty(t, task.getReplicas(),
+		"EC-shard sources (ShardIds>0) must not appear in replica delete list")
+}
+
+// EC-shard cleanup must be a no-op when sources carry only the regular
+// volume replica (ShardIds empty). The destination volume server should not
+// receive any unmount/delete calls.
+func TestCleanupStaleEcShardsSkipsRegularReplicas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	clusterHarness := framework.StartVolumeCluster(t, matrix.P1())
+	conn, grpcClient := framework.DialVolumeServer(t, clusterHarness.VolumeGRPCAddress())
+	defer conn.Close()
+
+	const volumeID = uint32(9479)
+	framework.AllocateVolume(t, grpcClient, volumeID, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	task := NewErasureCodingTask(
+		"9478-no-stale",
+		clusterHarness.VolumeServerAddress(),
+		volumeID,
+		"",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	task.sources = []*worker_pb.TaskSource{
+		{Node: clusterHarness.VolumeServerAddress(), VolumeId: volumeID}, // replica
+	}
+
+	require.NoError(t, task.cleanupStaleEcShards(ctx),
+		"cleanup with only replica sources must succeed without touching the server")
+
+	// The .dat volume is untouched.
+	_, err := grpcClient.VolumeStatus(ctx, &volume_server_pb.VolumeStatusRequest{VolumeId: volumeID})
+	require.NoError(t, err, "regular volume must remain after cleanupStaleEcShards no-op")
+}
+
+// makeTinyEcShardFile writes a small file we can stream through ReceiveFile.
+// The contents do not need to be a valid shard — the volume server's
+// "is mounted" guard runs before any content is consumed, and on the success
+// path the file just lands on disk to confirm acceptance.
+func makeTinyEcShardFile(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "shard.bin")
+	require.NoError(t, os.WriteFile(p, []byte("ec-shard-placeholder"), 0o600))
+	return p
+}
+
+// sendShardViaReceiveFile streams a shard file to the volume server via the
+// same gRPC API the EC worker uses (volume_grpc_copy.go:ReceiveFile). It
+// returns the error the server replies with so tests can distinguish the
+// "is mounted; refusing overwrite" guard from transport errors.
+func sendShardViaReceiveFile(
+	ctx context.Context,
+	client volume_server_pb.VolumeServerClient,
+	volumeID uint32,
+	collection string,
+	shardID uint32,
+	filePath string,
+) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	stream, err := client.ReceiveFile(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := stream.Send(&volume_server_pb.ReceiveFileRequest{
+		Data: &volume_server_pb.ReceiveFileRequest_Info{
+			Info: &volume_server_pb.ReceiveFileInfo{
+				VolumeId:   volumeID,
+				Ext:        erasure_coding.ToExt(int(shardID)),
+				Collection: collection,
+				IsEcVolume: true,
+				ShardId:    shardID,
+				FileSize:   uint64(info.Size()),
+			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if err := stream.Send(&volume_server_pb.ReceiveFileRequest{
+				Data: &volume_server_pb.ReceiveFileRequest_FileContent{
+					FileContent: buf[:n],
+				},
+			}); err != nil {
+				return err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return &receiveFileServerError{msg: resp.Error}
+	}
+	return nil
+}
+
+type receiveFileServerError struct{ msg string }
+
+func (e *receiveFileServerError) Error() string { return e.msg }

--- a/weed/worker/tasks/erasure_coding/ec_task_stale_shard_cleanup_test.go
+++ b/weed/worker/tasks/erasure_coding/ec_task_stale_shard_cleanup_test.go
@@ -20,17 +20,10 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// Reproduces the cross-server stale-EC-shard collision reported as a 4.24
-// recurrence of #9478: a previous EC encode left partial shards mounted on
-// destination servers that are NOT the .dat owner, so PR #9480's same-store
-// prune doesn't fire. The EC scheduler keeps re-proposing, and every retry
-// hits ReceiveFile's "ec volume %d is mounted; refusing overwrite" guard on
-// those destinations. Worker must clear stale shards from each destination
-// before distributing.
-//
-// The test sets up the post-failure state on a single volume server,
-// confirms the refusal, then drives the new cleanupStaleEcShards helper
-// and asserts the next ReceiveFile attempt succeeds.
+// Reproduces a stuck re-encode: partial EC shards mounted on a destination
+// from a previous failed encode cause ReceiveFile to refuse with the
+// mounted-volume guard. cleanupStaleEcShards must clear them so the next
+// ReceiveFile lands.
 func TestCleanupStaleEcShardsBeforeDistribute(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -62,9 +55,8 @@ func TestCleanupStaleEcShardsBeforeDistribute(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Mount a partial subset to mimic the half-done previous distribute that
-	// the user reported on 10.0.14.12 / .13 / .9: 1-3 shards mounted per node,
-	// no .dat on the destination, nothing left to trigger #9480's prune.
+	// Partial subset mimics a half-finished previous distribute: shards
+	// mounted on the destination with no .dat to anchor a same-store prune.
 	staleShards := []uint32{0, 1, 2}
 	_, err = grpcClient.VolumeEcShardsMount(ctx, &volume_server_pb.VolumeEcShardsMountRequest{
 		VolumeId: volumeID, Collection: collection,
@@ -74,8 +66,7 @@ func TestCleanupStaleEcShardsBeforeDistribute(t *testing.T) {
 
 	shardPath := makeTinyEcShardFile(t)
 
-	// Pre-fix state: ReceiveFile against the mounted EC volume is refused.
-	// This is the exact symptom 4.24 keeps logging in the user's cluster.
+	// Pre-cleanup: the mounted partial EC blocks ReceiveFile.
 	err = sendShardViaReceiveFile(ctx, grpcClient, volumeID, collection, 0, shardPath)
 	require.Error(t, err, "expected ReceiveFile to be refused while EC volume is mounted")
 	require.True(t,
@@ -83,11 +74,10 @@ func TestCleanupStaleEcShardsBeforeDistribute(t *testing.T) {
 			strings.Contains(err.Error(), "unmount before ReceiveFile"),
 		"expected refusal to name the mounted-volume guard, got: %v", err)
 
-	// Drive the worker-side cleanup we expect ec_task to perform before
-	// distributing. The source is keyed by len(ShardIds)>0; getReplicas
-	// must NOT treat this as a regular volume replica to delete.
+	// ShardIds set marks this as an EC-shard cleanup source: cleanup will
+	// target it; getReplicas must skip it.
 	task := NewErasureCodingTask(
-		"9478-xserver",
+		"stale-ec-xserver",
 		clusterHarness.VolumeServerAddress(),
 		volumeID,
 		collection,
@@ -105,24 +95,18 @@ func TestCleanupStaleEcShardsBeforeDistribute(t *testing.T) {
 
 	require.NoError(t, task.cleanupStaleEcShards(ctx))
 
-	// EC volume should no longer be mounted on the destination.
 	_, infoErr := grpcClient.VolumeEcShardsInfo(ctx, &volume_server_pb.VolumeEcShardsInfoRequest{VolumeId: volumeID})
-	require.Error(t, infoErr, "EC volume should be gone from server after cleanupStaleEcShards")
+	require.Error(t, infoErr, "EC volume should be gone after cleanupStaleEcShards")
 
-	// The new shard transfer that previously collided now goes through.
 	require.NoError(t,
 		sendShardViaReceiveFile(ctx, grpcClient, volumeID, collection, 0, shardPath),
-		"ReceiveFile must succeed after stale shards are cleaned up")
+		"ReceiveFile must succeed after cleanup")
 
-	// getReplicas must skip EC-shard sources so the post-encode VolumeDelete
-	// step does not run against destination-only nodes.
 	require.Empty(t, task.getReplicas(),
-		"EC-shard sources (ShardIds>0) must not appear in replica delete list")
+		"EC-shard sources must not appear in replica delete list")
 }
 
-// EC-shard cleanup must be a no-op when sources carry only the regular
-// volume replica (ShardIds empty). The destination volume server should not
-// receive any unmount/delete calls.
+// Cleanup is a no-op when sources carry only the regular .dat replica.
 func TestCleanupStaleEcShardsSkipsRegularReplicas(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -139,28 +123,25 @@ func TestCleanupStaleEcShardsSkipsRegularReplicas(t *testing.T) {
 	defer cancel()
 
 	task := NewErasureCodingTask(
-		"9478-no-stale",
+		"no-stale-ec",
 		clusterHarness.VolumeServerAddress(),
 		volumeID,
 		"",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	task.sources = []*worker_pb.TaskSource{
-		{Node: clusterHarness.VolumeServerAddress(), VolumeId: volumeID}, // replica
+		{Node: clusterHarness.VolumeServerAddress(), VolumeId: volumeID},
 	}
 
-	require.NoError(t, task.cleanupStaleEcShards(ctx),
-		"cleanup with only replica sources must succeed without touching the server")
+	require.NoError(t, task.cleanupStaleEcShards(ctx))
 
-	// The .dat volume is untouched.
 	_, err := grpcClient.VolumeStatus(ctx, &volume_server_pb.VolumeStatusRequest{VolumeId: volumeID})
-	require.NoError(t, err, "regular volume must remain after cleanupStaleEcShards no-op")
+	require.NoError(t, err, "regular volume must remain untouched")
 }
 
-// makeTinyEcShardFile writes a small file we can stream through ReceiveFile.
-// The contents do not need to be a valid shard — the volume server's
-// "is mounted" guard runs before any content is consumed, and on the success
-// path the file just lands on disk to confirm acceptance.
+// makeTinyEcShardFile writes a placeholder payload — the mounted-volume
+// guard fires before any content is consumed, so the bytes don't need to
+// be a real shard.
 func makeTinyEcShardFile(t *testing.T) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "shard.bin")
@@ -168,10 +149,8 @@ func makeTinyEcShardFile(t *testing.T) string {
 	return p
 }
 
-// sendShardViaReceiveFile streams a shard file to the volume server via the
-// same gRPC API the EC worker uses (volume_grpc_copy.go:ReceiveFile). It
-// returns the error the server replies with so tests can distinguish the
-// "is mounted; refusing overwrite" guard from transport errors.
+// sendShardViaReceiveFile streams a shard file through the same ReceiveFile
+// gRPC the EC worker uses, returning the server's reply error verbatim.
 func sendShardViaReceiveFile(
 	ctx context.Context,
 	client volume_server_pb.VolumeServerClient,


### PR DESCRIPTION
Follow-up to #9480 for the 4.24 recurrence reported in https://github.com/seaweedfs/seaweedfs/issues/9478#issuecomment-4450250610.

## What goes wrong

Volume 1546 in the reporter's cluster is stuck in an infinite EC retry loop. The healthy `.dat` replicas live on 10.0.14.11 and 10.0.14.14, while partial EC shards from an earlier failed encode remain mounted on 10.0.14.12 / .13 / .9. Every encode attempt logs:

```
ReceiveFile: ec volume 1546 is mounted; refusing overwrite for .ec01
```

`pruneIncompleteEcWithSiblingDat` (#9480) only clears partial EC when the `.dat` is on a sibling disk of the **same** store. Cross-server the leftovers stay mounted, so `volume_grpc_copy.go:570` refuses every `ReceiveFile`. Detection already enumerates those leftovers as `CleanupECShards` sources but the worker never acts on them — `getReplicas()` only drives `VolumeDelete` of the regular `.dat`, never `VolumeEcShardsUnmount` / `VolumeEcShardsDelete`.

## Fix

- Thread per-disk shard ids from the topology (`ActiveTopology.GetECShardLocations`) through `TaskSourceSpec` and `TaskSource.shard_ids`. Presence of `shard_ids` on the wire is the EC-shard-vs-replica discriminator the worker uses.
- New `cleanupStaleEcShards` step in `ec_task.go` between `generateEcShardsLocally` and `distributeEcShards`. Per destination node, union the shard ids and issue `VolumeEcShardsUnmount` followed by `VolumeEcShardsDelete`. Both RPCs are already idempotent on missing shards.
- `getReplicas` now skips sources carrying `shard_ids` so the post-encode `VolumeDelete` doesn't run against destination-only nodes.

The order matters: cleanup runs after the worker has the source `.dat`/`.idx` copied off and a full local shard set generated, so anything we wipe on the destination is strictly redundant.

## Recovery for an already-stuck cluster

Once this lands, the next scheduler cycle clears the leftover EC mounts and the encode completes. No manual `volume.ec.delete` needed.

## Test

`weed/worker/tasks/erasure_coding/ec_task_stale_shard_cleanup_test.go`:

- `TestCleanupStaleEcShardsBeforeDistribute` reproduces the bug: generate shards, mount a partial subset, assert `ReceiveFile` refuses with "is mounted", run `cleanupStaleEcShards`, assert the next `ReceiveFile` lands and the EC volume is no longer mounted.
- `TestCleanupStaleEcShardsSkipsRegularReplicas` confirms the cleanup is a no-op when sources carry only the regular `.dat` replica.

Both fail without the helper and pass with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Volume replica entries and task sources now include shard-id metadata; location queries emit shard IDs.
  * Redistribution now performs automatic cleanup of stale erasure-coded shards on destination nodes.

* **Bug Fixes**
  * Replica selection refined to avoid treating regular replicas as EC-shard cleanup targets.

* **Tests**
  * New integration tests validating stale EC-shard cleanup behavior and replica selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9499)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->