### PR TITLE
fix(tests): make 32-bit GOARCH tests build and run

### DIFF
--- a/weed/command/filer_sync_verify_test.go
+++ b/weed/command/filer_sync_verify_test.go
@@ -48,20 +48,24 @@ func (c *verifyTestInnerClient) ListEntries(_ context.Context, in *filer_pb.List
 
 // verifyTestFilerClient implements filer_pb.FilerClient and tracks concurrent
 // WithFilerClient invocations to let tests verify the global concurrency bound.
+// inFlight/peakFlight use atomic.Int64 (not bare int64 + sync/atomic funcs) so
+// the fields are 8-byte aligned even on 32-bit platforms — bare int64 fields
+// after a pointer-sized field panic with "unaligned 64-bit atomic operation"
+// on 386/arm/mips.
 type verifyTestFilerClient struct {
 	entriesByDir map[string][]*filer_pb.Entry
-	inFlight     int64 // accessed via atomic
-	peakFlight   int64 // accessed via atomic
+	inFlight     atomic.Int64
+	peakFlight   atomic.Int64
 	delay        time.Duration
 }
 
 func (c *verifyTestFilerClient) WithFilerClient(_ bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	// track peak concurrent in-flight listings
-	n := atomic.AddInt64(&c.inFlight, 1)
-	defer atomic.AddInt64(&c.inFlight, -1)
+	n := c.inFlight.Add(1)
+	defer c.inFlight.Add(-1)
 	for {
-		peak := atomic.LoadInt64(&c.peakFlight)
-		if n <= peak || atomic.CompareAndSwapInt64(&c.peakFlight, peak, n) {
+		peak := c.peakFlight.Load()
+		if n <= peak || c.peakFlight.CompareAndSwap(peak, n) {
 			break
 		}
 	}
@@ -219,11 +223,11 @@ func TestVerifySyncConcurrencyBound(t *testing.T) {
 		t.Errorf("unexpected diffs in identical tree")
 	}
 
-	if peak := atomic.LoadInt64(&clientA.peakFlight); peak > verifySyncConcurrency {
+	if peak := clientA.peakFlight.Load(); peak > verifySyncConcurrency {
 		t.Errorf("clientA peak concurrent listings = %d, want ≤ %d (verifySyncConcurrency)",
 			peak, verifySyncConcurrency)
 	}
-	if peak := atomic.LoadInt64(&clientB.peakFlight); peak > verifySyncConcurrency {
+	if peak := clientB.peakFlight.Load(); peak > verifySyncConcurrency {
 		t.Errorf("clientB peak concurrent listings = %d, want ≤ %d (verifySyncConcurrency)",
 			peak, verifySyncConcurrency)
 	}

--- a/weed/server/nfs/rpc_version_filter_test.go
+++ b/weed/server/nfs/rpc_version_filter_test.go
@@ -98,8 +98,9 @@ func TestVersionFilterRejectsNFSv4WithProgMismatch(t *testing.T) {
 	}
 
 	xid, low, high := readPROGMismatchReply(t, conn)
-	if xid != 0xdeadbeef {
-		t.Errorf("xid=%x want %x", xid, 0xdeadbeef)
+	const wantXID uint32 = 0xdeadbeef
+	if xid != wantXID {
+		t.Errorf("xid=%x want %x", xid, wantXID)
 	}
 	if low != supportedNFSVer || high != supportedNFSVer {
 		t.Errorf("supported range=(%d,%d) want (%d,%d)", low, high, supportedNFSVer, supportedNFSVer)


### PR DESCRIPTION
Fixes #9503.

Two independent 32-bit problems surfaced in the void-linux build:

**`weed/command/filer_sync_verify_test.go`** — `verifyTestFilerClient` had bare `int64` atomic counters (`inFlight`, `peakFlight`) after a pointer-sized map header. On 32-bit the fields land at a 4-byte-aligned offset, so `atomic.AddInt64` panics with `unaligned 64-bit atomic operation`. Switched to `atomic.Int64`, which the stdlib guarantees is 8-byte aligned on every platform — no longer depends on field-ordering tricks.

**`weed/server/nfs/rpc_version_filter_test.go`** — `t.Errorf("xid=%x want %x", xid, 0xdeadbeef)` passed an untyped constant that default-promotes to `int`. On 32-bit `int` is 32 bits and `0xdeadbeef` (3735928559) overflows it, so the file failed to compile. Bound the value to a typed `const wantXID uint32` used in both the comparison and the error message.

Verified with `GOOS=linux GOARCH=386 go test -c` for both packages, plus the normal `go test` on the host arch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for improved concurrency tracking and code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9507)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->