### PR TITLE
helm: decouple JWT signing from cert-manager mTLS (fixes #9506)

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -74,6 +74,10 @@ jobs:
           # Admin UI Users tab calls only when jwt.filer_signing.key is in
           # security.toml. Operators must be able to enable that without
           # the cert-manager mTLS bundle.
+          # Install PyYAML explicitly: this block runs before the later
+          # security+S3 block that does the same install, and we don't
+          # want to rely on the runner image shipping it.
+          pip install pyyaml -q
           python3 - "$CHART_DIR" <<'PYEOF'
           import subprocess, sys, yaml
           chart = sys.argv[1]
@@ -160,10 +164,15 @@ jobs:
           # decoupling change accidentally regressing the mTLS path.
           out = render({"global.seaweedfs.enableSecurity": "true"})
           cm = configmap(out, "test-seaweedfs-security-config")
-          if cm is None or "[grpc.master]" not in cm["data"]["security.toml"]:
-              failed.append("enableSecurity=true: full security.toml regressed")
+          if cm is None:
+              failed.append("enableSecurity=true: security ConfigMap missing")
           else:
-              print("✓ enableSecurity=true: full security.toml with [grpc.*] preserved")
+              toml = cm["data"]["security.toml"]
+              missing = [s for s in ("[jwt.signing]", "[grpc.master]") if s not in toml]
+              if missing:
+                  failed.append(f"enableSecurity=true: security.toml missing {missing}")
+              else:
+                  print("✓ enableSecurity=true: security.toml has [jwt.signing] + [grpc.*] preserved")
 
           # Case 5: helper must tolerate explicit nulls (gemini-code-assist
           # PR review). securityConfig=null was the parens-pattern crash

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -68,6 +68,125 @@ jobs:
           grep -q "security-config" /tmp/security.yaml
           echo "✓ Security configuration renders correctly"
 
+          echo ""
+          echo "=== Testing IAM gRPC opt-in path (issue #9506) ==="
+          # Regression test: the filer registers the IAM gRPC service the
+          # Admin UI Users tab calls only when jwt.filer_signing.key is in
+          # security.toml. Operators must be able to enable that without
+          # the cert-manager mTLS bundle.
+          python3 - "$CHART_DIR" <<'PYEOF'
+          import subprocess, sys, yaml
+          chart = sys.argv[1]
+
+          def render(values):
+              args = ["helm", "template", "test", chart]
+              for k, v in values.items():
+                  args += ["--set", f"{k}={v}"]
+              return subprocess.check_output(args, text=True)
+
+          def docs(manifest):
+              return [d for d in yaml.safe_load_all(manifest) if d]
+
+          def configmap(manifest, name):
+              for d in docs(manifest):
+                  if d.get("kind") == "ConfigMap" and d["metadata"]["name"] == name:
+                      return d
+              return None
+
+          def workload_mounts(manifest, name):
+              for d in docs(manifest):
+                  if d.get("kind") not in ("Deployment", "StatefulSet"):
+                      continue
+                  if d["metadata"]["name"] != name:
+                      continue
+                  pod = d["spec"]["template"]["spec"]
+                  vols = {v["name"] for v in pod.get("volumes", [])}
+                  mounts = set()
+                  for c in pod.get("containers", []):
+                      for vm in c.get("volumeMounts", []):
+                          mounts.add(vm["name"])
+                  return vols, mounts
+              return None, None
+
+          failed = []
+
+          # Case 1: defaults. The chart historically rendered nothing
+          # security-related; preserve that so this PR is non-breaking on
+          # existing installs.
+          out = render({})
+          if configmap(out, "test-seaweedfs-security-config") is not None:
+              failed.append("defaults: security ConfigMap should not render")
+          else:
+              print("✓ defaults: no security-config ConfigMap (unchanged)")
+
+          # Case 2: filerWrite=true alone (the documented issue #9506
+          # workaround). Configmap must render with [jwt.filer_signing]
+          # and NO [grpc.*] sections (cert paths only exist with mTLS).
+          out = render({
+              "global.seaweedfs.securityConfig.jwtSigning.filerWrite": "true",
+              "admin.enabled": "true",
+          })
+          cm = configmap(out, "test-seaweedfs-security-config")
+          if cm is None:
+              failed.append("filerWrite=true: security ConfigMap missing")
+          else:
+              toml = cm["data"]["security.toml"]
+              if "[jwt.filer_signing]" not in toml:
+                  failed.append("filerWrite=true: security.toml missing [jwt.filer_signing]")
+              if "[grpc" in toml:
+                  failed.append("filerWrite=true: security.toml unexpectedly has [grpc.*] (would need cert mounts)")
+              if "[jwt.filer_signing]" in toml and "[grpc" not in toml:
+                  print("✓ filerWrite=true: security.toml has [jwt.filer_signing], no [grpc.*]")
+
+          # Case 3: filer + admin pods must MOUNT the security ConfigMap
+          # under filerWrite=true so the JWT key reaches both processes.
+          # Cert volumes must NOT be present (no mTLS).
+          for wl in ("test-seaweedfs-filer", "test-seaweedfs-admin"):
+              vols, mounts = workload_mounts(out, wl)
+              if vols is None:
+                  failed.append(f"filerWrite=true: workload {wl} not found")
+                  continue
+              if "security-config" not in vols or "security-config" not in mounts:
+                  failed.append(f"filerWrite=true: {wl} does not mount security-config (IAM gRPC would still fail)")
+              else:
+                  print(f"✓ filerWrite=true: {wl} mounts security-config")
+              cert_vols = {v for v in vols if v.endswith("-cert")}
+              if cert_vols:
+                  failed.append(f"filerWrite=true: {wl} unexpectedly has cert volumes {sorted(cert_vols)}")
+
+          # Case 4: enableSecurity=true must still render the full toml
+          # with both [jwt.signing] and [grpc.*]. Guards against the
+          # decoupling change accidentally regressing the mTLS path.
+          out = render({"global.seaweedfs.enableSecurity": "true"})
+          cm = configmap(out, "test-seaweedfs-security-config")
+          if cm is None or "[grpc.master]" not in cm["data"]["security.toml"]:
+              failed.append("enableSecurity=true: full security.toml regressed")
+          else:
+              print("✓ enableSecurity=true: full security.toml with [grpc.*] preserved")
+
+          # Case 5: helper must tolerate explicit nulls (gemini-code-assist
+          # PR review). securityConfig=null was the parens-pattern crash
+          # the helper review caught.
+          for null_path in ("global.seaweedfs.securityConfig",
+                            "global.seaweedfs.securityConfig.jwtSigning"):
+              try:
+                  out = render({null_path: "null"})
+              except subprocess.CalledProcessError as e:
+                  failed.append(f"{null_path}=null: render failed: {e.output[:200] if e.output else e}")
+                  continue
+              if configmap(out, "test-seaweedfs-security-config") is not None:
+                  failed.append(f"{null_path}=null: should not render configmap")
+              else:
+                  print(f"✓ {null_path}=null: render tolerates explicit null")
+
+          if failed:
+              print("\nFAIL:", file=sys.stderr)
+              for f in failed:
+                  print(f"  - {f}", file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+          echo "✓ IAM gRPC decoupling tests passed"
+
           echo "=== Testing with monitoring enabled ==="
           helm template test $CHART_DIR \
             --set global.seaweedfs.monitoring.enabled=true \

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -69,7 +69,7 @@ jobs:
           echo "✓ Security configuration renders correctly"
 
           echo ""
-          echo "=== Testing IAM gRPC opt-in path (issue #9506) ==="
+          echo "=== Testing IAM gRPC opt-in path ==="
           # Regression test: the filer registers the IAM gRPC service the
           # Admin UI Users tab calls only when jwt.filer_signing.key is in
           # security.toml. Operators must be able to enable that without
@@ -119,9 +119,10 @@ jobs:
           else:
               print("✓ defaults: no security-config ConfigMap (unchanged)")
 
-          # Case 2: filerWrite=true alone (the documented issue #9506
-          # workaround). Configmap must render with [jwt.filer_signing]
-          # and NO [grpc.*] sections (cert paths only exist with mTLS).
+          # Case 2: filerWrite=true alone is the documented opt-in for
+          # the Admin UI Users tab. Configmap must render with
+          # [jwt.filer_signing] and NO [grpc.*] sections (cert paths
+          # only exist with mTLS).
           out = render({
               "global.seaweedfs.securityConfig.jwtSigning.filerWrite": "true",
               "admin.enabled": "true",

--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -3,4 +3,4 @@ description: SeaweedFS
 name: seaweedfs
 appVersion: "4.25"
 # Dev note: Trigger a helm chart release by `git tag -a helm-<version>`
-version: 4.25.0
+version: 4.25.1

--- a/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -180,11 +180,13 @@ spec:
             - name: admin-logs
               mountPath: /logs
             {{- end }}
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -275,10 +277,12 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.admin.logs.claimName }}
         {{- end }}
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -330,11 +330,13 @@ spec:
               mountPath: /etc/seaweedfs/master.toml
               subPath: master.toml
               readOnly: true
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
               readOnly: true
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               mountPath: /usr/local/share/ca-certificates/ca/
               readOnly: true
@@ -461,10 +463,12 @@ spec:
         - name: master-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-master-config
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -117,11 +117,13 @@ spec:
               name: config-users
               readOnly: true
             {{- end }}
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -179,10 +181,12 @@ spec:
             secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
             {{- end }}
         {{- end }}
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -276,7 +276,8 @@ spec:
               name: swfs-s3-tls
             {{- end }}
             {{- end }}
-          {{- $isJwtEnabled := or .Values.global.seaweedfs.securityConfig.jwtSigning.filerWrite .Values.global.seaweedfs.securityConfig.jwtSigning.filerRead }}
+          {{- $jwt := (.Values.global.seaweedfs.securityConfig).jwtSigning | default dict }}
+          {{- $isJwtEnabled := or $jwt.filerWrite $jwt.filerRead }}
           {{- if .Values.filer.readinessProbe.enabled }}
           readinessProbe:
           {{- if or $isJwtEnabled .Values.filer.readinessProbe.tcpSocket }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -234,11 +234,13 @@ spec:
               mountPath: /etc/seaweedfs/notification.toml
               subPath: notification.toml
             {{- end }}
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -368,10 +370,12 @@ spec:
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-notification-config
         {{- end }}
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -188,11 +188,13 @@ spec:
               readOnly: true
               mountPath: /etc/seaweedfs/master.toml
               subPath: master.toml
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -287,10 +289,12 @@ spec:
         - name: master-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-master-config
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -156,11 +156,13 @@ spec:
               name: config-users
               readOnly: true
             {{- end }}
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -249,10 +251,12 @@ spec:
         - name: logs
           emptyDir: {}
         {{- end }}
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -176,11 +176,13 @@ spec:
             - mountPath: /etc/sw/ssh
               name: config-ssh
               readOnly: true
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -264,10 +266,12 @@ spec:
         - name: logs
           emptyDir: {}
         {{- end }}
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -332,18 +332,8 @@ Create the name of the service account to use
 {{- .Values.global.seaweedfs.serviceAccountName | default "seaweedfs" -}}
 {{- end -}}
 
-{{/*
-True when security.toml should be rendered and mounted. enableSecurity covers
-the full mTLS bundle (cert-manager + [grpc.*] sections); the jwtSigning.*
-toggles render only the [jwt.*] sections, which the filer needs in order to
-register the IAM gRPC service the Admin UI talks to. Either path requires the
-ConfigMap to exist and be mounted into pods that read it.
-
-volumeWrite is intentionally excluded from the trigger because it defaults to
-true; including it here would make every fresh install start mounting
-security.toml regardless of intent. Users who want JWT signing without mTLS
-opt in via volumeRead, filerWrite, or filerRead.
-*/}}
+{{/* True when security.toml should be rendered and mounted. volumeWrite is
+     excluded since it defaults to true. */}}
 {{- define "seaweedfs.securityConfigEnabled" -}}
 {{- $jwt := (.Values.global.seaweedfs.securityConfig).jwtSigning | default dict -}}
 {{- if or .Values.global.seaweedfs.enableSecurity $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -332,6 +332,25 @@ Create the name of the service account to use
 {{- .Values.global.seaweedfs.serviceAccountName | default "seaweedfs" -}}
 {{- end -}}
 
+{{/*
+True when security.toml should be rendered and mounted. enableSecurity covers
+the full mTLS bundle (cert-manager + [grpc.*] sections); the jwtSigning.*
+toggles render only the [jwt.*] sections, which the filer needs in order to
+register the IAM gRPC service the Admin UI talks to. Either path requires the
+ConfigMap to exist and be mounted into pods that read it.
+
+volumeWrite is intentionally excluded from the trigger because it defaults to
+true; including it here would make every fresh install start mounting
+security.toml regardless of intent. Users who want JWT signing without mTLS
+opt in via volumeRead, filerWrite, or filerRead.
+*/}}
+{{- define "seaweedfs.securityConfigEnabled" -}}
+{{- $jwt := (.Values.global.seaweedfs.securityConfig).jwtSigning | default dict -}}
+{{- if or .Values.global.seaweedfs.enableSecurity $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{/* S3 TLS cert/key arguments, using custom secret if s3.tlsSecret is set */}}
 {{- define "seaweedfs.s3.tlsArgs" -}}
 {{- $prefix := .prefix -}}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -335,7 +335,8 @@ Create the name of the service account to use
 {{/* True when security.toml should be rendered and mounted. volumeWrite is
      excluded since it defaults to true. */}}
 {{- define "seaweedfs.securityConfigEnabled" -}}
-{{- $jwt := (.Values.global.seaweedfs.securityConfig).jwtSigning | default dict -}}
+{{- $sec := (.Values.global.seaweedfs).securityConfig | default dict -}}
+{{- $jwt := $sec.jwtSigning | default dict -}}
 {{- if or .Values.global.seaweedfs.enableSecurity $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}
 true
 {{- end -}}

--- a/k8s/charts/seaweedfs/templates/shared/security-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/security-configmap.yaml
@@ -1,5 +1,5 @@
 {{- include "seaweedfs.compat" . -}}
-{{- if .Values.global.seaweedfs.enableSecurity }}
+{{- if include "seaweedfs.securityConfigEnabled" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -55,6 +55,7 @@ data:
     key = "{{ dig "jwt" "filer_signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
     {{- end }}
 
+    {{- if .Values.global.seaweedfs.enableSecurity }}
     # all grpc tls authentications are mutual
     # the values for the following ca, cert, and key are paths to the PERM files.
     [grpc]
@@ -94,4 +95,5 @@ data:
     [https.volume]
     cert = ""
     key  = ""
+    {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -211,11 +211,13 @@ spec:
             - name: idx
               mountPath: "/idx/"
             {{- end }}
-            {{- if $.Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" $ }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if $.Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -333,10 +335,12 @@ spec:
           emptyDir: {}
        {{- end }}
      {{- end }}
-     {{- if $.Values.global.seaweedfs.enableSecurity }}
+     {{- if include "seaweedfs.securityConfigEnabled" $ }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" $ }}-security-config
+     {{- end }}
+     {{- if $.Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" $ }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -149,11 +149,13 @@ spec:
             - name: worker-logs
               mountPath: /logs
             {{- end }}
-            {{- if .Values.global.seaweedfs.enableSecurity }}
+            {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
@@ -252,10 +254,12 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.worker.logs.claimName }}
         {{- end }}
-        {{- if .Values.global.seaweedfs.enableSecurity }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
         - name: security-config
           configMap:
             name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
         - name: ca-cert
           secret:
             secretName: {{ include "seaweedfs.fullname" . }}-ca-cert

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -18,15 +18,8 @@ global:
     loggingLevel: 1
     enableSecurity: false
     masterServer: null
-    # JWT signing keys rendered into security.toml. Setting volumeRead,
-    # filerWrite, or filerRead to true here will mount security.toml into the
-    # relevant pods even when enableSecurity is false (which only controls the
-    # cert-manager mTLS bundle). volumeWrite, which defaults to true, is only
-    # honored when security.toml is otherwise being rendered.
-    # The Admin UI Users tab needs the filer to register the IAM gRPC service,
-    # which requires jwt.filer_signing.key — set filerWrite: true to enable
-    # that without pulling in cert-manager. Note that turning on filerWrite
-    # also makes the filer require JWT-signed HTTP writes.
+    # filerWrite: true mounts security.toml on filer + admin without needing
+    # enableSecurity (mTLS); required for the Admin UI Users tab.
     securityConfig:
       jwtSigning:
         volumeWrite: true

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -18,6 +18,15 @@ global:
     loggingLevel: 1
     enableSecurity: false
     masterServer: null
+    # JWT signing keys rendered into security.toml. Setting volumeRead,
+    # filerWrite, or filerRead to true here will mount security.toml into the
+    # relevant pods even when enableSecurity is false (which only controls the
+    # cert-manager mTLS bundle). volumeWrite, which defaults to true, is only
+    # honored when security.toml is otherwise being rendered.
+    # The Admin UI Users tab needs the filer to register the IAM gRPC service,
+    # which requires jwt.filer_signing.key — set filerWrite: true to enable
+    # that without pulling in cert-manager. Note that turning on filerWrite
+    # also makes the filer require JWT-signed HTTP writes.
     securityConfig:
       jwtSigning:
         volumeWrite: true


### PR DESCRIPTION
## Why

Since 4.24 the filer requires \`jwt.filer_signing.key\` in \`security.toml\` to register the \`SeaweedIdentityAccessManagement\` gRPC service the Admin UI Users tab calls (PR #9442). The chart only rendered \`security.toml\` under \`global.seaweedfs.enableSecurity\`, which also pulls in cert-manager for full mTLS — much heavier than the Admin UI needs. Helm operators without cert-manager have no way to flip the JWT key on, and the Users tab fails with \`Unimplemented\` after upgrading past 4.24 (#9506).

## What

- Add helper \`seaweedfs.securityConfigEnabled\` — true when \`enableSecurity\` OR any explicit \`jwtSigning\` toggle (\`volumeRead\`, \`filerWrite\`, \`filerRead\`) is set.
- \`security-configmap.yaml\` renders under the helper; the \`[grpc.*]\` / \`[https.*]\` sections inside stay gated on \`enableSecurity\` (they reference cert paths only mounted with cert-manager).
- Every pod template (filer, admin, master, volume, s3, sftp, cosi, worker, all-in-one) splits the \`security-config\` mount onto the helper and keeps the \`*-cert\` mounts on \`enableSecurity\`.
- \`volumeWrite\` is intentionally excluded from the helper trigger because it defaults to \`true\`; including it would silently start mounting \`security.toml\` on every fresh install.

## Behavior matrix

| Configuration                                    | Before                       | After                                                          |
| ------------------------------------------------ | ---------------------------- | -------------------------------------------------------------- |
| defaults                                         | no configmap                 | no configmap (unchanged)                                       |
| \`enableSecurity=true\`                          | full toml + cert mounts      | full toml + cert mounts (unchanged)                            |
| \`enableSecurity=false\` + \`filerWrite=true\`   | configmap not rendered (bug) | configmap with \`[jwt.*]\` only, mounted on filer + admin etc. |

## Workaround for the Admin UI Users tab

\`\`\`yaml
global:
  seaweedfs:
    securityConfig:
      jwtSigning:
        filerWrite: true
\`\`\`

No cert-manager required.

Fixes #9506.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * security.toml is now mounted conditionally when JWT signing flags or related security settings are enabled, allowing selective security config per component.

* **Documentation**
  * Clarified when security.toml is mounted for filer/admin and that the Admin UI Users tab requires mTLS.

* **Chores**
  * Helm chart version bumped to 4.25.1.

* **Tests**
  * Added CI checks validating conditional rendering across JWT/mTLS combinations and null-safe behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9508)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->