### PR TITLE
fix: ListBucketsHandler for pathStyleDomains

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -102,8 +102,8 @@ type S3ApiServer struct {
 	// is nil in this commit; a follow-up wires in an in-memory chunk cache.
 	readerCache *filer.ReaderCache
 
-	versionsHealQueue       *versionsHealQueue
-	versionsReconcilerStop  func()
+	versionsHealQueue      *versionsHealQueue
+	versionsReconcilerStop func()
 }
 
 type objectWriteLock interface {
@@ -673,6 +673,10 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 		// Register path-style domains
 		for _, domain := range pathStyleDomains {
 			routers = append(routers, apiRouter.Host(domain).PathPrefix("/{bucket}").Subrouter())
+			apiRouter.Host(domain).
+				Methods(http.MethodGet).
+				Path("/").
+				HandlerFunc(track(s3a.iam.Auth(s3a.ListBucketsHandler, ACTION_LIST), "LIST"))
 		}
 
 		// Register virtual-host style domains
@@ -680,8 +684,9 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 			routers = append(routers, apiRouter.Host(
 				fmt.Sprintf("%s.%s", "{bucket:.+}", virtualHost)).Subrouter())
 		}
+	} else {
+		routers = append(routers, apiRouter.PathPrefix("/{bucket}").Subrouter())
 	}
-	routers = append(routers, apiRouter.PathPrefix("/{bucket}").Subrouter())
 
 	// Get CORS middleware instance with caching
 	corsMiddleware := s3a.getCORSMiddleware()


### PR DESCRIPTION
# What problem are we solving?

Not work listen bucket for host.s3.localhost
```
aws --profile local s3 --endpoint-url http://host.s3.localhost:8000 ls s3://
```
weed -v 3 server -ip 127.0.0.1 -s3 -s3.domainName s3.localhost,host.s3.localhost -filer -filer.maxMB=64 -volume.max=0 -master.volumeSizeLimitMB=100 -volume.preStopSeconds=1 -s3.port=8000 -s3.allowDeleteBucketNotEmpty=true -s3.config=./docker/compose/s3.json -metricsPort=9324
```



# How are we solving the problem?

add ListBucketsHandler for  pathStyleDomains

# How is the PR tested?

Localy


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined S3 API server routing configuration to properly handle bucket access and list operations across domain-based deployments.
* Improved handling of both virtual-host and path-style domain configurations for consistent S3 API endpoint behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9510)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->