### PR TITLE
helm(admin): support secretExtraEnvironmentVars (refs #9511)

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -135,6 +135,12 @@ spec:
                 {{ toYaml $value | nindent 16 | trim }}
             {{- end -}}
             {{- end }}
+            {{- if .Values.admin.secretExtraEnvironmentVars }}
+            {{- range $key, $value := .Values.admin.secretExtraEnvironmentVars }}
+            - name: {{ $key }}
+              valueFrom: {{ toYaml $value | nindent 16 }}
+            {{- end }}
+            {{- end }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -135,8 +135,10 @@ spec:
                 {{ toYaml $value | nindent 16 | trim }}
             {{- end -}}
             {{- end }}
-            {{- if .Values.admin.secretExtraEnvironmentVars }}
-            {{- range $key, $value := .Values.admin.secretExtraEnvironmentVars }}
+            {{- $secretExtraEnvironmentVars := .Values.admin.secretExtraEnvironmentVars }}
+            {{- if $secretExtraEnvironmentVars }}
+            {{- range $key := keys $secretExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $secretExtraEnvironmentVars $key }}
             - name: {{ $key }}
               valueFrom: {{ toYaml $value | nindent 16 }}
             {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1288,6 +1288,13 @@ admin:
 
   extraEnvironmentVars: {}
 
+  # secret env variables (e.g. for injecting OIDC client secret from a Kubernetes Secret)
+  secretExtraEnvironmentVars: {}
+    # WEED_ADMIN_OIDC_CLIENT_SECRET:
+    #   secretKeyRef:
+    #     name: seaweedfs-admin-oidc
+    #     key: client_secret
+
   # Health checks
   livenessProbe:
     enabled: true


### PR DESCRIPTION
## Summary

- Adds `admin.secretExtraEnvironmentVars` to the Helm chart, mirroring the existing pattern on the filer (`k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml`).
- Lets users project any sensitive `WEED_*` value into the admin pod via `valueFrom.secretKeyRef` instead of inlining it as plaintext in `values.yaml`.
- Documents the new field in `values.yaml` with an OIDC client-secret example.

## Why

Surfaced by issue #9511: an enterprise OIDC deployment had to inline `WEED_ADMIN_OIDC_CLIENT_SECRET` as a plain string under `admin.extraEnvironmentVars`, which is not GitOps-safe (commits the secret to the values file).

Example after this change:

```yaml
admin:
  extraEnvironmentVars:
    WEED_ADMIN_OIDC_ENABLED: "true"
    WEED_ADMIN_OIDC_ISSUER: "https://idp.example.com/realms/seaweed"
    WEED_ADMIN_OIDC_CLIENT_ID: "seaweedfs-admin-ui"
    # ...
  secretExtraEnvironmentVars:
    WEED_ADMIN_OIDC_CLIENT_SECRET:
      secretKeyRef:
        name: seaweedfs-admin-oidc
        key: client_secret
```

The new key is purely additive — when unset (default `{}`), rendered output is unchanged.

## Test plan

- [x] `helm lint k8s/charts/seaweedfs`
- [x] `helm template` with `secretExtraEnvironmentVars` set renders the expected `valueFrom.secretKeyRef` env entry on the admin container.
- [x] `helm template` with default values produces no diff vs. previous chart output for the admin statefulset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin deployment now supports configurable secret-backed environment variables via the chart values, allowing secure injection of multiple secrets into the admin component.
  * These extra environment variables are optional and merge with existing env vars, preserving current startup behavior when not set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9513)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->