### PR TITLE
fix(ec): mirror EC sidecars onto every shard-bearing disk at startup

### DIFF
--- a/seaweed-volume/src/storage/mod.rs
+++ b/seaweed-volume/src/storage/mod.rs
@@ -4,6 +4,7 @@ pub mod idx;
 pub mod needle;
 pub mod needle_map;
 pub mod store;
+pub mod store_ec_mirror;
 pub mod store_ec_reconcile;
 pub mod super_block;
 pub mod types;

--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -96,28 +96,16 @@ impl Store {
         // re-loading shards we just cleaned up.
         self.prune_incomplete_ec_with_sibling_dat();
 
-        // Before the cross-disk virtual-mount fallback runs,
-        // physically copy EC sidecars (.ecx / .ecj / .vif) onto
-        // every disk that holds shards but is missing them. The EC
-        // lifecycle (encode / decode / balance / vacuum / repair)
-        // promises a same-disk layout: every shard lives alongside
-        // its own metadata. Mirroring at boot restores that
-        // invariant after ec.balance or ec.rebuild has split shards
-        // from their index across disks of the same volume server,
-        // so each disk can mount self-contained instead of reaching
-        // across.
+        // Physically mirror EC sidecars onto every shard-bearing disk
+        // so each disk mounts self-contained. Must run before the
+        // cross-disk reconciler so the orphan pass can prefer the
+        // local idx_directory.
         self.mirror_ec_metadata_to_shard_disks();
 
-        // After every disk has finished its per-disk EC scan, sweep
-        // the store for shards that live on a disk without local index
-        // files and load them by reaching across to a sibling disk's
-        // .ecx / .ecj / .vif (seaweedfs/seaweedfs#9212 / #9244).
-        // ec.balance / ec.rebuild can move shards onto a destination
-        // node's second disk while leaving the index on the disk that
-        // already held the volume; without this pass those orphan
-        // shards stay invisible to the master. Even after the mirror
-        // pass above, this stays as the fallback for volumes whose
-        // mirror failed (read-only target disk, partial copy, etc.).
+        // Cross-disk fallback for orphan shards (seaweedfs/seaweedfs#9212):
+        // ec.balance can land shards on one disk while leaving the index
+        // on another. Still needed after the mirror pass for volumes
+        // whose mirror failed (read-only target, partial copy).
         self.reconcile_ec_shards_across_disks();
 
         Ok(())

--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -96,6 +96,18 @@ impl Store {
         // re-loading shards we just cleaned up.
         self.prune_incomplete_ec_with_sibling_dat();
 
+        // Before the cross-disk virtual-mount fallback runs,
+        // physically copy EC sidecars (.ecx / .ecj / .vif) onto
+        // every disk that holds shards but is missing them. The EC
+        // lifecycle (encode / decode / balance / vacuum / repair)
+        // promises a same-disk layout: every shard lives alongside
+        // its own metadata. Mirroring at boot restores that
+        // invariant after ec.balance or ec.rebuild has split shards
+        // from their index across disks of the same volume server,
+        // so each disk can mount self-contained instead of reaching
+        // across.
+        self.mirror_ec_metadata_to_shard_disks();
+
         // After every disk has finished its per-disk EC scan, sweep
         // the store for shards that live on a disk without local index
         // files and load them by reaching across to a sibling disk's
@@ -103,7 +115,9 @@ impl Store {
         // ec.balance / ec.rebuild can move shards onto a destination
         // node's second disk while leaving the index on the disk that
         // already held the volume; without this pass those orphan
-        // shards stay invisible to the master.
+        // shards stay invisible to the master. Even after the mirror
+        // pass above, this stays as the fallback for volumes whose
+        // mirror failed (read-only target disk, partial copy, etc.).
         self.reconcile_ec_shards_across_disks();
 
         Ok(())
@@ -118,6 +132,7 @@ impl Store {
             }
         }
         self.prune_incomplete_ec_with_sibling_dat();
+        self.mirror_ec_metadata_to_shard_disks();
         self.reconcile_ec_shards_across_disks();
     }
 

--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -102,10 +102,10 @@ impl Store {
         // local idx_directory.
         self.mirror_ec_metadata_to_shard_disks();
 
-        // Cross-disk fallback for orphan shards (seaweedfs/seaweedfs#9212):
-        // ec.balance can land shards on one disk while leaving the index
-        // on another. Still needed after the mirror pass for volumes
-        // whose mirror failed (read-only target, partial copy).
+        // Cross-disk fallback for orphan shards — ec.balance can land
+        // shards on one disk while leaving the index on another. Still
+        // needed after the mirror pass for volumes whose mirror failed
+        // (read-only target, partial copy).
         self.reconcile_ec_shards_across_disks();
 
         Ok(())

--- a/seaweed-volume/src/storage/store_ec_mirror.rs
+++ b/seaweed-volume/src/storage/store_ec_mirror.rs
@@ -1,0 +1,485 @@
+//! Physical EC sidecar mirroring across disks of the same volume server.
+//!
+//! Mirrors `weed/storage/store_ec_mirror.go`. The EC lifecycle
+//! (encode / decode / balance / vacuum / repair) promises a same-disk
+//! layout: every shard lives alongside its own `.ecx` / `.ecj` /
+//! `.vif` so the `EcVolume` can mount self-contained. Without this
+//! pass, a disk that received shards through `ec.balance` or
+//! `ec.rebuild` — where only the first shard carries
+//! `copy_ecx_file=true` and subsequent shards land via auto-select —
+//! can end up with the `.ec??` files but no local sidecars. The
+//! orphan reconcile then mounts the shards by pointing the EcVolume
+//! at the sibling disk's index files; reads work, but any failure on
+//! the index-owning disk (a removed drive, a corrupted fs, an
+//! operator who unmounted the wrong sled) takes the shards with it.
+//!
+//! This module physically replicates the sidecars onto each
+//! shard-bearing disk so the shards stay readable as long as their
+//! own disk is up. Runs before `reconcile_ec_shards_across_disks` at
+//! boot; the cross-disk fallback is preserved for cases where
+//! mirroring fails (read-only target, out of space, partial copy) so
+//! the volume stays available.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use tracing::{info, warn};
+
+use crate::storage::disk_location::{parse_collection_volume_id_pub, DiskLocation};
+use crate::storage::store::Store;
+use crate::storage::types::VolumeId;
+
+/// EC sidecars that must travel with the shards. Order matches
+/// `EcVolume::new`'s open sequence so a partial mirror is diagnosable
+/// by walking the list and stopping at the first destination that
+/// does not yet have its copy.
+const EC_MIRRORED_SIDECARS: &[&str] = &[".ecx", ".ecj", ".vif"];
+
+/// Key for matching shard-bearing disks to their sidecar owners.
+/// Per-collection because two collections may share a volume id.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct EcKey {
+    collection: String,
+    vid: VolumeId,
+}
+
+/// Records both the disk index that owns the `.ecx` and the actual
+/// directory it lives in. The directory matters because
+/// `index_ecx_owners` scans both `idx_directory` and `directory` —
+/// when `.ecx` lives in `directory` (legacy pre-`-dir.idx` layout),
+/// we want to read the file from where it actually is.
+#[derive(Clone, Debug)]
+struct EcxOwner {
+    location: usize,
+    idx_dir: String,
+    data_dir: String,
+}
+
+impl Store {
+    /// Mirror EC sidecars onto every disk of this store that holds
+    /// shards but is missing the matching `.ecx` / `.ecj` / `.vif`.
+    /// Idempotent: a destination that already has the sidecar is
+    /// left untouched, and a missing source sidecar is not an error.
+    ///
+    /// Runs before `reconcile_ec_shards_across_disks` so the
+    /// downstream orphan-shard pass sees the freshly-mirrored layout
+    /// and can mount each disk against its own `idx_directory`.
+    pub fn mirror_ec_metadata_to_shard_disks(&mut self) {
+        if self.locations.len() < 2 {
+            return;
+        }
+        let owners = self.index_ecx_owners_for_mirror();
+        if owners.is_empty() {
+            return;
+        }
+
+        // Two-pass to satisfy the borrow checker: gather work under
+        // an immutable borrow, then apply copies disk-by-disk under
+        // independent mutable borrows.
+        struct Mirror<'a> {
+            target_idx: usize,
+            owner: &'a EcxOwner,
+            collection: String,
+            vid: VolumeId,
+        }
+        let mut mirrors: Vec<Mirror> = Vec::new();
+        for (loc_idx, loc) in self.locations.iter().enumerate() {
+            let orphans = collect_shard_disk_volumes(loc);
+            for (key, _shards) in orphans {
+                let Some(owner) = owners.get(&key) else {
+                    continue;
+                };
+                if owner.location == loc_idx {
+                    continue;
+                }
+                if disk_has_all_sidecars(loc, &key.collection, key.vid) {
+                    continue;
+                }
+                mirrors.push(Mirror {
+                    target_idx: loc_idx,
+                    owner,
+                    collection: key.collection,
+                    vid: key.vid,
+                });
+            }
+        }
+
+        for m in mirrors {
+            let loc_dir = self.locations[m.target_idx].directory.clone();
+            let loc_idx_dir = self.locations[m.target_idx].idx_directory.clone();
+            match mirror_sidecars_for_volume(
+                &m.owner.idx_dir,
+                &m.owner.data_dir,
+                &loc_dir,
+                &loc_idx_dir,
+                &m.collection,
+                m.vid,
+            ) {
+                Ok(0) => {}
+                Ok(copied) => {
+                    info!(
+                        volume_id = m.vid.0,
+                        collection = %m.collection,
+                        from = %m.owner.data_dir,
+                        to = %loc_dir,
+                        copied,
+                        "mirrored EC sidecar(s) for same-disk invariant",
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        volume_id = m.vid.0,
+                        collection = %m.collection,
+                        from = %m.owner.data_dir,
+                        to = %loc_dir,
+                        error = %e,
+                        "mirror EC sidecars failed; cross-disk fallback will handle this volume",
+                    );
+                }
+            }
+        }
+    }
+
+    /// Build a `(collection, vid) -> EcxOwner` map of which disk owns
+    /// the `.ecx` and which directory it actually lives in.
+    /// Counterpart to `index_ecx_owners` in `store_ec_reconcile.rs`;
+    /// kept private here so the mirror is self-contained and can
+    /// record both `idx_dir` and `data_dir` for source-side fallback
+    /// when `.vif` lives in the data dir but `.ecx` is in the idx
+    /// dir (or vice versa).
+    fn index_ecx_owners_for_mirror(&self) -> HashMap<EcKey, EcxOwner> {
+        let mut owners: HashMap<EcKey, EcxOwner> = HashMap::new();
+        for (loc_idx, loc) in self.locations.iter().enumerate() {
+            let mut seen: Vec<&str> = Vec::with_capacity(2);
+            for scan in [loc.idx_directory.as_str(), loc.directory.as_str()] {
+                if scan.is_empty() || seen.contains(&scan) {
+                    continue;
+                }
+                seen.push(scan);
+                let Ok(read) = fs::read_dir(scan) else {
+                    continue;
+                };
+                for ent in read.flatten() {
+                    if ent.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                        continue;
+                    }
+                    let name = ent.file_name().to_string_lossy().into_owned();
+                    let Some(base) = name.strip_suffix(".ecx") else {
+                        continue;
+                    };
+                    let Some((collection, vid)) = parse_collection_volume_id_pub(base) else {
+                        continue;
+                    };
+                    owners
+                        .entry(EcKey { collection, vid })
+                        .or_insert_with(|| EcxOwner {
+                            location: loc_idx,
+                            idx_dir: scan.to_string(),
+                            data_dir: loc.directory.clone(),
+                        });
+                }
+            }
+        }
+        owners
+    }
+}
+
+/// True iff the destination disk already has every EC sidecar that
+/// the mirror would otherwise install. Checks the modern routing
+/// first (idx_directory for .ecx/.ecj, directory for .vif) and then
+/// the opposite directory as a fallback — matching
+/// `EcVolume::new`'s own open-with-fallback contract. Without the
+/// fallback, a destination that still has a legacy pre-`-dir.idx`
+/// .ecx in its data dir would be re-mirrored into idx_directory and
+/// end up with two copies on disk.
+fn disk_has_all_sidecars(loc: &DiskLocation, collection: &str, vid: VolumeId) -> bool {
+    for ext in EC_MIRRORED_SIDECARS {
+        let primary = sidecar_dest_path(&loc.directory, &loc.idx_directory, collection, vid, ext);
+        if path_is_regular_file(&primary) {
+            continue;
+        }
+        if loc.idx_directory != loc.directory {
+            // .ecx/.ecj could be in directory (pre-`-dir.idx`), .vif
+            // could be in idx_directory (uncommon but allowed by
+            // EcVolume::new's .vif lookup).
+            let (fallback_data, fallback_idx) = if *ext == ".vif" {
+                (loc.idx_directory.as_str(), loc.directory.as_str())
+            } else {
+                (loc.directory.as_str(), loc.directory.as_str())
+            };
+            let fallback = sidecar_dest_path(fallback_data, fallback_idx, collection, vid, ext);
+            if path_is_regular_file(&fallback) {
+                continue;
+            }
+        }
+        return false;
+    }
+    true
+}
+
+/// Existence + regular-file check rolled into one boolean. Used by
+/// the sidecar-presence ladder above so the fallback logic stays
+/// readable.
+fn path_is_regular_file(path: &str) -> bool {
+    fs::metadata(path).map(|m| !m.is_dir()).unwrap_or(false)
+}
+
+/// Routing: `.ecx` / `.ecj` go to `idx_directory`, `.vif` goes to
+/// `directory`. Matches `EcVolume::new`'s lookup order.
+fn sidecar_dest_path(
+    data_dir: &str,
+    idx_dir: &str,
+    collection: &str,
+    vid: VolumeId,
+    ext: &str,
+) -> String {
+    let dir = if ext == ".vif" { data_dir } else { idx_dir };
+    if collection.is_empty() {
+        format!("{}/{}{}", dir, vid.0, ext)
+    } else {
+        format!("{}/{}_{}{}", dir, collection, vid.0, ext)
+    }
+}
+
+/// Mirror the three EC sidecars from one disk to another. Returns
+/// the count of files actually copied (skipping pre-existing
+/// destinations and missing optional sources). Errors abort on the
+/// first failure so the caller's warn-and-continue handles partial
+/// state.
+fn mirror_sidecars_for_volume(
+    src_idx_dir: &str,
+    src_data_dir: &str,
+    dst_data_dir: &str,
+    dst_idx_dir: &str,
+    collection: &str,
+    vid: VolumeId,
+) -> io::Result<usize> {
+    let mut copied = 0usize;
+    for ext in EC_MIRRORED_SIDECARS {
+        let dst = sidecar_dest_path(dst_data_dir, dst_idx_dir, collection, vid, ext);
+        if fs::metadata(&dst).is_ok() {
+            continue;
+        }
+        let candidates = [
+            sidecar_dest_path(src_data_dir, src_idx_dir, collection, vid, ext),
+            sidecar_dest_path(src_idx_dir, src_data_dir, collection, vid, ext), // legacy swap
+        ];
+        let mut src_path: Option<String> = None;
+        for c in candidates.iter() {
+            if fs::metadata(c).map(|m| !m.is_dir()).unwrap_or(false) {
+                src_path = Some(c.clone());
+                break;
+            }
+        }
+        let Some(src) = src_path else {
+            continue;
+        };
+        copy_sidecar_atomic(Path::new(&src), Path::new(&dst))?;
+        copied += 1;
+    }
+    Ok(copied)
+}
+
+/// Copy a single sidecar atomically: write to `<dst>.mirror.tmp`,
+/// fsync, rename. A pre-existing `<dst>.mirror.tmp` from a previous
+/// interrupted boot is removed first so `O_EXCL` doesn't refuse the
+/// open.
+fn copy_sidecar_atomic(src: &Path, dst: &Path) -> io::Result<()> {
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut src_file = fs::File::open(src)?;
+    let tmp = {
+        let mut s = dst.as_os_str().to_owned();
+        s.push(".mirror.tmp");
+        std::path::PathBuf::from(s)
+    };
+    let _ = fs::remove_file(&tmp);
+    let mut dst_file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)?;
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = src_file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        dst_file.write_all(&buf[..n])?;
+    }
+    dst_file.sync_all()?;
+    drop(dst_file);
+    if let Err(e) = fs::rename(&tmp, dst) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Walk this disk's data directory and return (collection, vid)
+/// groups that have any `.ec??` files on disk. Used by the mirror
+/// pass to find candidate destinations.
+fn collect_shard_disk_volumes(loc: &DiskLocation) -> HashMap<EcKey, Vec<String>> {
+    let mut out: HashMap<EcKey, Vec<String>> = HashMap::new();
+    let Ok(read) = fs::read_dir(&loc.directory) else {
+        return out;
+    };
+    for ent in read.flatten() {
+        if ent.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = ent.file_name().to_string_lossy().into_owned();
+        let Some(dot) = name.rfind('.') else {
+            continue;
+        };
+        let (base, ext) = name.split_at(dot);
+        if crate::storage::disk_location::is_ec_shard_extension(ext).is_none() {
+            continue;
+        }
+        match ent.metadata() {
+            Ok(meta) if meta.len() > 0 => {}
+            _ => continue,
+        }
+        let Some((collection, vid)) = parse_collection_volume_id_pub(base) else {
+            continue;
+        };
+        out.entry(EcKey { collection, vid })
+            .or_default()
+            .push(name);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MinFreeSpace;
+    use crate::storage::needle_map::NeedleMapKind;
+    use crate::storage::types::DiskType;
+    use crate::storage::volume::{VifEcShardConfig, VifVolumeInfo};
+    use tempfile::TempDir;
+
+    fn plant_shard(dir: &Path, collection: &str, vid: u32, shard_id: u8) {
+        let path = if collection.is_empty() {
+            dir.join(format!("{}.ec{:02}", vid, shard_id))
+        } else {
+            dir.join(format!("{}_{}.ec{:02}", collection, vid, shard_id))
+        };
+        fs::write(&path, b"shard data nonempty").unwrap();
+    }
+
+    fn plant_ecx(dir: &Path, collection: &str, vid: u32, bytes: &[u8]) {
+        let path = dir.join(format!("{}_{}.ecx", collection, vid));
+        fs::write(&path, bytes).unwrap();
+    }
+
+    fn plant_ecj(dir: &Path, collection: &str, vid: u32, bytes: &[u8]) {
+        let path = dir.join(format!("{}_{}.ecj", collection, vid));
+        fs::write(&path, bytes).unwrap();
+    }
+
+    fn plant_vif(dir: &Path, collection: &str, vid: u32, data_shards: u32, parity_shards: u32) {
+        let vif = VifVolumeInfo {
+            version: 3,
+            ec_shard_config: Some(VifEcShardConfig {
+                data_shards,
+                parity_shards,
+            }),
+            ..Default::default()
+        };
+        let path = dir.join(format!("{}_{}.vif", collection, vid));
+        fs::write(&path, serde_json::to_string(&vif).unwrap()).unwrap();
+    }
+
+    fn add_loc(store: &mut Store, dir: &Path) {
+        store
+            .add_location(
+                dir.to_str().unwrap(),
+                dir.to_str().unwrap(),
+                100,
+                DiskType::HardDrive,
+                MinFreeSpace::Percent(0.0),
+                Vec::new(),
+            )
+            .unwrap();
+    }
+
+    /// dir0: orphan shards. dir1: shard 1 + every sidecar. After
+    /// add_location finishes, dir0 must have its own copy of every
+    /// sidecar so the EcVolume there mounts self-contained.
+    #[test]
+    fn mirror_copies_sidecars_to_shard_only_disk() {
+        let tmp = TempDir::new().unwrap();
+        let dir0 = tmp.path().join("data0");
+        let dir1 = tmp.path().join("data1");
+        fs::create_dir_all(&dir0).unwrap();
+        fs::create_dir_all(&dir1).unwrap();
+
+        let collection = "video-recordings";
+        let vid = 4121u32;
+
+        plant_shard(&dir0, collection, vid, 0);
+        plant_shard(&dir0, collection, vid, 12);
+        plant_shard(&dir1, collection, vid, 1);
+
+        let ecx = vec![0xA1u8; 20];
+        let ecj = vec![0xB2u8; 16];
+        plant_ecx(&dir1, collection, vid, &ecx);
+        plant_ecj(&dir1, collection, vid, &ecj);
+        plant_vif(&dir1, collection, vid, 10, 4);
+
+        let mut store = Store::new(NeedleMapKind::InMemory);
+        add_loc(&mut store, &dir0);
+        add_loc(&mut store, &dir1);
+
+        for ext in [".ecx", ".ecj", ".vif"] {
+            let dst = dir0.join(format!("{}_{}{}", collection, vid, ext));
+            assert!(
+                dst.exists(),
+                "mirror did not install sidecar {} on dir0",
+                ext
+            );
+        }
+        let ecx_dst = fs::read(dir0.join(format!("{}_{}.ecx", collection, vid))).unwrap();
+        assert_eq!(ecx_dst, ecx, ".ecx mirrored bytes differ from source");
+        let ecj_dst = fs::read(dir0.join(format!("{}_{}.ecj", collection, vid))).unwrap();
+        assert_eq!(ecj_dst, ecj, ".ecj mirrored bytes differ from source");
+    }
+
+    /// dir0 already has its own sidecars (different .ecx bytes than
+    /// dir1's). The mirror must NOT overwrite them.
+    #[test]
+    fn mirror_preserves_existing_destination_sidecars() {
+        let tmp = TempDir::new().unwrap();
+        let dir0 = tmp.path().join("data0");
+        let dir1 = tmp.path().join("data1");
+        fs::create_dir_all(&dir0).unwrap();
+        fs::create_dir_all(&dir1).unwrap();
+
+        let collection = "video-recordings";
+        let vid = 7777u32;
+
+        plant_shard(&dir0, collection, vid, 0);
+        plant_shard(&dir0, collection, vid, 12);
+        plant_shard(&dir1, collection, vid, 1);
+
+        let ecx_owner = vec![0xC3u8; 20];
+        let ecx_local = vec![0x5Au8; 20];
+        let ecj_bytes = vec![0xD4u8; 16];
+        plant_ecx(&dir1, collection, vid, &ecx_owner);
+        plant_ecj(&dir1, collection, vid, &ecj_bytes);
+        plant_vif(&dir1, collection, vid, 10, 4);
+        plant_ecx(&dir0, collection, vid, &ecx_local);
+        plant_ecj(&dir0, collection, vid, &ecj_bytes);
+        plant_vif(&dir0, collection, vid, 10, 4);
+
+        let mut store = Store::new(NeedleMapKind::InMemory);
+        add_loc(&mut store, &dir0);
+        add_loc(&mut store, &dir1);
+
+        let post = fs::read(dir0.join(format!("{}_{}.ecx", collection, vid))).unwrap();
+        assert_eq!(post, ecx_local, "mirror overwrote dir0's existing .ecx");
+    }
+}

--- a/seaweed-volume/src/storage/store_ec_mirror.rs
+++ b/seaweed-volume/src/storage/store_ec_mirror.rs
@@ -1,24 +1,5 @@
-//! Physical EC sidecar mirroring across disks of the same volume server.
-//!
-//! Mirrors `weed/storage/store_ec_mirror.go`. The EC lifecycle
-//! (encode / decode / balance / vacuum / repair) promises a same-disk
-//! layout: every shard lives alongside its own `.ecx` / `.ecj` /
-//! `.vif` so the `EcVolume` can mount self-contained. Without this
-//! pass, a disk that received shards through `ec.balance` or
-//! `ec.rebuild` — where only the first shard carries
-//! `copy_ecx_file=true` and subsequent shards land via auto-select —
-//! can end up with the `.ec??` files but no local sidecars. The
-//! orphan reconcile then mounts the shards by pointing the EcVolume
-//! at the sibling disk's index files; reads work, but any failure on
-//! the index-owning disk (a removed drive, a corrupted fs, an
-//! operator who unmounted the wrong sled) takes the shards with it.
-//!
-//! This module physically replicates the sidecars onto each
-//! shard-bearing disk so the shards stay readable as long as their
-//! own disk is up. Runs before `reconcile_ec_shards_across_disks` at
-//! boot; the cross-disk fallback is preserved for cases where
-//! mirroring fails (read-only target, out of space, partial copy) so
-//! the volume stays available.
+//! Physical EC sidecar mirroring across disks of the same volume
+//! server. Mirrors `weed/storage/store_ec_mirror.go`.
 
 use std::collections::HashMap;
 use std::fs;
@@ -31,25 +12,15 @@ use crate::storage::disk_location::{parse_collection_volume_id_pub, DiskLocation
 use crate::storage::store::Store;
 use crate::storage::types::VolumeId;
 
-/// EC sidecars that must travel with the shards. Order matches
-/// `EcVolume::new`'s open sequence so a partial mirror is diagnosable
-/// by walking the list and stopping at the first destination that
-/// does not yet have its copy.
+// Listed in `EcVolume::new`'s open order.
 const EC_MIRRORED_SIDECARS: &[&str] = &[".ecx", ".ecj", ".vif"];
 
-/// Key for matching shard-bearing disks to their sidecar owners.
-/// Per-collection because two collections may share a volume id.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct EcKey {
     collection: String,
     vid: VolumeId,
 }
 
-/// Records both the disk index that owns the `.ecx` and the actual
-/// directory it lives in. The directory matters because
-/// `index_ecx_owners` scans both `idx_directory` and `directory` —
-/// when `.ecx` lives in `directory` (legacy pre-`-dir.idx` layout),
-/// we want to read the file from where it actually is.
 #[derive(Clone, Debug)]
 struct EcxOwner {
     location: usize,
@@ -58,14 +29,10 @@ struct EcxOwner {
 }
 
 impl Store {
-    /// Mirror EC sidecars onto every disk of this store that holds
-    /// shards but is missing the matching `.ecx` / `.ecj` / `.vif`.
-    /// Idempotent: a destination that already has the sidecar is
-    /// left untouched, and a missing source sidecar is not an error.
-    ///
-    /// Runs before `reconcile_ec_shards_across_disks` so the
-    /// downstream orphan-shard pass sees the freshly-mirrored layout
-    /// and can mount each disk against its own `idx_directory`.
+    /// Mirror EC sidecars onto every shard-bearing disk that lacks
+    /// them, so each disk mounts self-contained. Runs before
+    /// `reconcile_ec_shards_across_disks` so the orphan pass can
+    /// prefer the local idx_directory.
     pub fn mirror_ec_metadata_to_shard_disks(&mut self) {
         if self.locations.len() < 2 {
             return;
@@ -75,9 +42,8 @@ impl Store {
             return;
         }
 
-        // Two-pass to satisfy the borrow checker: gather work under
-        // an immutable borrow, then apply copies disk-by-disk under
-        // independent mutable borrows.
+        // Two-pass: gather work under an immutable borrow, then apply
+        // copies under independent mutable borrows.
         struct Mirror<'a> {
             target_idx: usize,
             owner: &'a EcxOwner,
@@ -142,13 +108,9 @@ impl Store {
         }
     }
 
-    /// Build a `(collection, vid) -> EcxOwner` map of which disk owns
-    /// the `.ecx` and which directory it actually lives in.
-    /// Counterpart to `index_ecx_owners` in `store_ec_reconcile.rs`;
-    /// kept private here so the mirror is self-contained and can
-    /// record both `idx_dir` and `data_dir` for source-side fallback
-    /// when `.vif` lives in the data dir but `.ecx` is in the idx
-    /// dir (or vice versa).
+    // Records both idx_dir (where .ecx was found) and data_dir, so
+    // the mirror can resolve .vif from data_dir even when .ecx lives
+    // in idx_directory.
     fn index_ecx_owners_for_mirror(&self) -> HashMap<EcKey, EcxOwner> {
         let mut owners: HashMap<EcKey, EcxOwner> = HashMap::new();
         for (loc_idx, loc) in self.locations.iter().enumerate() {
@@ -186,14 +148,9 @@ impl Store {
     }
 }
 
-/// True iff the destination disk already has every EC sidecar that
-/// the mirror would otherwise install. Checks the modern routing
-/// first (idx_directory for .ecx/.ecj, directory for .vif) and then
-/// the opposite directory as a fallback — matching
-/// `EcVolume::new`'s own open-with-fallback contract. Without the
-/// fallback, a destination that still has a legacy pre-`-dir.idx`
-/// .ecx in its data dir would be re-mirrored into idx_directory and
-/// end up with two copies on disk.
+// Checks the modern routing and the opposite directory — without
+// that fallback, a destination with a legacy pre-`-dir.idx` .ecx in
+// its data dir would be re-mirrored into idx_directory.
 fn disk_has_all_sidecars(loc: &DiskLocation, collection: &str, vid: VolumeId) -> bool {
     for ext in EC_MIRRORED_SIDECARS {
         let primary = sidecar_dest_path(&loc.directory, &loc.idx_directory, collection, vid, ext);
@@ -201,9 +158,6 @@ fn disk_has_all_sidecars(loc: &DiskLocation, collection: &str, vid: VolumeId) ->
             continue;
         }
         if loc.idx_directory != loc.directory {
-            // .ecx/.ecj could be in directory (pre-`-dir.idx`), .vif
-            // could be in idx_directory (uncommon but allowed by
-            // EcVolume::new's .vif lookup).
             let (fallback_data, fallback_idx) = if *ext == ".vif" {
                 (loc.idx_directory.as_str(), loc.directory.as_str())
             } else {
@@ -219,15 +173,11 @@ fn disk_has_all_sidecars(loc: &DiskLocation, collection: &str, vid: VolumeId) ->
     true
 }
 
-/// Existence + regular-file check rolled into one boolean. Used by
-/// the sidecar-presence ladder above so the fallback logic stays
-/// readable.
 fn path_is_regular_file(path: &str) -> bool {
     fs::metadata(path).map(|m| !m.is_dir()).unwrap_or(false)
 }
 
-/// Routing: `.ecx` / `.ecj` go to `idx_directory`, `.vif` goes to
-/// `directory`. Matches `EcVolume::new`'s lookup order.
+// `.ecx`/`.ecj` route to idx_directory, `.vif` to directory.
 fn sidecar_dest_path(
     data_dir: &str,
     idx_dir: &str,
@@ -243,11 +193,6 @@ fn sidecar_dest_path(
     }
 }
 
-/// Mirror the three EC sidecars from one disk to another. Returns
-/// the count of files actually copied (skipping pre-existing
-/// destinations and missing optional sources). Errors abort on the
-/// first failure so the caller's warn-and-continue handles partial
-/// state.
 fn mirror_sidecars_for_volume(
     src_idx_dir: &str,
     src_data_dir: &str,
@@ -259,12 +204,15 @@ fn mirror_sidecars_for_volume(
     let mut copied = 0usize;
     for ext in EC_MIRRORED_SIDECARS {
         let dst = sidecar_dest_path(dst_data_dir, dst_idx_dir, collection, vid, ext);
+        // An existing local copy is authoritative — it may be newer
+        // than the owner's after a delete journal append.
         if fs::metadata(&dst).is_ok() {
             continue;
         }
+
         let candidates = [
             sidecar_dest_path(src_data_dir, src_idx_dir, collection, vid, ext),
-            sidecar_dest_path(src_idx_dir, src_data_dir, collection, vid, ext), // legacy swap
+            sidecar_dest_path(src_idx_dir, src_data_dir, collection, vid, ext),
         ];
         let mut src_path: Option<String> = None;
         for c in candidates.iter() {
@@ -282,10 +230,6 @@ fn mirror_sidecars_for_volume(
     Ok(copied)
 }
 
-/// Copy a single sidecar atomically: write to `<dst>.mirror.tmp`,
-/// fsync, rename. A pre-existing `<dst>.mirror.tmp` from a previous
-/// interrupted boot is removed first so `O_EXCL` doesn't refuse the
-/// open.
 fn copy_sidecar_atomic(src: &Path, dst: &Path) -> io::Result<()> {
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)?;
@@ -318,9 +262,6 @@ fn copy_sidecar_atomic(src: &Path, dst: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Walk this disk's data directory and return (collection, vid)
-/// groups that have any `.ec??` files on disk. Used by the mirror
-/// pass to find candidate destinations.
 fn collect_shard_disk_volumes(loc: &DiskLocation) -> HashMap<EcKey, Vec<String>> {
     let mut out: HashMap<EcKey, Vec<String>> = HashMap::new();
     let Ok(read) = fs::read_dir(&loc.directory) else {
@@ -406,9 +347,6 @@ mod tests {
             .unwrap();
     }
 
-    /// dir0: orphan shards. dir1: shard 1 + every sidecar. After
-    /// add_location finishes, dir0 must have its own copy of every
-    /// sidecar so the EcVolume there mounts self-contained.
     #[test]
     fn mirror_copies_sidecars_to_shard_only_disk() {
         let tmp = TempDir::new().unwrap();
@@ -448,8 +386,6 @@ mod tests {
         assert_eq!(ecj_dst, ecj, ".ecj mirrored bytes differ from source");
     }
 
-    /// dir0 already has its own sidecars (different .ecx bytes than
-    /// dir1's). The mirror must NOT overwrite them.
     #[test]
     fn mirror_preserves_existing_destination_sidecars() {
         let tmp = TempDir::new().unwrap();

--- a/seaweed-volume/src/storage/store_ec_reconcile.rs
+++ b/seaweed-volume/src/storage/store_ec_reconcile.rs
@@ -26,6 +26,17 @@ use crate::storage::store::Store;
 use crate::storage::super_block::SUPER_BLOCK_SIZE;
 use crate::storage::types::VolumeId;
 
+/// Where the local `.ecx` would live on `dir` for `(collection, vid)`.
+/// Helper for the post-mirror "is the local `.ecx` present?" check;
+/// shared between this module and `store_ec_mirror.rs`.
+pub(crate) fn ec_local_ecx_path(dir: &str, collection: &str, vid: VolumeId) -> String {
+    if collection.is_empty() {
+        format!("{}/{}.ecx", dir, vid.0)
+    } else {
+        format!("{}/{}_{}.ecx", dir, collection, vid.0)
+    }
+}
+
 /// Sibling-disk `.dat` candidate for `prune_incomplete_ec_with_sibling_dat`.
 /// We record both the disk index and the file's size: the size is
 /// consulted before deleting any EC artefacts. A zero-byte or truncated
@@ -79,7 +90,11 @@ impl Store {
         // Snapshot of orphan shards, keyed by (loc_idx, ec_key) so we
         // can release the immutable borrow on self.locations before
         // calling mount_ec_shards_with_idx_dir (which needs &mut).
-        let mut to_load: Vec<(usize, EcKey, Vec<(String, u32)>, EcxOwnerInfo)> = Vec::new();
+        // `use_local_idx` is the post-mirror fast path: when the
+        // physical mirror in mirror_ec_metadata_to_shard_disks has
+        // already installed the sidecars on this disk, mount against
+        // `loc.idx_directory` so the EcVolume is self-contained.
+        let mut to_load: Vec<(usize, EcKey, Vec<(String, u32)>, EcxOwnerInfo, bool)> = Vec::new();
         for (loc_idx, loc) in self.locations.iter().enumerate() {
             let orphans = collect_orphan_ec_shards(loc, loc_idx);
             for (key, shards) in orphans {
@@ -93,34 +108,63 @@ impl Store {
                     );
                     continue;
                 };
-                if owner.location == loc_idx && owner.idx_dir == loc.idx_directory {
+                // After the mirror pass runs, this disk may have its
+                // own local `.ecx`. Prefer the local idx so the
+                // EcVolume mounts self-contained; the cross-disk
+                // fallback only matters if the mirror failed.
+                let local_ecx = ec_local_ecx_path(&loc.idx_directory, &key.collection, key.vid);
+                let local_ecx_in_data = ec_local_ecx_path(&loc.directory, &key.collection, key.vid);
+                let use_local_idx = std::path::Path::new(&local_ecx).exists()
+                    || std::path::Path::new(&local_ecx_in_data).exists();
+
+                if !use_local_idx
+                    && owner.location == loc_idx
+                    && owner.idx_dir == loc.idx_directory
+                {
                     // Normal same-disk case: load_all_ec_shards already
                     // attempted the mount via `loc.idx_directory` and
                     // logged the underlying failure. No point retrying
                     // the same call.
                     continue;
                 }
-                // Either a cross-disk owner OR a same-disk owner whose
-                // `.ecx` actually lives in `loc.directory` (the legacy
-                // pre-`-dir.idx` layout). The latter wasn't tried by
-                // load_all_ec_shards, which only looked in
-                // `self.idx_directory`, so we still need to retry it
-                // here with the owner's discovered idx_dir.
-                to_load.push((loc_idx, key, shards, owner.clone()));
+                to_load.push((loc_idx, key, shards, owner.clone(), use_local_idx));
             }
         }
 
-        for (loc_idx, key, shards, owner) in to_load {
+        for (loc_idx, key, shards, owner, use_local_idx) in to_load {
             let shard_names: Vec<&str> = shards.iter().map(|(n, _)| n.as_str()).collect();
+            let loc_dir = self.locations[loc_idx].directory.clone();
+            let shard_ids: Vec<u32> = shards.iter().map(|(_, sid)| *sid).collect();
+
+            if use_local_idx {
+                info!(
+                    volume_id = key.vid.0,
+                    collection = %key.collection,
+                    directory = %loc_dir,
+                    "loading orphan EC shards against locally-mirrored sidecars: {:?}",
+                    shard_names,
+                );
+                let loc = &mut self.locations[loc_idx];
+                if let Err(e) = loc.mount_ec_shards(key.vid, &key.collection, &shard_ids, "") {
+                    loc.unmount_ec_shards(key.vid, &shard_ids);
+                    warn!(
+                        volume_id = key.vid.0,
+                        directory = %loc_dir,
+                        "local-mirror shard load failed: {}",
+                        e,
+                    );
+                }
+                continue;
+            }
+
             info!(
                 volume_id = key.vid.0,
                 collection = %key.collection,
                 from = %self.locations[owner.location].directory,
-                to = %self.locations[loc_idx].directory,
+                to = %loc_dir,
                 "loading orphan EC shards using index files from sibling disk (issue #9212): {:?}",
                 shard_names,
             );
-            let shard_ids: Vec<u32> = shards.iter().map(|(_, sid)| *sid).collect();
             let owner_idx_dir = owner.idx_dir.clone();
             let loc = &mut self.locations[loc_idx];
             if let Err(e) = loc.mount_ec_shards_with_idx_dir(
@@ -141,7 +185,7 @@ impl Store {
                 loc.unmount_ec_shards(key.vid, &shard_ids);
                 warn!(
                     volume_id = key.vid.0,
-                    directory = %loc.directory,
+                    directory = %loc_dir,
                     "cross-disk shard load failed: {}",
                     e,
                 );

--- a/seaweed-volume/src/storage/store_ec_reconcile.rs
+++ b/seaweed-volume/src/storage/store_ec_reconcile.rs
@@ -26,9 +26,6 @@ use crate::storage::store::Store;
 use crate::storage::super_block::SUPER_BLOCK_SIZE;
 use crate::storage::types::VolumeId;
 
-/// Where the local `.ecx` would live on `dir` for `(collection, vid)`.
-/// Helper for the post-mirror "is the local `.ecx` present?" check;
-/// shared between this module and `store_ec_mirror.rs`.
 pub(crate) fn ec_local_ecx_path(dir: &str, collection: &str, vid: VolumeId) -> String {
     if collection.is_empty() {
         format!("{}/{}.ecx", dir, vid.0)
@@ -87,13 +84,9 @@ impl Store {
             return;
         }
 
-        // Snapshot of orphan shards, keyed by (loc_idx, ec_key) so we
-        // can release the immutable borrow on self.locations before
-        // calling mount_ec_shards_with_idx_dir (which needs &mut).
         // `use_local_idx` is the post-mirror fast path: when the
-        // physical mirror in mirror_ec_metadata_to_shard_disks has
-        // already installed the sidecars on this disk, mount against
-        // `loc.idx_directory` so the EcVolume is self-contained.
+        // mirror already installed sidecars locally, mount against
+        // loc.idx_directory instead of the owner disk.
         let mut to_load: Vec<(usize, EcKey, Vec<(String, u32)>, EcxOwnerInfo, bool)> = Vec::new();
         for (loc_idx, loc) in self.locations.iter().enumerate() {
             let orphans = collect_orphan_ec_shards(loc, loc_idx);
@@ -108,10 +101,6 @@ impl Store {
                     );
                     continue;
                 };
-                // After the mirror pass runs, this disk may have its
-                // own local `.ecx`. Prefer the local idx so the
-                // EcVolume mounts self-contained; the cross-disk
-                // fallback only matters if the mirror failed.
                 let local_ecx = ec_local_ecx_path(&loc.idx_directory, &key.collection, key.vid);
                 let local_ecx_in_data = ec_local_ecx_path(&loc.directory, &key.collection, key.vid);
                 let use_local_idx = std::path::Path::new(&local_ecx).exists()
@@ -121,10 +110,8 @@ impl Store {
                     && owner.location == loc_idx
                     && owner.idx_dir == loc.idx_directory
                 {
-                    // Normal same-disk case: load_all_ec_shards already
-                    // attempted the mount via `loc.idx_directory` and
-                    // logged the underlying failure. No point retrying
-                    // the same call.
+                    // Same-disk no-op: load_all_ec_shards already
+                    // tried and logged the failure.
                     continue;
                 }
                 to_load.push((loc_idx, key, shards, owner.clone(), use_local_idx));

--- a/test/volume_server/grpc/ec_multi_disk_lifecycle_test.go
+++ b/test/volume_server/grpc/ec_multi_disk_lifecycle_test.go
@@ -205,8 +205,21 @@ func TestEcLifecycleAcrossMultipleDisks(t *testing.T) {
 		t.Fatalf("VolumeEcShardsRebuild expected to rebuild shard %d, got %v",
 			repairTargetShard, rebuildResp.GetRebuiltShardIds())
 	}
-	if _, statErr := os.Stat(shardPath); statErr != nil {
-		t.Fatalf("rebuild did not restore shard %d on disk 0 (%s): %v", repairTargetShard, shardPath, statErr)
+	// The rebuilder picks whichever disk hosts the most shards plus a
+	// matching .ecx. After the boot-time mirror runs, every shard-
+	// bearing disk owns its own sidecars, so rebuild can legitimately
+	// restore the shard on either disk — accept both.
+	rebuiltOn := -1
+	for i, dir := range dataDirs {
+		candidate := filepath.Join(dir, shardFileName(collection, volumeID, repairTargetShard))
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			rebuiltOn = i
+			shardPath = candidate
+			break
+		}
+	}
+	if rebuiltOn < 0 {
+		t.Fatalf("rebuild did not restore shard %d on any disk (checked %v)", repairTargetShard, dataDirs)
 	}
 
 	if _, err := grpcClient3.VolumeEcShardsMount(ctx, &volume_server_pb.VolumeEcShardsMountRequest{

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -164,13 +164,26 @@ func NewStore(
 	// we just cleaned up.
 	s.pruneIncompleteEcWithSiblingDat()
 
+	// Before the cross-disk virtual-mount fallback runs, physically copy
+	// EC sidecars (.ecx / .ecj / .vif) onto every disk that holds shards
+	// but is missing them. The EC lifecycle (encode / decode / balance /
+	// vacuum / repair) promises a same-disk layout: every shard lives
+	// alongside its own metadata. Mirroring at boot restores that
+	// invariant after ec.balance or ec.rebuild has split shards from
+	// their index across disks of the same volume server, so each disk
+	// can mount self-contained instead of reaching across to a sibling.
+	s.mirrorEcMetadataToShardDisks()
+
 	// After every DiskLocation has finished its per-disk EC scan, sweep the
 	// store for shards that live on a disk without local index files and
 	// load them by reaching across to a sibling disk's .ecx / .ecj / .vif.
 	// This is the volume-server side of issue #9212: ec.balance can move
 	// shards onto a destination node's second disk while leaving the index
 	// on the disk that already held the volume, and without this pass those
-	// orphan shards stay invisible to the master.
+	// orphan shards stay invisible to the master. Even after the mirror
+	// pass above, this stays as the fallback for volumes whose mirror
+	// failed (read-only target disk, partial copy, etc.) so the cluster
+	// stays available.
 	s.reconcileEcShardsAcrossDisks()
 
 	// Resolve state.pb's directory via the first disk location so it inherits

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -169,10 +169,10 @@ func NewStore(
 	// reconciler so the orphan pass can prefer the local IdxDirectory.
 	s.mirrorEcMetadataToShardDisks()
 
-	// Cross-disk fallback for orphan shards (issue #9212): ec.balance
-	// can land shards on one disk while leaving the index on another.
-	// Still needed after the mirror pass for volumes whose mirror
-	// failed (read-only target, out of space, partial copy).
+	// Cross-disk fallback for orphan shards — ec.balance can land
+	// shards on one disk while leaving the index on another. Still
+	// needed after the mirror pass for volumes whose mirror failed
+	// (read-only target, out of space, partial copy).
 	s.reconcileEcShardsAcrossDisks()
 
 	// Resolve state.pb's directory via the first disk location so it inherits

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -164,26 +164,15 @@ func NewStore(
 	// we just cleaned up.
 	s.pruneIncompleteEcWithSiblingDat()
 
-	// Before the cross-disk virtual-mount fallback runs, physically copy
-	// EC sidecars (.ecx / .ecj / .vif) onto every disk that holds shards
-	// but is missing them. The EC lifecycle (encode / decode / balance /
-	// vacuum / repair) promises a same-disk layout: every shard lives
-	// alongside its own metadata. Mirroring at boot restores that
-	// invariant after ec.balance or ec.rebuild has split shards from
-	// their index across disks of the same volume server, so each disk
-	// can mount self-contained instead of reaching across to a sibling.
+	// Physically mirror EC sidecars onto every shard-bearing disk so
+	// each disk mounts self-contained. Must run before the cross-disk
+	// reconciler so the orphan pass can prefer the local IdxDirectory.
 	s.mirrorEcMetadataToShardDisks()
 
-	// After every DiskLocation has finished its per-disk EC scan, sweep the
-	// store for shards that live on a disk without local index files and
-	// load them by reaching across to a sibling disk's .ecx / .ecj / .vif.
-	// This is the volume-server side of issue #9212: ec.balance can move
-	// shards onto a destination node's second disk while leaving the index
-	// on the disk that already held the volume, and without this pass those
-	// orphan shards stay invisible to the master. Even after the mirror
-	// pass above, this stays as the fallback for volumes whose mirror
-	// failed (read-only target disk, partial copy, etc.) so the cluster
-	// stays available.
+	// Cross-disk fallback for orphan shards (issue #9212): ec.balance
+	// can land shards on one disk while leaving the index on another.
+	// Still needed after the mirror pass for volumes whose mirror
+	// failed (read-only target, out of space, partial copy).
 	s.reconcileEcShardsAcrossDisks()
 
 	// Resolve state.pb's directory via the first disk location so it inherits

--- a/weed/storage/store_ec_mirror.go
+++ b/weed/storage/store_ec_mirror.go
@@ -1,0 +1,246 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+)
+
+// ecMirroredSidecars is the set of EC metadata files that must travel
+// with the shards. Each disk that holds .ec?? files for a
+// (collection, vid) on this volume server is expected to also hold a
+// local copy of these files so the EcVolume can mount self-contained —
+// without reaching across to a sibling disk for its index, journal, or
+// volume info.
+//
+// `.ecx` is the sorted needle index produced at encode time.
+// `.ecj` is the deletion journal appended on every blob delete.
+// `.vif` is the VolumeInfo (version, datFileSize, EC ratio, ttl).
+//
+// Listed in the order NewEcVolume opens them at mount, so a partial
+// mirror can be diagnosed by walking the list and stopping at the
+// first destination that does not yet have its copy.
+var ecMirroredSidecars = []string{".ecx", ".ecj", ".vif"}
+
+// mirrorEcMetadataToShardDisks copies the EC sidecar files (.ecx,
+// .ecj, .vif) onto every disk of this store that holds EC shards but
+// is missing the matching sidecars. The goal is the same-disk
+// invariant promised by the EC lifecycle: encode / decode / balance /
+// vacuum / repair must leave every shard alongside its own metadata,
+// so the EcVolume can mount without reaching across to a sibling
+// disk.
+//
+// Without this pass, a disk that received shards through ec.balance
+// or ec.rebuild — where only the first shard carries
+// CopyEcxFile=true and subsequent shards land via auto-select — can
+// end up with the .ec?? files but no local .ecx / .ecj / .vif. The
+// orphan-shard reconciler in reconcileEcShardsAcrossDisks then mounts
+// the shards by pointing the EcVolume at the sibling disk's index
+// files. Reads work, but any failure on the index-owning disk (a
+// removed drive, a corrupted ext4, an operator who unmounted the
+// wrong sled) takes the shards with it.
+//
+// Mirroring physically replicates the sidecars onto each
+// shard-bearing disk so the shards stay readable as long as their own
+// disk is up. Idempotent: a destination that already has its sidecar
+// is skipped, and a missing source sidecar is not an error.
+//
+// Runs before reconcileEcShardsAcrossDisks so the orphan-shard pass
+// sees the freshly-mirrored layout and can mount each disk against
+// its own IdxDirectory rather than falling back to the cross-disk
+// path. The cross-disk fallback is preserved for cases where
+// mirroring fails (out of disk space, read-only target, etc.) so the
+// volume stays available.
+func (s *Store) mirrorEcMetadataToShardDisks() {
+	if len(s.Locations) < 2 {
+		return
+	}
+
+	ecxOwners := s.indexEcxOwners()
+	if len(ecxOwners) == 0 {
+		return
+	}
+
+	for _, loc := range s.Locations {
+		orphans := loc.collectOrphanEcShards()
+		if len(orphans) == 0 {
+			continue
+		}
+		for key := range orphans {
+			owner, ok := ecxOwners[key]
+			if !ok {
+				continue
+			}
+			// Same-disk owner: the per-disk loader will have already
+			// surfaced any failure. Mirroring to the same disk is a
+			// no-op anyway (source == destination).
+			if owner.location == loc {
+				continue
+			}
+			// Skip if this destination already has every sidecar — common
+			// when mirroring ran successfully on a previous startup and
+			// the operator hasn't disturbed the layout.
+			if loc.hasAllEcSidecarsLocally(key.collection, key.vid) {
+				continue
+			}
+			copied, err := loc.mirrorEcSidecarsFrom(owner, key.collection, key.vid)
+			if err != nil {
+				// Don't abort the whole pass on a single failure: the
+				// cross-disk reconciler downstream still gives this
+				// volume a working (if non-mirrored) mount.
+				glog.Warningf("ec volume %d (collection=%q): mirror sidecars from %s to %s failed after %d files: %v; cross-disk fallback will handle this volume",
+					key.vid, key.collection, owner.location.Directory, loc.Directory, copied, err)
+				continue
+			}
+			if copied > 0 {
+				glog.V(0).Infof("ec volume %d (collection=%q): mirrored %d sidecar(s) from %s to %s for same-disk invariant",
+					key.vid, key.collection, copied, owner.location.Directory, loc.Directory)
+			}
+		}
+	}
+}
+
+// hasAllEcSidecarsLocally reports whether this disk already has every
+// EC sidecar that ecMirroredSidecars expects, in the directory where
+// NewEcVolume looks for it (IdxDirectory for .ecx/.ecj, Directory for
+// .vif).
+func (l *DiskLocation) hasAllEcSidecarsLocally(collection string, vid needle.VolumeId) bool {
+	for _, ext := range ecMirroredSidecars {
+		dst := l.ecSidecarDestPath(collection, vid, ext)
+		if _, err := os.Stat(dst); err != nil {
+			// Either NotExist or another error — pessimistically treat
+			// as missing so the caller attempts a fresh mirror.
+			return false
+		}
+	}
+	return true
+}
+
+// ecSidecarDestPath returns where on this disk a given EC sidecar
+// extension is expected to live. Keeps the routing logic close to
+// NewEcVolume's lookup order:
+//
+//	.ecx / .ecj → IdxDirectory (sorted index, deletion journal)
+//	.vif        → Directory   (volume info next to .dat / shards)
+func (l *DiskLocation) ecSidecarDestPath(collection string, vid needle.VolumeId, ext string) string {
+	if ext == ".vif" {
+		return erasure_coding.EcShardFileName(collection, l.Directory, int(vid)) + ext
+	}
+	return erasure_coding.EcShardFileName(collection, l.IdxDirectory, int(vid)) + ext
+}
+
+// mirrorEcSidecarsFrom copies every sidecar in ecMirroredSidecars
+// from the owner disk to this disk. Returns the count of files
+// successfully copied — a non-zero count with a non-nil error
+// indicates a partial mirror, which the caller logs but otherwise
+// leaves to the cross-disk fallback.
+//
+// Source resolution per file: check the owner's recorded idxDir first
+// (matches indexEcxOwners' "where I actually found .ecx" record),
+// then fall back to the owner's data Directory. This matches
+// removeEcVolumeFiles' two-directory cleanup contract — we read from
+// wherever the owner actually put the file.
+//
+// Each copy is atomic: write to <dst>.tmp, fsync, rename. A
+// pre-existing destination is left untouched (no overwrite), so a
+// half-finished mirror from a previous startup is healed file-by-file
+// without rewriting bytes that are already correct.
+func (l *DiskLocation) mirrorEcSidecarsFrom(owner ecxOwnerInfo, collection string, vid needle.VolumeId) (int, error) {
+	srcIdxBase := erasure_coding.EcShardFileName(collection, owner.idxDir, int(vid))
+	srcDataBase := erasure_coding.EcShardFileName(collection, owner.location.Directory, int(vid))
+
+	copied := 0
+	for _, ext := range ecMirroredSidecars {
+		dst := l.ecSidecarDestPath(collection, vid, ext)
+		// Don't overwrite a sidecar that's already present: an
+		// existing local copy is authoritative (it may be newer than
+		// the owner's after a delete journal append).
+		if _, err := os.Stat(dst); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return copied, fmt.Errorf("stat %s: %w", dst, err)
+		}
+
+		// Pick the source: idxDir first (where the owner reported
+		// finding .ecx), then the owner's data dir as a fallback for
+		// .vif (and for legacy layouts that left .ecx in Directory).
+		var src string
+		for _, candidate := range []string{srcIdxBase + ext, srcDataBase + ext} {
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				src = candidate
+				break
+			}
+		}
+		if src == "" {
+			glog.V(1).Infof("ec volume %d (collection=%q): sidecar %s not found on owner %s; skipping mirror",
+				vid, collection, ext, owner.location.Directory)
+			continue
+		}
+
+		if err := copyEcSidecarAtomic(src, dst); err != nil {
+			return copied, fmt.Errorf("copy %s: %w", ext, err)
+		}
+		copied++
+	}
+	return copied, nil
+}
+
+// copyEcSidecarAtomic copies src to dst via a sibling .tmp file and a
+// rename, fsyncing the data before the rename. Crash-safe: a partial
+// write leaves the .tmp orphaned (cleaned up on the next mirror pass
+// via the os.Remove on failure) and the canonical dst stays absent so
+// a retry recognises it still needs to copy.
+//
+// Caller has already verified dst does not exist; we still pass
+// O_EXCL on the tmp create so a concurrent mirror can't both fight
+// for the same temp path.
+func copyEcSidecarAtomic(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source %s: %w", src, err)
+	}
+	defer srcFile.Close()
+
+	// Make sure the destination directory exists. Locations created
+	// before -dir.idx was set may not have the idx tree yet on a
+	// fresh disk; MkdirAll is a no-op when it already does.
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+	}
+
+	tmpDst := dst + ".mirror.tmp"
+	// O_EXCL guards against a stale tmp from a previous interrupted
+	// run; if it's there, blow it away and retry.
+	_ = os.Remove(tmpDst)
+	dstFile, err := os.OpenFile(tmpDst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmpDst, err)
+	}
+	cleanup := func() {
+		_ = dstFile.Close()
+		_ = os.Remove(tmpDst)
+	}
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		cleanup()
+		return fmt.Errorf("copy bytes %s -> %s: %w", src, tmpDst, err)
+	}
+	if err := dstFile.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("fsync %s: %w", tmpDst, err)
+	}
+	if err := dstFile.Close(); err != nil {
+		_ = os.Remove(tmpDst)
+		return fmt.Errorf("close %s: %w", tmpDst, err)
+	}
+	if err := os.Rename(tmpDst, dst); err != nil {
+		_ = os.Remove(tmpDst)
+		return fmt.Errorf("rename %s -> %s: %w", tmpDst, dst, err)
+	}
+	return nil
+}

--- a/weed/storage/store_ec_mirror.go
+++ b/weed/storage/store_ec_mirror.go
@@ -106,19 +106,44 @@ func (s *Store) mirrorEcMetadataToShardDisks() {
 }
 
 // hasAllEcSidecarsLocally reports whether this disk already has every
-// EC sidecar that ecMirroredSidecars expects, in the directory where
-// NewEcVolume looks for it (IdxDirectory for .ecx/.ecj, Directory for
-// .vif).
+// EC sidecar ecMirroredSidecars expects. Checks the modern routing
+// first (IdxDirectory for .ecx/.ecj, Directory for .vif) and then the
+// opposite directory as a fallback — matching NewEcVolume's own
+// open-with-fallback contract and HasEcxFileOnDisk. Without the
+// fallback, a destination that still has a legacy pre-`-dir.idx`
+// .ecx in its data dir would be re-mirrored into IdxDirectory and
+// end up with two copies on disk.
 func (l *DiskLocation) hasAllEcSidecarsLocally(collection string, vid needle.VolumeId) bool {
 	for _, ext := range ecMirroredSidecars {
-		dst := l.ecSidecarDestPath(collection, vid, ext)
-		if _, err := os.Stat(dst); err != nil {
-			// Either NotExist or another error — pessimistically treat
-			// as missing so the caller attempts a fresh mirror.
-			return false
+		primary := l.ecSidecarDestPath(collection, vid, ext)
+		if statRegular(primary) {
+			continue
 		}
+		// Fall back to the opposite directory for the legacy layout:
+		// .ecx/.ecj could be in Directory (pre-`-dir.idx`), .vif
+		// could be in IdxDirectory (uncommon but allowed by
+		// NewEcVolume's .vif lookup).
+		if l.IdxDirectory != l.Directory {
+			fallbackDir := l.Directory
+			if ext == ".vif" {
+				fallbackDir = l.IdxDirectory
+			}
+			fallback := erasure_coding.EcShardFileName(collection, fallbackDir, int(vid)) + ext
+			if statRegular(fallback) {
+				continue
+			}
+		}
+		return false
 	}
 	return true
+}
+
+// statRegular returns true iff path exists and is a regular file
+// (not a directory). Used by the sidecar-presence checks; keeps the
+// fallback ladder readable.
+func statRegular(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 // ecSidecarDestPath returns where on this disk a given EC sidecar

--- a/weed/storage/store_ec_mirror.go
+++ b/weed/storage/store_ec_mirror.go
@@ -11,51 +11,15 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 )
 
-// ecMirroredSidecars is the set of EC metadata files that must travel
-// with the shards. Each disk that holds .ec?? files for a
-// (collection, vid) on this volume server is expected to also hold a
-// local copy of these files so the EcVolume can mount self-contained —
-// without reaching across to a sibling disk for its index, journal, or
-// volume info.
-//
-// `.ecx` is the sorted needle index produced at encode time.
-// `.ecj` is the deletion journal appended on every blob delete.
-// `.vif` is the VolumeInfo (version, datFileSize, EC ratio, ttl).
-//
-// Listed in the order NewEcVolume opens them at mount, so a partial
-// mirror can be diagnosed by walking the list and stopping at the
-// first destination that does not yet have its copy.
+// Listed in the order NewEcVolume opens them.
 var ecMirroredSidecars = []string{".ecx", ".ecj", ".vif"}
 
-// mirrorEcMetadataToShardDisks copies the EC sidecar files (.ecx,
-// .ecj, .vif) onto every disk of this store that holds EC shards but
-// is missing the matching sidecars. The goal is the same-disk
-// invariant promised by the EC lifecycle: encode / decode / balance /
-// vacuum / repair must leave every shard alongside its own metadata,
-// so the EcVolume can mount without reaching across to a sibling
-// disk.
-//
-// Without this pass, a disk that received shards through ec.balance
-// or ec.rebuild — where only the first shard carries
-// CopyEcxFile=true and subsequent shards land via auto-select — can
-// end up with the .ec?? files but no local .ecx / .ecj / .vif. The
-// orphan-shard reconciler in reconcileEcShardsAcrossDisks then mounts
-// the shards by pointing the EcVolume at the sibling disk's index
-// files. Reads work, but any failure on the index-owning disk (a
-// removed drive, a corrupted ext4, an operator who unmounted the
-// wrong sled) takes the shards with it.
-//
-// Mirroring physically replicates the sidecars onto each
-// shard-bearing disk so the shards stay readable as long as their own
-// disk is up. Idempotent: a destination that already has its sidecar
-// is skipped, and a missing source sidecar is not an error.
-//
-// Runs before reconcileEcShardsAcrossDisks so the orphan-shard pass
-// sees the freshly-mirrored layout and can mount each disk against
-// its own IdxDirectory rather than falling back to the cross-disk
-// path. The cross-disk fallback is preserved for cases where
-// mirroring fails (out of disk space, read-only target, etc.) so the
-// volume stays available.
+// mirrorEcMetadataToShardDisks physically copies .ecx / .ecj / .vif
+// onto every disk that holds EC shards but lacks the matching
+// sidecars, so each shard-bearing disk mounts self-contained instead
+// of reaching across to a sibling. Runs before
+// reconcileEcShardsAcrossDisks; the cross-disk virtual mount stays
+// as the fallback when mirroring fails.
 func (s *Store) mirrorEcMetadataToShardDisks() {
 	if len(s.Locations) < 2 {
 		return
@@ -76,23 +40,14 @@ func (s *Store) mirrorEcMetadataToShardDisks() {
 			if !ok {
 				continue
 			}
-			// Same-disk owner: the per-disk loader will have already
-			// surfaced any failure. Mirroring to the same disk is a
-			// no-op anyway (source == destination).
 			if owner.location == loc {
 				continue
 			}
-			// Skip if this destination already has every sidecar — common
-			// when mirroring ran successfully on a previous startup and
-			// the operator hasn't disturbed the layout.
 			if loc.hasAllEcSidecarsLocally(key.collection, key.vid) {
 				continue
 			}
 			copied, err := loc.mirrorEcSidecarsFrom(owner, key.collection, key.vid)
 			if err != nil {
-				// Don't abort the whole pass on a single failure: the
-				// cross-disk reconciler downstream still gives this
-				// volume a working (if non-mirrored) mount.
 				glog.Warningf("ec volume %d (collection=%q): mirror sidecars from %s to %s failed after %d files: %v; cross-disk fallback will handle this volume",
 					key.vid, key.collection, owner.location.Directory, loc.Directory, copied, err)
 				continue
@@ -105,31 +60,21 @@ func (s *Store) mirrorEcMetadataToShardDisks() {
 	}
 }
 
-// hasAllEcSidecarsLocally reports whether this disk already has every
-// EC sidecar ecMirroredSidecars expects. Checks the modern routing
-// first (IdxDirectory for .ecx/.ecj, Directory for .vif) and then the
-// opposite directory as a fallback — matching NewEcVolume's own
-// open-with-fallback contract and HasEcxFileOnDisk. Without the
-// fallback, a destination that still has a legacy pre-`-dir.idx`
-// .ecx in its data dir would be re-mirrored into IdxDirectory and
-// end up with two copies on disk.
+// hasAllEcSidecarsLocally checks both the modern routing and the
+// opposite directory (legacy pre-`-dir.idx` layout) — without the
+// fallback, a destination that still has .ecx in its data dir would
+// be re-mirrored into IdxDirectory.
 func (l *DiskLocation) hasAllEcSidecarsLocally(collection string, vid needle.VolumeId) bool {
 	for _, ext := range ecMirroredSidecars {
-		primary := l.ecSidecarDestPath(collection, vid, ext)
-		if statRegular(primary) {
+		if statRegular(l.ecSidecarDestPath(collection, vid, ext)) {
 			continue
 		}
-		// Fall back to the opposite directory for the legacy layout:
-		// .ecx/.ecj could be in Directory (pre-`-dir.idx`), .vif
-		// could be in IdxDirectory (uncommon but allowed by
-		// NewEcVolume's .vif lookup).
 		if l.IdxDirectory != l.Directory {
 			fallbackDir := l.Directory
 			if ext == ".vif" {
 				fallbackDir = l.IdxDirectory
 			}
-			fallback := erasure_coding.EcShardFileName(collection, fallbackDir, int(vid)) + ext
-			if statRegular(fallback) {
+			if statRegular(erasure_coding.EcShardFileName(collection, fallbackDir, int(vid)) + ext) {
 				continue
 			}
 		}
@@ -138,20 +83,13 @@ func (l *DiskLocation) hasAllEcSidecarsLocally(collection string, vid needle.Vol
 	return true
 }
 
-// statRegular returns true iff path exists and is a regular file
-// (not a directory). Used by the sidecar-presence checks; keeps the
-// fallback ladder readable.
 func statRegular(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
 }
 
-// ecSidecarDestPath returns where on this disk a given EC sidecar
-// extension is expected to live. Keeps the routing logic close to
-// NewEcVolume's lookup order:
-//
-//	.ecx / .ecj → IdxDirectory (sorted index, deletion journal)
-//	.vif        → Directory   (volume info next to .dat / shards)
+// ecSidecarDestPath routes .ecx/.ecj to IdxDirectory and .vif to
+// Directory, matching NewEcVolume's open order.
 func (l *DiskLocation) ecSidecarDestPath(collection string, vid needle.VolumeId, ext string) string {
 	if ext == ".vif" {
 		return erasure_coding.EcShardFileName(collection, l.Directory, int(vid)) + ext
@@ -159,22 +97,6 @@ func (l *DiskLocation) ecSidecarDestPath(collection string, vid needle.VolumeId,
 	return erasure_coding.EcShardFileName(collection, l.IdxDirectory, int(vid)) + ext
 }
 
-// mirrorEcSidecarsFrom copies every sidecar in ecMirroredSidecars
-// from the owner disk to this disk. Returns the count of files
-// successfully copied — a non-zero count with a non-nil error
-// indicates a partial mirror, which the caller logs but otherwise
-// leaves to the cross-disk fallback.
-//
-// Source resolution per file: check the owner's recorded idxDir first
-// (matches indexEcxOwners' "where I actually found .ecx" record),
-// then fall back to the owner's data Directory. This matches
-// removeEcVolumeFiles' two-directory cleanup contract — we read from
-// wherever the owner actually put the file.
-//
-// Each copy is atomic: write to <dst>.tmp, fsync, rename. A
-// pre-existing destination is left untouched (no overwrite), so a
-// half-finished mirror from a previous startup is healed file-by-file
-// without rewriting bytes that are already correct.
 func (l *DiskLocation) mirrorEcSidecarsFrom(owner ecxOwnerInfo, collection string, vid needle.VolumeId) (int, error) {
 	srcIdxBase := erasure_coding.EcShardFileName(collection, owner.idxDir, int(vid))
 	srcDataBase := erasure_coding.EcShardFileName(collection, owner.location.Directory, int(vid))
@@ -182,18 +104,14 @@ func (l *DiskLocation) mirrorEcSidecarsFrom(owner ecxOwnerInfo, collection strin
 	copied := 0
 	for _, ext := range ecMirroredSidecars {
 		dst := l.ecSidecarDestPath(collection, vid, ext)
-		// Don't overwrite a sidecar that's already present: an
-		// existing local copy is authoritative (it may be newer than
-		// the owner's after a delete journal append).
+		// An existing local copy is authoritative — it may be newer
+		// than the owner's after a delete journal append.
 		if _, err := os.Stat(dst); err == nil {
 			continue
 		} else if !os.IsNotExist(err) {
 			return copied, fmt.Errorf("stat %s: %w", dst, err)
 		}
 
-		// Pick the source: idxDir first (where the owner reported
-		// finding .ecx), then the owner's data dir as a fallback for
-		// .vif (and for legacy layouts that left .ecx in Directory).
 		var src string
 		for _, candidate := range []string{srcIdxBase + ext, srcDataBase + ext} {
 			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
@@ -215,15 +133,10 @@ func (l *DiskLocation) mirrorEcSidecarsFrom(owner ecxOwnerInfo, collection strin
 	return copied, nil
 }
 
-// copyEcSidecarAtomic copies src to dst via a sibling .tmp file and a
-// rename, fsyncing the data before the rename. Crash-safe: a partial
-// write leaves the .tmp orphaned (cleaned up on the next mirror pass
-// via the os.Remove on failure) and the canonical dst stays absent so
-// a retry recognises it still needs to copy.
-//
-// Caller has already verified dst does not exist; we still pass
-// O_EXCL on the tmp create so a concurrent mirror can't both fight
-// for the same temp path.
+// copyEcSidecarAtomic writes to <dst>.mirror.tmp, fsyncs, renames.
+// Crash-safe: a partial write leaves the tmp orphaned and the
+// canonical dst absent so retries recognise the file still needs
+// copying.
 func copyEcSidecarAtomic(src, dst string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
@@ -231,16 +144,11 @@ func copyEcSidecarAtomic(src, dst string) error {
 	}
 	defer srcFile.Close()
 
-	// Make sure the destination directory exists. Locations created
-	// before -dir.idx was set may not have the idx tree yet on a
-	// fresh disk; MkdirAll is a no-op when it already does.
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
 
 	tmpDst := dst + ".mirror.tmp"
-	// O_EXCL guards against a stale tmp from a previous interrupted
-	// run; if it's there, blow it away and retry.
 	_ = os.Remove(tmpDst)
 	dstFile, err := os.OpenFile(tmpDst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {

--- a/weed/storage/store_ec_mirror_test.go
+++ b/weed/storage/store_ec_mirror_test.go
@@ -14,17 +14,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-// TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars sets up the
-// same orphan-shard layout as TestLoadEcShardsWhenIndexFilesOnDifferentDisk
-// (shards on dir0, sidecars on dir1) and asserts the additional
-// guarantee: after NewStore returns, dir0 has its OWN copy of every EC
-// sidecar so the EcVolume mounts self-contained instead of reaching
-// across to dir1.
-//
-// The mirror is the load-bearing piece for the EC lifecycle (encode /
-// decode / balance / vacuum / repair) same-disk invariant. Without it,
-// a future failure of dir1 (the index owner) silently disables every
-// shard on dir0, even though those shards are physically fine.
+// Orphan layout: shards on dir0, sidecars on dir1. After NewStore,
+// dir0 must own a local copy of every sidecar.
 func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 	tempDir := t.TempDir()
 	dir0 := filepath.Join(tempDir, "data1")
@@ -55,17 +46,11 @@ func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 		f.Close()
 	}
 
-	// dir0: orphan shards 0 and 12; no sidecars locally yet.
 	writeShard(dir0, 0)
 	writeShard(dir0, 12)
-
-	// dir1: sidecars + shard 1.
 	writeShard(dir1, 1)
 	base1 := erasure_coding.EcShardFileName(collection, dir1, int(vid))
 
-	// Sentinel bytes in each sidecar so we can detect that the mirrored
-	// copy on dir0 is byte-for-byte identical and not, say, a stub
-	// created by NewEcVolume's "missing .vif" fallback.
 	ecxBytes := bytes.Repeat([]byte{0xA1}, 20)
 	ecjBytes := bytes.Repeat([]byte{0xB2}, 16)
 	if err := os.WriteFile(base1+".ecx", ecxBytes, 0o644); err != nil {
@@ -116,31 +101,23 @@ func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 
 	base0 := erasure_coding.EcShardFileName(collection, dir0, int(vid))
 
-	// dir0 must have received byte-identical copies of .ecx and .ecj.
-	// (.vif is checked separately below: NewEcVolume's version
-	// verification rewrites .vif when the mounted shard's header
-	// disagrees with the recorded version, so byte-equality is not the
-	// right invariant for .vif on synthetic-shard fixtures.)
+	// .vif drifts on first mount via version-correction, so byte
+	// equality is only the right invariant for .ecx and .ecj.
 	for _, ext := range []string{".ecx", ".ecj"} {
-		src := base1 + ext
-		dst := base0 + ext
-		gotBytes, err := os.ReadFile(dst)
+		gotBytes, err := os.ReadFile(base0 + ext)
 		if err != nil {
 			t.Errorf("sidecar %s not mirrored to dir0: %v", ext, err)
 			continue
 		}
-		wantBytes, err := os.ReadFile(src)
+		wantBytes, err := os.ReadFile(base1 + ext)
 		if err != nil {
-			t.Fatalf("read source %s: %v", src, err)
+			t.Fatalf("read source %s: %v", base1+ext, err)
 		}
 		if !bytes.Equal(gotBytes, wantBytes) {
 			t.Errorf("sidecar %s content mismatch between dir0 and dir1", ext)
 		}
 	}
 
-	// .vif must exist on dir0 and decode to the same EC ratio the
-	// source advertised; the exact bytes can drift due to
-	// version-correction on first mount.
 	dir0Info, _, found, err := volume_info.MaybeLoadVolumeInfo(base0 + ".vif")
 	if err != nil || !found {
 		t.Errorf("dir0 .vif missing or unreadable after mirror: err=%v found=%v", err, found)
@@ -151,9 +128,6 @@ func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 			dir0Info.EcShardConfig, dataShards, parityShards)
 	}
 
-	// The shards on dir0 must still be loaded — same guarantee as the
-	// pre-mirror orphan reconciler — and the EcVolume's index handle
-	// must resolve to dir0 itself, not to dir1.
 	loc0 := store.Locations[0]
 	ev0, found := loc0.FindEcVolume(vid)
 	if !found {
@@ -168,8 +142,6 @@ func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 		t.Errorf("dir0 EcVolume .ecx resolved at %q, want %q (local mirrored copy)", got, want)
 	}
 
-	// dir1 must keep its own self-contained mount for shard 1; the
-	// mirror does not touch the source.
 	loc1 := store.Locations[1]
 	ev1, found := loc1.FindEcVolume(vid)
 	if !found {
@@ -179,7 +151,6 @@ func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 		t.Errorf("dir1 shard 1 missing after mirror")
 	}
 
-	// Shards on dir0 must not have been destroyed by any cleanup path.
 	for _, sid := range []int{0, 12} {
 		shardPath := base0 + erasure_coding.ToExt(sid)
 		fi, err := os.Stat(shardPath)
@@ -193,11 +164,9 @@ func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
 	}
 }
 
-// TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored guards against
-// the mirror pass rewriting sidecars that already match. Idempotency
-// matters because the pass runs on every startup; an unconditional
-// rewrite would slowly amplify into "fsync every EC volume's metadata
-// on boot," which is expensive on large clusters.
+// A pre-existing destination .ecx must not be overwritten — local
+// copies are authoritative because they may have absorbed delete
+// journal updates not yet on the owner.
 func TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored(t *testing.T) {
 	tempDir := t.TempDir()
 	dir0 := filepath.Join(tempDir, "data1")
@@ -251,11 +220,8 @@ func TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored(t *testing.T) {
 	plantShard(dir0, 12)
 	plantShard(dir1, 1)
 
-	// Both dirs already have sidecars; we plant deliberately different
-	// .ecx bytes so we can prove the mirror does NOT clobber the
-	// pre-existing destination with the owner's copy. .ecx is the
-	// strongest signal here — unlike .vif, EcVolume never rewrites
-	// .ecx at mount, so any drift would be the mirror's fault.
+	// Deliberately different .ecx bytes on each side so any overwrite
+	// shows up as a diff. .ecx never rewrites at mount, unlike .vif.
 	ecxOwner := bytes.Repeat([]byte{0xC3}, 20)
 	ecxLocal := bytes.Repeat([]byte{0x5A}, 20)
 	ecjBytes := bytes.Repeat([]byte{0xD4}, 16)
@@ -302,9 +268,6 @@ func TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored(t *testing.T) {
 			postEcx[:4], ecxLocal[:4])
 	}
 
-	// And the volume must still mount on both disks with its own
-	// local .ecx — the same-disk invariant the mirror is here to
-	// preserve.
 	if loc0 := store.Locations[0]; loc0 == nil {
 		t.Fatal("loc0 unexpectedly nil")
 	} else if ev, found := loc0.FindEcVolume(vid); !found {

--- a/weed/storage/store_ec_mirror_test.go
+++ b/weed/storage/store_ec_mirror_test.go
@@ -1,0 +1,315 @@
+package storage
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"github.com/seaweedfs/seaweedfs/weed/storage/volume_info"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars sets up the
+// same orphan-shard layout as TestLoadEcShardsWhenIndexFilesOnDifferentDisk
+// (shards on dir0, sidecars on dir1) and asserts the additional
+// guarantee: after NewStore returns, dir0 has its OWN copy of every EC
+// sidecar so the EcVolume mounts self-contained instead of reaching
+// across to dir1.
+//
+// The mirror is the load-bearing piece for the EC lifecycle (encode /
+// decode / balance / vacuum / repair) same-disk invariant. Without it,
+// a future failure of dir1 (the index owner) silently disables every
+// shard on dir0, even though those shards are physically fine.
+func TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars(t *testing.T) {
+	tempDir := t.TempDir()
+	dir0 := filepath.Join(tempDir, "data1")
+	dir1 := filepath.Join(tempDir, "data2")
+	for _, d := range []string{dir0, dir1} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	collection := "video-recordings"
+	vid := needle.VolumeId(4121)
+	const dataShards, parityShards = 10, 4
+	const datSize int64 = 10 * 1024 * 1024
+	expectedShardSize := calculateExpectedShardSize(datSize, dataShards)
+
+	writeShard := func(dir string, shardId int) {
+		t.Helper()
+		base := erasure_coding.EcShardFileName(collection, dir, int(vid))
+		f, err := os.Create(base + erasure_coding.ToExt(shardId))
+		if err != nil {
+			t.Fatalf("create shard %d in %s: %v", shardId, dir, err)
+		}
+		if err := f.Truncate(expectedShardSize); err != nil {
+			f.Close()
+			t.Fatalf("truncate shard %d in %s: %v", shardId, dir, err)
+		}
+		f.Close()
+	}
+
+	// dir0: orphan shards 0 and 12; no sidecars locally yet.
+	writeShard(dir0, 0)
+	writeShard(dir0, 12)
+
+	// dir1: sidecars + shard 1.
+	writeShard(dir1, 1)
+	base1 := erasure_coding.EcShardFileName(collection, dir1, int(vid))
+
+	// Sentinel bytes in each sidecar so we can detect that the mirrored
+	// copy on dir0 is byte-for-byte identical and not, say, a stub
+	// created by NewEcVolume's "missing .vif" fallback.
+	ecxBytes := bytes.Repeat([]byte{0xA1}, 20)
+	ecjBytes := bytes.Repeat([]byte{0xB2}, 16)
+	if err := os.WriteFile(base1+".ecx", ecxBytes, 0o644); err != nil {
+		t.Fatalf("write .ecx: %v", err)
+	}
+	if err := os.WriteFile(base1+".ecj", ecjBytes, 0o644); err != nil {
+		t.Fatalf("write .ecj: %v", err)
+	}
+	if err := volume_info.SaveVolumeInfo(base1+".vif", &volume_server_pb.VolumeInfo{
+		Version:     uint32(needle.Version3),
+		DatFileSize: datSize,
+		EcShardConfig: &volume_server_pb.EcShardConfig{
+			DataShards:   dataShards,
+			ParityShards: parityShards,
+		},
+	}); err != nil {
+		t.Fatalf("save .vif: %v", err)
+	}
+
+	store := NewStore(nil, "localhost", 8080, 18080, "http://localhost:8080", "store-id",
+		[]string{dir0, dir1},
+		[]int32{100, 100},
+		[]util.MinFreeSpace{{}, {}},
+		"",
+		NeedleMapInMemory,
+		[]types.DiskType{types.HardDriveType, types.HardDriveType},
+		nil,
+		3,
+	)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-store.NewEcShardsChan:
+			case <-store.NewVolumesChan:
+			case <-store.DeletedVolumesChan:
+			case <-store.DeletedEcShardsChan:
+			case <-store.StateUpdateChan:
+			case <-done:
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		store.Close()
+		close(done)
+	})
+
+	base0 := erasure_coding.EcShardFileName(collection, dir0, int(vid))
+
+	// dir0 must have received byte-identical copies of .ecx and .ecj.
+	// (.vif is checked separately below: NewEcVolume's version
+	// verification rewrites .vif when the mounted shard's header
+	// disagrees with the recorded version, so byte-equality is not the
+	// right invariant for .vif on synthetic-shard fixtures.)
+	for _, ext := range []string{".ecx", ".ecj"} {
+		src := base1 + ext
+		dst := base0 + ext
+		gotBytes, err := os.ReadFile(dst)
+		if err != nil {
+			t.Errorf("sidecar %s not mirrored to dir0: %v", ext, err)
+			continue
+		}
+		wantBytes, err := os.ReadFile(src)
+		if err != nil {
+			t.Fatalf("read source %s: %v", src, err)
+		}
+		if !bytes.Equal(gotBytes, wantBytes) {
+			t.Errorf("sidecar %s content mismatch between dir0 and dir1", ext)
+		}
+	}
+
+	// .vif must exist on dir0 and decode to the same EC ratio the
+	// source advertised; the exact bytes can drift due to
+	// version-correction on first mount.
+	dir0Info, _, found, err := volume_info.MaybeLoadVolumeInfo(base0 + ".vif")
+	if err != nil || !found {
+		t.Errorf("dir0 .vif missing or unreadable after mirror: err=%v found=%v", err, found)
+	} else if dir0Info.EcShardConfig == nil ||
+		dir0Info.EcShardConfig.DataShards != dataShards ||
+		dir0Info.EcShardConfig.ParityShards != parityShards {
+		t.Errorf("dir0 .vif has wrong EC ratio after mirror: got %+v, want %d+%d",
+			dir0Info.EcShardConfig, dataShards, parityShards)
+	}
+
+	// The shards on dir0 must still be loaded — same guarantee as the
+	// pre-mirror orphan reconciler — and the EcVolume's index handle
+	// must resolve to dir0 itself, not to dir1.
+	loc0 := store.Locations[0]
+	ev0, found := loc0.FindEcVolume(vid)
+	if !found {
+		t.Fatalf("dir0 EcVolume %d not loaded after startup mirror", vid)
+	}
+	for _, sid := range []erasure_coding.ShardId{0, 12} {
+		if _, ok := ev0.FindEcVolumeShard(sid); !ok {
+			t.Errorf("shard %d not registered on dir0 after mirror", sid)
+		}
+	}
+	if got, want := filepath.Dir(ev0.FileName(".ecx")), dir0; got != want {
+		t.Errorf("dir0 EcVolume .ecx resolved at %q, want %q (local mirrored copy)", got, want)
+	}
+
+	// dir1 must keep its own self-contained mount for shard 1; the
+	// mirror does not touch the source.
+	loc1 := store.Locations[1]
+	ev1, found := loc1.FindEcVolume(vid)
+	if !found {
+		t.Fatalf("dir1 EcVolume %d not loaded after startup mirror", vid)
+	}
+	if _, ok := ev1.FindEcVolumeShard(1); !ok {
+		t.Errorf("dir1 shard 1 missing after mirror")
+	}
+
+	// Shards on dir0 must not have been destroyed by any cleanup path.
+	for _, sid := range []int{0, 12} {
+		shardPath := base0 + erasure_coding.ToExt(sid)
+		fi, err := os.Stat(shardPath)
+		if err != nil {
+			t.Errorf("shard %d on dir0 lost after mirror: %v", sid, err)
+			continue
+		}
+		if fi.Size() != expectedShardSize {
+			t.Errorf("shard %d on dir0 truncated by mirror pass: size %d, want %d", sid, fi.Size(), expectedShardSize)
+		}
+	}
+}
+
+// TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored guards against
+// the mirror pass rewriting sidecars that already match. Idempotency
+// matters because the pass runs on every startup; an unconditional
+// rewrite would slowly amplify into "fsync every EC volume's metadata
+// on boot," which is expensive on large clusters.
+func TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored(t *testing.T) {
+	tempDir := t.TempDir()
+	dir0 := filepath.Join(tempDir, "data1")
+	dir1 := filepath.Join(tempDir, "data2")
+	for _, d := range []string{dir0, dir1} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	collection := "video-recordings"
+	vid := needle.VolumeId(7777)
+	const dataShards, parityShards = 10, 4
+	const datSize int64 = 10 * 1024 * 1024
+	expectedShardSize := calculateExpectedShardSize(datSize, dataShards)
+
+	plantShard := func(dir string, shardId int) {
+		base := erasure_coding.EcShardFileName(collection, dir, int(vid))
+		f, err := os.Create(base + erasure_coding.ToExt(shardId))
+		if err != nil {
+			t.Fatalf("create shard %d in %s: %v", shardId, dir, err)
+		}
+		if err := f.Truncate(expectedShardSize); err != nil {
+			f.Close()
+			t.Fatalf("truncate shard %d in %s: %v", shardId, dir, err)
+		}
+		f.Close()
+	}
+
+	plantSidecars := func(dir string, ecx, ecj []byte) {
+		base := erasure_coding.EcShardFileName(collection, dir, int(vid))
+		if err := os.WriteFile(base+".ecx", ecx, 0o644); err != nil {
+			t.Fatalf("write %s.ecx: %v", base, err)
+		}
+		if err := os.WriteFile(base+".ecj", ecj, 0o644); err != nil {
+			t.Fatalf("write %s.ecj: %v", base, err)
+		}
+		if err := volume_info.SaveVolumeInfo(base+".vif", &volume_server_pb.VolumeInfo{
+			Version:     uint32(needle.Version3),
+			DatFileSize: datSize,
+			EcShardConfig: &volume_server_pb.EcShardConfig{
+				DataShards:   dataShards,
+				ParityShards: parityShards,
+			},
+		}); err != nil {
+			t.Fatalf("save %s.vif: %v", base, err)
+		}
+	}
+
+	plantShard(dir0, 0)
+	plantShard(dir0, 12)
+	plantShard(dir1, 1)
+
+	// Both dirs already have sidecars; we plant deliberately different
+	// .ecx bytes so we can prove the mirror does NOT clobber the
+	// pre-existing destination with the owner's copy. .ecx is the
+	// strongest signal here — unlike .vif, EcVolume never rewrites
+	// .ecx at mount, so any drift would be the mirror's fault.
+	ecxOwner := bytes.Repeat([]byte{0xC3}, 20)
+	ecxLocal := bytes.Repeat([]byte{0x5A}, 20)
+	ecjBytes := bytes.Repeat([]byte{0xD4}, 16)
+	plantSidecars(dir1, ecxOwner, ecjBytes)
+	plantSidecars(dir0, ecxLocal, ecjBytes)
+
+	base0 := erasure_coding.EcShardFileName(collection, dir0, int(vid))
+
+	store := NewStore(nil, "localhost", 8080, 18080, "http://localhost:8080", "store-id",
+		[]string{dir0, dir1},
+		[]int32{100, 100},
+		[]util.MinFreeSpace{{}, {}},
+		"",
+		NeedleMapInMemory,
+		[]types.DiskType{types.HardDriveType, types.HardDriveType},
+		nil,
+		3,
+	)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-store.NewEcShardsChan:
+			case <-store.NewVolumesChan:
+			case <-store.DeletedVolumesChan:
+			case <-store.DeletedEcShardsChan:
+			case <-store.StateUpdateChan:
+			case <-done:
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		store.Close()
+		close(done)
+	})
+
+	postEcx, err := os.ReadFile(base0 + ".ecx")
+	if err != nil {
+		t.Fatalf("read dir0 .ecx after NewStore: %v", err)
+	}
+	if !bytes.Equal(ecxLocal, postEcx) {
+		t.Errorf("dir0 .ecx was overwritten by mirror pass; pre-existing destination must be preserved (got first 4 bytes %x, want %x)",
+			postEcx[:4], ecxLocal[:4])
+	}
+
+	// And the volume must still mount on both disks with its own
+	// local .ecx — the same-disk invariant the mirror is here to
+	// preserve.
+	if loc0 := store.Locations[0]; loc0 == nil {
+		t.Fatal("loc0 unexpectedly nil")
+	} else if ev, found := loc0.FindEcVolume(vid); !found {
+		t.Errorf("dir0 EcVolume %d not loaded", vid)
+	} else if got, want := filepath.Dir(ev.FileName(".ecx")), dir0; got != want {
+		t.Errorf("dir0 .ecx resolved at %q, want %q", got, want)
+	}
+}

--- a/weed/storage/store_ec_reconcile.go
+++ b/weed/storage/store_ec_reconcile.go
@@ -79,6 +79,21 @@ func (s *Store) reconcileEcShardsAcrossDisks() {
 					key.vid, key.collection, loc.Directory, shards)
 				continue
 			}
+			// If mirrorEcMetadataToShardDisks already copied the sidecars
+			// onto this disk, prefer the local IdxDirectory: the shard
+			// then mounts self-contained and survives any subsequent
+			// failure of the owner disk. The cross-disk fallback below
+			// stays as the rescue path for volumes whose mirror failed
+			// (read-only target, out of space, partial copy on a previous
+			// boot, etc.).
+			if loc.HasEcxFileOnDisk(key.collection, key.vid) {
+				glog.V(0).Infof("ec volume %d (collection=%q): loading orphan shards %v on %s against locally-mirrored sidecars",
+					key.vid, key.collection, shards, loc.Directory)
+				if err := loc.loadEcShards(shards, key.collection, key.vid, loc.ecShardNotifyHandler); err != nil {
+					glog.Errorf("ec volume %d on %s: local-mirror shard load failed: %v", key.vid, loc.Directory, err)
+				}
+				continue
+			}
 			if owner.location == loc {
 				// .ecx is on this same disk, but loadAllEcShards still
 				// did not load these shards — handleFoundEcxFile already

--- a/weed/storage/store_ec_reconcile.go
+++ b/weed/storage/store_ec_reconcile.go
@@ -79,13 +79,9 @@ func (s *Store) reconcileEcShardsAcrossDisks() {
 					key.vid, key.collection, loc.Directory, shards)
 				continue
 			}
-			// If mirrorEcMetadataToShardDisks already copied the sidecars
-			// onto this disk, prefer the local IdxDirectory: the shard
-			// then mounts self-contained and survives any subsequent
-			// failure of the owner disk. The cross-disk fallback below
-			// stays as the rescue path for volumes whose mirror failed
-			// (read-only target, out of space, partial copy on a previous
-			// boot, etc.).
+			// Post-mirror fast path: when the local .ecx is present,
+			// mount self-contained against IdxDirectory instead of
+			// the owner disk.
 			if loc.HasEcxFileOnDisk(key.collection, key.vid) {
 				glog.V(0).Infof("ec volume %d (collection=%q): loading orphan shards %v on %s against locally-mirrored sidecars",
 					key.vid, key.collection, shards, loc.Directory)


### PR DESCRIPTION
## Summary

In a multi-disk volume server, `ec.balance` and `ec.rebuild` can land shards on a disk that does not also hold the matching `.ecx` / `.ecj` / `.vif` index files. The orphan-shard reconciler in `reconcileEcShardsAcrossDisks` (#9244) already loads those shards by pointing the `EcVolume` at the sibling disk's index files; reads work, but any failure on the index-owning disk silently disables every shard on the other disk, even though those shards are physically fine.

This change adds `mirrorEcMetadataToShardDisks`, a startup pass that physically replicates `.ecx` / `.ecj` / `.vif` onto each disk that holds shards but is missing them. After mirroring, the cross-disk reconciler prefers the local `IdxDirectory` so the `EcVolume` mounts self-contained.

## Why

The EC lifecycle (encode / decode / balance / vacuum / repair) was already documented as promising a same-disk layout — every shard alongside its own metadata — but nothing actively maintained that invariant when shards moved between disks of the same volume server. The cross-disk virtual mount was a working read path, not a self-healing one.

## Behavior

- **New shard-only disk at boot**: mirror copies `.ecx` / `.ecj` / `.vif` onto it. `reconcileEcShardsAcrossDisks` then loads via the local `IdxDirectory`, so the disk is self-contained from this boot forward.
- **Disk already self-contained**: mirror is a no-op.
- **Pre-existing destination sidecar with different bytes**: preserved (not overwritten) — the local copy is treated as authoritative.
- **Mirror fails (read-only target, out of space, …)**: warn + fall through to the existing cross-disk virtual mount so the cluster stays available.

Each copy is atomic (`<dst>.mirror.tmp` + `fsync` + `rename`). The pass runs once per `Store.NewStore` (and once per `LoadNewVolumes` for the hot-add path).

## Test plan

- [x] New unit tests in `store_ec_mirror_test.go`:
  - `TestMirrorEcMetadataOnStartup_PhysicallyCopiesSidecars`: orphan layout (shards on dir0, sidecars on dir1) → after `NewStore`, dir0 has byte-identical `.ecx` / `.ecj` copies and a valid `.vif`, and its `EcVolume` resolves `.ecx` against dir0.
  - `TestMirrorEcMetadataOnStartup_NoOpWhenAlreadyMirrored`: dir0 already has a different `.ecx` than dir1 → mirror does NOT overwrite the local copy.
- [x] Existing `TestLoadEcShardsWhenIndexFilesOnDifferentDisk`, `TestReconcileNoOpWhenEachDiskIsSelfContained`, `TestMountEcShards_LocatesEcxOnSiblingDisk`, `TestMountEcShards_SameDiskEcxStillWorks` all still pass.
- [x] `go test ./weed/storage/...` full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a startup pass that physically mirrors erasure-coding sidecar metadata onto shard-bearing disks so mounts prefer same-disk metadata. Mirroring is idempotent, atomic, preserves existing local sidecars, logs failures, and falls back to cross-disk mounting when needed. Orphan-shard reconciliation now prefers mirrored local metadata.

* **Tests**
  * Added unit tests validating atomic startup copying and no‑op behavior when sidecars already exist.
  * Updated lifecycle test to accept rebuilt shards appearing on either disk.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->