### PR TITLE
fix(mount): don't release file handles from FUSE Forget

### DIFF
--- a/weed/mount/filehandle_map.go
+++ b/weed/mount/filehandle_map.go
@@ -66,31 +66,6 @@ func (i *FileHandleToInode) AcquireFileHandle(wfs *WFS, inode uint64, entry *fil
 	return fh
 }
 
-func (i *FileHandleToInode) ReleaseByInode(inode uint64) *FileHandle {
-	i.Lock()
-	defer i.Unlock()
-	fh, found := i.inode2fh[inode]
-	if !found {
-		return nil
-	}
-	// If the counter is already <= 0, a prior Release already started the
-	// drain.  Return nil to prevent double-processing (e.g. Forget after Release).
-	if fh.counter <= 0 {
-		return nil
-	}
-	fh.counter--
-	if fh.counter <= 0 {
-		if fh.asyncFlushPending {
-			// Handle stays in fhMap so rename/unlink can find it during drain.
-			return fh
-		}
-		delete(i.inode2fh, inode)
-		delete(i.fh2inode, fh.fh)
-		return fh
-	}
-	return nil
-}
-
 func (i *FileHandleToInode) ReleaseByHandle(fh FileHandleId) *FileHandle {
 	i.Lock()
 	defer i.Unlock()

--- a/weed/mount/weedfs_forget.go
+++ b/weed/mount/weedfs_forget.go
@@ -63,13 +63,11 @@ Side effects: increments the lookup count on success
 
 */
 func (wfs *WFS) Forget(nodeid, nlookup uint64) {
+	// Forget only decrements the kernel's inode lookup count.  File handle
+	// lifecycle is driven independently by FUSE Open/Release — touching the
+	// fhMap here would couple two unrelated refcounts and could tear down a
+	// still-live handle if Forget ever raced ahead of Release.
 	wfs.inodeToPath.Forget(nodeid, nlookup, func(dir util.FullPath) {
 		wfs.metaCache.DeleteFolderChildren(context.Background(), dir)
 	})
-	// ReleaseByInode returns nil if the handle is already draining (counter
-	// was already <= 0 from a prior Release).  Only non-async handles that
-	// reach counter 0 here need cleanup.
-	if fhToRelease := wfs.fhMap.ReleaseByInode(nodeid); fhToRelease != nil {
-		fhToRelease.ReleaseHandle()
-	}
 }


### PR DESCRIPTION
## Summary

`Forget(nodeid, nlookup)` is the kernel telling us its inode lookup count dropped. It is independent of file handle lifecycle, which is driven by FUSE `Open`/`Release`. The existing implementation called `fhMap.ReleaseByInode(nodeid)` from `Forget`, decrementing the file handle counter and potentially deleting the handle entirely.

In normal flow this didn't fire — libfuse only sends `forget` for an open file after `release`, and the `counter <= 0` guard in `ReleaseByInode` made the call a no-op. But it coupled two unrelated refcounts and would tear down a still-live handle if `Forget` ever raced ahead of `Release` (kernel quirks, or future paths that hold FH refs without a matching FUSE open).

This change makes `Forget` do only what its name says — decrement the inode lookup count via `inodeToPath.Forget`. `ReleaseByInode` becomes unused and is removed.

Reported by @1978629634.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file handle cleanup logic to better decouple handle lifecycle management from metadata forget operations, ensuring handles are released independently through their respective FUSE operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->