### PR TITLE
fix(filer): load -s3.config static identities into the filer's CredentialManager

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -236,6 +236,12 @@ func runFiler(cmd *Command, args []string) bool {
 	filerSftpOptions.resolvePaths()
 	util.LoadSecurityConfiguration()
 
+	// Share the S3 static identity config file with the filer regardless of
+	// whether the embedded S3 gateway runs on this node: the IAM gRPC service
+	// the admin UI and weed shell talk to is wired up unconditionally, and it
+	// needs the same identities the S3 server would load from -s3.config.
+	f.s3ConfigFile = filerS3Options.config
+
 	switch {
 	case *f.metricsHttpIp != "":
 		// noting to do, use f.metricsHttpIp


### PR DESCRIPTION
## Summary
- When `weed filer` started its embedded S3 gateway with `-s3 -s3.config`, only the S3 server loaded the `s3.json` static identities. The filer's own `CredentialManager` stayed empty, so the IAM gRPC service backing the admin UI and `weed shell` returned only dynamic users.
- Mirror the wiring `weed server` already does and hand the same config path to the filer.

Fixes #9533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures S3 credential configuration is loaded into the IAM service during filer startup, improving identity handling for S3 operations. This resolves issues where S3 access could fail or use incorrect credentials, leading to more reliable authentication and fewer access errors when interacting with S3-backed storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->