### PR TITLE
fix(s3): keep host-less bucket catch-all so reverse proxies work

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -684,9 +684,12 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 			routers = append(routers, apiRouter.Host(
 				fmt.Sprintf("%s.%s", "{bucket:.+}", virtualHost)).Subrouter())
 		}
-	} else {
-		routers = append(routers, apiRouter.PathPrefix("/{bucket}").Subrouter())
 	}
+	// Always register a Host-less path-style catch-all last so requests that
+	// arrive via an IP, an unlisted hostname, or a reverse proxy that rewrites
+	// the Host header still match bucket routes. Host-specific routers above
+	// take precedence because they were registered first.
+	routers = append(routers, apiRouter.PathPrefix("/{bucket}").Subrouter())
 
 	// Get CORS middleware instance with caching
 	corsMiddleware := s3a.getCORSMiddleware()

--- a/weed/s3api/s3api_server_routing_test.go
+++ b/weed/s3api/s3api_server_routing_test.go
@@ -296,3 +296,43 @@ func TestRouting_IAMMatcherLogic(t *testing.T) {
 		})
 	}
 }
+
+// TestRouting_BucketRouteMatchesAnyHost is a regression test for issue #9539.
+// When DomainName is configured, bucket-prefix routes must still match for
+// requests whose Host header does not match a configured domain (for example,
+// requests forwarded by a reverse proxy that rewrites Host to an internal
+// upstream address). A Host-less path-style catch-all is registered after the
+// host-specific routers so it only fires when no Host matcher applies.
+func TestRouting_BucketRouteMatchesAnyHost(t *testing.T) {
+	cases := []struct {
+		name       string
+		domainName string
+		host       string
+	}{
+		{"virtual-host domain configured, request via IP", "s3.example.com", "10.0.0.5:8333"},
+		{"virtual-host domain configured, request via unrelated host", "s3.example.com", "internal-upstream:8333"},
+		{"path-style + virtual-host configured, request via IP", "s3.example.com,api.s3.example.com", "10.0.0.5:8333"},
+		{"domain configured, request via the bare configured host (no bucket subdomain)", "s3.example.com", "s3.example.com"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := mux.NewRouter()
+			s3a := setupRoutingTestServer(t)
+			s3a.option.DomainName = tc.domainName
+			s3a.registerRouter(router)
+
+			req, _ := http.NewRequest(http.MethodHead, "http://"+tc.host+"/some-bucket", nil)
+			req.Host = tc.host
+
+			var match mux.RouteMatch
+			if !router.Match(req, &match) {
+				t.Fatalf("expected HEAD /some-bucket with Host=%q to match a bucket route (domainName=%q); got no match (err=%v)",
+					tc.host, tc.domainName, match.MatchErr)
+			}
+			if match.MatchErr != nil {
+				t.Fatalf("route matched but reported error: %v", match.MatchErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Symptom

On 4.26, `mc ls <alias>/` against `weed s3` behind a reverse proxy (e.g. Caddy) returns 503, while hitting the s3 port directly works. 4.25 was fine.

## Cause

In 4.26, the path-style ListBuckets fix moved the host-less catch-all `apiRouter.PathPrefix("/{bucket}")` into an `else` branch. Once `s3.domainName` is set, every bucket-prefix route is gated on a Host matcher. Requests that arrive via an IP, an unlisted hostname, or a reverse proxy that rewrites Host miss every router and fall through to `NotFoundHandler` (405) — which Caddy then surfaces to mc as 503.

Was actually flagged in the original PR review but merged anyway.

## Fix

Register the path-style catch-all unconditionally, after the host-specific routers. Host-specific routes still win when their matcher applies (registered first); the catch-all only fires for everything else. Mirrors the 4.25 behavior.

## Test

Added `TestRouting_BucketRouteMatchesAnyHost` covering IP, unrelated host, and bare-configured-host with `domainName` set. Verified it fails on the unfixed code with "no matching route was found" and passes after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed bucket routing to ensure requests are properly matched in all configurations, including when domain-based routing is enabled.

* **Tests**
  * Added test coverage for bucket route matching in domain-based routing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->