### PR TITLE
fix(ec_balance): skip volumes with pending erasure_coding tasks

### DIFF
--- a/weed/worker/tasks/ec_balance/detection.go
+++ b/weed/worker/tasks/ec_balance/detection.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/seaweedfs/seaweedfs/weed/admin/topology"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
@@ -94,19 +93,23 @@ func Detection(
 		return nil, false, nil
 	}
 
-	// Exclude volumes that have a pending or in-flight erasure-coding task.
-	// Encoding and repair both register as TaskTypeErasureCoding; moving
-	// shards on a volume mid-encode is the race that produces the
-	// "shard 58.2 balanced while encoding is retrying" symptom — partial
-	// shard sets get rearranged while the encode is still trying to mount
-	// the original layout, leaving orphan and duplicate shards behind.
-	skippedDueToEC := 0
+	// Exclude volumes with any pending or in-flight task. The motivating
+	// race is EC encoding/repair vs ec_balance — moving shards on a volume
+	// mid-encode produces the "shard 58.2 balanced while encoding is
+	// retrying" symptom: partial shard sets get rearranged while the
+	// encode is still trying to mount the original layout, leaving orphan
+	// and duplicate shards behind. The broader filter (HasAnyTask) also
+	// keeps redundant ec_balance proposals from piling up on a volume
+	// whose earlier balance move hasn't completed yet, and keeps any
+	// other maintenance operation that touches the volume from racing
+	// with shard moves.
+	skippedDueToTasks := 0
 	for collection, volumeIDs := range collections {
 		filtered := volumeIDs[:0]
 		for _, vid := range volumeIDs {
-			if clusterInfo.ActiveTopology.HasTask(vid, topology.TaskTypeErasureCoding) {
-				skippedDueToEC++
-				glog.V(2).Infof("EC balance: skip volume %d (collection=%q) because an erasure_coding task is pending or in flight", vid, collection)
+			if clusterInfo.ActiveTopology.HasAnyTask(vid) {
+				skippedDueToTasks++
+				glog.V(2).Infof("EC balance: skip volume %d (collection=%q) because a task is pending or in flight", vid, collection)
 				continue
 			}
 			filtered = append(filtered, vid)
@@ -117,8 +120,8 @@ func Detection(
 			collections[collection] = filtered
 		}
 	}
-	if skippedDueToEC > 0 {
-		glog.V(1).Infof("EC balance: skipped %d volume(s) with active erasure_coding tasks", skippedDueToEC)
+	if skippedDueToTasks > 0 {
+		glog.V(1).Infof("EC balance: skipped %d volume(s) with active tasks", skippedDueToTasks)
 	}
 	if len(collections) == 0 {
 		return nil, false, nil

--- a/weed/worker/tasks/ec_balance/detection.go
+++ b/weed/worker/tasks/ec_balance/detection.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/admin/topology"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
@@ -90,6 +91,36 @@ func Detection(
 	collections := collectECCollections(nodes, ecConfig)
 	if len(collections) == 0 {
 		glog.V(1).Infof("EC balance: no EC volumes found matching filters")
+		return nil, false, nil
+	}
+
+	// Exclude volumes that have a pending or in-flight erasure-coding task.
+	// Encoding and repair both register as TaskTypeErasureCoding; moving
+	// shards on a volume mid-encode is the race that produces the
+	// "shard 58.2 balanced while encoding is retrying" symptom — partial
+	// shard sets get rearranged while the encode is still trying to mount
+	// the original layout, leaving orphan and duplicate shards behind.
+	skippedDueToEC := 0
+	for collection, volumeIDs := range collections {
+		filtered := volumeIDs[:0]
+		for _, vid := range volumeIDs {
+			if clusterInfo.ActiveTopology.HasTask(vid, topology.TaskTypeErasureCoding) {
+				skippedDueToEC++
+				glog.V(2).Infof("EC balance: skip volume %d (collection=%q) because an erasure_coding task is pending or in flight", vid, collection)
+				continue
+			}
+			filtered = append(filtered, vid)
+		}
+		if len(filtered) == 0 {
+			delete(collections, collection)
+		} else {
+			collections[collection] = filtered
+		}
+	}
+	if skippedDueToEC > 0 {
+		glog.V(1).Infof("EC balance: skipped %d volume(s) with active erasure_coding tasks", skippedDueToEC)
+	}
+	if len(collections) == 0 {
 		return nil, false, nil
 	}
 

--- a/weed/worker/tasks/ec_balance/detection_test.go
+++ b/weed/worker/tasks/ec_balance/detection_test.go
@@ -640,12 +640,11 @@ func buildUnbalancedTwoVolumeTopology() *master_pb.TopologyInfo {
 }
 
 // TestDetection_ExcludesVolumesWithPendingErasureCodingTask verifies that
-// a volume with an in-flight (pending or assigned) erasure_coding task is
-// dropped from the ec_balance scan. Without this filter, ec_balance would
-// happily move shards of a volume that EC encoding is still trying to
-// complete — exactly the race observed where an encode retry repeatedly
-// failed and ec_balance moved shards in between attempts, leaving orphan
-// and duplicate shards on disk.
+// a volume with an in-flight erasure_coding task is dropped from the
+// ec_balance scan. The filter is HasAnyTask, so this is the motivating
+// case (encoding/repair race) but the same filter also protects against
+// other in-flight maintenance. The companion test below pins the
+// "previous ec_balance task on the same volume also blocks" behavior.
 func TestDetection_ExcludesVolumesWithPendingErasureCodingTask(t *testing.T) {
 	topoInfo := buildUnbalancedTwoVolumeTopology()
 	at := topology.NewActiveTopology(10)
@@ -691,9 +690,50 @@ func TestDetection_ExcludesVolumesWithPendingErasureCodingTask(t *testing.T) {
 	}
 }
 
+// TestDetection_ExcludesVolumesWithPendingEcBalanceTask pins the broader
+// HasAnyTask filter: a previously-queued ec_balance task on the same
+// volume should also block a new round of detection from piling on more
+// moves before the first one has been applied to topology.
+func TestDetection_ExcludesVolumesWithPendingEcBalanceTask(t *testing.T) {
+	topoInfo := buildUnbalancedTwoVolumeTopology()
+	at := topology.NewActiveTopology(10)
+	if err := at.UpdateTopology(topoInfo); err != nil {
+		t.Fatalf("UpdateTopology: %v", err)
+	}
+
+	err := at.AddPendingTask(topology.TaskSpec{
+		TaskID:     "ec-balance-100-prev",
+		TaskType:   topology.TaskTypeECBalance,
+		VolumeID:   100,
+		VolumeSize: 1 << 30,
+		Sources: []topology.TaskSourceSpec{
+			{ServerID: "server1:8080", DiskID: 0},
+		},
+		Destinations: []topology.TaskDestinationSpec{
+			{ServerID: "server3:8080", DiskID: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddPendingTask: %v", err)
+	}
+
+	cfg := NewDefaultConfig()
+	cfg.MinServerCount = 1
+
+	results, _, err := Detection(context.Background(), nil, &types.ClusterInfo{ActiveTopology: at}, cfg, 0)
+	if err != nil {
+		t.Fatalf("Detection: %v", err)
+	}
+	for _, r := range results {
+		if r.VolumeID == 100 {
+			t.Errorf("ec_balance emitted a move for volume 100 while a previous ec_balance task is still pending: %s", r.Reason)
+		}
+	}
+}
+
 // TestDetection_NoExclusionWhenNoActiveTask is a regression guard so the
 // filter does not accidentally drop volumes when ActiveTopology has no
-// erasure_coding task — the imbalance is still real and must be acted on.
+// task — the imbalance is still real and must be acted on.
 func TestDetection_NoExclusionWhenNoActiveTask(t *testing.T) {
 	topoInfo := buildUnbalancedTwoVolumeTopology()
 	at := topology.NewActiveTopology(10)

--- a/weed/worker/tasks/ec_balance/detection_test.go
+++ b/weed/worker/tasks/ec_balance/detection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/seaweedfs/seaweedfs/weed/admin/topology"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/worker/types"
@@ -585,3 +586,142 @@ func TestExceedsImbalanceThreshold(t *testing.T) {
 
 // helper to avoid unused import
 var _ = erasure_coding.DataShardsCount
+
+// buildUnbalancedTwoVolumeTopology returns a topology where two EC volumes
+// each have all 14 shards stacked on one node, so the detection algorithm
+// has imbalance to act on. Both servers are on the same rack so the
+// imbalance shows up in phase 3 (within-rack) and phase 4 (global).
+func buildUnbalancedTwoVolumeTopology() *master_pb.TopologyInfo {
+	mkNode := func(id string, volumeID uint32) *master_pb.DataNodeInfo {
+		return &master_pb.DataNodeInfo{
+			Id:      id,
+			Address: id,
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"hdd": {
+					Type:            "hdd",
+					MaxVolumeCount:  100,
+					FreeVolumeCount: 50,
+					EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+						{Id: volumeID, Collection: "c", EcIndexBits: 0x3FFF, DiskId: 0},
+					},
+				},
+			},
+		}
+	}
+	return &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{
+			{
+				Id: "dc1",
+				RackInfos: []*master_pb.RackInfo{
+					{
+						Id: "rack1",
+						DataNodeInfos: []*master_pb.DataNodeInfo{
+							mkNode("server1:8080", 100),
+							mkNode("server2:8080", 200),
+							// Third server is empty — phase 3 / 4 will
+							// propose moves to spread shards onto it.
+							{
+								Id:      "server3:8080",
+								Address: "server3:8080",
+								DiskInfos: map[string]*master_pb.DiskInfo{
+									"hdd": {
+										Type:            "hdd",
+										MaxVolumeCount:  100,
+										FreeVolumeCount: 100,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestDetection_ExcludesVolumesWithPendingErasureCodingTask verifies that
+// a volume with an in-flight (pending or assigned) erasure_coding task is
+// dropped from the ec_balance scan. Without this filter, ec_balance would
+// happily move shards of a volume that EC encoding is still trying to
+// complete — exactly the race observed where an encode retry repeatedly
+// failed and ec_balance moved shards in between attempts, leaving orphan
+// and duplicate shards on disk.
+func TestDetection_ExcludesVolumesWithPendingErasureCodingTask(t *testing.T) {
+	topoInfo := buildUnbalancedTwoVolumeTopology()
+	at := topology.NewActiveTopology(10)
+	if err := at.UpdateTopology(topoInfo); err != nil {
+		t.Fatalf("UpdateTopology: %v", err)
+	}
+
+	// Volume 100 has a pending EC encoding task; volume 200 does not.
+	// The detector should produce moves for 200 but skip 100 entirely.
+	err := at.AddPendingTask(topology.TaskSpec{
+		TaskID:     "ec-encode-100",
+		TaskType:   topology.TaskTypeErasureCoding,
+		VolumeID:   100,
+		VolumeSize: 1 << 30,
+		Sources: []topology.TaskSourceSpec{
+			{ServerID: "server1:8080", DiskID: 0},
+		},
+		Destinations: []topology.TaskDestinationSpec{
+			{ServerID: "server3:8080", DiskID: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddPendingTask: %v", err)
+	}
+
+	cfg := NewDefaultConfig()
+	cfg.MinServerCount = 1
+
+	clusterInfo := &types.ClusterInfo{ActiveTopology: at}
+
+	results, _, err := Detection(context.Background(), nil, clusterInfo, cfg, 0)
+	if err != nil {
+		t.Fatalf("Detection: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatalf("expected ec_balance moves for volume 200; got none")
+	}
+	for _, r := range results {
+		if r.VolumeID == 100 {
+			t.Errorf("ec_balance emitted a move for volume 100 while an erasure_coding task is pending: %s", r.Reason)
+		}
+	}
+}
+
+// TestDetection_NoExclusionWhenNoActiveTask is a regression guard so the
+// filter does not accidentally drop volumes when ActiveTopology has no
+// erasure_coding task — the imbalance is still real and must be acted on.
+func TestDetection_NoExclusionWhenNoActiveTask(t *testing.T) {
+	topoInfo := buildUnbalancedTwoVolumeTopology()
+	at := topology.NewActiveTopology(10)
+	if err := at.UpdateTopology(topoInfo); err != nil {
+		t.Fatalf("UpdateTopology: %v", err)
+	}
+
+	cfg := NewDefaultConfig()
+	cfg.MinServerCount = 1
+
+	results, _, err := Detection(context.Background(), nil, &types.ClusterInfo{ActiveTopology: at}, cfg, 0)
+	if err != nil {
+		t.Fatalf("Detection: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("expected ec_balance moves when no erasure_coding tasks are in flight; got none")
+	}
+
+	saw100, saw200 := false, false
+	for _, r := range results {
+		if r.VolumeID == 100 {
+			saw100 = true
+		}
+		if r.VolumeID == 200 {
+			saw200 = true
+		}
+	}
+	if !saw100 || !saw200 {
+		t.Errorf("expected moves for both volumes; saw100=%v saw200=%v", saw100, saw200)
+	}
+}


### PR DESCRIPTION
## Summary

- The ec_balance detector built its move list directly from topology with no check against in-flight EC encoding or repair work. A volume that EC encoding was still trying to complete (or retrying after a failed mount) could see its shards moved by ec_balance in between attempts.
- The race produces exactly the symptom operators see in multi-disk EC clusters: a failed encode of a volume leaves a partial shard layout, ec_balance moves a shard to a different node, the encode retries against the now-rearranged layout, and the final state is orphan + duplicate shards spread across nodes — even though no single component "fails."
- After ``collectECCollections``, filter each collection's volume id list against ``clusterInfo.ActiveTopology.HasTask(vid, TaskTypeErasureCoding)``. ``TaskTypeErasureCoding`` covers both initial encode and repair, so one filter closes both races. Phases 1-3 use the filtered map directly; phase 4 (global) already honors ``allowedVids``, so removing a vid from the map also removes it from ``allowedVids``.

## Test plan

- [x] ``go test ./weed/worker/tasks/ec_balance/...``
- [x] New ``TestDetection_ExcludesVolumesWithPendingErasureCodingTask`` — a pending encoding task on one of two imbalanced volumes; only the other one gets moves.
- [x] New ``TestDetection_NoExclusionWhenNoActiveTask`` — both volumes get moves when no encoding tasks are pending, regression guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exclude volumes that have active or pending erasure-coding tasks from rebalancing detection, skip and log them, and avoid producing results when no eligible collections remain.
* **Tests**
  * Added regression tests covering exclusion behavior and ensuring detection still produces moves when no active tasks exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->