### PR TITLE
fix(test): reserve mini ports on all interfaces; bound risingwave cleanup shell

### DIFF
--- a/test/s3tables/catalog_risingwave/setup_test.go
+++ b/test/s3tables/catalog_risingwave/setup_test.go
@@ -411,7 +411,12 @@ func createIcebergTable(t *testing.T, env *TestEnvironment, bucketName, namespac
 func listFilerContents(t *testing.T, env *TestEnvironment, path string) {
 	t.Helper()
 
-	cmd := exec.Command("weed", "shell",
+	// Bound diagnostic listing so a hung weed shell during cleanup can't
+	// burn the whole 20-minute test timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "weed", "shell",
 		fmt.Sprintf("-master=%s", env.hostMasterAddress()),
 	)
 	cmd.Stdin = strings.NewReader(fmt.Sprintf("fs.ls -R %s\nexit\n", path))

--- a/test/testutil/ports.go
+++ b/test/testutil/ports.go
@@ -51,6 +51,13 @@ func MustAllocatePorts(t *testing.T, count int) []int {
 // from recycling ports between allocations. Use this when ports will be
 // passed to weed mini without explicit gRPC port flags, so mini will
 // derive gRPC ports as HTTP + 10000.
+//
+// Listeners are bound on all interfaces (":port") rather than 127.0.0.1
+// to match weed mini's availability check (isPortAvailable). A port can
+// be free on loopback but held by another process on a different
+// interface; reserving only on loopback lets mini's check fail and
+// trigger gRPC port shifting, which then causes weed shell to dial the
+// wrong port and hang.
 func AllocateMiniPorts(count int) ([]int, error) {
 	const (
 		minPort = 10000
@@ -75,12 +82,12 @@ func AllocateMiniPorts(count int) ([]int, error) {
 				continue
 			}
 
-			l1, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			l1, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 			if err != nil {
 				continue
 			}
 
-			l2, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", grpcPort))
+			l2, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
 			if err != nil {
 				l1.Close()
 				continue
@@ -145,11 +152,11 @@ func AllocatePortSet(miniCount, regularCount int) (mini []int, regular []int, er
 			if reserved[port] || reserved[grpcPort] {
 				continue
 			}
-			l1, lErr := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			l1, lErr := net.Listen("tcp", fmt.Sprintf(":%d", port))
 			if lErr != nil {
 				continue
 			}
-			l2, lErr := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", grpcPort))
+			l2, lErr := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
 			if lErr != nil {
 				l1.Close()
 				continue
@@ -168,7 +175,7 @@ func AllocatePortSet(miniCount, regularCount int) (mini []int, regular []int, er
 
 	regular = make([]int, 0, regularCount)
 	for i := 0; i < regularCount; i++ {
-		l, lErr := net.Listen("tcp", "127.0.0.1:0")
+		l, lErr := net.Listen("tcp", ":0")
 		if lErr != nil {
 			return nil, nil, lErr
 		}


### PR DESCRIPTION
## Summary

`MustFreeMiniPorts` reserved listener ports on `127.0.0.1` only, but `weed mini`'s availability check binds on all interfaces (`isPortAvailable` listens on `:port`). When another process held the master gRPC port on a non-loopback interface, mini logged `gRPC port N for Master is not available, finding alternative...` and shifted to a different gRPC port. `weed shell -master=<HOST:HTTP_PORT>` still derives gRPC as `HTTP+10000`, so it dialed the original unused port and hung until the 30s context deadline killed it.

Bind the reservation listeners on `:port` in `AllocateMiniPorts` and `AllocatePortSet` so a reserved port is guaranteed free on every interface mini checks.

Independently, `listFilerContents` in `catalog_risingwave` used `exec.Command` with no timeout. When it hit the same hang during failure-cleanup, it consumed the entire 20-minute Go test timeout and produced the panic stack in the run log. Switched it to a 30s `exec.CommandContext`.

Reproduced from https://github.com/seaweedfs/seaweedfs/actions/runs/26056770736/job/76606706419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test cleanup operations that could cause extended timeouts and excessive runtime delays when shutting down tests.
  * Improved port availability detection to properly check all network interfaces instead of only loopback, preventing false port conflicts and gRPC port shifting issues.

* **Documentation**
  * Expanded documentation describing port binding behavior and its relationship to network interface availability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->