### PR TITLE
volume: accept legacy needle CRC encoding on read

### DIFF
--- a/weed/storage/needle/needle_read_tail.go
+++ b/weed/storage/needle/needle_read_tail.go
@@ -13,10 +13,10 @@ func (n *Needle) readNeedleTail(needleBody []byte, version Version) error {
 	if len(n.Data) > 0 {
 		expectedChecksum := CRC(util.BytesToUint32(needleBody[0:NeedleChecksumSize]))
 		dataChecksum := NewCRC(n.Data)
-		if expectedChecksum != dataChecksum {
-			// the crc.Value() function is to be deprecated. this double checking is for backward compatibility
-			// with seaweed version using crc.Value() instead of uint32(crc), which appears in commit 056c480eb
-			// and switch appeared in version 3.09.
+		if expectedChecksum != dataChecksum && uint32(expectedChecksum) != dataChecksum.Value() {
+			// crc.Value() is the deprecated legacy transform used before commit 056c480eb
+			// (volume server <3.09). Accept either encoding so .dat files written by older
+			// versions still verify after an upgrade.
 			stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorCRC).Inc()
 			return fmt.Errorf("invalid CRC for needle %v (got %08x, want %08x), data on disk corrupted: %w", n.Id, dataChecksum, expectedChecksum, ErrorCorrupted)
 		}

--- a/weed/storage/needle/needle_read_tail_test.go
+++ b/weed/storage/needle/needle_read_tail_test.go
@@ -1,0 +1,53 @@
+package needle
+
+import (
+	"testing"
+
+	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// .dat files written by volume server versions prior to 3.09 (before commit
+// 056c480eb) store the needle checksum using the legacy CRC.Value() transform.
+// Reads of such needles must still verify after an upgrade.
+func TestReadNeedleTailLegacyChecksum(t *testing.T) {
+	data := []byte("hello seaweed")
+	rawChecksum := NewCRC(data)
+	legacyChecksum := rawChecksum.Value()
+
+	tail := make([]byte, NeedleChecksumSize+TimestampSize)
+	util.Uint32toBytes(tail[0:NeedleChecksumSize], legacyChecksum)
+
+	n := &Needle{Data: data}
+	if err := n.readNeedleTail(tail, Version3); err != nil {
+		t.Fatalf("legacy checksum should verify, got %v", err)
+	}
+	if n.Checksum != rawChecksum {
+		t.Fatalf("expected raw checksum stored, got %x want %x", uint32(n.Checksum), uint32(rawChecksum))
+	}
+}
+
+func TestReadNeedleTailRawChecksum(t *testing.T) {
+	data := []byte("hello seaweed")
+	rawChecksum := NewCRC(data)
+
+	tail := make([]byte, NeedleChecksumSize+TimestampSize)
+	util.Uint32toBytes(tail[0:NeedleChecksumSize], uint32(rawChecksum))
+
+	n := &Needle{Data: data}
+	if err := n.readNeedleTail(tail, Version3); err != nil {
+		t.Fatalf("raw checksum should verify, got %v", err)
+	}
+}
+
+func TestReadNeedleTailCorrupted(t *testing.T) {
+	data := []byte("hello seaweed")
+
+	tail := make([]byte, NeedleChecksumSize+TimestampSize)
+	util.Uint32toBytes(tail[0:NeedleChecksumSize], 0xdeadbeef)
+
+	n := &Needle{Data: data}
+	if err := n.readNeedleTail(tail, Version3); err == nil {
+		t.Fatal("expected CRC mismatch error, got nil")
+	}
+}


### PR DESCRIPTION
Volumes written by versions before 3.09 (commit 056c480eb, June 2022) store the needle checksum using the deprecated `CRC.Value()` transform: `(crc>>15 | crc<<17) + 0xa282ead8`. Versions after that store the raw `uint32(crc)`. The verifier originally accepted both, but when the read path was refactored into `readNeedleTail`, the fallback was dropped and only a comment about it remains.

The result: a `.dat` file copied from an old install (e.g. 1.18) fails verification on modern volume servers with `invalid CRC ... data on disk corrupted`, even though the bytes are intact. `weed fix` doesn't help because it only rebuilds the `.idx`; the checksum lives in the `.dat`.

This restores the dual check, matching the fallback that still exists on the `ReadNeedleData` path in `volume_read.go`. Added unit tests covering legacy-encoded, raw-encoded, and genuinely corrupt tails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward compatibility for data file checksum validation, allowing proper verification of files created with earlier versions.

* **Tests**
  * Added test coverage for checksum verification across legacy and current formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->