### PR TITLE
fix(volume): tombstone integrity check no longer flips volumes read-only (fixes #9563)

### DIFF
--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -3592,6 +3592,57 @@ mod tests {
         assert!(matches!(err, VolumeError::Deleted));
     }
 
+    // Guard the Rust integrity-check tombstone path against the Go regression
+    // where verifyDeletedNeedleIntegrity forwarded TombstoneFileSize into the
+    // needle-size check, mismatched against the on-disk Size=0 header, and
+    // sent every volume with a trailing deletion read-only on load. The Rust
+    // check guards its size comparison with !size.is_deleted(); this test
+    // keeps that guarantee from silently regressing.
+    #[test]
+    fn test_check_volume_data_integrity_with_deletion_tombstone() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        {
+            let mut v = make_test_volume(dir);
+            for i in 1..=3 {
+                let data = format!("data {}", i);
+                let mut n = Needle {
+                    id: NeedleId(i),
+                    cookie: Cookie(i as u32),
+                    data: data.as_bytes().to_vec(),
+                    data_size: data.len() as u32,
+                    ..Needle::default()
+                };
+                v.write_needle(&mut n, true).unwrap();
+            }
+            v.delete_needle(&mut Needle {
+                id: NeedleId(2),
+                cookie: Cookie(2),
+                ..Needle::default()
+            })
+            .unwrap();
+            v.sync_to_disk().unwrap();
+        }
+
+        let v = Volume::new(
+            dir,
+            dir,
+            "",
+            VolumeId(1),
+            NeedleMapKind::InMemory,
+            None,
+            None,
+            0,
+            Version::current(),
+        )
+        .unwrap();
+        assert!(
+            !v.is_no_write_or_delete(),
+            "volume should not be read-only after reload with trailing deletion tombstone"
+        );
+    }
+
     #[test]
     fn test_volume_multiple_needles() {
         let tmp = TempDir::new().unwrap();

--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -243,7 +243,11 @@ func verifyNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version,
 
 func verifyDeletedNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version, offset int64, key types.NeedleId) (lastAppendAtNs uint64, err error) {
 	n := new(needle.Needle)
-	size := types.TombstoneFileSize
+	// Tombstones are appended with DataSize=0, so the on-disk header carries
+	// Size=0. TombstoneFileSize (-1) lives only in the .idx; passing it to
+	// ReadData fails the size check and triggers the 32GB wrap-around retry,
+	// which reads past EOF and falsely marks the volume read-only.
+	size := types.Size(0)
 	if err = n.ReadData(datFile, offset, size, v); err != nil {
 		return n.AppendAtNs, fmt.Errorf("read data [%d,%d) : %v", offset, offset+needle.GetActualSize(size, v), err)
 	}

--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -154,8 +154,14 @@ func doCheckAndFixVolumeData(v *Volume, indexFile *os.File, indexOffset int64) (
 		return 0, nil
 	}
 	if size < 0 {
-		// read the deletion entry
+		// read the deletion entry. Pass io.EOF and ErrorSizeMismatch through
+		// unwrapped so CheckVolumeDataIntegrity can recognize them and run its
+		// trailing-truncation / wrap-around recovery loop, matching the live
+		// branch below.
 		if lastAppendAtNs, err = verifyDeletedNeedleIntegrity(v.DataBackend, v.Version(), offset.ToActualOffset(), key); err != nil {
+			if err == io.EOF || err == ErrorSizeMismatch {
+				return lastAppendAtNs, err
+			}
 			return lastAppendAtNs, fmt.Errorf("verifyDeletedNeedleIntegrity %s failed: %v", indexFile.Name(), err)
 		}
 	} else {
@@ -249,6 +255,11 @@ func verifyDeletedNeedleIntegrity(datFile backend.BackendStorageFile, v needle.V
 	// which reads past EOF and falsely marks the volume read-only.
 	size := types.Size(0)
 	if err = n.ReadData(datFile, offset, size, v); err != nil {
+		// Preserve io.EOF and ErrorSizeMismatch as-is so CheckVolumeDataIntegrity
+		// can detect trailing truncation and trigger its wrap-around retry.
+		if err == io.EOF || err == ErrorSizeMismatch {
+			return n.AppendAtNs, err
+		}
 		return n.AppendAtNs, fmt.Errorf("read data [%d,%d) : %v", offset, offset+needle.GetActualSize(size, v), err)
 	}
 	if n.Id != key {

--- a/weed/storage/volume_checking_test.go
+++ b/weed/storage/volume_checking_test.go
@@ -81,6 +81,51 @@ func TestScrubVolumeData(t *testing.T) {
 	}
 }
 
+// TestCheckVolumeDataIntegrityWithDeletionTombstone guards the size argument
+// passed to ReadData when verifying a trailing deletion tombstone. The .idx
+// entry carries TombstoneFileSize (-1) but the appended tombstone needle in
+// .dat carries Size=0. Forwarding the .idx size into ReadData fails the size
+// check, activates the 32GB 4-byte-offset wrap-around retry, and surfaces EOF;
+// CheckVolumeDataIntegrity then treats the volume as corrupt and the loader
+// marks every such volume read-only on startup.
+func TestCheckVolumeDataIntegrityWithDeletionTombstone(t *testing.T) {
+	dir := t.TempDir()
+
+	v, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, needle.GetCurrentVersion(), 0, 0)
+	if err != nil {
+		t.Fatalf("volume creation: %v", err)
+	}
+	defer v.Close()
+
+	for i := 1; i <= 3; i++ {
+		n := newRandomNeedle(uint64(i))
+		if _, _, _, err := v.writeNeedle2(n, true, false); err != nil {
+			t.Fatalf("write needle %d: %v", i, err)
+		}
+	}
+	// Delete a live needle so a tombstone (Size=0 on disk, -1 in idx) is the
+	// last entry the integrity check examines.
+	if _, err := v.doDeleteRequest(newEmptyNeedle(2)); err != nil {
+		t.Fatalf("delete needle: %v", err)
+	}
+	if err := v.DataBackend.Sync(); err != nil {
+		t.Fatalf("sync .dat: %v", err)
+	}
+	if err := v.nm.Sync(); err != nil {
+		t.Fatalf("sync .idx: %v", err)
+	}
+
+	idxFile, err := os.OpenFile(v.FileName(".idx"), os.O_RDONLY, 0644)
+	if err != nil {
+		t.Fatalf("open .idx: %v", err)
+	}
+	defer idxFile.Close()
+
+	if _, err := CheckVolumeDataIntegrity(v, idxFile); err != nil {
+		t.Fatalf("CheckVolumeDataIntegrity should succeed with a trailing deletion tombstone: %v", err)
+	}
+}
+
 // TestMaxNeedleEnd ensures the needle map's MaxNeedleEnd accumulator lets
 // volume.load() detect an .idx that references bytes past the end of the .dat
 // — the deeper-than-tail corruption shape from issue #8928 that the existing

--- a/weed/storage/volume_checking_test.go
+++ b/weed/storage/volume_checking_test.go
@@ -121,8 +121,15 @@ func TestCheckVolumeDataIntegrityWithDeletionTombstone(t *testing.T) {
 	}
 	defer idxFile.Close()
 
-	if _, err := CheckVolumeDataIntegrity(v, idxFile); err != nil {
+	lastAppendAtNs, err := CheckVolumeDataIntegrity(v, idxFile)
+	if err != nil {
 		t.Fatalf("CheckVolumeDataIntegrity should succeed with a trailing deletion tombstone: %v", err)
+	}
+	// V3 tombstones still record AppendAtNs; a zero return means ReadData
+	// bailed out before populating the needle and would mask future regressions
+	// that quietly skip the tombstone body.
+	if lastAppendAtNs == 0 {
+		t.Errorf("expected non-zero lastAppendAtNs for V3 deletion tombstone, got 0")
 	}
 }
 


### PR DESCRIPTION
## What

`verifyDeletedNeedleIntegrity` was forwarding `types.TombstoneFileSize` (-1) into `Needle.ReadData`. A deletion tombstone is appended to `.dat` with `DataSize=0`, so the on-disk needle header carries `Size=0`. `TombstoneFileSize` is only the `.idx` sentinel for *"this entry is deleted"* — it never appears in a needle header.

`ReadBytes` therefore failed its `n.Size != size` check on every tombstone, returned `ErrorSizeMismatch`, and triggered the 4-byte-offset wrap-around retry in `ReadData` (`offset + 32 GB`). On any volume large enough that `offset + 32 GB` exceeds the `.dat` file size, the retry hit EOF, `CheckVolumeDataIntegrity` reported corruption, and the loader set `noWriteOrDelete = true` — flipping every affected volume read-only on startup.

The user-visible symptom is exactly the log shape in the bug report:

```
needle_read.go:52 ...col-01_148.dat read 0 dataSize 32 offset 65875227080 fileSize 31515488744: EOF
volume_loading.go:195 volumeDataIntegrityChecking failed verifyDeletedNeedleIntegrity ...col-01_148.idx failed: read data [...] : EOF
```

(`offset 65875227080 ≈ 31515488712 + 34359738368` — the original offset plus the 32 GB wrap-around step.)

## Trigger

Any volume server upgraded to 4.23+ whose last 10 `.idx` entries on any volume contain at least one deletion. In practice that is almost any volume where the most recent operations included a delete.

## Fix

Pass `Size(0)` so the size check matches the on-disk tombstone header. One-line behavioural change; the function still verifies the needle ID matches the index key and still reads `AppendAtNs` for V3.

## Tests

- **Go**: `TestCheckVolumeDataIntegrityWithDeletionTombstone` writes three needles, deletes one, syncs, asserts `CheckVolumeDataIntegrity` succeeds with a tombstone at the `.idx` tail. Reverting only the fix while keeping the test reproduces the exact `read 0 dataSize 32 offset <orig+32GB> ... : EOF` log line from the bug report.
- **Rust**: `test_check_volume_data_integrity_with_deletion_tombstone` mirrors the Go test (write three, delete one, sync, reload, assert volume is not flipped read-only).

## Why existing tests missed it

- No test in the suite called `CheckVolumeDataIntegrity` at all.
- `TestScrubVolumeData` uses a fixture with 10 trailing deletion entries — the exact trigger condition — but calls `scrubVolumeData`, which explicitly `return nil`s on `size.IsDeleted()`. The deletion code path was unreachable from any test.

## Rust mirror

The Rust port already guards its equivalent size check with `!size.is_deleted()` (`seaweed-volume/src/storage/volume.rs:1859`) and reads tombstone `AppendAtNs` with `body_size=0`, so the same bug does not apply. No source change in Rust; the regression test is added defensively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integrity check now correctly handles deleted/tombstone entries so volumes aren’t incorrectly marked read-only during validation.
  * Recovery logic for trailing or truncated tombstones is preserved so on-disk tombstones don’t cause false failures.

* **Tests**
  * Added regression tests covering deleted-record/tombstone scenarios to ensure integrity checks and reload behavior remain correct.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->