### PR TITLE
feat(s3): stub bucket configuration list endpoints

### DIFF
--- a/weed/s3api/s3api_bucket_config_stubs.go
+++ b/weed/s3api/s3api_bucket_config_stubs.go
@@ -1,0 +1,71 @@
+package s3api
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+)
+
+// Stub responses for bucket configuration sub-resources that SeaweedFS does
+// not store (analytics, inventory, intelligent-tiering, metrics). AWS SDKs
+// probe these on bucket discovery; returning a well-formed empty list keeps
+// them happy instead of failing with MethodNotAllowed.
+
+const s3XMLNamespace = "http://s3.amazonaws.com/doc/2006-03-01/"
+
+type listBucketAnalyticsConfigurationsResult struct {
+	XMLName     xml.Name `xml:"ListBucketAnalyticsConfigurationsResult"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	IsTruncated bool     `xml:"IsTruncated"`
+}
+
+type listInventoryConfigurationsResult struct {
+	XMLName     xml.Name `xml:"ListInventoryConfigurationsResult"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	IsTruncated bool     `xml:"IsTruncated"`
+}
+
+type listBucketIntelligentTieringConfigurationsResult struct {
+	XMLName     xml.Name `xml:"ListBucketIntelligentTieringConfigurationsResult"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	IsTruncated bool     `xml:"IsTruncated"`
+}
+
+type listBucketMetricsConfigurationsResult struct {
+	XMLName     xml.Name `xml:"ListBucketMetricsConfigurationsResult"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	IsTruncated bool     `xml:"IsTruncated"`
+}
+
+func (s3a *S3ApiServer) GetAnalyticsConfiguration(w http.ResponseWriter, r *http.Request) {
+	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
+}
+
+func (s3a *S3ApiServer) ListBucketAnalyticsConfigurations(w http.ResponseWriter, r *http.Request) {
+	writeSuccessResponseXML(w, r, listBucketAnalyticsConfigurationsResult{Xmlns: s3XMLNamespace})
+}
+
+func (s3a *S3ApiServer) GetInventoryConfiguration(w http.ResponseWriter, r *http.Request) {
+	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
+}
+
+func (s3a *S3ApiServer) ListBucketInventoryConfigurations(w http.ResponseWriter, r *http.Request) {
+	writeSuccessResponseXML(w, r, listInventoryConfigurationsResult{Xmlns: s3XMLNamespace})
+}
+
+func (s3a *S3ApiServer) GetIntelligentTieringConfiguration(w http.ResponseWriter, r *http.Request) {
+	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
+}
+
+func (s3a *S3ApiServer) ListBucketIntelligentTieringConfigurations(w http.ResponseWriter, r *http.Request) {
+	writeSuccessResponseXML(w, r, listBucketIntelligentTieringConfigurationsResult{Xmlns: s3XMLNamespace})
+}
+
+func (s3a *S3ApiServer) GetMetricsConfiguration(w http.ResponseWriter, r *http.Request) {
+	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
+}
+
+func (s3a *S3ApiServer) ListBucketMetricsConfigurations(w http.ResponseWriter, r *http.Request) {
+	writeSuccessResponseXML(w, r, listBucketMetricsConfigurationsResult{Xmlns: s3XMLNamespace})
+}

--- a/weed/s3api/s3api_bucket_config_stubs.go
+++ b/weed/s3api/s3api_bucket_config_stubs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
@@ -38,34 +39,70 @@ type listBucketMetricsConfigurationsResult struct {
 	IsTruncated bool     `xml:"IsTruncated"`
 }
 
+// stubBucketGuard fails with NoSuchBucket when the bucket does not exist, so
+// that AWS's documented precedence (bucket lookup before sub-resource lookup)
+// is preserved across these stub endpoints.
+func (s3a *S3ApiServer) stubBucketGuard(w http.ResponseWriter, r *http.Request) bool {
+	bucket, _ := s3_constants.GetBucketAndObject(r)
+	if err := s3a.checkBucket(r, bucket); err != s3err.ErrNone {
+		s3err.WriteErrorResponse(w, r, err)
+		return false
+	}
+	return true
+}
+
 func (s3a *S3ApiServer) GetAnalyticsConfiguration(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
 }
 
 func (s3a *S3ApiServer) ListBucketAnalyticsConfigurations(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	writeSuccessResponseXML(w, r, listBucketAnalyticsConfigurationsResult{Xmlns: s3XMLNamespace})
 }
 
 func (s3a *S3ApiServer) GetInventoryConfiguration(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
 }
 
 func (s3a *S3ApiServer) ListBucketInventoryConfigurations(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	writeSuccessResponseXML(w, r, listInventoryConfigurationsResult{Xmlns: s3XMLNamespace})
 }
 
 func (s3a *S3ApiServer) GetIntelligentTieringConfiguration(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
 }
 
 func (s3a *S3ApiServer) ListBucketIntelligentTieringConfigurations(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	writeSuccessResponseXML(w, r, listBucketIntelligentTieringConfigurationsResult{Xmlns: s3XMLNamespace})
 }
 
 func (s3a *S3ApiServer) GetMetricsConfiguration(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchConfiguration)
 }
 
 func (s3a *S3ApiServer) ListBucketMetricsConfigurations(w http.ResponseWriter, r *http.Request) {
+	if !s3a.stubBucketGuard(w, r) {
+		return
+	}
 	writeSuccessResponseXML(w, r, listBucketMetricsConfigurationsResult{Xmlns: s3XMLNamespace})
 }

--- a/weed/s3api/s3api_bucket_config_stubs_test.go
+++ b/weed/s3api/s3api_bucket_config_stubs_test.go
@@ -1,0 +1,72 @@
+package s3api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestBucketConfigStubs(t *testing.T) {
+	const bucket = "stub-bucket"
+	s3a := &S3ApiServer{}
+
+	listCases := []struct {
+		name        string
+		query       string
+		rootElement string
+		handler     http.HandlerFunc
+	}{
+		{"AnalyticsList", "analytics", "ListBucketAnalyticsConfigurationsResult", s3a.ListBucketAnalyticsConfigurations},
+		{"InventoryList", "inventory", "ListInventoryConfigurationsResult", s3a.ListBucketInventoryConfigurations},
+		{"IntelligentTieringList", "intelligent-tiering", "ListBucketIntelligentTieringConfigurationsResult", s3a.ListBucketIntelligentTieringConfigurations},
+		{"MetricsList", "metrics", "ListBucketMetricsConfigurationsResult", s3a.ListBucketMetricsConfigurations},
+	}
+	for _, tc := range listCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/"+bucket+"?"+tc.query, nil)
+			req = mux.SetURLVars(req, map[string]string{"bucket": bucket})
+			rr := httptest.NewRecorder()
+			tc.handler(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+			}
+			body := rr.Body.String()
+			if !strings.Contains(body, "<"+tc.rootElement) {
+				t.Fatalf("expected root element %q in body: %s", tc.rootElement, body)
+			}
+			if !strings.Contains(body, "<IsTruncated>false</IsTruncated>") {
+				t.Fatalf("expected IsTruncated=false in body: %s", body)
+			}
+		})
+	}
+
+	getCases := []struct {
+		name    string
+		query   string
+		handler http.HandlerFunc
+	}{
+		{"AnalyticsGet", "analytics&id=x", s3a.GetAnalyticsConfiguration},
+		{"InventoryGet", "inventory&id=x", s3a.GetInventoryConfiguration},
+		{"IntelligentTieringGet", "intelligent-tiering&id=x", s3a.GetIntelligentTieringConfiguration},
+		{"MetricsGet", "metrics&id=x", s3a.GetMetricsConfiguration},
+	}
+	for _, tc := range getCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/"+bucket+"?"+tc.query, nil)
+			req = mux.SetURLVars(req, map[string]string{"bucket": bucket})
+			rr := httptest.NewRecorder()
+			tc.handler(rr, req)
+
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), "<Code>NoSuchConfiguration</Code>") {
+				t.Fatalf("expected NoSuchConfiguration code in body: %s", rr.Body.String())
+			}
+		})
+	}
+}

--- a/weed/s3api/s3api_bucket_config_stubs_test.go
+++ b/weed/s3api/s3api_bucket_config_stubs_test.go
@@ -5,13 +5,22 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
 func TestBucketConfigStubs(t *testing.T) {
 	const bucket = "stub-bucket"
-	s3a := &S3ApiServer{}
+	s3a := &S3ApiServer{
+		iam:               &IdentityAccessManagement{isAuthEnabled: true},
+		bucketConfigCache: NewBucketConfigCache(time.Minute),
+	}
+	s3a.bucketConfigCache.Set(bucket, &BucketConfig{
+		Name:  bucket,
+		Entry: &filer_pb.Entry{Name: bucket},
+	})
 
 	listCases := []struct {
 		name        string

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -841,6 +841,16 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 		bucket.Methods(http.MethodPut).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutPublicAccessBlockHandler, ACTION_ADMIN)), "PUT")).Queries("publicAccessBlock", "")
 		bucket.Methods(http.MethodDelete).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.DeletePublicAccessBlockHandler, ACTION_ADMIN)), "DELETE")).Queries("publicAccessBlock", "")
 
+		// Empty bucket configuration stubs for AWS-SDK compatibility (analytics, inventory, intelligent-tiering, metrics)
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetAnalyticsConfiguration, ACTION_READ)), "GET")).Queries("analytics", "", "id", "{id:.*}")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.ListBucketAnalyticsConfigurations, ACTION_READ)), "GET")).Queries("analytics", "")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetInventoryConfiguration, ACTION_READ)), "GET")).Queries("inventory", "", "id", "{id:.*}")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.ListBucketInventoryConfigurations, ACTION_READ)), "GET")).Queries("inventory", "")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetIntelligentTieringConfiguration, ACTION_READ)), "GET")).Queries("intelligent-tiering", "", "id", "{id:.*}")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.ListBucketIntelligentTieringConfigurations, ACTION_READ)), "GET")).Queries("intelligent-tiering", "")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetMetricsConfiguration, ACTION_READ)), "GET")).Queries("metrics", "", "id", "{id:.*}")
+		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.ListBucketMetricsConfigurations, ACTION_READ)), "GET")).Queries("metrics", "")
+
 		// ListObjectsV2
 		bucket.Methods(http.MethodGet).HandlerFunc(track(s3a.AuthWithPublicRead(func(w http.ResponseWriter, r *http.Request) {
 			limitedHandler, _ := s3a.cb.Limit(s3a.ListObjectsV2Handler, ACTION_LIST)

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -149,6 +149,8 @@ const (
 
 	// Object key length errors
 	ErrKeyTooLongError
+
+	ErrNoSuchConfiguration
 )
 
 // Error message constants for checksum validation
@@ -622,6 +624,12 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "KeyTooLongError",
 		Description:    "Your key is too long.",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+
+	ErrNoSuchConfiguration: {
+		Code:           "NoSuchConfiguration",
+		Description:    "The specified configuration does not exist.",
+		HTTPStatusCode: http.StatusNotFound,
 	},
 }
 


### PR DESCRIPTION
## Summary

Adds Get and List handlers for the four AWS-S3 bucket configuration families that SDKs commonly probe:

- Analytics
- Inventory
- IntelligentTiering
- Metrics

List returns an empty result with `IsTruncated=false`. Single-get-with-id returns a new `NoSuchConfiguration` error (404) rather than overloading `NoSuchKey`, so SDK error parsers stay predictable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3 bucket-configuration compatibility: GET for single configs returns NoSuchConfiguration (404); List endpoints return empty, well-formed S3 XML lists for analytics, inventory, intelligent-tiering, and metrics.

* **Tests**
  * Added tests asserting GET endpoints yield NoSuchConfiguration and List endpoints return 200 with properly formed, empty XML responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->