### PR TITLE
chore(weed/command): prune unused functions

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -90,7 +90,6 @@ type miniProgress struct {
 	elapsed  map[string]time.Duration
 	isTTY    bool
 	rendered bool
-	closed   bool
 }
 
 const miniProgressNameWidth = 12
@@ -148,9 +147,6 @@ func (p *miniProgress) stopped(name string)  { p.update(name, "stopped") }
 // ESC[2K clears the line — leaving the cursor parked one line below the last
 // row so the next print (welcome banner, shutdown messages) flows naturally.
 func (p *miniProgress) renderLocked() {
-	if p.closed {
-		return
-	}
 	if p.rendered {
 		fmt.Printf("\033[%dA", len(p.order))
 	}

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -141,7 +141,6 @@ func (p *miniProgress) update(name, state string) {
 func (p *miniProgress) starting(name string) { p.update(name, "starting") }
 func (p *miniProgress) ready(name string)    { p.update(name, "ready") }
 func (p *miniProgress) failed(name string)   { p.update(name, "failed") }
-func (p *miniProgress) stopping(name string) { p.update(name, "stopping") }
 func (p *miniProgress) stopped(name string)  { p.update(name, "stopped") }
 
 // renderLocked redraws every row in the board. Caller must hold p.mu and
@@ -192,14 +191,6 @@ func (p *miniProgress) reset(services []string, initialState string) {
 	if p.isTTY {
 		p.renderLocked()
 	}
-}
-
-// close prevents further redraws (e.g. before a Fatalf so the panic doesn't
-// repaint the board). Safe to call multiple times.
-func (p *miniProgress) close() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.closed = true
 }
 
 // reportMiniStopped marks a service as fully stopped on the progress board.
@@ -264,21 +255,6 @@ func resetMiniClients() {
 	s := &miniClientsState{}
 	s.ctx, s.cancel = context.WithCancel(parent)
 	miniClients = s
-}
-
-// onMiniClientsShutdown runs fn when mini shutdown is triggered, and tracks
-// it so the interrupt hook can wait for it to drain. No-op outside mini.
-func onMiniClientsShutdown(fn func()) {
-	s := miniClients
-	if s == nil {
-		return
-	}
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		<-s.ctx.Done()
-		fn()
-	}()
 }
 
 // trackMiniClient registers an externally-managed goroutine (one that


### PR DESCRIPTION
This removes three unused functions from `weed/command`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal initialization and shutdown coordination for the mini-client subsystem by removing redundant convenience helpers and cleanup paths, resulting in a small code reduction. No user-facing behavior or public interfaces changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->