### PR TITLE
fix(mount): keep periodic metadata flush from dropping concurrent chunk uploads

### DIFF
--- a/weed/mount/weedfs_metadata_flush.go
+++ b/weed/mount/weedfs_metadata_flush.go
@@ -152,11 +152,14 @@ func (wfs *WFS) flushFileMetadata(fh *FileHandle) error {
 	// request can't observe a half-merged state.
 	var requestEntry *filer_pb.Entry
 	fh.UpdateEntry(func(e *filer_pb.Entry) {
+		// e.Chunks[snapshotLen:] is whatever async uploaders appended while
+		// we processed the snapshot. processedPrefix is freshly built and not
+		// referenced elsewhere, so we can append straight onto it.
 		var tail []*filer_pb.FileChunk
 		if len(e.Chunks) > snapshotLen {
-			tail = append([]*filer_pb.FileChunk(nil), e.Chunks[snapshotLen:]...)
+			tail = e.Chunks[snapshotLen:]
 		}
-		e.Chunks = append(append([]*filer_pb.FileChunk(nil), processedPrefix...), tail...)
+		e.Chunks = append(processedPrefix, tail...)
 		requestEntry = proto.Clone(e).(*filer_pb.Entry)
 	})
 	request := &filer_pb.CreateEntryRequest{

--- a/weed/mount/weedfs_metadata_flush.go
+++ b/weed/mount/weedfs_metadata_flush.go
@@ -104,25 +104,36 @@ func (wfs *WFS) flushFileMetadata(fh *FileHandle) error {
 
 	glog.V(4).Infof("flushFileMetadata %s fh %d", fileFullPath, fh.fh)
 
-	entry := fh.GetEntry()
-	if entry == nil {
+	if fh.GetEntry() == nil {
 		return nil
 	}
-	entry.Name = name
 
-	// Do not stamp mtime/ctime here. Write/SetAttr already maintain
-	// them on the entry; overwriting at periodic-flush time clobbered
-	// user-set mtime (utimes/touch -m -d) once the timer fired.
+	// Snapshot the current chunk list. Async uploader goroutines call
+	// entry.AppendChunks while we run CompactFileChunks / MaybeManifestize
+	// below — those steps can take seconds (manifest upload is a round trip).
+	// We must remember the snapshot length so we can splice any chunks that
+	// land after the snapshot back in once we reassign entry.Chunks; without
+	// that, the naked overwrite below clobbers them and the file ends up
+	// missing chunk references for data the volumes already store.
+	var snapshotChunks []*filer_pb.FileChunk
+	var snapshotLen int
+	fh.UpdateEntry(func(e *filer_pb.Entry) {
+		// Do not stamp mtime/ctime here. Write/SetAttr already maintain
+		// them on the entry; overwriting at periodic-flush time clobbered
+		// user-set mtime (utimes/touch -m -d) once the timer fired.
+		e.Name = name
+		snapshotLen = len(e.Chunks)
+		if snapshotLen > 0 {
+			snapshotChunks = append([]*filer_pb.FileChunk(nil), e.Chunks...)
+		}
+	})
 
-	// Get current chunks - these include chunks that have been uploaded
-	// but not yet persisted to filer metadata
-	chunks := entry.GetChunks()
-	if len(chunks) == 0 {
+	if snapshotLen == 0 {
 		return nil
 	}
 
 	// Separate manifest and non-manifest chunks
-	manifestChunks, nonManifestChunks := filer.SeparateManifestChunks(chunks)
+	manifestChunks, nonManifestChunks := filer.SeparateManifestChunks(snapshotChunks)
 
 	// Compact chunks to remove fully overlapped ones
 	compactedChunks, _ := filer.CompactFileChunks(context.Background(), wfs.LookupFn(), nonManifestChunks)
@@ -133,11 +144,21 @@ func (wfs *WFS) flushFileMetadata(fh *FileHandle) error {
 		glog.V(0).Infof("flushFileMetadata MaybeManifestize: %v", manifestErr)
 	}
 
-	entry.Chunks = append(compactedChunks, manifestChunks...)
+	processedPrefix := append(compactedChunks, manifestChunks...)
 
-	// Clone the proto entry so mapPbIdFromLocalToFiler does not mutate the
-	// file handle's live entry (same race as in flushMetadataToFiler).
-	requestEntry := proto.Clone(entry.GetEntry()).(*filer_pb.Entry)
+	// Splice the processed snapshot back in, preserving any chunks that
+	// async uploaders appended after our snapshot, and clone the resulting
+	// entry for the filer request while still holding the lock so the
+	// request can't observe a half-merged state.
+	var requestEntry *filer_pb.Entry
+	fh.UpdateEntry(func(e *filer_pb.Entry) {
+		var tail []*filer_pb.FileChunk
+		if len(e.Chunks) > snapshotLen {
+			tail = append([]*filer_pb.FileChunk(nil), e.Chunks[snapshotLen:]...)
+		}
+		e.Chunks = append(append([]*filer_pb.FileChunk(nil), processedPrefix...), tail...)
+		requestEntry = proto.Clone(e).(*filer_pb.Entry)
+	})
 	request := &filer_pb.CreateEntryRequest{
 		Directory:                string(dir),
 		Entry:                    requestEntry,
@@ -161,7 +182,7 @@ func (wfs *WFS) flushFileMetadata(fh *FileHandle) error {
 		wfs.inodeToPath.InvalidateChildrenCache(util.FullPath(dir))
 	}
 
-	glog.V(3).Infof("flushed metadata for %s with %d chunks", fileFullPath, len(entry.GetChunks()))
+	glog.V(3).Infof("flushed metadata for %s with %d chunks", fileFullPath, len(requestEntry.GetChunks()))
 
 	// Note: We do NOT clear dirtyMetadata here because:
 	// 1. There may still be dirty pages in the write buffer


### PR DESCRIPTION
## Problem

Large sequential writes through a FUSE mount can silently corrupt the file. A `cat` of two 15 GiB files into a third produces a file whose md5 differs from the streamed input, reproducibly. The file is full size and reads back stably, but contains zero-filled holes at 2 MiB chunk boundaries.

The corrupted regions correspond to gaps in the file's chunk list. The chunk data is still present on the volume servers; the file just lost the references to it.

## Cause

`flushFileMetadata` (the periodic metadata flush, every 2 min) does a read-modify-write on `entry.Chunks` that is not safe against the async uploader goroutines:

1. read `entry.Chunks`
2. run `CompactFileChunks` + `MaybeManifestize` — seconds-long, the manifest upload is a network round trip
3. `entry.Chunks = append(compactedChunks, manifestChunks...)`

While step 2 runs, uploader goroutines append freshly uploaded chunks via `entry.AppendChunks` (which locks). Step 3 overwrites the slice without re-reading, discarding every chunk appended during the window. A multi-minute write hits several flush cycles, each dropping a batch of references.

The close-path flush (`flushMetadataToFiler`) is unaffected: it runs after `FlushData()` has drained all uploads and holds the same exclusive file-handle lock as the periodic flush.

## Fix

Snapshot the chunk list under the entry lock and record its length, do the slow compaction/manifestization on the snapshot, then re-acquire the lock and splice the processed prefix in front of any chunks that arrived after the snapshot. The filer request is cloned inside the same critical section so it can't observe a half-merged state.

## Verification

Repro (2x15 GiB cat) corrupts on master, passes with `-metadataFlushSeconds=0`, and passes with the fix and the periodic flush enabled. `go test ./weed/mount/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in file metadata flush that could cause inconsistent state during concurrent operations.
  * Improved handling of recent file modifications during metadata updates so new writes are preserved and file creation/updates are more reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->