### PR TITLE
fix(shell): volume.balance no longer drains all volumes onto one server

### DIFF
--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -564,6 +564,15 @@ func isGoodMove(placement *super_block.ReplicaPlacement, existingReplicas []*Vol
 	return satisfyReplicaPlacement(placement, existingReplicasExceptSourceNode, targetLocation)
 }
 
+func removeVolumeInfo(diskInfo *master_pb.DiskInfo, volumeId uint32) {
+	for i, volumeInfo := range diskInfo.VolumeInfos {
+		if volumeInfo.Id == volumeId {
+			diskInfo.VolumeInfos = append(diskInfo.VolumeInfos[:i], diskInfo.VolumeInfos[i+1:]...)
+			return
+		}
+	}
+}
+
 func adjustAfterMove(v *master_pb.VolumeInformationMessage, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, emptyNode *Node) {
 	delete(fullNode.selectedVolumes, v.Id)
 	if emptyNode.selectedVolumes != nil {
@@ -576,13 +585,19 @@ func adjustAfterMove(v *master_pb.VolumeInformationMessage, volumeReplicas map[u
 			replica.location.dc == fullNode.dc {
 			loc := newLocation(emptyNode.dc, emptyNode.rack, emptyNode.info)
 			replica.location = &loc
+			// Move the volume's size accounting between disks so that
+			// capacityByMinVolumeDensity recomputes ratios correctly on the next
+			// iteration. Without this the density view stays stale and the planner
+			// keeps draining the same node, moving every volume onto one server.
 			for diskType, diskInfo := range fullNode.info.DiskInfos {
 				if diskType == v.DiskType {
+					removeVolumeInfo(diskInfo, v.Id)
 					addVolumeCount(diskInfo, -1)
 				}
 			}
 			for diskType, diskInfo := range emptyNode.info.DiskInfos {
 				if diskType == v.DiskType {
+					diskInfo.VolumeInfos = append(diskInfo.VolumeInfos, v)
 					addVolumeCount(diskInfo, 1)
 				}
 			}

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -567,7 +567,11 @@ func isGoodMove(placement *super_block.ReplicaPlacement, existingReplicas []*Vol
 func removeVolumeInfo(diskInfo *master_pb.DiskInfo, volumeId uint32) {
 	for i, volumeInfo := range diskInfo.VolumeInfos {
 		if volumeInfo.Id == volumeId {
-			diskInfo.VolumeInfos = append(diskInfo.VolumeInfos[:i], diskInfo.VolumeInfos[i+1:]...)
+			// order does not matter here, so swap with the last and truncate
+			last := len(diskInfo.VolumeInfos) - 1
+			diskInfo.VolumeInfos[i] = diskInfo.VolumeInfos[last]
+			diskInfo.VolumeInfos[last] = nil
+			diskInfo.VolumeInfos = diskInfo.VolumeInfos[:last]
 			return
 		}
 	}
@@ -589,17 +593,13 @@ func adjustAfterMove(v *master_pb.VolumeInformationMessage, volumeReplicas map[u
 			// capacityByMinVolumeDensity recomputes ratios correctly on the next
 			// iteration. Without this the density view stays stale and the planner
 			// keeps draining the same node, moving every volume onto one server.
-			for diskType, diskInfo := range fullNode.info.DiskInfos {
-				if diskType == v.DiskType {
-					removeVolumeInfo(diskInfo, v.Id)
-					addVolumeCount(diskInfo, -1)
-				}
+			if fullDisk, found := fullNode.info.DiskInfos[v.DiskType]; found {
+				removeVolumeInfo(fullDisk, v.Id)
+				addVolumeCount(fullDisk, -1)
 			}
-			for diskType, diskInfo := range emptyNode.info.DiskInfos {
-				if diskType == v.DiskType {
-					diskInfo.VolumeInfos = append(diskInfo.VolumeInfos, v)
-					addVolumeCount(diskInfo, 1)
-				}
+			if emptyDisk, found := emptyNode.info.DiskInfos[v.DiskType]; found {
+				emptyDisk.VolumeInfos = append(emptyDisk.VolumeInfos, v)
+				addVolumeCount(emptyDisk, 1)
 			}
 			return
 		}

--- a/weed/shell/command_volume_balance_test.go
+++ b/weed/shell/command_volume_balance_test.go
@@ -262,6 +262,64 @@ func TestBalance(t *testing.T) {
 
 }
 
+// Regression test: a freshly added empty volume server must end up sharing the
+// data roughly evenly, not having every volume drained onto it. Before the fix,
+// adjustAfterMove never updated the per-disk VolumeInfos that the density-based
+// capacity function reads, so the planner saw a stale topology and moved every
+// volume from the full node onto the empty one.
+func TestBalanceDoesNotDrainOntoOneNode(t *testing.T) {
+	const mb = 1024 * 1024
+	volumeSizeLimitMb := uint64(100)
+
+	makeNode := func(id string, volumes []*master_pb.VolumeInformationMessage) *Node {
+		return &Node{
+			info: &master_pb.DataNodeInfo{
+				Id: id,
+				DiskInfos: map[string]*master_pb.DiskInfo{
+					"": {
+						MaxVolumeCount: 10,
+						VolumeCount:    int64(len(volumes)),
+						VolumeInfos:    volumes,
+					},
+				},
+			},
+			dc:   "dc1",
+			rack: "rack1",
+		}
+	}
+
+	var fullVolumes []*master_pb.VolumeInformationMessage
+	for id := uint32(1); id <= 6; id++ {
+		fullVolumes = append(fullVolumes, &master_pb.VolumeInformationMessage{Id: id, Size: 95 * mb})
+	}
+	fullNode := makeNode("full", fullVolumes)
+	emptyNode := makeNode("empty", nil)
+	nodes := []*Node{fullNode, emptyNode}
+
+	volumeReplicas := map[uint32][]*VolumeReplica{}
+	for _, v := range fullVolumes {
+		loc := newLocation("dc1", "rack1", fullNode.info)
+		volumeReplicas[v.Id] = []*VolumeReplica{{location: &loc, info: v}}
+	}
+
+	for _, n := range nodes {
+		n.selectVolumes(func(v *master_pb.VolumeInformationMessage) bool { return true })
+	}
+
+	if err := balanceSelectedVolume(nil, types.HardDriveType, volumeReplicas, nodes, sortWritableVolumes, volumeSizeLimitMb, false); err != nil {
+		t.Fatalf("balanceSelectedVolume: %v", err)
+	}
+
+	fullCount := len(fullNode.info.DiskInfos[""].VolumeInfos)
+	emptyCount := len(emptyNode.info.DiskInfos[""].VolumeInfos)
+	if fullCount == 0 || emptyCount == 0 {
+		t.Fatalf("expected volumes spread across both nodes, got full=%d empty=%d", fullCount, emptyCount)
+	}
+	if diff := fullCount - emptyCount; diff > 1 || diff < -1 {
+		t.Fatalf("expected balanced distribution within one volume, got full=%d empty=%d", fullCount, emptyCount)
+	}
+}
+
 func TestVolumeSelection(t *testing.T) {
 	topologyInfo := parseOutput(topoData)
 


### PR DESCRIPTION
## Problem

`volume.balance -apply` moves every volume off one server onto another instead of evening them out. Add a fresh empty volume server, run balance, and the whole cluster's data drains onto it; run it again and it drains back. It never settles.

## Cause

The balancer ranks servers by data-size density: `capacityByMinVolumeDensity` sums each disk's `VolumeInfos[].Size`. After choosing a move, `adjustAfterMove` updates the in-memory topology so the next iteration re-ranks correctly — but it only touched `VolumeCount` and the `selectedVolumes` map, never the `VolumeInfos` the density function actually reads.

So a server's density never changed as volumes left it. Its ratio stayed above the ideal, the move condition stayed true, and the loop kept moving volumes until that server was empty.

## Fix

`adjustAfterMove` now moves the volume's `VolumeInfo` from the source disk to the target disk, so density recomputes each iteration and the loop converges to an even split.

`TestBalanceDoesNotDrainOntoOneNode` covers it — fails on the old code (6/0), passes now (3/3). The existing `TestBalance` only checked for errors, and its fixture volumes are far below the volume size limit, so the density path was never exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume balancing so volume metadata moves with volumes between nodes, yielding more accurate capacity and density calculations after relocations.

* **Tests**
  * Added a regression test ensuring balancing does not drain all volumes from a heavily-used node onto a newly added empty node and keeps distributions within expected bounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->