### PR TITLE
fix(shell): volumeServer.evacuate no longer panics on a nil volume

### DIFF
--- a/weed/shell/command_volume_server_evacuate.go
+++ b/weed/shell/command_volume_server_evacuate.go
@@ -136,7 +136,10 @@ func (c *commandVolumeServerEvacuate) evacuateNormalVolumes(commandEnv *CommandE
 				}
 			}
 			volumeReplicas, _ := collectVolumeReplicaLocations(c.topologyInfo)
-			for _, vol := range diskInfo.VolumeInfos {
+			// A successful move calls adjustAfterMove, which removes the volume from
+			// this disk's VolumeInfos in place. Iterate over a snapshot so removals
+			// don't leave nil holes in the slice we are ranging over.
+			for _, vol := range slices.Clone(diskInfo.VolumeInfos) {
 				hasMoved, err := moveAwayOneNormalVolume(commandEnv, volumeReplicas, vol, thisNode, otherNodes, applyChange)
 				if err != nil {
 					fmt.Fprintf(writer, "move away volume %d from %s: %v\n", vol.Id, volumeServer, err)


### PR DESCRIPTION
## Problem

`volumeServer.evacuate` panics with a nil pointer dereference at `command_volume_server_evacuate.go:264` (`vol.DiskType` on a nil `*VolumeInformationMessage`).

This is not test-only. A real `volumeServer.evacuate -node=X -apply` (which holds a `lock`) moves the first volume, then panics on a later iteration, leaving the server partially drained. The same panic happens in simulation while a lock is held. It only avoids the panic when no lock is held, in which case it fails early with "lock is lost" instead. `TestVolumeServerEvacuate` reaches the crash because a nil `CommandEnv` counts as locked, so it fails 100% of the time.

## Root cause

`adjustAfterMove` removes the moved volume from the source disk's `VolumeInfos` in place: it swaps the entry with the last one and nils the tail (`VolumeInfos[last] = nil`). `evacuateNormalVolumes` ranges directly over that same slice while moving, so the niled tail slot is read on a later iteration as a nil volume, and the next move attempt dereferences `vol.DiskType`.

The nil slot is always the rightmost one and `last` only shrinks, so nothing rewrites it; the loop reaches that index on its final pass. One successful move is enough to guarantee the panic. `volume.balance` is unaffected because it iterates a separate `candidateVolumes` snapshot built from the `selectedVolumes` map; evacuate was the only caller ranging over the live `VolumeInfos`.

## Fix

Iterate over a snapshot (`slices.Clone`) of the disk's `VolumeInfos` so in-place removals during a move cannot leave nil holes in the loop. Each volume is still attempted exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of volume server evacuation by fixing an issue where disk volume transfers could fail or become incomplete during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->