### PR TITLE
fix(filer): don't disable the SQL idle connection pool when unconfigured

### DIFF
--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -140,7 +140,12 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	}
 
 	store.DB = sql.OpenDB(connector)
-	store.DB.SetMaxIdleConns(maxIdle)
+	// SetMaxIdleConns(0) keeps no idle connections, so every query opens and
+	// closes a fresh connection. When unconfigured, leave database/sql's
+	// default idle pool of 2 in place instead.
+	if maxIdle > 0 {
+		store.DB.SetMaxIdleConns(maxIdle)
+	}
 	store.DB.SetMaxOpenConns(maxOpen)
 	store.DB.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -33,6 +33,8 @@ func (store *MysqlStore) GetName() string {
 }
 
 func (store *MysqlStore) Initialize(configuration util.Configuration, prefix string) (err error) {
+	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
+	configuration.SetDefault(prefix+"connection_max_idle", 2)
 	return store.initialize(
 		configuration.GetString(prefix+"dsn"),
 		configuration.GetString(prefix+"upsertQuery"),
@@ -140,10 +142,7 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	}
 
 	store.DB = sql.OpenDB(connector)
-	// maxIdle 0 would disable the idle pool; keep database/sql's default of 2.
-	if maxIdle > 0 {
-		store.DB.SetMaxIdleConns(maxIdle)
-	}
+	store.DB.SetMaxIdleConns(maxIdle)
 	store.DB.SetMaxOpenConns(maxOpen)
 	store.DB.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -140,9 +140,7 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	}
 
 	store.DB = sql.OpenDB(connector)
-	// SetMaxIdleConns(0) keeps no idle connections, so every query opens and
-	// closes a fresh connection. When unconfigured, leave database/sql's
-	// default idle pool of 2 in place instead.
+	// maxIdle 0 would disable the idle pool; keep database/sql's default of 2.
 	if maxIdle > 0 {
 		store.DB.SetMaxIdleConns(maxIdle)
 	}

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -77,7 +77,12 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, err)
 	}
 
-	store.DB.SetMaxIdleConns(maxIdle)
+	// SetMaxIdleConns(0) keeps no idle connections, so every query opens and
+	// closes a fresh connection. When unconfigured, leave database/sql's
+	// default idle pool of 2 in place instead.
+	if maxIdle > 0 {
+		store.DB.SetMaxIdleConns(maxIdle)
+	}
 	store.DB.SetMaxOpenConns(maxOpen)
 	store.DB.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -33,6 +33,8 @@ func (store *MysqlStore2) GetName() string {
 }
 
 func (store *MysqlStore2) Initialize(configuration util.Configuration, prefix string) (err error) {
+	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
+	configuration.SetDefault(prefix+"connection_max_idle", 2)
 	return store.initialize(
 		configuration.GetString(prefix+"createTable"),
 		configuration.GetString(prefix+"upsertQuery"),
@@ -77,10 +79,7 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, err)
 	}
 
-	// maxIdle 0 would disable the idle pool; keep database/sql's default of 2.
-	if maxIdle > 0 {
-		store.DB.SetMaxIdleConns(maxIdle)
-	}
+	store.DB.SetMaxIdleConns(maxIdle)
 	store.DB.SetMaxOpenConns(maxOpen)
 	store.DB.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -77,9 +77,7 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, err)
 	}
 
-	// SetMaxIdleConns(0) keeps no idle connections, so every query opens and
-	// closes a fresh connection. When unconfigured, leave database/sql's
-	// default idle pool of 2 in place instead.
+	// maxIdle 0 would disable the idle pool; keep database/sql's default of 2.
 	if maxIdle > 0 {
 		store.DB.SetMaxIdleConns(maxIdle)
 	}

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -28,6 +28,8 @@ func (store *PostgresStore) GetName() string {
 }
 
 func (store *PostgresStore) Initialize(configuration util.Configuration, prefix string) (err error) {
+	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
+	configuration.SetDefault(prefix+"connection_max_idle", 2)
 	return store.initialize(
 		configuration.GetString(prefix+"upsertQuery"),
 		configuration.GetBool(prefix+"enableUpsert"),

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -33,6 +33,8 @@ func (store *PostgresStore2) GetName() string {
 }
 
 func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix string) (err error) {
+	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
+	configuration.SetDefault(prefix+"connection_max_idle", 2)
 	return store.initialize(
 		configuration.GetString(prefix+"createTable"),
 		configuration.GetString(prefix+"upsertQuery"),

--- a/weed/util/pgxutil/pgx_conn.go
+++ b/weed/util/pgxutil/pgx_conn.go
@@ -145,9 +145,7 @@ func OpenDB(dsn, adaptedDSN string, pgbouncerCompatible bool, maxIdle, maxOpen, 
 	}
 
 	db := stdlib.OpenDB(*connConfig)
-	// SetMaxIdleConns(0) keeps no idle connections, so every query opens and
-	// closes a fresh connection. When unconfigured, leave database/sql's
-	// default idle pool of 2 in place instead.
+	// maxIdle 0 would disable the idle pool; keep database/sql's default of 2.
 	if maxIdle > 0 {
 		db.SetMaxIdleConns(maxIdle)
 	}

--- a/weed/util/pgxutil/pgx_conn.go
+++ b/weed/util/pgxutil/pgx_conn.go
@@ -145,10 +145,7 @@ func OpenDB(dsn, adaptedDSN string, pgbouncerCompatible bool, maxIdle, maxOpen, 
 	}
 
 	db := stdlib.OpenDB(*connConfig)
-	// maxIdle 0 would disable the idle pool; keep database/sql's default of 2.
-	if maxIdle > 0 {
-		db.SetMaxIdleConns(maxIdle)
-	}
+	db.SetMaxIdleConns(maxIdle)
 	db.SetMaxOpenConns(maxOpen)
 	db.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 

--- a/weed/util/pgxutil/pgx_conn.go
+++ b/weed/util/pgxutil/pgx_conn.go
@@ -145,7 +145,12 @@ func OpenDB(dsn, adaptedDSN string, pgbouncerCompatible bool, maxIdle, maxOpen, 
 	}
 
 	db := stdlib.OpenDB(*connConfig)
-	db.SetMaxIdleConns(maxIdle)
+	// SetMaxIdleConns(0) keeps no idle connections, so every query opens and
+	// closes a fresh connection. When unconfigured, leave database/sql's
+	// default idle pool of 2 in place instead.
+	if maxIdle > 0 {
+		db.SetMaxIdleConns(maxIdle)
+	}
 	db.SetMaxOpenConns(maxOpen)
 	db.SetConnMaxLifetime(time.Duration(maxLifetimeSeconds) * time.Second)
 


### PR DESCRIPTION
## Problem

The SQL filer stores (mysql, mysql2, postgres, postgres2) read `connection_max_idle` with `GetInt`, which returns `0` both when the key is absent and when it's explicitly set to `0`. That value is passed straight to `SetMaxIdleConns`.

In Go's `database/sql`, *not* calling `SetMaxIdleConns` leaves a default idle pool of 2, but calling `SetMaxIdleConns(0)` keeps **zero** idle connections. So a deployment that simply never configures `connection_max_idle` gets no connection reuse - every query opens a fresh connection (TCP + TLS + auth) and closes it on return.

## Fix

Apply the default at the config layer with `SetDefault` (the same pattern used by the tarantool/redis/ydb stores) rather than guarding the `SetMaxIdleConns` call:

```go
configuration.SetDefault(prefix+"connection_max_idle", 2)
```

This distinguishes the two cases viper otherwise collapses:

- key absent -> reads back as 2, so the idle pool stays on
- key explicitly `0` (toml or `WEED_*_CONNECTION_MAX_IDLE=0`) -> flows through to `SetMaxIdleConns(0)`, so operators can still disable idle pooling on purpose
- key set to N -> N

`SetMaxOpenConns` / `SetConnMaxLifetime` are unchanged - for those, `0` already matches the stdlib default (unlimited / no expiry).

Setting `connection_max_idle` to a positive value behaves exactly as before. The default of 2 is just a floor; production deployments should still tune `connection_max_idle` / `connection_max_open` explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Database connection pools now default to a maximum of 2 idle connections when not explicitly configured. Users can override this default or set it to 0 to disable idle connection pooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->