### PR TITLE
test(ec): make multi-disk EC balance disk-spread assertion deterministic

### DIFF
--- a/test/erasure_coding/multidisk_shardloss_test.go
+++ b/test/erasure_coding/multidisk_shardloss_test.go
@@ -72,6 +72,26 @@ func TestMultiDiskECBalanceNoShardLoss(t *testing.T) {
 	t.Logf("using volume %d", volumeId)
 	time.Sleep(3 * time.Second)
 
+	// Populate every server's disks with volumes so the balancer can see and
+	// target each physical disk. The master only enumerates disks that already
+	// hold a volume or EC shard — an empty disk leaves no trace in the topology
+	// (heartbeats aggregate capacity per disk type, not per physical disk). So
+	// without pre-populating, the post-encode balance would collapse each node's
+	// shards onto the single disk that happened to hold data, and whether the
+	// fillers spread across disks is environment-dependent (master volume-growth
+	// timing). Growing a few volumes per server makes the multi-disk layout
+	// deterministic: the volume server places each new volume on its least-loaded
+	// disk, so a handful of grows touches every disk.
+	for i := 0; i < 3; i++ {
+		server := fmt.Sprintf("127.0.0.1:809%d", i)
+		out, growErr := captureCommandOutput(t, shell.Commands[findCommandIndex("volume.grow")],
+			[]string{"-collection", "test", "-dataNode", server, "-count", "4"}, commandEnv)
+		require.NoError(t, growErr, "volume.grow on %s failed: %s", server, out)
+	}
+	// Let the freshly grown volumes reach the master via heartbeat before encoding
+	// so collectEcNodes sees every disk.
+	time.Sleep(5 * time.Second)
+
 	locked, unlock := tryLockWithTimeout(t, commandEnv, 15*time.Second)
 	require.True(t, locked, "could not acquire shell lock")
 	defer unlock()


### PR DESCRIPTION
## Problem

`TestMultiDiskECBalanceNoShardLoss` (added in #9594) is flaky. It asserts that after `ec.balance` the volume's EC shards span more than one disk per node, but that only holds for disks the balancer can actually see.

The master enumerates a physical disk only when it already holds a volume or EC shard — an empty disk leaves no trace, because heartbeats aggregate capacity per disk *type*, not per physical disk. So whether the post-encode balance spread shards depended on how the master happened to place the tiny filler volumes across disks, which varies by environment.

Observed directly in the #9594 CI history on the same code:
- run 26208904825 — EC Integration Tests **passed** (shards landed on multiple disks)
- run 26209545851 — EC Integration Tests **failed**: `"3" is not greater than "3"` … `got 3 disks across 3 nodes`

## Fix

Grow a few volumes on each server before encoding so every physical disk holds a volume and is therefore visible to the balancer. The volume server places each new volume on its least-loaded disk, so a handful of grows touches every disk, making the spread deterministic.

The assertion still has teeth: it counts disks holding shard *files*, so a balancer that genuinely failed to spread would still collapse to one disk per node and fail the test.

## Testing

Ran `TestMultiDiskECBalanceNoShardLoss` repeatedly on `master` + this change; consistently passes with shards spread across 5-8 disks (was non-deterministically 3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved multi-disk erasure coding balance test coverage by pre-populating server disks to better reflect real-world scenarios and validate proper shard distribution across multiple storage devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->