### PR TITLE
fix(redis3): prevent filer crash from inconsistent skiplist ends

### DIFF
--- a/weed/filer/redis3/ItemList.go
+++ b/weed/filer/redis3/ItemList.go
@@ -127,7 +127,7 @@ func (nl *ItemList) WriteName(name string) error {
 			// collect names before name, add them to X
 			namesToX, err := nl.NodeRangeBeforeExclusive(prevNodeReference, name)
 			if err != nil {
-				return nil
+				return err
 			}
 			// delete skiplist reference to old node
 			if _, err := nl.skipList.DeleteByKey(prevNodeReference.Key); err != nil {
@@ -136,32 +136,32 @@ func (nl *ItemList) WriteName(name string) error {
 			// add namesToY and name to a new X
 			namesToX = append(namesToX, name)
 			if err := nl.ItemAdd([]byte(namesToX[0]), 0, namesToX...); err != nil {
-				return nil
+				return err
 			}
 			// remove names less than name from current Y
 			if err := nl.NodeDeleteBeforeExclusive(prevNodeReference, name); err != nil {
-				return nil
+				return err
 			}
 
 			// point skip list to current Y
 			if err := nl.ItemAdd(lookupKey, prevNodeReference.ElementPointer); err != nil {
-				return nil
+				return err
 			}
 			return nil
 		} else {
 			// collect names after name, add them to Y
 			namesToY, err := nl.NodeRangeAfterExclusive(prevNodeReference, name)
 			if err != nil {
-				return nil
+				return err
 			}
 			// add namesToY and name to a new Y
 			namesToY = append(namesToY, name)
 			if err := nl.ItemAdd(lookupKey, 0, namesToY...); err != nil {
-				return nil
+				return err
 			}
 			// remove names after name from current X
 			if err := nl.NodeDeleteAfterExclusive(prevNodeReference, name); err != nil {
-				return nil
+				return err
 			}
 			return nil
 		}

--- a/weed/util/skiplist/skiplist.go
+++ b/weed/util/skiplist/skiplist.go
@@ -240,9 +240,10 @@ func (t *SkipList) DeleteByKey(key []byte) (id int64, err error) {
 				}
 			}
 
-			// Link from start needs readjustments.
-			startNextKey := t.StartLevels[index].Key
-			if compareElement(nextNode, startNextKey) == 0 {
+			// Match by id, not the cached key: redis3 re-keys nodes in place,
+			// so StartLevels[index].Key can be stale and skip this update while
+			// the end readjustment below still clears EndLevels[index].
+			if t.StartLevels[index] != nil && t.StartLevels[index].ElementPointer == nextNode.Id {
 				t.HasChanges = true
 				t.StartLevels[index] = nextNode.Next[index]
 				// This was our currently highest node!
@@ -307,8 +308,14 @@ func (t *SkipList) InsertByKey(key []byte, idIfKnown int64, value []byte) (id in
 	newFirst := true
 	newLast := true
 	if !t.IsEmpty() {
-		newFirst = compareElement(elem, t.StartLevels[0].Key) < 0
-		newLast = compareElement(elem, t.EndLevels[0].Key) > 0
+		// Guard each end: a persisted skiplist may have one end nil, so
+		// self-heal instead of dereferencing it.
+		if t.StartLevels[0] != nil {
+			newFirst = compareElement(elem, t.StartLevels[0].Key) < 0
+		}
+		if t.EndLevels[0] != nil {
+			newLast = compareElement(elem, t.EndLevels[0].Key) > 0
+		}
 	}
 
 	normallyInserted := false

--- a/weed/util/skiplist/skiplist_test.go
+++ b/weed/util/skiplist/skiplist_test.go
@@ -29,6 +29,49 @@ func TestReverseInsert(t *testing.T) {
 
 }
 
+// TestDeleteRekeyedNode reproduces the redis3 filer crash: a node re-keyed in
+// place leaves a stale StartLevels key, so deleting it must still clear both
+// ends together rather than leaving EndLevels[0] nil for the next insert.
+func TestDeleteRekeyedNode(t *testing.T) {
+	list := New(memStore)
+
+	list.InsertByKey([]byte("b"), 1, []byte("b"))
+
+	// Drifted start reference: same element id, stale cached key.
+	list.StartLevels[0] = &SkipListElementReference{ElementPointer: 1, Key: []byte("stale")}
+
+	if _, err := list.DeleteByKey([]byte("b")); err != nil {
+		t.Fatal(err)
+	}
+
+	if (list.StartLevels[0] == nil) != (list.EndLevels[0] == nil) {
+		t.Fatalf("inconsistent ends after delete: start=%v end=%v", list.StartLevels[0], list.EndLevels[0])
+	}
+
+	if _, err := list.InsertByKey([]byte("c"), 2, []byte("c")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok, _ := list.Find([]byte("c")); !ok {
+		t.Fatal("expected to find inserted key")
+	}
+}
+
+// TestInsertByKeyRecoversInconsistentEnds: a persisted skiplist with
+// StartLevels[0] set but EndLevels[0] nil must self-heal, not crash on load.
+func TestInsertByKeyRecoversInconsistentEnds(t *testing.T) {
+	list := New(memStore)
+	list.InsertByKey([]byte("m"), 1, []byte("m"))
+
+	list.EndLevels[0] = nil
+
+	if _, err := list.InsertByKey([]byte("n"), 2, []byte("n")); err != nil {
+		t.Fatal(err)
+	}
+	if list.IsEmpty() {
+		t.Fatal("list should not be empty")
+	}
+}
+
 func TestInsertAndFind(t *testing.T) {
 
 	k0 := []byte("0")


### PR DESCRIPTION
The redis3 filer store crashes the whole process during a rename or delete:

```
panic: runtime error: invalid memory address or nil pointer dereference
skiplist.(*SkipList).InsertByKey   skiplist.go:311
redis3.(*ItemList).ItemAdd         ItemList.go
redis3.(*ItemList).DeleteName      ItemList.go
redis3.removeChild ... DeleteEntry ... moveSelfEntry (StreamRenameEntry)
```

## Root cause

`InsertByKey` line 311 dereferences `t.EndLevels[0].Key`, but the surrounding guard is only `if !t.IsEmpty()`, which checks `StartLevels[0]` alone. The crash therefore means the skiplist reached an impossible state: `StartLevels[0] != nil` while `EndLevels[0] == nil`.

That state comes from `DeleteByKey`, which adjusts the two ends asymmetrically:

- the start side cleared `StartLevels[index]` only when the deleted node matched the *cached* `StartLevels[index].Key`
- the end side cleared `EndLevels[index]` purely structurally (`Next == nil`)

The redis3 `ItemList` re-keys a node while keeping its id (`DeleteName` re-adds a batch node under its new leading name with the same id). That leaves the cached `Key` in a start/end reference stale relative to the element it points to. When such a node was the only one at a level and got deleted, the stale key comparison skipped the start update while the end update still set `EndLevels[index]` to nil. The next `InsertByKey` then crashed the filer. The corrupt ends also serialize to Redis and reload identically, so an affected directory crash-loops the filer until repaired.

## Fix

- `DeleteByKey` now matches the deleted node by its unique id (`ElementPointer`) instead of the drift-prone cached key, so both ends stay consistent.
- `InsertByKey` guards each end reference independently, so a skiplist already persisted in the corrupt state in Redis self-heals on load instead of crashing.

## Also: propagate errors from WriteName node split

While reviewing the same path, `ItemList.WriteName` case 2.3 (node split) returned `nil` instead of the error in seven branches. The split runs a multi-step sequence (`DeleteByKey`, `ItemAdd`, redis range-delete, `ItemAdd`); a swallowed failure let `WriteName` report success while the skiplist was half-updated, which the caller then persisted - silently corrupting the directory listing and setting up the very inconsistent-ends state above. These now return the error.

## Tests

Two regression tests in `skiplist_test.go`. With the production fix reverted, `TestInsertByKeyRecoversInconsistentEnds` reproduces the exact panic at `skiplist.go:311` and `TestDeleteRekeyedNode` shows the dangling `start=...key:"stale" end=<nil>` state. Both pass with the fix; the full `weed/util/skiplist` suite stays green.

Fixes #9601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skiplist robustness to handle stale or inconsistent internal pointers when reloading persisted data.
  * Fixed error handling during item-list split/recomposition so failures from intermediate operations are surfaced instead of ignored.

* **Tests**
  * Added tests covering deletion and insertion recovery scenarios for drifted or missing internal references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->