### PR TITLE
fix(filersink): return lock-free snapshot from ActiveTransfers

### DIFF
--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -242,9 +242,11 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 	}
 
 	transferStatus := &ChunkTransferStatus{
-		ChunkFileId: sourceChunk.GetFileIdString(),
-		Path:        path,
-		Status:      "downloading",
+		ChunkTransferSnapshot: ChunkTransferSnapshot{
+			ChunkFileId: sourceChunk.GetFileIdString(),
+			Path:        path,
+			Status:      "downloading",
+		},
 	}
 	fs.activeTransfers.Store(sourceChunk.GetFileIdString(), transferStatus)
 	defer fs.activeTransfers.Delete(sourceChunk.GetFileIdString())

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -22,17 +22,23 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-// ChunkTransferStatus tracks the progress of a single chunk being replicated.
-// Fields are guarded by mu: ChunkFileId and Path are immutable after creation,
-// while BytesReceived, Status, and LastErr are updated by fetchAndWrite and
-// read by ActiveTransfers.
-type ChunkTransferStatus struct {
-	mu            sync.RWMutex
+// ChunkTransferSnapshot is a lock-free, copyable view of a chunk transfer's
+// progress, returned by ActiveTransfers.
+type ChunkTransferSnapshot struct {
 	ChunkFileId   string
 	Path          string
 	BytesReceived int64
 	Status        string // "downloading", "uploading", or "waiting 10s" etc.
 	LastErr       string
+}
+
+// ChunkTransferStatus tracks the progress of a single chunk being replicated.
+// Fields are guarded by mu: ChunkFileId and Path are immutable after creation,
+// while BytesReceived, Status, and LastErr are updated by fetchAndWrite and
+// read by ActiveTransfers.
+type ChunkTransferStatus struct {
+	mu sync.RWMutex
+	ChunkTransferSnapshot
 }
 
 type FilerSink struct {
@@ -134,18 +140,12 @@ func (fs *FilerSink) SetChunkConcurrency(concurrency int) {
 }
 
 // ActiveTransfers returns an immutable snapshot of all in-progress chunk transfers.
-func (fs *FilerSink) ActiveTransfers() []ChunkTransferStatus {
-	var transfers []ChunkTransferStatus
+func (fs *FilerSink) ActiveTransfers() []ChunkTransferSnapshot {
+	var transfers []ChunkTransferSnapshot
 	fs.activeTransfers.Range(func(key, value any) bool {
 		t := value.(*ChunkTransferStatus)
 		t.mu.RLock()
-		transfers = append(transfers, ChunkTransferStatus{
-			ChunkFileId:   t.ChunkFileId,
-			Path:          t.Path,
-			BytesReceived: t.BytesReceived,
-			Status:        t.Status,
-			LastErr:       t.LastErr,
-		})
+		transfers = append(transfers, t.ChunkTransferSnapshot)
 		t.mu.RUnlock()
 		return true
 	})


### PR DESCRIPTION
`ChunkTransferStatus` embeds a `sync.RWMutex`, so `ActiveTransfers()` returning `[]ChunkTransferStatus` made callers copy the lock when ranging over the result, which `go vet` flags:

```
command/filer_sync.go:410:11: range var t copies lock: ...filersink.ChunkTransferStatus contains sync.RWMutex
```

Split the data fields into a copyable `ChunkTransferSnapshot`, embed it in `ChunkTransferStatus` alongside the mutex, and return `[]ChunkTransferSnapshot` from `ActiveTransfers()`. The snapshot carries no lock, so iterating it is safe. Field mutations in `fetchAndWrite` keep working through the embedded struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data structure for tracking file transfer progress during replication operations, enhancing consistency and thread-safety of transfer status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->