### PR TITLE
test(volume): fix race in TestReplicatedUploadSucceedsImmediatelyAfterAllocate

### DIFF
--- a/test/volume_server/http/replication_lifecycle_test.go
+++ b/test/volume_server/http/replication_lifecycle_test.go
@@ -2,6 +2,8 @@ package volume_server_http_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -44,6 +46,17 @@ func TestReplicatedUploadSucceedsImmediatelyAfterAllocate(t *testing.T) {
 	fid := framework.NewFileID(volumeID, 881001, 0x0B0C0D0E)
 	payload := []byte("replicated-upload-after-allocate")
 
+	// The master only learns about replica locations through volume-server
+	// heartbeats, which lag behind the direct AllocateVolume gRPC calls above.
+	// In production a client obtains its fid from the master assign flow, which
+	// guarantees the master already knows every replica; this test crafts the
+	// fid by hand, so the replicated write would otherwise look up the master
+	// before the second replica is registered and fail with a 500. Wait until
+	// the master reports both replicas before uploading.
+	if !waitForMasterReplicaCount(t, client, clusterHarness.MasterURL(), volumeID, 2, 10*time.Second) {
+		t.Fatalf("master did not report 2 replica locations for volume %d within deadline", volumeID)
+	}
+
 	uploadResp := framework.UploadBytes(t, client, clusterHarness.VolumeAdminURL(0), fid, payload)
 	_ = framework.ReadAllAndClose(t, uploadResp)
 	if uploadResp.StatusCode != http.StatusCreated {
@@ -60,4 +73,30 @@ func TestReplicatedUploadSucceedsImmediatelyAfterAllocate(t *testing.T) {
 	if string(replicaBody) != string(payload) {
 		t.Fatalf("replica body mismatch: got %q want %q", string(replicaBody), string(payload))
 	}
+}
+
+// waitForMasterReplicaCount polls the master volume lookup until it reports at
+// least want locations for volumeID, or the timeout elapses.
+func waitForMasterReplicaCount(t testing.TB, client *http.Client, masterURL string, volumeID uint32, want int, timeout time.Duration) bool {
+	t.Helper()
+
+	lookupURL := fmt.Sprintf("%s/dir/lookup?volumeId=%d", masterURL, volumeID)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp := framework.DoRequest(t, client, mustNewRequest(t, http.MethodGet, lookupURL))
+		body := framework.ReadAllAndClose(t, resp)
+		if resp.StatusCode == http.StatusOK {
+			var result struct {
+				Locations []struct {
+					Url string `json:"url"`
+				} `json:"locations"`
+			}
+			if err := json.Unmarshal(body, &result); err == nil && len(result.Locations) >= want {
+				return true
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return false
 }


### PR DESCRIPTION
## Problem

`TestReplicatedUploadSucceedsImmediatelyAfterAllocate` is flaky. It allocates a replicated volume (replication `001`, 2 copies) on both nodes via direct `AllocateVolume` gRPC calls, then uploads immediately to node0.

The volume server replicates a write by looking up the volume's replica locations from the master. But the master only learns about replica locations through volume-server heartbeats, which lag behind the direct `AllocateVolume` gRPC calls. When the upload races ahead of the second replica's heartbeat, the lookup returns only 1 location and the replicated write fails with HTTP 500:

```
store_replicate.go: replicating operations [1] is less than volume 115 replication copy count [2]
common.go: response method:POST URL:/115,... with httpStatus:500
```

```
replication_lifecycle_test.go:50: replicated upload expected 201, got 500
```

## Fix

In production a client obtains its fid from the master assign flow, which only succeeds once the master knows every replica. This test crafts the fid by hand, bypassing that guarantee. The fix waits until the master reports both replicas (via `/dir/lookup`) before uploading — mirroring the precondition the assign flow would otherwise provide.

Test-only change. Verified with `-count=3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced replication lifecycle test with improved validation to verify master replica count synchronization before HTTP upload operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->