### PR TITLE
master: accept volume-server Ping targets on follower masters

### DIFF
--- a/weed/server/master_grpc_server_admin.go
+++ b/weed/server/master_grpc_server_admin.go
@@ -170,10 +170,17 @@ func (ms *MasterServer) isKnownPingTarget(ctx context.Context, target string, ta
 	case cluster.FilerType, cluster.BrokerType, cluster.S3Type:
 		return ms.Cluster.IsKnownNode(targetType, addr)
 	case cluster.VolumeServerType:
-		if ms.Topo == nil {
-			return false
+		if ms.Topo != nil && ms.Topo.LookupDataNodeByAddress(addr) != nil {
+			return true
 		}
-		return ms.Topo.LookupDataNodeByAddress(addr) != nil
+		// Only the leader receives volume-server heartbeats, so a follower's
+		// topology is empty. Fall back to the volume-server set the master
+		// learns over its own MasterClient subscription to the leader, the
+		// same source the filer gate trusts.
+		if ms.MasterClient != nil {
+			return ms.MasterClient.HasVolumeServer(addr)
+		}
+		return false
 	case cluster.MasterType:
 		if ms.option != nil && ms.option.Master.Equals(addr) {
 			return true

--- a/weed/server/master_grpc_server_admin_ping_test.go
+++ b/weed/server/master_grpc_server_admin_ping_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
 	"github.com/seaweedfs/seaweedfs/weed/topology"
+	"github.com/seaweedfs/seaweedfs/weed/wdclient"
+	"google.golang.org/grpc"
 )
 
 func TestMasterIsKnownPingTarget(t *testing.T) {
@@ -59,6 +61,36 @@ func TestMasterIsKnownPingTarget(t *testing.T) {
 				t.Fatalf("isKnownPingTarget(%q,%q) = %v, want %v", tc.target, tc.targetType, got, tc.want)
 			}
 		})
+	}
+}
+
+// On a follower master the topology is empty because only the leader receives
+// volume-server heartbeats. The gate must then fall back to the volume-server
+// set learned over the MasterClient subscription instead of rejecting every
+// volume-server target. The positive MasterClient.HasVolumeServer lookup is
+// covered by wdclient.TestHasVolumeServer; here we lock in that an empty
+// topology no longer short-circuits to false and that the fallback is
+// nil-safe.
+func TestMasterIsKnownPingTargetFollowerEmptyTopology(t *testing.T) {
+	ctx := context.Background()
+	vs := "10.0.0.10:8080.18080"
+
+	// No topology and no MasterClient: nothing to consult, so reject.
+	bare := &MasterServer{option: &MasterOption{Master: pb.ServerAddress("10.0.0.1:9333")}}
+	if bare.isKnownPingTarget(ctx, vs, cluster.VolumeServerType) {
+		t.Fatalf("volume server must be unknown without topology or MasterClient")
+	}
+
+	// Empty topology plus a MasterClient that has not learned this volume
+	// server yet: still reject, but exercise the MasterClient fallback path.
+	mc := wdclient.NewMasterClient(grpc.EmptyDialOption{}, "", cluster.MasterType, "", "", "", pb.ServerDiscovery{})
+	follower := &MasterServer{
+		option:       &MasterOption{Master: pb.ServerAddress("10.0.0.1:9333")},
+		Topo:         topology.NewTopology("test", sequence.NewMemorySequencer(), 32*1024, 5, false),
+		MasterClient: mc,
+	}
+	if follower.isKnownPingTarget(ctx, vs, cluster.VolumeServerType) {
+		t.Fatalf("volume server must be unknown until the MasterClient learns it")
 	}
 }
 


### PR DESCRIPTION
## Problem

`cluster.check` reports `rpc error: code = InvalidArgument desc = unknown ping target <vs>:8080.18080 of type volumeServer` for every non-leader master, while the leader passes. It looks like a network/firewall problem but isn't.

`cluster.check` asks every master to ping every volume server. The master Ping gate validates a `volumeServer` target only against the local topology (`ms.Topo.LookupDataNodeByAddress`). Only the leader receives volume-server heartbeats, so a follower's topology is empty and the lookup always returns nil. Probes through the leader succeed; probes through followers are falsely rejected.

This was introduced when the Ping admission gate was added.

## Fix

Fall back to the volume-server set the master learns over its own `MasterClient` subscription to the leader, the same source the filer gate already trusts. A follower's `MasterClient` is kept connected to the leader and its vid map tracks every volume server.

The anti-SSRF intent is preserved: Ping still only dials recognized cluster members.

```go
case cluster.VolumeServerType:
    if ms.Topo != nil && ms.Topo.LookupDataNodeByAddress(addr) != nil {
        return true
    }
    if ms.MasterClient != nil {
        return ms.MasterClient.HasVolumeServer(addr)
    }
    return false
```

Added a regression test for the empty-topology fallback and nil-safety; the positive `HasVolumeServer` lookup is already covered by `wdclient.TestHasVolumeServer`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced volume server discovery in follower masters to properly check available topology information and fall back to alternative sources when the primary topology is empty.

* **Tests**
  * Added comprehensive test coverage for follower master behavior when topology information is unavailable, ensuring correct validation of volume server targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->