### PR TITLE
fix(docker): restore executable bit on prebuilt weed-volume

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -42,6 +42,10 @@ RUN if [ -f "/prebuilt/weed-volume-${TARGETARCH}" ]; then \
       echo "Skipping Rust build for $TARGETARCH (unsupported)" && \
       touch /weed-volume; \
     fi
+# Pre-built binaries arrive via GitHub Actions artifacts, which drop the
+# executable bit, so the copied file is 0644 and exec fails with "Permission
+# denied". Restore it (no-op for the empty placeholder, which stays size 0).
+RUN chmod 0755 /weed-volume
 
 FROM alpine AS final
 LABEL author="Chris Lu"


### PR DESCRIPTION
The published image ships the Rust volume server at `/usr/bin/weed-volume`, but as `0644`, so `volume-rust` dies with:

```
/entrypoint.sh: exec: line 90: /usr/bin/weed-volume: Permission denied
```

GitHub Actions artifacts don't preserve the executable bit: CI builds the binary `0755`, `upload-artifact` zips it (dropping +x), `download-artifact` restores it `0644`, and the workflow `cp` plus both Dockerfile copies preserve that mode. `weed` is unaffected because `go install` writes it inside the same build and it never round-trips through an artifact.

`chmod 0755 /weed-volume` in the `rust_builder` stage, covering every arch and variant. No-op for the empty placeholder on unsupported arches (stays size 0, so the entrypoint still reports it unavailable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a build issue where executable permissions were not properly preserved on compiled binaries during the container build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->