### PR TITLE
fix(s3api/list): cancel ListEntries stream in hasChildren

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -332,13 +332,13 @@ func (s3a *S3ApiServer) hasChildren(bucket, prefix string) bool {
 	bucketDir := s3a.bucketDir(bucket)
 	fullPath := bucketDir + "/" + cleanPrefix
 
-	// Try to list one child object in the directory
-	var found bool
-	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
-		var listErr error
-		found, listErr = filerDirectoryHasChildren(client, fullPath)
-		return listErr
-	})
+	// List one child object. filer_pb.List cancels the underlying ListEntries
+	// stream when it returns, so gRPC's per-stream client goroutine is not leaked.
+	found := false
+	err := filer_pb.List(context.Background(), s3a, fullPath, "", func(*filer_pb.Entry, bool) error {
+		found = true
+		return nil
+	}, "", true, 1)
 
 	if err == nil {
 		return found
@@ -348,29 +348,6 @@ func (s3a *S3ApiServer) hasChildren(bucket, prefix string) bool {
 	}
 	glog.V(1).Infof("hasChildren: list entries failed for %s/%s: %v", bucket, cleanPrefix, err)
 	return true
-}
-
-func filerDirectoryHasChildren(client filer_pb.SeaweedFilerClient, fullPath string) (bool, error) {
-	request := &filer_pb.ListEntriesRequest{
-		Directory:          fullPath,
-		Limit:              1,
-		InclusiveStartFrom: true,
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	stream, err := client.ListEntries(ctx, request)
-	if err != nil {
-		return false, err
-	}
-
-	if _, err = stream.Recv(); err != nil {
-		if err == io.EOF {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 // checkDirectoryObject checks if the object is a directory object (ends with "/") and if it exists

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -333,38 +333,44 @@ func (s3a *S3ApiServer) hasChildren(bucket, prefix string) bool {
 	fullPath := bucketDir + "/" + cleanPrefix
 
 	// Try to list one child object in the directory
+	var found bool
 	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
-		request := &filer_pb.ListEntriesRequest{
-			Directory:          fullPath,
-			Limit:              1,
-			InclusiveStartFrom: true,
-		}
-
-		stream, err := client.ListEntries(context.Background(), request)
-		if err != nil {
-			return err
-		}
-
-		// Check if we got at least one entry
-		_, err = stream.Recv()
-		if err == io.EOF {
-			return io.EOF // No children
-		}
-		if err != nil {
-			return err
-		}
-		return nil
+		var listErr error
+		found, listErr = filerDirectoryHasChildren(client, fullPath)
+		return listErr
 	})
 
-	// If we got an entry (not EOF), then it has children
 	if err == nil {
-		return true
+		return found
 	}
-	if errors.Is(err, io.EOF) || errors.Is(err, filer_pb.ErrNotFound) {
+	if errors.Is(err, filer_pb.ErrNotFound) {
 		return false
 	}
 	glog.V(1).Infof("hasChildren: list entries failed for %s/%s: %v", bucket, cleanPrefix, err)
 	return true
+}
+
+func filerDirectoryHasChildren(client filer_pb.SeaweedFilerClient, fullPath string) (bool, error) {
+	request := &filer_pb.ListEntriesRequest{
+		Directory:          fullPath,
+		Limit:              1,
+		InclusiveStartFrom: true,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := client.ListEntries(ctx, request)
+	if err != nil {
+		return false, err
+	}
+
+	if _, err = stream.Recv(); err != nil {
+		if err == io.EOF {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // checkDirectoryObject checks if the object is a directory object (ends with "/") and if it exists

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -324,7 +324,7 @@ func removeDuplicateSlashes(object string) string {
 //	hasChildren("bucket", "empty-dir") where no children exist → false
 //
 // Performance: ~1-5ms per call (one gRPC LIST request with Limit=1)
-func (s3a *S3ApiServer) hasChildren(bucket, prefix string) bool {
+func (s3a *S3ApiServer) hasChildren(ctx context.Context, bucket, prefix string) bool {
 	// Clean up prefix: remove leading slashes
 	cleanPrefix := strings.TrimPrefix(prefix, "/")
 
@@ -334,8 +334,10 @@ func (s3a *S3ApiServer) hasChildren(bucket, prefix string) bool {
 
 	// List one child object. filer_pb.List cancels the underlying ListEntries
 	// stream when it returns, so gRPC's per-stream client goroutine is not leaked.
+	// The caller's request context is propagated so the probe is cancelled if the
+	// client disconnects.
 	found := false
-	err := filer_pb.List(context.Background(), s3a, fullPath, "", func(*filer_pb.Entry, bool) error {
+	err := filer_pb.List(ctx, s3a, fullPath, "", func(*filer_pb.Entry, bool) error {
 		found = true
 		return nil
 	}, "", true, 1)
@@ -2320,7 +2322,7 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 			}
 			if isZeroByteFile {
 				// Check if it has children (making it an implicit directory)
-				if s3a.hasChildren(bucket, object) {
+				if s3a.hasChildren(r.Context(), bucket, object) {
 					// This is an implicit directory with children
 					// Return 404 to force clients (like s3fs) to use LIST-based discovery
 					s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)

--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -109,7 +109,7 @@ func (s3a *S3ApiServer) ListObjectsV2Handler(w http.ResponseWriter, r *http.Requ
 	// Adjust marker if it ends with delimiter to skip all entries with that prefix
 	marker = adjustMarkerForDelimiter(marker, delimiter)
 
-	response, err := s3a.listFilerEntries(bucket, originalPrefix, maxKeys, marker, delimiter, encodingTypeUrl, fetchOwner)
+	response, err := s3a.listFilerEntries(r.Context(), bucket, originalPrefix, maxKeys, marker, delimiter, encodingTypeUrl, fetchOwner)
 
 	if err != nil {
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
@@ -173,7 +173,7 @@ func (s3a *S3ApiServer) ListObjectsV1Handler(w http.ResponseWriter, r *http.Requ
 	// Adjust marker if it ends with delimiter to skip all entries with that prefix
 	marker = adjustMarkerForDelimiter(marker, delimiter)
 
-	response, err := s3a.listFilerEntries(bucket, originalPrefix, uint16(maxKeys), marker, delimiter, encodingTypeUrl, true)
+	response, err := s3a.listFilerEntries(r.Context(), bucket, originalPrefix, uint16(maxKeys), marker, delimiter, encodingTypeUrl, true)
 
 	if err != nil {
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
@@ -232,7 +232,7 @@ func sanitizeV1MarkerEcho(response *ListBucketResult, marker string, encodingTyp
 	}
 }
 
-func (s3a *S3ApiServer) listFilerEntries(bucket string, originalPrefix string, maxKeys uint16, originalMarker string, delimiter string, encodingTypeUrl bool, fetchOwner bool) (response ListBucketResult, err error) {
+func (s3a *S3ApiServer) listFilerEntries(ctx context.Context, bucket string, originalPrefix string, maxKeys uint16, originalMarker string, delimiter string, encodingTypeUrl bool, fetchOwner bool) (response ListBucketResult, err error) {
 	// convert full path prefix into directory name and prefix for entry name
 	requestDir, prefix, marker := normalizePrefixMarker(originalPrefix, originalMarker)
 	bucketPrefix := s3a.bucketPrefix(bucket)
@@ -307,7 +307,7 @@ func (s3a *S3ApiServer) listFilerEntries(bucket string, originalPrefix string, m
 						if normalizedPrefix != "" {
 							relativePath := strings.TrimPrefix(fmt.Sprintf("%s/%s", dir, entry.Name), bucketPrefix)
 							relativePath = strings.TrimPrefix(relativePath, "/")
-							if normalizedPrefix == relativePath && !s3a.hasChildren(bucket, relativePath) && !entry.IsDirectoryKeyObject() {
+							if normalizedPrefix == relativePath && !s3a.hasChildren(ctx, bucket, relativePath) && !entry.IsDirectoryKeyObject() {
 								return
 							}
 						}


### PR DESCRIPTION
# What problem are we solving?
We observed steady goroutine growth in filer/S3. A goroutine dump showed ~20k goroutines parked in google.golang.org/grpc.newClientStreamWithParams.func4.


# How are we solving the problem?
The leak was caused by S3ApiServer.hasChildren(): it called ListEntries with Limit=1, read a single response, and returned without canceling the stream context. For gRPC server-streaming RPCs, grpc keeps a watcher goroutine alive until the stream reaches EOF or its context is canceled.

Wrap the ListEntries call in a cancellable context and cancel it after the single-entry probe finishes. This preserves the existing hasChildren behavior while ensuring the early return closes the stream properly.

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved directory child-detection and error handling to reduce incorrect "empty" results and make directory state checks more conservative.
  * Passed request context through listing and lookup paths to ensure more consistent behavior during directory probes.

* **Bug Fixes**
  * Made implicit-directory (s3fs compatibility) 404 decisions more accurate, reducing false-not-found responses during object/head requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->