### PR TITLE
feat(helm): add volume.rust toggle to run the Rust volume server

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -137,6 +137,9 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
+              {{- if $volume.rust }}
+              exec /usr/bin/weed-volume \
+              {{- else }}
               exec /usr/bin/weed \
                 {{- if $volume.logs }}
                 -logdir=/logs \
@@ -149,6 +152,7 @@ spec:
                 -v={{ $.Values.global.seaweedfs.loggingLevel }} \
                 {{- end }}
                 volume \
+              {{- end }}
                 -port={{ $volume.port }} \
                 {{- if $volume.metricsPort }}
                 -metricsPort={{ $volume.metricsPort }} \
@@ -180,7 +184,7 @@ spec:
                 {{- if $volume.imagesFixOrientation }}
                 -images.fix.orientation \
                 {{- end }}
-                {{- if $volume.pulseSeconds }}
+                {{- if and $volume.pulseSeconds (not $volume.rust) }}
                 -pulseSeconds={{ $volume.pulseSeconds }} \
                 {{- end }}
                 {{- if $volume.index }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -305,6 +305,11 @@ volume:
   enabled: true
   imageOverride: null
   restartPolicy: null
+  # Run the Rust volume server (/usr/bin/weed-volume) instead of the Go one.
+  # Requires an image that ships the Rust binary (amd64/arm64). The Go-only
+  # log flags (-logtostderr/-logdir/-v) and -pulseSeconds are dropped; set log
+  # level via the RUST_LOG env var in extraEnvironmentVars if needed.
+  rust: false
   port: 8080
   grpcPort: 18080
   metricsPort: 9327


### PR DESCRIPTION
Adds a `volume.rust` value (default `false`). When set, the volume StatefulSet execs `/usr/bin/weed-volume` instead of `weed volume`:

- drops the Go-only `-logtostderr`/`-logdir`/`-v` preamble and the `volume` subcommand
- drops `-pulseSeconds` (no Rust equivalent)
- keeps the shared flag block and `extraArgs` unchanged — the Rust binary accepts the same `-port -dir -max -rack -dataCenter -ip.bind -readMode -ip -compactionMBps -minFreeSpacePercent -index -metricsPort -master` and the upload/download limit + inflight-timeout flags

`rust: false` renders byte-identical to before. The Rust server logs to stderr; set `RUST_LOG` via `extraEnvironmentVars` for verbosity.

Requires an image whose `weed-volume` is executable (#9616).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust-based volume server implementation. Users can now optionally enable an alternative Rust-compiled volume server for both amd64 and arm64 architectures, complementing the default Go implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->