### PR TITLE
s3: dial the object lock's primary filer directly

### DIFF
--- a/weed/cluster/lock_client.go
+++ b/weed/cluster/lock_client.go
@@ -70,6 +70,18 @@ func (lc *LockClient) hostForKey(key string) pb.ServerAddress {
 	return lc.seedFiler
 }
 
+// PrimaryForKey returns the ring owner for key, or "" before any ring arrives.
+// Unlike hostForKey it does not fall back to the seed, so a route-by-key caller
+// stays on the distributed lock until the ring is known.
+func (lc *LockClient) PrimaryForKey(key string) pb.ServerAddress {
+	lc.ringMu.RLock()
+	defer lc.ringMu.RUnlock()
+	if lc.ring == nil {
+		return ""
+	}
+	return lc.ring.GetPrimary(key)
+}
+
 type LiveLock struct {
 	key                 string
 	renewToken          string

--- a/weed/cluster/lock_client.go
+++ b/weed/cluster/lock_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +20,14 @@ type LockClient struct {
 	maxLockDuration time.Duration
 	sleepDuration   time.Duration
 	seedFiler       pb.ServerAddress
+
+	// ring is an optional client-side view of the filer lock hash ring. When
+	// populated, a new lock starts at the key's primary filer instead of the
+	// seed filer, avoiding the seed->primary forward hop. A stale view stays
+	// correct: the filer forwards to the real primary as a fallback.
+	ringMu      sync.RWMutex
+	ring        *lock_manager.HashRing
+	ringVersion int64
 }
 
 func NewLockClient(grpcDialOption grpc.DialOption, seedFiler pb.ServerAddress) *LockClient {
@@ -28,6 +37,37 @@ func NewLockClient(grpcDialOption grpc.DialOption, seedFiler pb.ServerAddress) *
 		sleepDuration:   2473 * time.Millisecond,
 		seedFiler:       seedFiler,
 	}
+}
+
+// SetRing updates the client-side view of the filer lock ring. It mirrors the
+// master's LockRingUpdate broadcasts so the client computes the same primary
+// the filers do. Updates older than the current version are ignored to tolerate
+// reordered broadcasts; version 0 is always accepted (bootstrap).
+func (lc *LockClient) SetRing(servers []pb.ServerAddress, version int64) {
+	lc.ringMu.Lock()
+	defer lc.ringMu.Unlock()
+	if version != 0 && version < lc.ringVersion {
+		return
+	}
+	lc.ringVersion = version
+	if lc.ring == nil {
+		lc.ring = lock_manager.NewHashRing(lock_manager.DefaultVnodeCount)
+	}
+	lc.ring.SetServers(servers)
+}
+
+// hostForKey returns the filer that should own key per the current ring view,
+// falling back to the seed filer when no view has been received yet.
+func (lc *LockClient) hostForKey(key string) pb.ServerAddress {
+	lc.ringMu.RLock()
+	defer lc.ringMu.RUnlock()
+	if lc.ring == nil {
+		return lc.seedFiler
+	}
+	if primary := lc.ring.GetPrimary(key); primary != "" {
+		return primary
+	}
+	return lc.seedFiler
 }
 
 type LiveLock struct {
@@ -51,7 +91,7 @@ type LiveLock struct {
 func (lc *LockClient) NewShortLivedLock(key string, owner string) (lock *LiveLock) {
 	lock = &LiveLock{
 		key:            key,
-		hostFiler:      lc.seedFiler,
+		hostFiler:      lc.hostForKey(key),
 		cancelCh:       make(chan struct{}),
 		expireAtNs:     time.Now().Add(5 * time.Second).UnixNano(),
 		grpcDialOption: lc.grpcDialOption,
@@ -72,7 +112,7 @@ func (lc *LockClient) NewBlockingLongLivedLock(key, owner string, lockTTL time.D
 	}
 	lock := &LiveLock{
 		key:            key,
-		hostFiler:      lc.seedFiler,
+		hostFiler:      lc.hostForKey(key),
 		cancelCh:       make(chan struct{}),
 		expireAtNs:     time.Now().Add(lockTTL).UnixNano(),
 		grpcDialOption: lc.grpcDialOption,
@@ -110,7 +150,7 @@ func (lc *LockClient) NewBlockingLongLivedLock(key, owner string, lockTTL time.D
 func (lc *LockClient) StartLongLivedLock(key string, owner string, onLockOwnerChange func(newLockOwner string), lockTTL time.Duration) (lock *LiveLock) {
 	lock = &LiveLock{
 		key:            key,
-		hostFiler:      lc.seedFiler,
+		hostFiler:      lc.hostForKey(key),
 		cancelCh:       make(chan struct{}),
 		expireAtNs:     time.Now().Add(lockTTL).UnixNano(),
 		grpcDialOption: lc.grpcDialOption,

--- a/weed/cluster/lock_client.go
+++ b/weed/cluster/lock_client.go
@@ -39,14 +39,14 @@ func NewLockClient(grpcDialOption grpc.DialOption, seedFiler pb.ServerAddress) *
 	}
 }
 
-// SetRing updates the client-side view of the filer lock ring. It mirrors the
-// master's LockRingUpdate broadcasts so the client computes the same primary
-// the filers do. Updates older than the current version are ignored to tolerate
-// reordered broadcasts; version 0 is always accepted (bootstrap).
+// SetRing mirrors the master's LockRingUpdate so the client computes the same
+// primary the filers do. A non-zero version at or below the current one is
+// ignored once a ring exists, dropping reordered and redundant broadcasts;
+// version 0 always applies (bootstrap).
 func (lc *LockClient) SetRing(servers []pb.ServerAddress, version int64) {
 	lc.ringMu.Lock()
 	defer lc.ringMu.Unlock()
-	if version != 0 && version < lc.ringVersion {
+	if version != 0 && version <= lc.ringVersion && lc.ring != nil {
 		return
 	}
 	lc.ringVersion = version

--- a/weed/cluster/lock_client_test.go
+++ b/weed/cluster/lock_client_test.go
@@ -71,3 +71,22 @@ func TestLockClientSetRingVersionGuard(t *testing.T) {
 		t.Errorf("bootstrap update not applied, got %q", got)
 	}
 }
+
+// PrimaryForKey returns "" before any ring is received (so a route-by-key
+// caller falls back to the distributed lock) and the ring owner afterwards,
+// unlike hostForKey which falls back to the seed.
+func TestLockClientPrimaryForKey(t *testing.T) {
+	lc := NewLockClient(nil, "seed:8888")
+	if got := lc.PrimaryForKey("k"); got != "" {
+		t.Errorf("expected empty before ring, got %q", got)
+	}
+
+	lc.SetRing([]pb.ServerAddress{"filer-a:8888", "filer-b:8888"}, 1)
+	got := lc.PrimaryForKey("k")
+	if got == "" {
+		t.Fatal("expected an owner after ring set")
+	}
+	if got != lc.hostForKey("k") {
+		t.Errorf("PrimaryForKey %q disagrees with hostForKey %q", got, lc.hostForKey("k"))
+	}
+}

--- a/weed/cluster/lock_client_test.go
+++ b/weed/cluster/lock_client_test.go
@@ -1,0 +1,73 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/cluster/lock_manager"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+)
+
+// The gateway must resolve a lock key to the same primary the filers do,
+// otherwise it dials the wrong filer and the lock still gets forwarded. Both
+// sides use the same HashRing over the same server set, so for every key the
+// client's hostForKey must equal the filer ring's GetPrimary.
+func TestLockClientHostMatchesFilerRing(t *testing.T) {
+	servers := []pb.ServerAddress{
+		"filer-a:8888", "filer-b:8888", "filer-c:8888", "filer-d:8888",
+	}
+
+	filerRing := lock_manager.NewHashRing(lock_manager.DefaultVnodeCount)
+	filerRing.SetServers(servers)
+
+	lc := NewLockClient(nil, "seed:8888")
+	lc.SetRing(servers, 1)
+
+	for _, key := range []string{
+		"s3.object.write:/buckets/b/obj-0",
+		"s3.object.write:/buckets/b/obj-1",
+		"s3.object.write:/buckets/b/obj-2",
+		"s3.object.write:/buckets/gosbench-0/w0obj-kilo-0877",
+		"some/other/key",
+	} {
+		if got, want := lc.hostForKey(key), filerRing.GetPrimary(key); got != want {
+			t.Errorf("key %q: client host %q != filer primary %q", key, got, want)
+		}
+	}
+}
+
+// Without a ring view, the client falls back to the seed filer (which the filer
+// forwards from), preserving the pre-optimization behavior.
+func TestLockClientHostFallsBackToSeed(t *testing.T) {
+	lc := NewLockClient(nil, "seed:8888")
+	if got := lc.hostForKey("any-key"); got != "seed:8888" {
+		t.Errorf("expected seed fallback, got %q", got)
+	}
+
+	// An empty ring (no members yet) also falls back to the seed.
+	lc.SetRing(nil, 1)
+	if got := lc.hostForKey("any-key"); got != "seed:8888" {
+		t.Errorf("expected seed fallback on empty ring, got %q", got)
+	}
+}
+
+// A stale (older-version) update must not regress a newer ring view, while
+// version 0 always applies as a bootstrap.
+func TestLockClientSetRingVersionGuard(t *testing.T) {
+	lc := NewLockClient(nil, "seed:8888")
+
+	newer := []pb.ServerAddress{"filer-a:8888", "filer-b:8888"}
+	lc.SetRing(newer, 10)
+	primaryAt10 := lc.hostForKey("k")
+
+	// Older version is ignored.
+	lc.SetRing([]pb.ServerAddress{"filer-z:8888"}, 5)
+	if got := lc.hostForKey("k"); got != primaryAt10 {
+		t.Errorf("stale update applied: host changed to %q", got)
+	}
+
+	// version 0 is always accepted.
+	lc.SetRing([]pb.ServerAddress{"filer-z:8888"}, 0)
+	if got := lc.hostForKey("k"); got != "filer-z:8888" {
+		t.Errorf("bootstrap update not applied, got %q", got)
+	}
+}

--- a/weed/cluster/lock_manager/hash_ring.go
+++ b/weed/cluster/lock_manager/hash_ring.go
@@ -145,7 +145,18 @@ func (hr *HashRing) rebuildRing() {
 	hr.vnodeToServer = make(map[uint32]pb.ServerAddress, len(hr.servers)*hr.vnodeCount)
 	hr.sortedHashes = make([]uint32, 0, len(hr.servers)*hr.vnodeCount)
 
+	// Iterate servers in a deterministic order. Map iteration order is randomized
+	// per process, so on the rare vnode-hash collision the last writer into
+	// vnodeToServer would otherwise differ between nodes, making them disagree on
+	// the primary for keys near that slot. Sorting keeps the ring identical on
+	// every node that holds the same server set.
+	servers := make([]pb.ServerAddress, 0, len(hr.servers))
 	for server := range hr.servers {
+		servers = append(servers, server)
+	}
+	sort.Slice(servers, func(i, j int) bool { return servers[i] < servers[j] })
+
+	for _, server := range servers {
 		for i := 0; i < hr.vnodeCount; i++ {
 			vnodeKey := vnodeKeyFor(server, i)
 			hash := hashKey(vnodeKey)

--- a/weed/cluster/lock_manager/hash_ring.go
+++ b/weed/cluster/lock_manager/hash_ring.go
@@ -145,11 +145,8 @@ func (hr *HashRing) rebuildRing() {
 	hr.vnodeToServer = make(map[uint32]pb.ServerAddress, len(hr.servers)*hr.vnodeCount)
 	hr.sortedHashes = make([]uint32, 0, len(hr.servers)*hr.vnodeCount)
 
-	// Iterate servers in a deterministic order. Map iteration order is randomized
-	// per process, so on the rare vnode-hash collision the last writer into
-	// vnodeToServer would otherwise differ between nodes, making them disagree on
-	// the primary for keys near that slot. Sorting keeps the ring identical on
-	// every node that holds the same server set.
+	// Sort so a vnode-hash collision resolves to the same server on every node;
+	// map iteration order alone is randomized per process.
 	servers := make([]pb.ServerAddress, 0, len(hr.servers))
 	for server := range hr.servers {
 		servers = append(servers, server)

--- a/weed/cluster/lock_manager/hash_ring_test.go
+++ b/weed/cluster/lock_manager/hash_ring_test.go
@@ -171,3 +171,38 @@ func TestHashRing_GetPrimary(t *testing.T) {
 	primary, _ := hr.GetPrimaryAndBackup("mykey")
 	assert.Equal(t, primary, hr.GetPrimary("mykey"))
 }
+
+// The ring must be identical on every node holding the same server set,
+// regardless of the order servers were added or supplied. Build rings several
+// ways and assert they agree on the primary for a wide range of keys.
+func TestHashRing_OrderIndependent(t *testing.T) {
+	servers := []pb.ServerAddress{
+		"filer-a:8888", "filer-b:8888", "filer-c:8888", "filer-d:8888", "filer-e:8888",
+	}
+
+	bySet := NewHashRing(50)
+	bySet.SetServers(servers)
+
+	byReverse := NewHashRing(50)
+	rev := append([]pb.ServerAddress(nil), servers...)
+	for i, j := 0, len(rev)-1; i < j; i, j = i+1, j-1 {
+		rev[i], rev[j] = rev[j], rev[i]
+	}
+	byReverse.SetServers(rev)
+
+	byAdd := NewHashRing(50)
+	for _, s := range []pb.ServerAddress{"filer-c:8888", "filer-e:8888", "filer-a:8888", "filer-d:8888", "filer-b:8888"} {
+		byAdd.AddServer(s)
+	}
+
+	for i := 0; i < 5000; i++ {
+		key := fmt.Sprintf("s3.object.write:/buckets/b/obj-%d", i)
+		p := bySet.GetPrimary(key)
+		if got := byReverse.GetPrimary(key); got != p {
+			t.Fatalf("reverse-order ring disagrees on %q: %s vs %s", key, got, p)
+		}
+		if got := byAdd.GetPrimary(key); got != p {
+			t.Fatalf("add-order ring disagrees on %q: %s vs %s", key, got, p)
+		}
+	}
+}

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -154,6 +154,7 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 	// Supports multiple filer addresses with automatic failover for high availability
 	var filerClient *wdclient.FilerClient
 	var masterClient *wdclient.MasterClient
+	var objectWriteLockClient *cluster.LockClient
 	if len(option.Masters) > 0 {
 		// Enable filer discovery via master
 		masterMap := make(map[string]pb.ServerAddress)
@@ -165,6 +166,21 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 			clientHost = util.DetectedHostAddress()
 		}
 		masterClient = wdclient.NewMasterClient(option.GrpcDialOption, option.FilerGroup, cluster.S3Type, pb.ServerAddress(util.JoinHostPort(clientHost, option.GrpcPort)), "", "", *pb.NewServiceDiscoveryFromMap(masterMap))
+		// Build the object-write lock client and subscribe to the master's
+		// lock-ring updates BEFORE starting the master loop, so the initial
+		// LockRingUpdate sent on connect isn't dropped (the master only delivers
+		// it once per connect). The masterClient already filters updates to this
+		// server's filer group.
+		if len(option.Filers) > 0 {
+			objectWriteLockClient = cluster.NewLockClient(option.GrpcDialOption, option.Filers[0])
+			masterClient.SetOnLockRingUpdateFn(func(update *master_pb.LockRingUpdate) {
+				servers := make([]pb.ServerAddress, 0, len(update.Servers))
+				for _, s := range update.Servers {
+					servers = append(servers, pb.ServerAddress(s))
+				}
+				objectWriteLockClient.SetRing(servers, update.Version)
+			})
+		}
 		// Start the master client connection loop - required for GetMaster() to work
 		go masterClient.KeepConnectedToMaster(context.Background())
 
@@ -265,18 +281,10 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 	}
 
 	if len(option.Filers) > 0 {
-		objectWriteLockClient := cluster.NewLockClient(option.GrpcDialOption, option.Filers[0])
-		// Mirror the master's lock-ring view so each object lock dials the key's
-		// primary filer directly instead of forwarding through the seed filer.
-		// The masterClient already filters updates to this server's filer group.
-		if masterClient != nil {
-			masterClient.SetOnLockRingUpdateFn(func(update *master_pb.LockRingUpdate) {
-				servers := make([]pb.ServerAddress, 0, len(update.Servers))
-				for _, s := range update.Servers {
-					servers = append(servers, pb.ServerAddress(s))
-				}
-				objectWriteLockClient.SetRing(servers, update.Version)
-			})
+		// Reuse the lock client built in the masters block (already subscribed to
+		// ring updates); create a plain one when no masters are configured.
+		if objectWriteLockClient == nil {
+			objectWriteLockClient = cluster.NewLockClient(option.GrpcDialOption, option.Filers[0])
 		}
 		s3ApiServer.newObjectWriteLock = func(bucket, object string) objectWriteLock {
 			lockKey := fmt.Sprintf("s3.object.write:%s", s3ApiServer.toFilerPath(bucket, object))

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -96,6 +96,8 @@ type S3ApiServer struct {
 	stsHandlers           *STSHandlers    // STS HTTP handlers for AssumeRoleWithWebIdentity
 	cipher                bool            // encrypt data on volume servers
 	newObjectWriteLock    func(bucket, object string) objectWriteLock
+	// objectWriteLockClient resolves a key's owner filer for route-by-key.
+	objectWriteLockClient *cluster.LockClient
 	// Shared ReaderCache used by the S3 GET streaming path. It lives for the
 	// lifetime of the server so that concurrent and repeat reads share a
 	// single in-flight download per chunk, and so that no per-request
@@ -286,6 +288,7 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 		if objectWriteLockClient == nil {
 			objectWriteLockClient = cluster.NewLockClient(option.GrpcDialOption, option.Filers[0])
 		}
+		s3ApiServer.objectWriteLockClient = objectWriteLockClient
 		s3ApiServer.newObjectWriteLock = func(bucket, object string) objectWriteLock {
 			lockKey := fmt.Sprintf("s3.object.write:%s", s3ApiServer.toFilerPath(bucket, object))
 			owner := fmt.Sprintf("s3api-%d", s3ApiServer.randomClientId)

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/iam/policy"
 	"github.com/seaweedfs/seaweedfs/weed/iam/sts"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_lifecycle_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
@@ -152,6 +153,7 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 	// Uses the battle-tested vidMap with filer-based lookups
 	// Supports multiple filer addresses with automatic failover for high availability
 	var filerClient *wdclient.FilerClient
+	var masterClient *wdclient.MasterClient
 	if len(option.Masters) > 0 {
 		// Enable filer discovery via master
 		masterMap := make(map[string]pb.ServerAddress)
@@ -162,7 +164,7 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 		if clientHost == "0.0.0.0" || clientHost == "" {
 			clientHost = util.DetectedHostAddress()
 		}
-		masterClient := wdclient.NewMasterClient(option.GrpcDialOption, option.FilerGroup, cluster.S3Type, pb.ServerAddress(util.JoinHostPort(clientHost, option.GrpcPort)), "", "", *pb.NewServiceDiscoveryFromMap(masterMap))
+		masterClient = wdclient.NewMasterClient(option.GrpcDialOption, option.FilerGroup, cluster.S3Type, pb.ServerAddress(util.JoinHostPort(clientHost, option.GrpcPort)), "", "", *pb.NewServiceDiscoveryFromMap(masterMap))
 		// Start the master client connection loop - required for GetMaster() to work
 		go masterClient.KeepConnectedToMaster(context.Background())
 
@@ -264,6 +266,18 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 
 	if len(option.Filers) > 0 {
 		objectWriteLockClient := cluster.NewLockClient(option.GrpcDialOption, option.Filers[0])
+		// Mirror the master's lock-ring view so each object lock dials the key's
+		// primary filer directly instead of forwarding through the seed filer.
+		// The masterClient already filters updates to this server's filer group.
+		if masterClient != nil {
+			masterClient.SetOnLockRingUpdateFn(func(update *master_pb.LockRingUpdate) {
+				servers := make([]pb.ServerAddress, 0, len(update.Servers))
+				for _, s := range update.Servers {
+					servers = append(servers, pb.ServerAddress(s))
+				}
+				objectWriteLockClient.SetRing(servers, update.Version)
+			})
+		}
 		s3ApiServer.newObjectWriteLock = func(bucket, object string) objectWriteLock {
 			lockKey := fmt.Sprintf("s3.object.write:%s", s3ApiServer.toFilerPath(bucket, object))
 			owner := fmt.Sprintf("s3api-%d", s3ApiServer.randomClientId)

--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -393,7 +393,13 @@ func (ms *MasterServer) KeepConnected(stream master_pb.Seaweed_KeepConnectedServ
 }
 
 func (ms *MasterServer) initialLockRingUpdate(clientType string, filerGroup string) *master_pb.KeepConnectedResponse {
-	if clientType != cluster.FilerType || ms.LockRingManager == nil {
+	if ms.LockRingManager == nil {
+		return nil
+	}
+	// Filers are ring members; S3 gateways are lock clients that need the same
+	// view to dial a key's primary directly. Both get the initial snapshot;
+	// later membership changes already broadcast to every connected client.
+	if clientType != cluster.FilerType && clientType != cluster.S3Type {
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

The S3 object write lock builds a fresh short-lived DLM lock per write, and each one starts at the seed filer (`Filers[0]`). When the seed filer isn't the key's consistent-hash-ring primary, the filer forwards the lock request to the primary. In multi-cluster / multi-region deployments that forward crosses clusters on **every** write, since the per-object short-lived lock is discarded after each write and never reuses the learned primary:

```
FILER LOCK: Forwarding to correct filer - from=...sierra... to=...hotel...
```

So every locked object write pays two hops: gateway -> seed filer, then seed filer -> primary filer (often cross-cluster).

## Change

Give the lock client a client-side view of the filer lock ring so it dials each key's primary filer directly, skipping the forward.

- `LockClient` gains a `HashRing` view with a version guard (`SetRing`). New locks start at the key's primary (`hostForKey`) instead of always the seed filer. With no view yet it falls back to the seed, so consumers that don't feed a ring (mount, MQ, admin) are unchanged.
- The S3 gateway feeds the view from the master `LockRingUpdate` broadcasts it already receives over the `KeepConnected` stream; the master client already filters those to this server's filer group.
- The master now sends the **initial** ring snapshot to S3 clients on connect, not just to filers. Membership-change broadcasts already reach every connected client, so the view tracks filers joining/leaving by version.

Correctness is unchanged: the client view is an optimization only. A stale view (e.g. mid-membership-change) still resolves correctly because the filer continues to forward to the real primary as a fallback. When the gateway dials the actual primary, `LockWithTimeout` returns no `movedTo`, so the forward is skipped.

## Test

`TestLockClientHostMatchesFilerRing` asserts the client resolves the same primary as a filer-side `HashRing` over the same server set, plus seed-fallback and version-guard behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can keep an optional local lock-ring view; lock requests prefer ring primaries and fall back to a seed filer. S3 server subscribes to lock-ring updates and reuses created lock clients.
  * Initial lock-ring snapshots are returned for both filer and S3 client types.

* **Bug Fixes**
  * Deterministic hash-ring construction to ensure consistent primary selection across nodes.

* **Tests**
  * Added tests for host selection, fallback behavior, versioned ring updates, and ring order-independence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->