### PR TITLE
filer: serialize same-path mutations with a local lock

### DIFF
--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/seaweedfs/seaweedfs/weed/cluster"
-
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
@@ -186,6 +184,13 @@ func (fs *FilerServer) CreateEntry(ctx context.Context, req *filer_pb.CreateEntr
 		newEntry.TtlSec = 0
 	}
 
+	// Serialize concurrent mutations to the same path on this filer so the
+	// read (existence/condition) and the write are atomic. Callers route a
+	// key's writes to this owner filer, making this local lock sufficient.
+	fullpath := util.NewFullPath(req.Directory, req.Entry.Name)
+	pathLock := fs.entryLockTable.AcquireLock("CreateEntry", fullpath, util.ExclusiveLock)
+	defer fs.entryLockTable.ReleaseLock(fullpath, pathLock)
+
 	ctx, eventSink := filer.WithMetadataEventSink(ctx)
 	createErr := fs.filer.CreateEntry(ctx, newEntry, req.OExcl, req.IsFromOtherCluster, req.Signatures, req.SkipCheckParentDirectory, so.MaxFileNameLength)
 
@@ -328,9 +333,11 @@ func (fs *FilerServer) AppendToEntry(ctx context.Context, req *filer_pb.AppendTo
 	glog.V(4).InfofCtx(ctx, "AppendToEntry %v", req)
 	fullpath := util.NewFullPath(req.Directory, req.EntryName)
 
-	lockClient := cluster.NewLockClient(fs.grpcDialOption, fs.option.Host)
-	lock := lockClient.NewShortLivedLock(string(fullpath), string(fs.option.Host))
-	defer lock.StopShortLivedLock()
+	// Serialize the read-modify-write against concurrent mutations to the same
+	// path on this filer. The append must route to this entry's owner filer for
+	// this local lock to be authoritative.
+	pathLock := fs.entryLockTable.AcquireLock("AppendToEntry", fullpath, util.ExclusiveLock)
+	defer fs.entryLockTable.ReleaseLock(fullpath, pathLock)
 
 	var offset int64 = 0
 	entry, err := fs.filer.FindEntry(ctx, fullpath)

--- a/weed/server/filer_grpc_server_create_lock_test.go
+++ b/weed/server/filer_grpc_server_create_lock_test.go
@@ -1,0 +1,59 @@
+package weed_server
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// Concurrent OExcl creates for the same path must yield exactly one winner. The
+// filer's CreateEntry is a FindEntry-then-Insert; without the per-path lock both
+// racers observe "not found" and both insert. The exclusive entry lock makes the
+// check-then-act atomic so the losers see ErrEntryAlreadyExists.
+func TestCreateEntryOExclSerialized(t *testing.T) {
+	store := newRenameTestStore()
+	store.findDelay = 5 * time.Millisecond
+	f := newRenameTestFiler(store)
+	f.DirBucketsPath = "/buckets"
+
+	fs := &FilerServer{
+		filer:          f,
+		option:         &FilerOption{},
+		entryLockTable: util.NewLockTable[util.FullPath](),
+	}
+
+	const racers = 8
+	var success int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			resp, err := fs.CreateEntry(context.Background(), &filer_pb.CreateEntryRequest{
+				Directory:                "/test",
+				OExcl:                    true,
+				SkipCheckParentDirectory: true,
+				Entry: &filer_pb.Entry{
+					Name:       "obj",
+					Attributes: &filer_pb.FuseAttributes{Mtime: 1700000000, FileMode: 0644, Inode: 1},
+				},
+			})
+			if err == nil && resp.Error == "" {
+				atomic.AddInt32(&success, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if success != 1 {
+		t.Fatalf("expected exactly 1 OExcl winner, got %d", success)
+	}
+}

--- a/weed/server/filer_grpc_server_rename_test.go
+++ b/weed/server/filer_grpc_server_rename_test.go
@@ -29,6 +29,7 @@ type renameTestStore struct {
 	findCalls map[string]int
 	commitErr error
 	deleteErr error
+	findDelay time.Duration // optional: widen check-then-act windows in tests
 }
 
 func newRenameTestStore() *renameTestStore {
@@ -69,6 +70,9 @@ func (s *renameTestStore) UpdateEntry(_ context.Context, entry *filer.Entry) err
 }
 
 func (s *renameTestStore) FindEntry(_ context.Context, p util.FullPath) (*filer.Entry, error) {
+	if s.findDelay > 0 {
+		time.Sleep(s.findDelay)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.findCalls[string(p)]++

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -124,6 +124,13 @@ type FilerServer struct {
 	// mountPeerRegistry backs the MountRegister / MountList RPCs for peer
 	// chunk sharing (tier 1). Always populated.
 	mountPeerRegistry *filer.MountPeerRegistry
+
+	// entryLockTable serializes mutations to the same entry path on this filer.
+	// It is the local serialization point for read-modify-write operations
+	// (conditional create, append) once writers for a key are routed to this
+	// node, replacing the distributed lock for that purpose. Idle keys are
+	// evicted automatically, so the table stays bounded.
+	entryLockTable *util.LockTable[util.FullPath]
 }
 
 func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption) (fs *FilerServer, err error) {
@@ -162,6 +169,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		inFlightDataLimitCond: sync.NewCond(new(sync.Mutex)),
 		recentCopyRequests:    make(map[string]recentCopyRequest),
 		CredentialManager:     option.CredentialManager,
+		entryLockTable:        util.NewLockTable[util.FullPath](),
 	}
 	fs.mountPeerRegistry = filer.NewMountPeerRegistry()
 	go fs.runMountPeerRegistrySweeper()


### PR DESCRIPTION
First of a three-part series that takes the S3 object-write path off the distributed lock and onto route-by-key + filer-local serialization.

## Problem

`Filer.CreateEntry` is an unlocked `FindEntry`-then-`InsertEntry`/`UpdateEntry`. Two concurrent creates to the same path race: `OExcl` (create-if-absent) can admit two creators, and there is no atomic check-then-act for conditional writes. This is exactly why the S3 path and `AppendToEntry` reach for the distributed lock — the filer can't serialize a key on its own.

## Change

Add a per-path exclusive lock to the `CreateEntry` gRPC handler using the existing `util.LockTable[util.FullPath]`, which already evicts idle keys so the table stays bounded. The read and the write now run inside one exclusive critical section on the filer.

This local lock is the authoritative serialization point only once a key's writes are routed to its owner filer (the follow-up gateway PR does that, using the lock-ring view from #9626). On its own, this PR already removes the single-filer check-then-act race.

`AppendToEntry` — itself a read-modify-write that previously borrowed the distributed lock — switches to the same per-path lock. There are no in-tree callers constructing `AppendToEntryRequest`; the operation now serializes within the owner filer, consistent with the route-by-key model.

## Test

`TestCreateEntryOExclSerialized` fires concurrent `OExcl` creates for one path through the real handler (with a widened check-then-act window) and asserts exactly one winner.

## Series

1. **this PR** — filer serializes same-path mutations locally
2. add a `Condition` field to `CreateEntryRequest` so the filer evaluates `If-Match`/`If-None-Match`/time conditions under the lock
3. S3 gateway routes non-versioned object writes to the owner filer and uses these instead of the distributed lock


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced serialization of concurrent file mutations on the same path to ensure atomic and consistent behavior for simultaneous file creation and append operations across the distributed file system.

* **Tests**
  * Added test coverage for exclusive file creation under concurrent access and improved test utilities for rename operation timing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->