### PR TITLE
s3: route versioned COPY and delete-marker off the DLM

### DIFF
--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -444,7 +444,16 @@ func (s3a *S3ApiServer) finalizeCopyDestination(dstBucket, dstObject, dstVersion
 			return "", "", err
 		}
 
-		if err = s3a.updateLatestVersionInDirectory(dstBucket, normalizedObject, versionId, versionFileName, dstEntry); err != nil {
+		// Route the pointer flip to the owner filer when known (off the
+		// distributed lock); RECOMPUTE_LATEST picks the just-written version.
+		if owner := s3a.objectWriteOwner(dstBucket, normalizedObject); owner != "" {
+			if code := s3a.routedVersionedFinalize(owner, dstBucket, normalizedObject, isNewFormatVersionId(versionId)); code != s3err.ErrNone {
+				if rollbackErr := s3a.rollbackCopyVersion(bucketDir, versionObjectPath); rollbackErr != nil {
+					glog.Errorf("CopyObjectHandler: failed to rollback version %s for %s/%s after routed finalize error: %v", versionId, dstBucket, normalizedObject, rollbackErr)
+				}
+				return "", "", fmt.Errorf("routed finalize for %s/%s: code %d", dstBucket, normalizedObject, code)
+			}
+		} else if err = s3a.updateLatestVersionInDirectory(dstBucket, normalizedObject, versionId, versionFileName, dstEntry); err != nil {
 			if rollbackErr := s3a.rollbackCopyVersion(bucketDir, versionObjectPath); rollbackErr != nil {
 				glog.Errorf("CopyObjectHandler: failed to rollback version %s for %s/%s after latest pointer update error: %v", versionId, dstBucket, normalizedObject, rollbackErr)
 			}

--- a/weed/s3api/s3api_object_handlers_delete.go
+++ b/weed/s3api/s3api_object_handlers_delete.go
@@ -238,6 +238,17 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 			}
 		}
 	}
+	// Versioned/suspended delete with no specific version: route off the lock when
+	// the bucket has an owner. createDeleteMarker routes its own pointer flip;
+	// object-lock buckets are excluded by routableWriteOwner and stay on the lock,
+	// and the If-Match precondition was already checked above. A specific-version
+	// delete keeps the lock (its recompute-after-delete is a separate change).
+	if !deleteHandled && versioningConfigured && versionId == "" {
+		if owner := s3a.routableWriteOwner(bucket, object); owner != "" {
+			deleteResult, deleteCode = s3a.deleteVersionedObject(r, bucket, object, versionId, versioningState)
+			deleteHandled = true
+		}
+	}
 	if !deleteHandled {
 		deleteCode = s3a.withObjectWriteLock(bucket, object, func() s3err.ErrorCode {
 			return s3a.checkDeleteIfMatch(bucket, object, versionId, versioningState, r.Header.Get(s3_constants.IfMatch), s3err.ErrPreconditionFailed)

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -242,8 +242,13 @@ func (s3a *S3ApiServer) createDeleteMarker(bucket, object string) (string, error
 		},
 		Extended: deleteMarkerExtended,
 	}
-	err = s3a.updateLatestVersionInDirectory(bucket, cleanObject, versionId, versionFileName, deleteMarkerEntry)
-	if err != nil {
+	// Route the pointer flip to the owner filer when known (off the distributed
+	// lock); RECOMPUTE_LATEST picks the just-written marker as the new latest.
+	if owner := s3a.objectWriteOwner(bucket, cleanObject); owner != "" {
+		if code := s3a.routedVersionedFinalize(owner, bucket, cleanObject, useInvertedFormat); code != s3err.ErrNone {
+			return "", fmt.Errorf("createDeleteMarker: routed finalize failed for %s/%s: code %d", bucket, object, code)
+		}
+	} else if err = s3a.updateLatestVersionInDirectory(bucket, cleanObject, versionId, versionFileName, deleteMarkerEntry); err != nil {
 		glog.Errorf("createDeleteMarker: failed to update latest version in directory: %v", err)
 		return "", fmt.Errorf("failed to update latest version in directory: %w", err)
 	}


### PR DESCRIPTION
Routes **versioned CopyObject** and **versioned delete-marker creation** off the distributed lock, reusing `FinalizeVersionedWrite` from the versioned-PutObject PR. No new filer op or proto.

> **Stacked PR** on the series (built on the MPU branch, which includes #9626–#9631). Merge after them.

## Why these fit

Both are the same shape as versioned PutObject — a **unique** version/marker file (`<obj>/.versions/<versionId>`, never collides) plus the **only contended mutation**, the latest-pointer flip (demote previous + set new) on the `.versions` directory entry. So both can serialize that flip on the `.versions` owner via `FinalizeVersionedWrite` (one local lock, precondition evaluated atomically) and drop the distributed lock.

## Change

- `finalizeCopyDestination` (VersioningEnabled) and `createDeleteMarker` gain an optional `owner` + `WriteCondition`. When the `.versions` owner is known they route the demote + pointer flip + precondition through `routedVersionedFinalize`, roll back the version/marker file if it fails, and return a precondition miss as `412`; otherwise they use the existing lock-based `updateLatestVersionInDirectory`.
- `CopyObjectHandler` and `DeleteObjectHandler` take the routed path for versioning-enabled destinations and skip `withObjectWriteLock`.

## Stays on the lock (deliberately)

Suspended versioning (multi-version `IsLatest` rewrite), version-specific deletes, the metadata-only self-copy, and the lifecycle delete-marker path. Each also falls back to the lock when the owner isn't known or the condition doesn't reduce to one primitive.

## Tests

Full `weed/s3api` suite passes locally; versioned copy/delete behavior is covered by the CI versioning suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of versioned S3 object copy and delete operations for better consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->