### PR TITLE
s3: route object-lock object writes off the distributed lock

### DIFF
--- a/weed/s3api/s3api_object_routed_write.go
+++ b/weed/s3api/s3api_object_routed_write.go
@@ -16,22 +16,26 @@ import (
 
 // routableWriteOwner returns the owner filer for an object's writes, or "" to
 // keep them on the distributed lock. All writes to one object (versioned,
-// suspended, non-versioned) share the owner; object-lock buckets stay on the
-// lock until WORM-guard routing. Any lookup error also falls back.
+// suspended, non-versioned) share the owner. Any lookup error falls back.
 func (s3a *S3ApiServer) routableWriteOwner(bucket, object string) pb.ServerAddress {
 	if object == "" || s3a.objectWriteLockClient == nil {
 		return ""
 	}
-	if locked, err := s3a.isObjectLockEnabled(bucket); err != nil || locked {
-		return ""
-	}
+	// Object-lock PUTs route: a versioned PUT creates a new version (never an
+	// overwrite of a locked one), and a non-versioned overwrite is WORM-checked
+	// gateway-side before dispatch. WORM-checked deletes use routedObjectOwner.
 	return s3a.objectWriteLockClient.PrimaryForKey(fmt.Sprintf("s3.object.write:%s", s3a.toFilerPath(bucket, object)))
 }
 
-// routedObjectOwner is routableWriteOwner restricted to non-versioned buckets,
-// for the unversioned DELETE fast path.
+// routedObjectOwner is routableWriteOwner restricted to non-versioned,
+// non-object-lock buckets, for the unversioned DELETE fast path.
 func (s3a *S3ApiServer) routedObjectOwner(bucket, object string) (pb.ServerAddress, bool) {
 	if configured, err := s3a.isVersioningConfigured(bucket); err != nil || configured {
+		return "", false
+	}
+	// An unversioned object-lock delete enforces WORM in the lock path; keep it
+	// on the lock rather than routing past the check.
+	if locked, err := s3a.isObjectLockEnabled(bucket); err != nil || locked {
 		return "", false
 	}
 	owner := s3a.routableWriteOwner(bucket, object)


### PR DESCRIPTION
Routes object-lock bucket object **writes** off the distributed lock (inverts this PR's original "keep on DLM" intent).

> Builds on the merged routing foundation (#9626/#9629/#9631/#9633).

## What changes

`routableWriteOwner` no longer excludes object-lock buckets:
- a versioned PUT creates a new version (never overwrites a locked one), so it routes;
- a non-versioned overwrite is already WORM-checked gateway-side before dispatch, so routing the create doesn't change WORM atomicity.

`routedObjectOwner` (the unversioned DELETE fast path) **still** excludes object-lock: that delete's WORM enforcement lives in the lock path, so it stays on the lock rather than routing past the check.

## Scope boundary (WORM-checked deletes stay on the lock)

Version-specific deletes remain on the distributed lock. Routing them safely needs the WORM check (`IF_EXTENDED_NOT_EQUAL` legal hold + `IF_EXTENDED_TIME_ELAPSED` retention) on the *version* entry **and** the latest-pointer recompute on the *object* entry under one transaction — two different condition targets, which `ObjectTransaction`'s single `lock_key`/condition can't express today. Governance-vs-compliance bypass also can't be decided without reading the version. Deferred to a focused follow-up that adds a per-mutation/condition-target primitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced object lock enforcement to ensure proper Write Once Read Many (WORM) protections are applied during delete operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->