### PR TITLE
filer: evaluate a write precondition in CreateEntry

### DIFF
--- a/other/java/client/src/main/proto/filer.proto
+++ b/other/java/client/src/main/proto/filer.proto
@@ -222,6 +222,41 @@ message CreateEntryRequest {
     bool is_from_other_cluster = 4;
     repeated int32 signatures = 5;
     bool skip_check_parent_directory = 6;
+    // Optional precondition evaluated against the current entry atomically with
+    // the write, under the filer's per-path lock. The caller must route the
+    // key's writes to this entry's owner filer for the check to be authoritative.
+    WriteCondition condition = 7;
+}
+
+// WriteCondition is the precondition the filer evaluates against the existing
+// entry before writing, under the per-path lock. A failed condition returns
+// FilerError PRECONDITION_FAILED. The client maps request semantics (e.g. RFC
+// 7232) to clauses; the filer just compares.
+//
+// A condition is a list of clauses that ALL must hold (logical AND). One clause
+// is the common case; several express what a single comparison cannot: an ETag
+// set (If-Match / If-None-Match with multiple values), weak-ETag comparison, and
+// compound conditions (e.g. If-Match + If-Unmodified-Since together).
+message WriteCondition {
+    enum Kind {
+        NONE                = 0; // unconditional
+        IF_NOT_EXISTS       = 1; // fail if the entry exists (If-None-Match: *)
+        IF_EXISTS           = 2; // fail if the entry is absent (If-Match: *)
+        IF_ETAG_MATCH       = 3; // fail if absent or etag matches none of the set (If-Match)
+        IF_ETAG_NOT_MATCH   = 4; // fail if present and etag matches any of the set (If-None-Match)
+        IF_UNMODIFIED_SINCE = 5; // fail if present and mtime > unix_time
+        IF_MODIFIED_SINCE   = 6; // fail if present and mtime <= unix_time
+    }
+    // Clause is one primitive comparison. IF_ETAG_MATCH holds when the current
+    // entry's ETag equals any value in etags; IF_ETAG_NOT_MATCH holds when it
+    // equals none. allow_weak permits weak-comparison (ignoring the W/ prefix).
+    message Clause {
+        Kind kind = 1;
+        repeated string etags = 2; // ETag set for IF_ETAG_* kinds
+        int64 unix_time = 3;       // bound (unix seconds) for IF_*_SINCE kinds
+        bool allow_weak = 4;       // compare ETags ignoring the weak (W/) marker
+    }
+    repeated Clause clauses = 1;   // all must hold (logical AND)
 }
 
 // Structured error codes for filer entry operations.
@@ -233,6 +268,7 @@ enum FilerError {
     EXISTING_IS_DIRECTORY = 3; // cannot overwrite directory with file
     EXISTING_IS_FILE      = 4; // cannot overwrite file with directory
     ENTRY_ALREADY_EXISTS  = 5; // O_EXCL and entry already exists
+    PRECONDITION_FAILED   = 6; // WriteCondition not satisfied
 }
 
 message CreateEntryResponse {
@@ -421,6 +457,7 @@ message SubscribeMetadataRequest {
     repeated string directories = 10;  // exact directory to watch
     bool client_supports_batching = 11; // client can unpack SubscribeMetadataResponse.events
     bool client_supports_metadata_chunks = 12; // client can read log file chunks from volume servers
+    bool client_supports_idle_heartbeat = 13; // server may send empty responses carrying the current time while the client is caught up
 }
 message SubscribeMetadataResponse {
     string directory = 1;

--- a/weed/pb/filer.proto
+++ b/weed/pb/filer.proto
@@ -222,6 +222,41 @@ message CreateEntryRequest {
     bool is_from_other_cluster = 4;
     repeated int32 signatures = 5;
     bool skip_check_parent_directory = 6;
+    // Optional precondition evaluated against the current entry atomically with
+    // the write, under the filer's per-path lock. The caller must route the
+    // key's writes to this entry's owner filer for the check to be authoritative.
+    WriteCondition condition = 7;
+}
+
+// WriteCondition is the precondition the filer evaluates against the existing
+// entry before writing, under the per-path lock. A failed condition returns
+// FilerError PRECONDITION_FAILED. The client maps request semantics (e.g. RFC
+// 7232) to clauses; the filer just compares.
+//
+// A condition is a list of clauses that ALL must hold (logical AND). One clause
+// is the common case; several express what a single comparison cannot: an ETag
+// set (If-Match / If-None-Match with multiple values), weak-ETag comparison, and
+// compound conditions (e.g. If-Match + If-Unmodified-Since together).
+message WriteCondition {
+    enum Kind {
+        NONE                = 0; // unconditional
+        IF_NOT_EXISTS       = 1; // fail if the entry exists (If-None-Match: *)
+        IF_EXISTS           = 2; // fail if the entry is absent (If-Match: *)
+        IF_ETAG_MATCH       = 3; // fail if absent or etag matches none of the set (If-Match)
+        IF_ETAG_NOT_MATCH   = 4; // fail if present and etag matches any of the set (If-None-Match)
+        IF_UNMODIFIED_SINCE = 5; // fail if present and mtime > unix_time
+        IF_MODIFIED_SINCE   = 6; // fail if present and mtime <= unix_time
+    }
+    // Clause is one primitive comparison. IF_ETAG_MATCH holds when the current
+    // entry's ETag equals any value in etags; IF_ETAG_NOT_MATCH holds when it
+    // equals none. allow_weak permits weak-comparison (ignoring the W/ prefix).
+    message Clause {
+        Kind kind = 1;
+        repeated string etags = 2; // ETag set for IF_ETAG_* kinds
+        int64 unix_time = 3;       // bound (unix seconds) for IF_*_SINCE kinds
+        bool allow_weak = 4;       // compare ETags ignoring the weak (W/) marker
+    }
+    repeated Clause clauses = 1;   // all must hold (logical AND)
 }
 
 // Structured error codes for filer entry operations.
@@ -233,6 +268,7 @@ enum FilerError {
     EXISTING_IS_DIRECTORY = 3; // cannot overwrite directory with file
     EXISTING_IS_FILE      = 4; // cannot overwrite file with directory
     ENTRY_ALREADY_EXISTS  = 5; // O_EXCL and entry already exists
+    PRECONDITION_FAILED   = 6; // WriteCondition not satisfied
 }
 
 message CreateEntryResponse {

--- a/weed/pb/filer_pb/filer.pb.go
+++ b/weed/pb/filer_pb/filer.pb.go
@@ -84,6 +84,7 @@ const (
 	FilerError_EXISTING_IS_DIRECTORY FilerError = 3 // cannot overwrite directory with file
 	FilerError_EXISTING_IS_FILE      FilerError = 4 // cannot overwrite file with directory
 	FilerError_ENTRY_ALREADY_EXISTS  FilerError = 5 // O_EXCL and entry already exists
+	FilerError_PRECONDITION_FAILED   FilerError = 6 // WriteCondition not satisfied
 )
 
 // Enum value maps for FilerError.
@@ -95,6 +96,7 @@ var (
 		3: "EXISTING_IS_DIRECTORY",
 		4: "EXISTING_IS_FILE",
 		5: "ENTRY_ALREADY_EXISTS",
+		6: "PRECONDITION_FAILED",
 	}
 	FilerError_value = map[string]int32{
 		"OK":                    0,
@@ -103,6 +105,7 @@ var (
 		"EXISTING_IS_DIRECTORY": 3,
 		"EXISTING_IS_FILE":      4,
 		"ENTRY_ALREADY_EXISTS":  5,
+		"PRECONDITION_FAILED":   6,
 	}
 )
 
@@ -131,6 +134,67 @@ func (x FilerError) Number() protoreflect.EnumNumber {
 // Deprecated: Use FilerError.Descriptor instead.
 func (FilerError) EnumDescriptor() ([]byte, []int) {
 	return file_filer_proto_rawDescGZIP(), []int{1}
+}
+
+type WriteCondition_Kind int32
+
+const (
+	WriteCondition_NONE                WriteCondition_Kind = 0 // unconditional
+	WriteCondition_IF_NOT_EXISTS       WriteCondition_Kind = 1 // fail if the entry exists (If-None-Match: *)
+	WriteCondition_IF_EXISTS           WriteCondition_Kind = 2 // fail if the entry is absent (If-Match: *)
+	WriteCondition_IF_ETAG_MATCH       WriteCondition_Kind = 3 // fail if absent or etag matches none of the set (If-Match)
+	WriteCondition_IF_ETAG_NOT_MATCH   WriteCondition_Kind = 4 // fail if present and etag matches any of the set (If-None-Match)
+	WriteCondition_IF_UNMODIFIED_SINCE WriteCondition_Kind = 5 // fail if present and mtime > unix_time
+	WriteCondition_IF_MODIFIED_SINCE   WriteCondition_Kind = 6 // fail if present and mtime <= unix_time
+)
+
+// Enum value maps for WriteCondition_Kind.
+var (
+	WriteCondition_Kind_name = map[int32]string{
+		0: "NONE",
+		1: "IF_NOT_EXISTS",
+		2: "IF_EXISTS",
+		3: "IF_ETAG_MATCH",
+		4: "IF_ETAG_NOT_MATCH",
+		5: "IF_UNMODIFIED_SINCE",
+		6: "IF_MODIFIED_SINCE",
+	}
+	WriteCondition_Kind_value = map[string]int32{
+		"NONE":                0,
+		"IF_NOT_EXISTS":       1,
+		"IF_EXISTS":           2,
+		"IF_ETAG_MATCH":       3,
+		"IF_ETAG_NOT_MATCH":   4,
+		"IF_UNMODIFIED_SINCE": 5,
+		"IF_MODIFIED_SINCE":   6,
+	}
+)
+
+func (x WriteCondition_Kind) Enum() *WriteCondition_Kind {
+	p := new(WriteCondition_Kind)
+	*p = x
+	return p
+}
+
+func (x WriteCondition_Kind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (WriteCondition_Kind) Descriptor() protoreflect.EnumDescriptor {
+	return file_filer_proto_enumTypes[2].Descriptor()
+}
+
+func (WriteCondition_Kind) Type() protoreflect.EnumType {
+	return &file_filer_proto_enumTypes[2]
+}
+
+func (x WriteCondition_Kind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use WriteCondition_Kind.Descriptor instead.
+func (WriteCondition_Kind) EnumDescriptor() ([]byte, []int) {
+	return file_filer_proto_rawDescGZIP(), []int{13, 0}
 }
 
 type LookupDirectoryEntryRequest struct {
@@ -1149,8 +1213,12 @@ type CreateEntryRequest struct {
 	IsFromOtherCluster       bool                   `protobuf:"varint,4,opt,name=is_from_other_cluster,json=isFromOtherCluster,proto3" json:"is_from_other_cluster,omitempty"`
 	Signatures               []int32                `protobuf:"varint,5,rep,packed,name=signatures,proto3" json:"signatures,omitempty"`
 	SkipCheckParentDirectory bool                   `protobuf:"varint,6,opt,name=skip_check_parent_directory,json=skipCheckParentDirectory,proto3" json:"skip_check_parent_directory,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	// Optional precondition evaluated against the current entry atomically with
+	// the write, under the filer's per-path lock. The caller must route the
+	// key's writes to this entry's owner filer for the check to be authoritative.
+	Condition     *WriteCondition `protobuf:"bytes,7,opt,name=condition,proto3" json:"condition,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateEntryRequest) Reset() {
@@ -1225,6 +1293,66 @@ func (x *CreateEntryRequest) GetSkipCheckParentDirectory() bool {
 	return false
 }
 
+func (x *CreateEntryRequest) GetCondition() *WriteCondition {
+	if x != nil {
+		return x.Condition
+	}
+	return nil
+}
+
+// WriteCondition is the precondition the filer evaluates against the existing
+// entry before writing, under the per-path lock. A failed condition returns
+// FilerError PRECONDITION_FAILED. The client maps request semantics (e.g. RFC
+// 7232) to clauses; the filer just compares.
+//
+// A condition is a list of clauses that ALL must hold (logical AND). One clause
+// is the common case; several express what a single comparison cannot: an ETag
+// set (If-Match / If-None-Match with multiple values), weak-ETag comparison, and
+// compound conditions (e.g. If-Match + If-Unmodified-Since together).
+type WriteCondition struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Clauses       []*WriteCondition_Clause `protobuf:"bytes,1,rep,name=clauses,proto3" json:"clauses,omitempty"` // all must hold (logical AND)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WriteCondition) Reset() {
+	*x = WriteCondition{}
+	mi := &file_filer_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WriteCondition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WriteCondition) ProtoMessage() {}
+
+func (x *WriteCondition) ProtoReflect() protoreflect.Message {
+	mi := &file_filer_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WriteCondition.ProtoReflect.Descriptor instead.
+func (*WriteCondition) Descriptor() ([]byte, []int) {
+	return file_filer_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *WriteCondition) GetClauses() []*WriteCondition_Clause {
+	if x != nil {
+		return x.Clauses
+	}
+	return nil
+}
+
 type CreateEntryResponse struct {
 	state         protoimpl.MessageState     `protogen:"open.v1"`
 	Error         string                     `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"` // kept for human readability + backward compat
@@ -1236,7 +1364,7 @@ type CreateEntryResponse struct {
 
 func (x *CreateEntryResponse) Reset() {
 	*x = CreateEntryResponse{}
-	mi := &file_filer_proto_msgTypes[13]
+	mi := &file_filer_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1248,7 +1376,7 @@ func (x *CreateEntryResponse) String() string {
 func (*CreateEntryResponse) ProtoMessage() {}
 
 func (x *CreateEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[13]
+	mi := &file_filer_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1261,7 +1389,7 @@ func (x *CreateEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateEntryResponse.ProtoReflect.Descriptor instead.
 func (*CreateEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{13}
+	return file_filer_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateEntryResponse) GetError() string {
@@ -1298,7 +1426,7 @@ type UpdateEntryRequest struct {
 
 func (x *UpdateEntryRequest) Reset() {
 	*x = UpdateEntryRequest{}
-	mi := &file_filer_proto_msgTypes[14]
+	mi := &file_filer_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1310,7 +1438,7 @@ func (x *UpdateEntryRequest) String() string {
 func (*UpdateEntryRequest) ProtoMessage() {}
 
 func (x *UpdateEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[14]
+	mi := &file_filer_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1323,7 +1451,7 @@ func (x *UpdateEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateEntryRequest.ProtoReflect.Descriptor instead.
 func (*UpdateEntryRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{14}
+	return file_filer_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *UpdateEntryRequest) GetDirectory() string {
@@ -1370,7 +1498,7 @@ type UpdateEntryResponse struct {
 
 func (x *UpdateEntryResponse) Reset() {
 	*x = UpdateEntryResponse{}
-	mi := &file_filer_proto_msgTypes[15]
+	mi := &file_filer_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1382,7 +1510,7 @@ func (x *UpdateEntryResponse) String() string {
 func (*UpdateEntryResponse) ProtoMessage() {}
 
 func (x *UpdateEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[15]
+	mi := &file_filer_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1395,7 +1523,7 @@ func (x *UpdateEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateEntryResponse.ProtoReflect.Descriptor instead.
 func (*UpdateEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{15}
+	return file_filer_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *UpdateEntryResponse) GetMetadataEvent() *SubscribeMetadataResponse {
@@ -1416,7 +1544,7 @@ type TouchAccessTimeRequest struct {
 
 func (x *TouchAccessTimeRequest) Reset() {
 	*x = TouchAccessTimeRequest{}
-	mi := &file_filer_proto_msgTypes[16]
+	mi := &file_filer_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1556,7 @@ func (x *TouchAccessTimeRequest) String() string {
 func (*TouchAccessTimeRequest) ProtoMessage() {}
 
 func (x *TouchAccessTimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[16]
+	mi := &file_filer_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1569,7 @@ func (x *TouchAccessTimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TouchAccessTimeRequest.ProtoReflect.Descriptor instead.
 func (*TouchAccessTimeRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{16}
+	return file_filer_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *TouchAccessTimeRequest) GetDirectory() string {
@@ -1475,7 +1603,7 @@ type TouchAccessTimeResponse struct {
 
 func (x *TouchAccessTimeResponse) Reset() {
 	*x = TouchAccessTimeResponse{}
-	mi := &file_filer_proto_msgTypes[17]
+	mi := &file_filer_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1487,7 +1615,7 @@ func (x *TouchAccessTimeResponse) String() string {
 func (*TouchAccessTimeResponse) ProtoMessage() {}
 
 func (x *TouchAccessTimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[17]
+	mi := &file_filer_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1500,7 +1628,7 @@ func (x *TouchAccessTimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TouchAccessTimeResponse.ProtoReflect.Descriptor instead.
 func (*TouchAccessTimeResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{17}
+	return file_filer_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TouchAccessTimeResponse) GetPersistedAtimeNs() int64 {
@@ -1528,7 +1656,7 @@ type AppendToEntryRequest struct {
 
 func (x *AppendToEntryRequest) Reset() {
 	*x = AppendToEntryRequest{}
-	mi := &file_filer_proto_msgTypes[18]
+	mi := &file_filer_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1540,7 +1668,7 @@ func (x *AppendToEntryRequest) String() string {
 func (*AppendToEntryRequest) ProtoMessage() {}
 
 func (x *AppendToEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[18]
+	mi := &file_filer_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1553,7 +1681,7 @@ func (x *AppendToEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppendToEntryRequest.ProtoReflect.Descriptor instead.
 func (*AppendToEntryRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{18}
+	return file_filer_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *AppendToEntryRequest) GetDirectory() string {
@@ -1585,7 +1713,7 @@ type AppendToEntryResponse struct {
 
 func (x *AppendToEntryResponse) Reset() {
 	*x = AppendToEntryResponse{}
-	mi := &file_filer_proto_msgTypes[19]
+	mi := &file_filer_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1597,7 +1725,7 @@ func (x *AppendToEntryResponse) String() string {
 func (*AppendToEntryResponse) ProtoMessage() {}
 
 func (x *AppendToEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[19]
+	mi := &file_filer_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1610,7 +1738,7 @@ func (x *AppendToEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppendToEntryResponse.ProtoReflect.Descriptor instead.
 func (*AppendToEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{19}
+	return file_filer_proto_rawDescGZIP(), []int{20}
 }
 
 type DeleteEntryRequest struct {
@@ -1630,7 +1758,7 @@ type DeleteEntryRequest struct {
 
 func (x *DeleteEntryRequest) Reset() {
 	*x = DeleteEntryRequest{}
-	mi := &file_filer_proto_msgTypes[20]
+	mi := &file_filer_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1642,7 +1770,7 @@ func (x *DeleteEntryRequest) String() string {
 func (*DeleteEntryRequest) ProtoMessage() {}
 
 func (x *DeleteEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[20]
+	mi := &file_filer_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1655,7 +1783,7 @@ func (x *DeleteEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEntryRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEntryRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{20}
+	return file_filer_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *DeleteEntryRequest) GetDirectory() string {
@@ -1724,7 +1852,7 @@ type DeleteEntryResponse struct {
 
 func (x *DeleteEntryResponse) Reset() {
 	*x = DeleteEntryResponse{}
-	mi := &file_filer_proto_msgTypes[21]
+	mi := &file_filer_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1736,7 +1864,7 @@ func (x *DeleteEntryResponse) String() string {
 func (*DeleteEntryResponse) ProtoMessage() {}
 
 func (x *DeleteEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[21]
+	mi := &file_filer_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1749,7 +1877,7 @@ func (x *DeleteEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEntryResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{21}
+	return file_filer_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DeleteEntryResponse) GetError() string {
@@ -1779,7 +1907,7 @@ type AtomicRenameEntryRequest struct {
 
 func (x *AtomicRenameEntryRequest) Reset() {
 	*x = AtomicRenameEntryRequest{}
-	mi := &file_filer_proto_msgTypes[22]
+	mi := &file_filer_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1791,7 +1919,7 @@ func (x *AtomicRenameEntryRequest) String() string {
 func (*AtomicRenameEntryRequest) ProtoMessage() {}
 
 func (x *AtomicRenameEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[22]
+	mi := &file_filer_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1804,7 +1932,7 @@ func (x *AtomicRenameEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AtomicRenameEntryRequest.ProtoReflect.Descriptor instead.
 func (*AtomicRenameEntryRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{22}
+	return file_filer_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AtomicRenameEntryRequest) GetOldDirectory() string {
@@ -1850,7 +1978,7 @@ type AtomicRenameEntryResponse struct {
 
 func (x *AtomicRenameEntryResponse) Reset() {
 	*x = AtomicRenameEntryResponse{}
-	mi := &file_filer_proto_msgTypes[23]
+	mi := &file_filer_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1862,7 +1990,7 @@ func (x *AtomicRenameEntryResponse) String() string {
 func (*AtomicRenameEntryResponse) ProtoMessage() {}
 
 func (x *AtomicRenameEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[23]
+	mi := &file_filer_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1875,7 +2003,7 @@ func (x *AtomicRenameEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AtomicRenameEntryResponse.ProtoReflect.Descriptor instead.
 func (*AtomicRenameEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{23}
+	return file_filer_proto_rawDescGZIP(), []int{24}
 }
 
 type StreamRenameEntryRequest struct {
@@ -1891,7 +2019,7 @@ type StreamRenameEntryRequest struct {
 
 func (x *StreamRenameEntryRequest) Reset() {
 	*x = StreamRenameEntryRequest{}
-	mi := &file_filer_proto_msgTypes[24]
+	mi := &file_filer_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1903,7 +2031,7 @@ func (x *StreamRenameEntryRequest) String() string {
 func (*StreamRenameEntryRequest) ProtoMessage() {}
 
 func (x *StreamRenameEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[24]
+	mi := &file_filer_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1916,7 +2044,7 @@ func (x *StreamRenameEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamRenameEntryRequest.ProtoReflect.Descriptor instead.
 func (*StreamRenameEntryRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{24}
+	return file_filer_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *StreamRenameEntryRequest) GetOldDirectory() string {
@@ -1965,7 +2093,7 @@ type StreamRenameEntryResponse struct {
 
 func (x *StreamRenameEntryResponse) Reset() {
 	*x = StreamRenameEntryResponse{}
-	mi := &file_filer_proto_msgTypes[25]
+	mi := &file_filer_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1977,7 +2105,7 @@ func (x *StreamRenameEntryResponse) String() string {
 func (*StreamRenameEntryResponse) ProtoMessage() {}
 
 func (x *StreamRenameEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[25]
+	mi := &file_filer_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1990,7 +2118,7 @@ func (x *StreamRenameEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamRenameEntryResponse.ProtoReflect.Descriptor instead.
 func (*StreamRenameEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{25}
+	return file_filer_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *StreamRenameEntryResponse) GetDirectory() string {
@@ -2032,7 +2160,7 @@ type AssignVolumeRequest struct {
 
 func (x *AssignVolumeRequest) Reset() {
 	*x = AssignVolumeRequest{}
-	mi := &file_filer_proto_msgTypes[26]
+	mi := &file_filer_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2044,7 +2172,7 @@ func (x *AssignVolumeRequest) String() string {
 func (*AssignVolumeRequest) ProtoMessage() {}
 
 func (x *AssignVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[26]
+	mi := &file_filer_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2185,7 @@ func (x *AssignVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssignVolumeRequest.ProtoReflect.Descriptor instead.
 func (*AssignVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{26}
+	return file_filer_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *AssignVolumeRequest) GetCount() int32 {
@@ -2145,7 +2273,7 @@ type AssignVolumeResponse struct {
 
 func (x *AssignVolumeResponse) Reset() {
 	*x = AssignVolumeResponse{}
-	mi := &file_filer_proto_msgTypes[27]
+	mi := &file_filer_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2157,7 +2285,7 @@ func (x *AssignVolumeResponse) String() string {
 func (*AssignVolumeResponse) ProtoMessage() {}
 
 func (x *AssignVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[27]
+	mi := &file_filer_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2170,7 +2298,7 @@ func (x *AssignVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssignVolumeResponse.ProtoReflect.Descriptor instead.
 func (*AssignVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{27}
+	return file_filer_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AssignVolumeResponse) GetFileId() string {
@@ -2231,7 +2359,7 @@ type LookupVolumeRequest struct {
 
 func (x *LookupVolumeRequest) Reset() {
 	*x = LookupVolumeRequest{}
-	mi := &file_filer_proto_msgTypes[28]
+	mi := &file_filer_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2243,7 +2371,7 @@ func (x *LookupVolumeRequest) String() string {
 func (*LookupVolumeRequest) ProtoMessage() {}
 
 func (x *LookupVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[28]
+	mi := &file_filer_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2256,7 +2384,7 @@ func (x *LookupVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupVolumeRequest.ProtoReflect.Descriptor instead.
 func (*LookupVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{28}
+	return file_filer_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LookupVolumeRequest) GetVolumeIds() []string {
@@ -2275,7 +2403,7 @@ type Locations struct {
 
 func (x *Locations) Reset() {
 	*x = Locations{}
-	mi := &file_filer_proto_msgTypes[29]
+	mi := &file_filer_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2287,7 +2415,7 @@ func (x *Locations) String() string {
 func (*Locations) ProtoMessage() {}
 
 func (x *Locations) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[29]
+	mi := &file_filer_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2300,7 +2428,7 @@ func (x *Locations) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Locations.ProtoReflect.Descriptor instead.
 func (*Locations) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{29}
+	return file_filer_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Locations) GetLocations() []*Location {
@@ -2322,7 +2450,7 @@ type Location struct {
 
 func (x *Location) Reset() {
 	*x = Location{}
-	mi := &file_filer_proto_msgTypes[30]
+	mi := &file_filer_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2334,7 +2462,7 @@ func (x *Location) String() string {
 func (*Location) ProtoMessage() {}
 
 func (x *Location) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[30]
+	mi := &file_filer_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2347,7 +2475,7 @@ func (x *Location) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Location.ProtoReflect.Descriptor instead.
 func (*Location) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{30}
+	return file_filer_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *Location) GetUrl() string {
@@ -2387,7 +2515,7 @@ type LookupVolumeResponse struct {
 
 func (x *LookupVolumeResponse) Reset() {
 	*x = LookupVolumeResponse{}
-	mi := &file_filer_proto_msgTypes[31]
+	mi := &file_filer_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2399,7 +2527,7 @@ func (x *LookupVolumeResponse) String() string {
 func (*LookupVolumeResponse) ProtoMessage() {}
 
 func (x *LookupVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[31]
+	mi := &file_filer_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2412,7 +2540,7 @@ func (x *LookupVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupVolumeResponse.ProtoReflect.Descriptor instead.
 func (*LookupVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{31}
+	return file_filer_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LookupVolumeResponse) GetLocationsMap() map[string]*Locations {
@@ -2431,7 +2559,7 @@ type Collection struct {
 
 func (x *Collection) Reset() {
 	*x = Collection{}
-	mi := &file_filer_proto_msgTypes[32]
+	mi := &file_filer_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2443,7 +2571,7 @@ func (x *Collection) String() string {
 func (*Collection) ProtoMessage() {}
 
 func (x *Collection) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[32]
+	mi := &file_filer_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2456,7 +2584,7 @@ func (x *Collection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Collection.ProtoReflect.Descriptor instead.
 func (*Collection) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{32}
+	return file_filer_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Collection) GetName() string {
@@ -2476,7 +2604,7 @@ type CollectionListRequest struct {
 
 func (x *CollectionListRequest) Reset() {
 	*x = CollectionListRequest{}
-	mi := &file_filer_proto_msgTypes[33]
+	mi := &file_filer_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2488,7 +2616,7 @@ func (x *CollectionListRequest) String() string {
 func (*CollectionListRequest) ProtoMessage() {}
 
 func (x *CollectionListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[33]
+	mi := &file_filer_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2501,7 +2629,7 @@ func (x *CollectionListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CollectionListRequest.ProtoReflect.Descriptor instead.
 func (*CollectionListRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{33}
+	return file_filer_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *CollectionListRequest) GetIncludeNormalVolumes() bool {
@@ -2527,7 +2655,7 @@ type CollectionListResponse struct {
 
 func (x *CollectionListResponse) Reset() {
 	*x = CollectionListResponse{}
-	mi := &file_filer_proto_msgTypes[34]
+	mi := &file_filer_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +2667,7 @@ func (x *CollectionListResponse) String() string {
 func (*CollectionListResponse) ProtoMessage() {}
 
 func (x *CollectionListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[34]
+	mi := &file_filer_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2552,7 +2680,7 @@ func (x *CollectionListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CollectionListResponse.ProtoReflect.Descriptor instead.
 func (*CollectionListResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{34}
+	return file_filer_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *CollectionListResponse) GetCollections() []*Collection {
@@ -2571,7 +2699,7 @@ type DeleteCollectionRequest struct {
 
 func (x *DeleteCollectionRequest) Reset() {
 	*x = DeleteCollectionRequest{}
-	mi := &file_filer_proto_msgTypes[35]
+	mi := &file_filer_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2583,7 +2711,7 @@ func (x *DeleteCollectionRequest) String() string {
 func (*DeleteCollectionRequest) ProtoMessage() {}
 
 func (x *DeleteCollectionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[35]
+	mi := &file_filer_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2596,7 +2724,7 @@ func (x *DeleteCollectionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteCollectionRequest.ProtoReflect.Descriptor instead.
 func (*DeleteCollectionRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{35}
+	return file_filer_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DeleteCollectionRequest) GetCollection() string {
@@ -2614,7 +2742,7 @@ type DeleteCollectionResponse struct {
 
 func (x *DeleteCollectionResponse) Reset() {
 	*x = DeleteCollectionResponse{}
-	mi := &file_filer_proto_msgTypes[36]
+	mi := &file_filer_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2626,7 +2754,7 @@ func (x *DeleteCollectionResponse) String() string {
 func (*DeleteCollectionResponse) ProtoMessage() {}
 
 func (x *DeleteCollectionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[36]
+	mi := &file_filer_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2639,7 +2767,7 @@ func (x *DeleteCollectionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteCollectionResponse.ProtoReflect.Descriptor instead.
 func (*DeleteCollectionResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{36}
+	return file_filer_proto_rawDescGZIP(), []int{37}
 }
 
 type StatisticsRequest struct {
@@ -2654,7 +2782,7 @@ type StatisticsRequest struct {
 
 func (x *StatisticsRequest) Reset() {
 	*x = StatisticsRequest{}
-	mi := &file_filer_proto_msgTypes[37]
+	mi := &file_filer_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2666,7 +2794,7 @@ func (x *StatisticsRequest) String() string {
 func (*StatisticsRequest) ProtoMessage() {}
 
 func (x *StatisticsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[37]
+	mi := &file_filer_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2679,7 +2807,7 @@ func (x *StatisticsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatisticsRequest.ProtoReflect.Descriptor instead.
 func (*StatisticsRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{37}
+	return file_filer_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StatisticsRequest) GetReplication() string {
@@ -2721,7 +2849,7 @@ type StatisticsResponse struct {
 
 func (x *StatisticsResponse) Reset() {
 	*x = StatisticsResponse{}
-	mi := &file_filer_proto_msgTypes[38]
+	mi := &file_filer_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2733,7 +2861,7 @@ func (x *StatisticsResponse) String() string {
 func (*StatisticsResponse) ProtoMessage() {}
 
 func (x *StatisticsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[38]
+	mi := &file_filer_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2746,7 +2874,7 @@ func (x *StatisticsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatisticsResponse.ProtoReflect.Descriptor instead.
 func (*StatisticsResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{38}
+	return file_filer_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StatisticsResponse) GetTotalSize() uint64 {
@@ -2780,7 +2908,7 @@ type PingRequest struct {
 
 func (x *PingRequest) Reset() {
 	*x = PingRequest{}
-	mi := &file_filer_proto_msgTypes[39]
+	mi := &file_filer_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2792,7 +2920,7 @@ func (x *PingRequest) String() string {
 func (*PingRequest) ProtoMessage() {}
 
 func (x *PingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[39]
+	mi := &file_filer_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2805,7 +2933,7 @@ func (x *PingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingRequest.ProtoReflect.Descriptor instead.
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{39}
+	return file_filer_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *PingRequest) GetTarget() string {
@@ -2833,7 +2961,7 @@ type PingResponse struct {
 
 func (x *PingResponse) Reset() {
 	*x = PingResponse{}
-	mi := &file_filer_proto_msgTypes[40]
+	mi := &file_filer_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2845,7 +2973,7 @@ func (x *PingResponse) String() string {
 func (*PingResponse) ProtoMessage() {}
 
 func (x *PingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[40]
+	mi := &file_filer_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2858,7 +2986,7 @@ func (x *PingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingResponse.ProtoReflect.Descriptor instead.
 func (*PingResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{40}
+	return file_filer_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PingResponse) GetStartTimeNs() int64 {
@@ -2890,7 +3018,7 @@ type GetFilerConfigurationRequest struct {
 
 func (x *GetFilerConfigurationRequest) Reset() {
 	*x = GetFilerConfigurationRequest{}
-	mi := &file_filer_proto_msgTypes[41]
+	mi := &file_filer_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2902,7 +3030,7 @@ func (x *GetFilerConfigurationRequest) String() string {
 func (*GetFilerConfigurationRequest) ProtoMessage() {}
 
 func (x *GetFilerConfigurationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[41]
+	mi := &file_filer_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2915,7 +3043,7 @@ func (x *GetFilerConfigurationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFilerConfigurationRequest.ProtoReflect.Descriptor instead.
 func (*GetFilerConfigurationRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{41}
+	return file_filer_proto_rawDescGZIP(), []int{42}
 }
 
 type GetFilerConfigurationResponse struct {
@@ -2940,7 +3068,7 @@ type GetFilerConfigurationResponse struct {
 
 func (x *GetFilerConfigurationResponse) Reset() {
 	*x = GetFilerConfigurationResponse{}
-	mi := &file_filer_proto_msgTypes[42]
+	mi := &file_filer_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2952,7 +3080,7 @@ func (x *GetFilerConfigurationResponse) String() string {
 func (*GetFilerConfigurationResponse) ProtoMessage() {}
 
 func (x *GetFilerConfigurationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[42]
+	mi := &file_filer_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2965,7 +3093,7 @@ func (x *GetFilerConfigurationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFilerConfigurationResponse.ProtoReflect.Descriptor instead.
 func (*GetFilerConfigurationResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{42}
+	return file_filer_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *GetFilerConfigurationResponse) GetMasters() []string {
@@ -3086,7 +3214,7 @@ type SubscribeMetadataRequest struct {
 
 func (x *SubscribeMetadataRequest) Reset() {
 	*x = SubscribeMetadataRequest{}
-	mi := &file_filer_proto_msgTypes[43]
+	mi := &file_filer_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3098,7 +3226,7 @@ func (x *SubscribeMetadataRequest) String() string {
 func (*SubscribeMetadataRequest) ProtoMessage() {}
 
 func (x *SubscribeMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[43]
+	mi := &file_filer_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3111,7 +3239,7 @@ func (x *SubscribeMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeMetadataRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{43}
+	return file_filer_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SubscribeMetadataRequest) GetClientName() string {
@@ -3211,7 +3339,7 @@ type SubscribeMetadataResponse struct {
 
 func (x *SubscribeMetadataResponse) Reset() {
 	*x = SubscribeMetadataResponse{}
-	mi := &file_filer_proto_msgTypes[44]
+	mi := &file_filer_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3223,7 +3351,7 @@ func (x *SubscribeMetadataResponse) String() string {
 func (*SubscribeMetadataResponse) ProtoMessage() {}
 
 func (x *SubscribeMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[44]
+	mi := &file_filer_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3236,7 +3364,7 @@ func (x *SubscribeMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeMetadataResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{44}
+	return file_filer_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *SubscribeMetadataResponse) GetDirectory() string {
@@ -3288,7 +3416,7 @@ type LogFileChunkRef struct {
 
 func (x *LogFileChunkRef) Reset() {
 	*x = LogFileChunkRef{}
-	mi := &file_filer_proto_msgTypes[45]
+	mi := &file_filer_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3300,7 +3428,7 @@ func (x *LogFileChunkRef) String() string {
 func (*LogFileChunkRef) ProtoMessage() {}
 
 func (x *LogFileChunkRef) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[45]
+	mi := &file_filer_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3313,7 +3441,7 @@ func (x *LogFileChunkRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogFileChunkRef.ProtoReflect.Descriptor instead.
 func (*LogFileChunkRef) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{45}
+	return file_filer_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *LogFileChunkRef) GetChunks() []*FileChunk {
@@ -3347,7 +3475,7 @@ type TraverseBfsMetadataRequest struct {
 
 func (x *TraverseBfsMetadataRequest) Reset() {
 	*x = TraverseBfsMetadataRequest{}
-	mi := &file_filer_proto_msgTypes[46]
+	mi := &file_filer_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3359,7 +3487,7 @@ func (x *TraverseBfsMetadataRequest) String() string {
 func (*TraverseBfsMetadataRequest) ProtoMessage() {}
 
 func (x *TraverseBfsMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[46]
+	mi := &file_filer_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3372,7 +3500,7 @@ func (x *TraverseBfsMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraverseBfsMetadataRequest.ProtoReflect.Descriptor instead.
 func (*TraverseBfsMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{46}
+	return file_filer_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *TraverseBfsMetadataRequest) GetDirectory() string {
@@ -3399,7 +3527,7 @@ type TraverseBfsMetadataResponse struct {
 
 func (x *TraverseBfsMetadataResponse) Reset() {
 	*x = TraverseBfsMetadataResponse{}
-	mi := &file_filer_proto_msgTypes[47]
+	mi := &file_filer_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3411,7 +3539,7 @@ func (x *TraverseBfsMetadataResponse) String() string {
 func (*TraverseBfsMetadataResponse) ProtoMessage() {}
 
 func (x *TraverseBfsMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[47]
+	mi := &file_filer_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3424,7 +3552,7 @@ func (x *TraverseBfsMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraverseBfsMetadataResponse.ProtoReflect.Descriptor instead.
 func (*TraverseBfsMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{47}
+	return file_filer_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *TraverseBfsMetadataResponse) GetDirectory() string {
@@ -3454,7 +3582,7 @@ type LogEntry struct {
 
 func (x *LogEntry) Reset() {
 	*x = LogEntry{}
-	mi := &file_filer_proto_msgTypes[48]
+	mi := &file_filer_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3466,7 +3594,7 @@ func (x *LogEntry) String() string {
 func (*LogEntry) ProtoMessage() {}
 
 func (x *LogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[48]
+	mi := &file_filer_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3479,7 +3607,7 @@ func (x *LogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogEntry.ProtoReflect.Descriptor instead.
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{48}
+	return file_filer_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *LogEntry) GetTsNs() int64 {
@@ -3528,7 +3656,7 @@ type KeepConnectedRequest struct {
 
 func (x *KeepConnectedRequest) Reset() {
 	*x = KeepConnectedRequest{}
-	mi := &file_filer_proto_msgTypes[49]
+	mi := &file_filer_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3540,7 +3668,7 @@ func (x *KeepConnectedRequest) String() string {
 func (*KeepConnectedRequest) ProtoMessage() {}
 
 func (x *KeepConnectedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[49]
+	mi := &file_filer_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3553,7 +3681,7 @@ func (x *KeepConnectedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeepConnectedRequest.ProtoReflect.Descriptor instead.
 func (*KeepConnectedRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{49}
+	return file_filer_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *KeepConnectedRequest) GetName() string {
@@ -3585,7 +3713,7 @@ type KeepConnectedResponse struct {
 
 func (x *KeepConnectedResponse) Reset() {
 	*x = KeepConnectedResponse{}
-	mi := &file_filer_proto_msgTypes[50]
+	mi := &file_filer_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3597,7 +3725,7 @@ func (x *KeepConnectedResponse) String() string {
 func (*KeepConnectedResponse) ProtoMessage() {}
 
 func (x *KeepConnectedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[50]
+	mi := &file_filer_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3610,7 +3738,7 @@ func (x *KeepConnectedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeepConnectedResponse.ProtoReflect.Descriptor instead.
 func (*KeepConnectedResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{50}
+	return file_filer_proto_rawDescGZIP(), []int{51}
 }
 
 type LocateBrokerRequest struct {
@@ -3622,7 +3750,7 @@ type LocateBrokerRequest struct {
 
 func (x *LocateBrokerRequest) Reset() {
 	*x = LocateBrokerRequest{}
-	mi := &file_filer_proto_msgTypes[51]
+	mi := &file_filer_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3634,7 +3762,7 @@ func (x *LocateBrokerRequest) String() string {
 func (*LocateBrokerRequest) ProtoMessage() {}
 
 func (x *LocateBrokerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[51]
+	mi := &file_filer_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3647,7 +3775,7 @@ func (x *LocateBrokerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocateBrokerRequest.ProtoReflect.Descriptor instead.
 func (*LocateBrokerRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{51}
+	return file_filer_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *LocateBrokerRequest) GetResource() string {
@@ -3667,7 +3795,7 @@ type LocateBrokerResponse struct {
 
 func (x *LocateBrokerResponse) Reset() {
 	*x = LocateBrokerResponse{}
-	mi := &file_filer_proto_msgTypes[52]
+	mi := &file_filer_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3679,7 +3807,7 @@ func (x *LocateBrokerResponse) String() string {
 func (*LocateBrokerResponse) ProtoMessage() {}
 
 func (x *LocateBrokerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[52]
+	mi := &file_filer_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3692,7 +3820,7 @@ func (x *LocateBrokerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocateBrokerResponse.ProtoReflect.Descriptor instead.
 func (*LocateBrokerResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{52}
+	return file_filer_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *LocateBrokerResponse) GetFound() bool {
@@ -3721,7 +3849,7 @@ type KvGetRequest struct {
 
 func (x *KvGetRequest) Reset() {
 	*x = KvGetRequest{}
-	mi := &file_filer_proto_msgTypes[53]
+	mi := &file_filer_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3733,7 +3861,7 @@ func (x *KvGetRequest) String() string {
 func (*KvGetRequest) ProtoMessage() {}
 
 func (x *KvGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[53]
+	mi := &file_filer_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3746,7 +3874,7 @@ func (x *KvGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvGetRequest.ProtoReflect.Descriptor instead.
 func (*KvGetRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{53}
+	return file_filer_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *KvGetRequest) GetKey() []byte {
@@ -3766,7 +3894,7 @@ type KvGetResponse struct {
 
 func (x *KvGetResponse) Reset() {
 	*x = KvGetResponse{}
-	mi := &file_filer_proto_msgTypes[54]
+	mi := &file_filer_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3778,7 +3906,7 @@ func (x *KvGetResponse) String() string {
 func (*KvGetResponse) ProtoMessage() {}
 
 func (x *KvGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[54]
+	mi := &file_filer_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3791,7 +3919,7 @@ func (x *KvGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvGetResponse.ProtoReflect.Descriptor instead.
 func (*KvGetResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{54}
+	return file_filer_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *KvGetResponse) GetValue() []byte {
@@ -3818,7 +3946,7 @@ type KvPutRequest struct {
 
 func (x *KvPutRequest) Reset() {
 	*x = KvPutRequest{}
-	mi := &file_filer_proto_msgTypes[55]
+	mi := &file_filer_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3830,7 +3958,7 @@ func (x *KvPutRequest) String() string {
 func (*KvPutRequest) ProtoMessage() {}
 
 func (x *KvPutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[55]
+	mi := &file_filer_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3843,7 +3971,7 @@ func (x *KvPutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvPutRequest.ProtoReflect.Descriptor instead.
 func (*KvPutRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{55}
+	return file_filer_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *KvPutRequest) GetKey() []byte {
@@ -3869,7 +3997,7 @@ type KvPutResponse struct {
 
 func (x *KvPutResponse) Reset() {
 	*x = KvPutResponse{}
-	mi := &file_filer_proto_msgTypes[56]
+	mi := &file_filer_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3881,7 +4009,7 @@ func (x *KvPutResponse) String() string {
 func (*KvPutResponse) ProtoMessage() {}
 
 func (x *KvPutResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[56]
+	mi := &file_filer_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3894,7 +4022,7 @@ func (x *KvPutResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvPutResponse.ProtoReflect.Descriptor instead.
 func (*KvPutResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{56}
+	return file_filer_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *KvPutResponse) GetError() string {
@@ -3917,7 +4045,7 @@ type FilerConf struct {
 
 func (x *FilerConf) Reset() {
 	*x = FilerConf{}
-	mi := &file_filer_proto_msgTypes[57]
+	mi := &file_filer_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3929,7 +4057,7 @@ func (x *FilerConf) String() string {
 func (*FilerConf) ProtoMessage() {}
 
 func (x *FilerConf) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[57]
+	mi := &file_filer_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3942,7 +4070,7 @@ func (x *FilerConf) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilerConf.ProtoReflect.Descriptor instead.
 func (*FilerConf) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{57}
+	return file_filer_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *FilerConf) GetVersion() int32 {
@@ -3974,7 +4102,7 @@ type CacheRemoteObjectToLocalClusterRequest struct {
 
 func (x *CacheRemoteObjectToLocalClusterRequest) Reset() {
 	*x = CacheRemoteObjectToLocalClusterRequest{}
-	mi := &file_filer_proto_msgTypes[58]
+	mi := &file_filer_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3986,7 +4114,7 @@ func (x *CacheRemoteObjectToLocalClusterRequest) String() string {
 func (*CacheRemoteObjectToLocalClusterRequest) ProtoMessage() {}
 
 func (x *CacheRemoteObjectToLocalClusterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[58]
+	mi := &file_filer_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3999,7 +4127,7 @@ func (x *CacheRemoteObjectToLocalClusterRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use CacheRemoteObjectToLocalClusterRequest.ProtoReflect.Descriptor instead.
 func (*CacheRemoteObjectToLocalClusterRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{58}
+	return file_filer_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *CacheRemoteObjectToLocalClusterRequest) GetDirectory() string {
@@ -4040,7 +4168,7 @@ type CacheRemoteObjectToLocalClusterResponse struct {
 
 func (x *CacheRemoteObjectToLocalClusterResponse) Reset() {
 	*x = CacheRemoteObjectToLocalClusterResponse{}
-	mi := &file_filer_proto_msgTypes[59]
+	mi := &file_filer_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4052,7 +4180,7 @@ func (x *CacheRemoteObjectToLocalClusterResponse) String() string {
 func (*CacheRemoteObjectToLocalClusterResponse) ProtoMessage() {}
 
 func (x *CacheRemoteObjectToLocalClusterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[59]
+	mi := &file_filer_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4065,7 +4193,7 @@ func (x *CacheRemoteObjectToLocalClusterResponse) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use CacheRemoteObjectToLocalClusterResponse.ProtoReflect.Descriptor instead.
 func (*CacheRemoteObjectToLocalClusterResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{59}
+	return file_filer_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *CacheRemoteObjectToLocalClusterResponse) GetEntry() *Entry {
@@ -4098,7 +4226,7 @@ type LockRequest struct {
 
 func (x *LockRequest) Reset() {
 	*x = LockRequest{}
-	mi := &file_filer_proto_msgTypes[60]
+	mi := &file_filer_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4110,7 +4238,7 @@ func (x *LockRequest) String() string {
 func (*LockRequest) ProtoMessage() {}
 
 func (x *LockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[60]
+	mi := &file_filer_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4123,7 +4251,7 @@ func (x *LockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockRequest.ProtoReflect.Descriptor instead.
 func (*LockRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{60}
+	return file_filer_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *LockRequest) GetName() string {
@@ -4174,7 +4302,7 @@ type LockResponse struct {
 
 func (x *LockResponse) Reset() {
 	*x = LockResponse{}
-	mi := &file_filer_proto_msgTypes[61]
+	mi := &file_filer_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4186,7 +4314,7 @@ func (x *LockResponse) String() string {
 func (*LockResponse) ProtoMessage() {}
 
 func (x *LockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[61]
+	mi := &file_filer_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4199,7 +4327,7 @@ func (x *LockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockResponse.ProtoReflect.Descriptor instead.
 func (*LockResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{61}
+	return file_filer_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *LockResponse) GetRenewToken() string {
@@ -4248,7 +4376,7 @@ type UnlockRequest struct {
 
 func (x *UnlockRequest) Reset() {
 	*x = UnlockRequest{}
-	mi := &file_filer_proto_msgTypes[62]
+	mi := &file_filer_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4260,7 +4388,7 @@ func (x *UnlockRequest) String() string {
 func (*UnlockRequest) ProtoMessage() {}
 
 func (x *UnlockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[62]
+	mi := &file_filer_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4273,7 +4401,7 @@ func (x *UnlockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockRequest.ProtoReflect.Descriptor instead.
 func (*UnlockRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{62}
+	return file_filer_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *UnlockRequest) GetName() string {
@@ -4307,7 +4435,7 @@ type UnlockResponse struct {
 
 func (x *UnlockResponse) Reset() {
 	*x = UnlockResponse{}
-	mi := &file_filer_proto_msgTypes[63]
+	mi := &file_filer_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4319,7 +4447,7 @@ func (x *UnlockResponse) String() string {
 func (*UnlockResponse) ProtoMessage() {}
 
 func (x *UnlockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[63]
+	mi := &file_filer_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4332,7 +4460,7 @@ func (x *UnlockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockResponse.ProtoReflect.Descriptor instead.
 func (*UnlockResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{63}
+	return file_filer_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UnlockResponse) GetError() string {
@@ -4359,7 +4487,7 @@ type FindLockOwnerRequest struct {
 
 func (x *FindLockOwnerRequest) Reset() {
 	*x = FindLockOwnerRequest{}
-	mi := &file_filer_proto_msgTypes[64]
+	mi := &file_filer_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4371,7 +4499,7 @@ func (x *FindLockOwnerRequest) String() string {
 func (*FindLockOwnerRequest) ProtoMessage() {}
 
 func (x *FindLockOwnerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[64]
+	mi := &file_filer_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4384,7 +4512,7 @@ func (x *FindLockOwnerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindLockOwnerRequest.ProtoReflect.Descriptor instead.
 func (*FindLockOwnerRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{64}
+	return file_filer_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *FindLockOwnerRequest) GetName() string {
@@ -4410,7 +4538,7 @@ type FindLockOwnerResponse struct {
 
 func (x *FindLockOwnerResponse) Reset() {
 	*x = FindLockOwnerResponse{}
-	mi := &file_filer_proto_msgTypes[65]
+	mi := &file_filer_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4422,7 +4550,7 @@ func (x *FindLockOwnerResponse) String() string {
 func (*FindLockOwnerResponse) ProtoMessage() {}
 
 func (x *FindLockOwnerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[65]
+	mi := &file_filer_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4435,7 +4563,7 @@ func (x *FindLockOwnerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindLockOwnerResponse.ProtoReflect.Descriptor instead.
 func (*FindLockOwnerResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{65}
+	return file_filer_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *FindLockOwnerResponse) GetOwner() string {
@@ -4460,7 +4588,7 @@ type Lock struct {
 
 func (x *Lock) Reset() {
 	*x = Lock{}
-	mi := &file_filer_proto_msgTypes[66]
+	mi := &file_filer_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4472,7 +4600,7 @@ func (x *Lock) String() string {
 func (*Lock) ProtoMessage() {}
 
 func (x *Lock) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[66]
+	mi := &file_filer_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4485,7 +4613,7 @@ func (x *Lock) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Lock.ProtoReflect.Descriptor instead.
 func (*Lock) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{66}
+	return file_filer_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *Lock) GetName() string {
@@ -4546,7 +4674,7 @@ type TransferLocksRequest struct {
 
 func (x *TransferLocksRequest) Reset() {
 	*x = TransferLocksRequest{}
-	mi := &file_filer_proto_msgTypes[67]
+	mi := &file_filer_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4558,7 +4686,7 @@ func (x *TransferLocksRequest) String() string {
 func (*TransferLocksRequest) ProtoMessage() {}
 
 func (x *TransferLocksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[67]
+	mi := &file_filer_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4571,7 +4699,7 @@ func (x *TransferLocksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransferLocksRequest.ProtoReflect.Descriptor instead.
 func (*TransferLocksRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{67}
+	return file_filer_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *TransferLocksRequest) GetLocks() []*Lock {
@@ -4589,7 +4717,7 @@ type TransferLocksResponse struct {
 
 func (x *TransferLocksResponse) Reset() {
 	*x = TransferLocksResponse{}
-	mi := &file_filer_proto_msgTypes[68]
+	mi := &file_filer_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4601,7 +4729,7 @@ func (x *TransferLocksResponse) String() string {
 func (*TransferLocksResponse) ProtoMessage() {}
 
 func (x *TransferLocksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[68]
+	mi := &file_filer_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4614,7 +4742,7 @@ func (x *TransferLocksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransferLocksResponse.ProtoReflect.Descriptor instead.
 func (*TransferLocksResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{68}
+	return file_filer_proto_rawDescGZIP(), []int{69}
 }
 
 type ReplicateLockRequest struct {
@@ -4632,7 +4760,7 @@ type ReplicateLockRequest struct {
 
 func (x *ReplicateLockRequest) Reset() {
 	*x = ReplicateLockRequest{}
-	mi := &file_filer_proto_msgTypes[69]
+	mi := &file_filer_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4644,7 +4772,7 @@ func (x *ReplicateLockRequest) String() string {
 func (*ReplicateLockRequest) ProtoMessage() {}
 
 func (x *ReplicateLockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[69]
+	mi := &file_filer_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4657,7 +4785,7 @@ func (x *ReplicateLockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicateLockRequest.ProtoReflect.Descriptor instead.
 func (*ReplicateLockRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{69}
+	return file_filer_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ReplicateLockRequest) GetName() string {
@@ -4717,7 +4845,7 @@ type ReplicateLockResponse struct {
 
 func (x *ReplicateLockResponse) Reset() {
 	*x = ReplicateLockResponse{}
-	mi := &file_filer_proto_msgTypes[70]
+	mi := &file_filer_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4729,7 +4857,7 @@ func (x *ReplicateLockResponse) String() string {
 func (*ReplicateLockResponse) ProtoMessage() {}
 
 func (x *ReplicateLockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[70]
+	mi := &file_filer_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4742,7 +4870,7 @@ func (x *ReplicateLockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicateLockResponse.ProtoReflect.Descriptor instead.
 func (*ReplicateLockResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{70}
+	return file_filer_proto_rawDescGZIP(), []int{71}
 }
 
 type StreamMutateEntryRequest struct {
@@ -4761,7 +4889,7 @@ type StreamMutateEntryRequest struct {
 
 func (x *StreamMutateEntryRequest) Reset() {
 	*x = StreamMutateEntryRequest{}
-	mi := &file_filer_proto_msgTypes[71]
+	mi := &file_filer_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4773,7 +4901,7 @@ func (x *StreamMutateEntryRequest) String() string {
 func (*StreamMutateEntryRequest) ProtoMessage() {}
 
 func (x *StreamMutateEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[71]
+	mi := &file_filer_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4786,7 +4914,7 @@ func (x *StreamMutateEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamMutateEntryRequest.ProtoReflect.Descriptor instead.
 func (*StreamMutateEntryRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{71}
+	return file_filer_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *StreamMutateEntryRequest) GetRequestId() uint64 {
@@ -4886,7 +5014,7 @@ type StreamMutateEntryResponse struct {
 
 func (x *StreamMutateEntryResponse) Reset() {
 	*x = StreamMutateEntryResponse{}
-	mi := &file_filer_proto_msgTypes[72]
+	mi := &file_filer_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4898,7 +5026,7 @@ func (x *StreamMutateEntryResponse) String() string {
 func (*StreamMutateEntryResponse) ProtoMessage() {}
 
 func (x *StreamMutateEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[72]
+	mi := &file_filer_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4911,7 +5039,7 @@ func (x *StreamMutateEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamMutateEntryResponse.ProtoReflect.Descriptor instead.
 func (*StreamMutateEntryResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{72}
+	return file_filer_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *StreamMutateEntryResponse) GetRequestId() uint64 {
@@ -5025,7 +5153,7 @@ type MountRegisterRequest struct {
 
 func (x *MountRegisterRequest) Reset() {
 	*x = MountRegisterRequest{}
-	mi := &file_filer_proto_msgTypes[73]
+	mi := &file_filer_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5037,7 +5165,7 @@ func (x *MountRegisterRequest) String() string {
 func (*MountRegisterRequest) ProtoMessage() {}
 
 func (x *MountRegisterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[73]
+	mi := &file_filer_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5050,7 +5178,7 @@ func (x *MountRegisterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountRegisterRequest.ProtoReflect.Descriptor instead.
 func (*MountRegisterRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{73}
+	return file_filer_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *MountRegisterRequest) GetPeerAddr() string {
@@ -5089,7 +5217,7 @@ type MountRegisterResponse struct {
 
 func (x *MountRegisterResponse) Reset() {
 	*x = MountRegisterResponse{}
-	mi := &file_filer_proto_msgTypes[74]
+	mi := &file_filer_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5101,7 +5229,7 @@ func (x *MountRegisterResponse) String() string {
 func (*MountRegisterResponse) ProtoMessage() {}
 
 func (x *MountRegisterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[74]
+	mi := &file_filer_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5114,7 +5242,7 @@ func (x *MountRegisterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountRegisterResponse.ProtoReflect.Descriptor instead.
 func (*MountRegisterResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{74}
+	return file_filer_proto_rawDescGZIP(), []int{75}
 }
 
 type MountListRequest struct {
@@ -5125,7 +5253,7 @@ type MountListRequest struct {
 
 func (x *MountListRequest) Reset() {
 	*x = MountListRequest{}
-	mi := &file_filer_proto_msgTypes[75]
+	mi := &file_filer_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5137,7 +5265,7 @@ func (x *MountListRequest) String() string {
 func (*MountListRequest) ProtoMessage() {}
 
 func (x *MountListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[75]
+	mi := &file_filer_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5150,7 +5278,7 @@ func (x *MountListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountListRequest.ProtoReflect.Descriptor instead.
 func (*MountListRequest) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{75}
+	return file_filer_proto_rawDescGZIP(), []int{76}
 }
 
 type MountListResponse struct {
@@ -5162,7 +5290,7 @@ type MountListResponse struct {
 
 func (x *MountListResponse) Reset() {
 	*x = MountListResponse{}
-	mi := &file_filer_proto_msgTypes[76]
+	mi := &file_filer_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5174,7 +5302,7 @@ func (x *MountListResponse) String() string {
 func (*MountListResponse) ProtoMessage() {}
 
 func (x *MountListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[76]
+	mi := &file_filer_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5187,7 +5315,7 @@ func (x *MountListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountListResponse.ProtoReflect.Descriptor instead.
 func (*MountListResponse) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{76}
+	return file_filer_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *MountListResponse) GetMounts() []*MountInfo {
@@ -5209,7 +5337,7 @@ type MountInfo struct {
 
 func (x *MountInfo) Reset() {
 	*x = MountInfo{}
-	mi := &file_filer_proto_msgTypes[77]
+	mi := &file_filer_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5221,7 +5349,7 @@ func (x *MountInfo) String() string {
 func (*MountInfo) ProtoMessage() {}
 
 func (x *MountInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[77]
+	mi := &file_filer_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5234,7 +5362,7 @@ func (x *MountInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountInfo.ProtoReflect.Descriptor instead.
 func (*MountInfo) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{77}
+	return file_filer_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *MountInfo) GetPeerAddr() string {
@@ -5265,6 +5393,77 @@ func (x *MountInfo) GetDataCenter() string {
 	return ""
 }
 
+// Clause is one primitive comparison. IF_ETAG_MATCH holds when the current
+// entry's ETag equals any value in etags; IF_ETAG_NOT_MATCH holds when it
+// equals none. allow_weak permits weak-comparison (ignoring the W/ prefix).
+type WriteCondition_Clause struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          WriteCondition_Kind    `protobuf:"varint,1,opt,name=kind,proto3,enum=filer_pb.WriteCondition_Kind" json:"kind,omitempty"`
+	Etags         []string               `protobuf:"bytes,2,rep,name=etags,proto3" json:"etags,omitempty"`                           // ETag set for IF_ETAG_* kinds
+	UnixTime      int64                  `protobuf:"varint,3,opt,name=unix_time,json=unixTime,proto3" json:"unix_time,omitempty"`    // bound (unix seconds) for IF_*_SINCE kinds
+	AllowWeak     bool                   `protobuf:"varint,4,opt,name=allow_weak,json=allowWeak,proto3" json:"allow_weak,omitempty"` // compare ETags ignoring the weak (W/) marker
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WriteCondition_Clause) Reset() {
+	*x = WriteCondition_Clause{}
+	mi := &file_filer_proto_msgTypes[80]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WriteCondition_Clause) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WriteCondition_Clause) ProtoMessage() {}
+
+func (x *WriteCondition_Clause) ProtoReflect() protoreflect.Message {
+	mi := &file_filer_proto_msgTypes[80]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WriteCondition_Clause.ProtoReflect.Descriptor instead.
+func (*WriteCondition_Clause) Descriptor() ([]byte, []int) {
+	return file_filer_proto_rawDescGZIP(), []int{13, 0}
+}
+
+func (x *WriteCondition_Clause) GetKind() WriteCondition_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return WriteCondition_NONE
+}
+
+func (x *WriteCondition_Clause) GetEtags() []string {
+	if x != nil {
+		return x.Etags
+	}
+	return nil
+}
+
+func (x *WriteCondition_Clause) GetUnixTime() int64 {
+	if x != nil {
+		return x.UnixTime
+	}
+	return 0
+}
+
+func (x *WriteCondition_Clause) GetAllowWeak() bool {
+	if x != nil {
+		return x.AllowWeak
+	}
+	return false
+}
+
 // if found, send the exact address
 // if not found, send the full list of existing brokers
 type LocateBrokerResponse_Resource struct {
@@ -5277,7 +5476,7 @@ type LocateBrokerResponse_Resource struct {
 
 func (x *LocateBrokerResponse_Resource) Reset() {
 	*x = LocateBrokerResponse_Resource{}
-	mi := &file_filer_proto_msgTypes[81]
+	mi := &file_filer_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5289,7 +5488,7 @@ func (x *LocateBrokerResponse_Resource) String() string {
 func (*LocateBrokerResponse_Resource) ProtoMessage() {}
 
 func (x *LocateBrokerResponse_Resource) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[81]
+	mi := &file_filer_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5302,7 +5501,7 @@ func (x *LocateBrokerResponse_Resource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocateBrokerResponse_Resource.ProtoReflect.Descriptor instead.
 func (*LocateBrokerResponse_Resource) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{52, 0}
+	return file_filer_proto_rawDescGZIP(), []int{53, 0}
 }
 
 func (x *LocateBrokerResponse_Resource) GetGrpcAddresses() string {
@@ -5343,7 +5542,7 @@ type FilerConf_PathConf struct {
 
 func (x *FilerConf_PathConf) Reset() {
 	*x = FilerConf_PathConf{}
-	mi := &file_filer_proto_msgTypes[82]
+	mi := &file_filer_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5355,7 +5554,7 @@ func (x *FilerConf_PathConf) String() string {
 func (*FilerConf_PathConf) ProtoMessage() {}
 
 func (x *FilerConf_PathConf) ProtoReflect() protoreflect.Message {
-	mi := &file_filer_proto_msgTypes[82]
+	mi := &file_filer_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5368,7 +5567,7 @@ func (x *FilerConf_PathConf) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilerConf_PathConf.ProtoReflect.Descriptor instead.
 func (*FilerConf_PathConf) Descriptor() ([]byte, []int) {
-	return file_filer_proto_rawDescGZIP(), []int{57, 0}
+	return file_filer_proto_rawDescGZIP(), []int{58, 0}
 }
 
 func (x *FilerConf_PathConf) GetLocationPrefix() string {
@@ -5587,7 +5786,7 @@ const file_filer_proto_rawDesc = "" +
 	"\bctime_ns\x18\x14 \x01(\x05R\actimeNs\x12\x1b\n" +
 	"\tcrtime_ns\x18\x15 \x01(\x05R\bcrtimeNs\x12\x14\n" +
 	"\x05atime\x18\x16 \x01(\x03R\x05atime\x12\x19\n" +
-	"\batime_ns\x18\x17 \x01(\x05R\aatimeNs\"\x82\x02\n" +
+	"\batime_ns\x18\x17 \x01(\x05R\aatimeNs\"\xba\x02\n" +
 	"\x12CreateEntryRequest\x12\x1c\n" +
 	"\tdirectory\x18\x01 \x01(\tR\tdirectory\x12%\n" +
 	"\x05entry\x18\x02 \x01(\v2\x0f.filer_pb.EntryR\x05entry\x12\x15\n" +
@@ -5596,7 +5795,24 @@ const file_filer_proto_rawDesc = "" +
 	"\n" +
 	"signatures\x18\x05 \x03(\x05R\n" +
 	"signatures\x12=\n" +
-	"\x1bskip_check_parent_directory\x18\x06 \x01(\bR\x18skipCheckParentDirectory\"\xac\x01\n" +
+	"\x1bskip_check_parent_directory\x18\x06 \x01(\bR\x18skipCheckParentDirectory\x126\n" +
+	"\tcondition\x18\a \x01(\v2\x18.filer_pb.WriteConditionR\tcondition\"\xea\x02\n" +
+	"\x0eWriteCondition\x129\n" +
+	"\aclauses\x18\x01 \x03(\v2\x1f.filer_pb.WriteCondition.ClauseR\aclauses\x1a\x8d\x01\n" +
+	"\x06Clause\x121\n" +
+	"\x04kind\x18\x01 \x01(\x0e2\x1d.filer_pb.WriteCondition.KindR\x04kind\x12\x14\n" +
+	"\x05etags\x18\x02 \x03(\tR\x05etags\x12\x1b\n" +
+	"\tunix_time\x18\x03 \x01(\x03R\bunixTime\x12\x1d\n" +
+	"\n" +
+	"allow_weak\x18\x04 \x01(\bR\tallowWeak\"\x8c\x01\n" +
+	"\x04Kind\x12\b\n" +
+	"\x04NONE\x10\x00\x12\x11\n" +
+	"\rIF_NOT_EXISTS\x10\x01\x12\r\n" +
+	"\tIF_EXISTS\x10\x02\x12\x11\n" +
+	"\rIF_ETAG_MATCH\x10\x03\x12\x15\n" +
+	"\x11IF_ETAG_NOT_MATCH\x10\x04\x12\x17\n" +
+	"\x13IF_UNMODIFIED_SINCE\x10\x05\x12\x15\n" +
+	"\x11IF_MODIFIED_SINCE\x10\x06\"\xac\x01\n" +
 	"\x13CreateEntryResponse\x12\x14\n" +
 	"\x05error\x18\x01 \x01(\tR\x05error\x12J\n" +
 	"\x0emetadata_event\x18\x02 \x01(\v2#.filer_pb.SubscribeMetadataResponseR\rmetadataEvent\x123\n" +
@@ -5955,7 +6171,7 @@ const file_filer_proto_rawDesc = "" +
 	"\x05SSE_C\x10\x01\x12\v\n" +
 	"\aSSE_KMS\x10\x02\x12\n" +
 	"\n" +
-	"\x06SSE_S3\x10\x03*\x8c\x01\n" +
+	"\x06SSE_S3\x10\x03*\xa5\x01\n" +
 	"\n" +
 	"FilerError\x12\x06\n" +
 	"\x02OK\x10\x00\x12\x17\n" +
@@ -5963,7 +6179,8 @@ const file_filer_proto_rawDesc = "" +
 	"\x0ePARENT_IS_FILE\x10\x02\x12\x19\n" +
 	"\x15EXISTING_IS_DIRECTORY\x10\x03\x12\x14\n" +
 	"\x10EXISTING_IS_FILE\x10\x04\x12\x18\n" +
-	"\x14ENTRY_ALREADY_EXISTS\x10\x052\xa5\x14\n" +
+	"\x14ENTRY_ALREADY_EXISTS\x10\x05\x12\x17\n" +
+	"\x13PRECONDITION_FAILED\x10\x062\xa5\x14\n" +
 	"\fSeaweedFiler\x12g\n" +
 	"\x14LookupDirectoryEntry\x12%.filer_pb.LookupDirectoryEntryRequest\x1a&.filer_pb.LookupDirectoryEntryResponse\"\x00\x12N\n" +
 	"\vListEntries\x12\x1c.filer_pb.ListEntriesRequest\x1a\x1d.filer_pb.ListEntriesResponse\"\x000\x01\x12L\n" +
@@ -6011,207 +6228,213 @@ func file_filer_proto_rawDescGZIP() []byte {
 	return file_filer_proto_rawDescData
 }
 
-var file_filer_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_filer_proto_msgTypes = make([]protoimpl.MessageInfo, 83)
+var file_filer_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_filer_proto_msgTypes = make([]protoimpl.MessageInfo, 85)
 var file_filer_proto_goTypes = []any{
 	(SSEType)(0),                                    // 0: filer_pb.SSEType
 	(FilerError)(0),                                 // 1: filer_pb.FilerError
-	(*LookupDirectoryEntryRequest)(nil),             // 2: filer_pb.LookupDirectoryEntryRequest
-	(*LookupDirectoryEntryResponse)(nil),            // 3: filer_pb.LookupDirectoryEntryResponse
-	(*ListEntriesRequest)(nil),                      // 4: filer_pb.ListEntriesRequest
-	(*ListEntriesResponse)(nil),                     // 5: filer_pb.ListEntriesResponse
-	(*RemoteEntry)(nil),                             // 6: filer_pb.RemoteEntry
-	(*Entry)(nil),                                   // 7: filer_pb.Entry
-	(*FullEntry)(nil),                               // 8: filer_pb.FullEntry
-	(*EventNotification)(nil),                       // 9: filer_pb.EventNotification
-	(*FileChunk)(nil),                               // 10: filer_pb.FileChunk
-	(*FileChunkManifest)(nil),                       // 11: filer_pb.FileChunkManifest
-	(*FileId)(nil),                                  // 12: filer_pb.FileId
-	(*FuseAttributes)(nil),                          // 13: filer_pb.FuseAttributes
-	(*CreateEntryRequest)(nil),                      // 14: filer_pb.CreateEntryRequest
-	(*CreateEntryResponse)(nil),                     // 15: filer_pb.CreateEntryResponse
-	(*UpdateEntryRequest)(nil),                      // 16: filer_pb.UpdateEntryRequest
-	(*UpdateEntryResponse)(nil),                     // 17: filer_pb.UpdateEntryResponse
-	(*TouchAccessTimeRequest)(nil),                  // 18: filer_pb.TouchAccessTimeRequest
-	(*TouchAccessTimeResponse)(nil),                 // 19: filer_pb.TouchAccessTimeResponse
-	(*AppendToEntryRequest)(nil),                    // 20: filer_pb.AppendToEntryRequest
-	(*AppendToEntryResponse)(nil),                   // 21: filer_pb.AppendToEntryResponse
-	(*DeleteEntryRequest)(nil),                      // 22: filer_pb.DeleteEntryRequest
-	(*DeleteEntryResponse)(nil),                     // 23: filer_pb.DeleteEntryResponse
-	(*AtomicRenameEntryRequest)(nil),                // 24: filer_pb.AtomicRenameEntryRequest
-	(*AtomicRenameEntryResponse)(nil),               // 25: filer_pb.AtomicRenameEntryResponse
-	(*StreamRenameEntryRequest)(nil),                // 26: filer_pb.StreamRenameEntryRequest
-	(*StreamRenameEntryResponse)(nil),               // 27: filer_pb.StreamRenameEntryResponse
-	(*AssignVolumeRequest)(nil),                     // 28: filer_pb.AssignVolumeRequest
-	(*AssignVolumeResponse)(nil),                    // 29: filer_pb.AssignVolumeResponse
-	(*LookupVolumeRequest)(nil),                     // 30: filer_pb.LookupVolumeRequest
-	(*Locations)(nil),                               // 31: filer_pb.Locations
-	(*Location)(nil),                                // 32: filer_pb.Location
-	(*LookupVolumeResponse)(nil),                    // 33: filer_pb.LookupVolumeResponse
-	(*Collection)(nil),                              // 34: filer_pb.Collection
-	(*CollectionListRequest)(nil),                   // 35: filer_pb.CollectionListRequest
-	(*CollectionListResponse)(nil),                  // 36: filer_pb.CollectionListResponse
-	(*DeleteCollectionRequest)(nil),                 // 37: filer_pb.DeleteCollectionRequest
-	(*DeleteCollectionResponse)(nil),                // 38: filer_pb.DeleteCollectionResponse
-	(*StatisticsRequest)(nil),                       // 39: filer_pb.StatisticsRequest
-	(*StatisticsResponse)(nil),                      // 40: filer_pb.StatisticsResponse
-	(*PingRequest)(nil),                             // 41: filer_pb.PingRequest
-	(*PingResponse)(nil),                            // 42: filer_pb.PingResponse
-	(*GetFilerConfigurationRequest)(nil),            // 43: filer_pb.GetFilerConfigurationRequest
-	(*GetFilerConfigurationResponse)(nil),           // 44: filer_pb.GetFilerConfigurationResponse
-	(*SubscribeMetadataRequest)(nil),                // 45: filer_pb.SubscribeMetadataRequest
-	(*SubscribeMetadataResponse)(nil),               // 46: filer_pb.SubscribeMetadataResponse
-	(*LogFileChunkRef)(nil),                         // 47: filer_pb.LogFileChunkRef
-	(*TraverseBfsMetadataRequest)(nil),              // 48: filer_pb.TraverseBfsMetadataRequest
-	(*TraverseBfsMetadataResponse)(nil),             // 49: filer_pb.TraverseBfsMetadataResponse
-	(*LogEntry)(nil),                                // 50: filer_pb.LogEntry
-	(*KeepConnectedRequest)(nil),                    // 51: filer_pb.KeepConnectedRequest
-	(*KeepConnectedResponse)(nil),                   // 52: filer_pb.KeepConnectedResponse
-	(*LocateBrokerRequest)(nil),                     // 53: filer_pb.LocateBrokerRequest
-	(*LocateBrokerResponse)(nil),                    // 54: filer_pb.LocateBrokerResponse
-	(*KvGetRequest)(nil),                            // 55: filer_pb.KvGetRequest
-	(*KvGetResponse)(nil),                           // 56: filer_pb.KvGetResponse
-	(*KvPutRequest)(nil),                            // 57: filer_pb.KvPutRequest
-	(*KvPutResponse)(nil),                           // 58: filer_pb.KvPutResponse
-	(*FilerConf)(nil),                               // 59: filer_pb.FilerConf
-	(*CacheRemoteObjectToLocalClusterRequest)(nil),  // 60: filer_pb.CacheRemoteObjectToLocalClusterRequest
-	(*CacheRemoteObjectToLocalClusterResponse)(nil), // 61: filer_pb.CacheRemoteObjectToLocalClusterResponse
-	(*LockRequest)(nil),                             // 62: filer_pb.LockRequest
-	(*LockResponse)(nil),                            // 63: filer_pb.LockResponse
-	(*UnlockRequest)(nil),                           // 64: filer_pb.UnlockRequest
-	(*UnlockResponse)(nil),                          // 65: filer_pb.UnlockResponse
-	(*FindLockOwnerRequest)(nil),                    // 66: filer_pb.FindLockOwnerRequest
-	(*FindLockOwnerResponse)(nil),                   // 67: filer_pb.FindLockOwnerResponse
-	(*Lock)(nil),                                    // 68: filer_pb.Lock
-	(*TransferLocksRequest)(nil),                    // 69: filer_pb.TransferLocksRequest
-	(*TransferLocksResponse)(nil),                   // 70: filer_pb.TransferLocksResponse
-	(*ReplicateLockRequest)(nil),                    // 71: filer_pb.ReplicateLockRequest
-	(*ReplicateLockResponse)(nil),                   // 72: filer_pb.ReplicateLockResponse
-	(*StreamMutateEntryRequest)(nil),                // 73: filer_pb.StreamMutateEntryRequest
-	(*StreamMutateEntryResponse)(nil),               // 74: filer_pb.StreamMutateEntryResponse
-	(*MountRegisterRequest)(nil),                    // 75: filer_pb.MountRegisterRequest
-	(*MountRegisterResponse)(nil),                   // 76: filer_pb.MountRegisterResponse
-	(*MountListRequest)(nil),                        // 77: filer_pb.MountListRequest
-	(*MountListResponse)(nil),                       // 78: filer_pb.MountListResponse
-	(*MountInfo)(nil),                               // 79: filer_pb.MountInfo
-	nil,                                             // 80: filer_pb.Entry.ExtendedEntry
-	nil,                                             // 81: filer_pb.UpdateEntryRequest.ExpectedExtendedEntry
-	nil,                                             // 82: filer_pb.LookupVolumeResponse.LocationsMapEntry
-	(*LocateBrokerResponse_Resource)(nil),           // 83: filer_pb.LocateBrokerResponse.Resource
-	(*FilerConf_PathConf)(nil),                      // 84: filer_pb.FilerConf.PathConf
+	(WriteCondition_Kind)(0),                        // 2: filer_pb.WriteCondition.Kind
+	(*LookupDirectoryEntryRequest)(nil),             // 3: filer_pb.LookupDirectoryEntryRequest
+	(*LookupDirectoryEntryResponse)(nil),            // 4: filer_pb.LookupDirectoryEntryResponse
+	(*ListEntriesRequest)(nil),                      // 5: filer_pb.ListEntriesRequest
+	(*ListEntriesResponse)(nil),                     // 6: filer_pb.ListEntriesResponse
+	(*RemoteEntry)(nil),                             // 7: filer_pb.RemoteEntry
+	(*Entry)(nil),                                   // 8: filer_pb.Entry
+	(*FullEntry)(nil),                               // 9: filer_pb.FullEntry
+	(*EventNotification)(nil),                       // 10: filer_pb.EventNotification
+	(*FileChunk)(nil),                               // 11: filer_pb.FileChunk
+	(*FileChunkManifest)(nil),                       // 12: filer_pb.FileChunkManifest
+	(*FileId)(nil),                                  // 13: filer_pb.FileId
+	(*FuseAttributes)(nil),                          // 14: filer_pb.FuseAttributes
+	(*CreateEntryRequest)(nil),                      // 15: filer_pb.CreateEntryRequest
+	(*WriteCondition)(nil),                          // 16: filer_pb.WriteCondition
+	(*CreateEntryResponse)(nil),                     // 17: filer_pb.CreateEntryResponse
+	(*UpdateEntryRequest)(nil),                      // 18: filer_pb.UpdateEntryRequest
+	(*UpdateEntryResponse)(nil),                     // 19: filer_pb.UpdateEntryResponse
+	(*TouchAccessTimeRequest)(nil),                  // 20: filer_pb.TouchAccessTimeRequest
+	(*TouchAccessTimeResponse)(nil),                 // 21: filer_pb.TouchAccessTimeResponse
+	(*AppendToEntryRequest)(nil),                    // 22: filer_pb.AppendToEntryRequest
+	(*AppendToEntryResponse)(nil),                   // 23: filer_pb.AppendToEntryResponse
+	(*DeleteEntryRequest)(nil),                      // 24: filer_pb.DeleteEntryRequest
+	(*DeleteEntryResponse)(nil),                     // 25: filer_pb.DeleteEntryResponse
+	(*AtomicRenameEntryRequest)(nil),                // 26: filer_pb.AtomicRenameEntryRequest
+	(*AtomicRenameEntryResponse)(nil),               // 27: filer_pb.AtomicRenameEntryResponse
+	(*StreamRenameEntryRequest)(nil),                // 28: filer_pb.StreamRenameEntryRequest
+	(*StreamRenameEntryResponse)(nil),               // 29: filer_pb.StreamRenameEntryResponse
+	(*AssignVolumeRequest)(nil),                     // 30: filer_pb.AssignVolumeRequest
+	(*AssignVolumeResponse)(nil),                    // 31: filer_pb.AssignVolumeResponse
+	(*LookupVolumeRequest)(nil),                     // 32: filer_pb.LookupVolumeRequest
+	(*Locations)(nil),                               // 33: filer_pb.Locations
+	(*Location)(nil),                                // 34: filer_pb.Location
+	(*LookupVolumeResponse)(nil),                    // 35: filer_pb.LookupVolumeResponse
+	(*Collection)(nil),                              // 36: filer_pb.Collection
+	(*CollectionListRequest)(nil),                   // 37: filer_pb.CollectionListRequest
+	(*CollectionListResponse)(nil),                  // 38: filer_pb.CollectionListResponse
+	(*DeleteCollectionRequest)(nil),                 // 39: filer_pb.DeleteCollectionRequest
+	(*DeleteCollectionResponse)(nil),                // 40: filer_pb.DeleteCollectionResponse
+	(*StatisticsRequest)(nil),                       // 41: filer_pb.StatisticsRequest
+	(*StatisticsResponse)(nil),                      // 42: filer_pb.StatisticsResponse
+	(*PingRequest)(nil),                             // 43: filer_pb.PingRequest
+	(*PingResponse)(nil),                            // 44: filer_pb.PingResponse
+	(*GetFilerConfigurationRequest)(nil),            // 45: filer_pb.GetFilerConfigurationRequest
+	(*GetFilerConfigurationResponse)(nil),           // 46: filer_pb.GetFilerConfigurationResponse
+	(*SubscribeMetadataRequest)(nil),                // 47: filer_pb.SubscribeMetadataRequest
+	(*SubscribeMetadataResponse)(nil),               // 48: filer_pb.SubscribeMetadataResponse
+	(*LogFileChunkRef)(nil),                         // 49: filer_pb.LogFileChunkRef
+	(*TraverseBfsMetadataRequest)(nil),              // 50: filer_pb.TraverseBfsMetadataRequest
+	(*TraverseBfsMetadataResponse)(nil),             // 51: filer_pb.TraverseBfsMetadataResponse
+	(*LogEntry)(nil),                                // 52: filer_pb.LogEntry
+	(*KeepConnectedRequest)(nil),                    // 53: filer_pb.KeepConnectedRequest
+	(*KeepConnectedResponse)(nil),                   // 54: filer_pb.KeepConnectedResponse
+	(*LocateBrokerRequest)(nil),                     // 55: filer_pb.LocateBrokerRequest
+	(*LocateBrokerResponse)(nil),                    // 56: filer_pb.LocateBrokerResponse
+	(*KvGetRequest)(nil),                            // 57: filer_pb.KvGetRequest
+	(*KvGetResponse)(nil),                           // 58: filer_pb.KvGetResponse
+	(*KvPutRequest)(nil),                            // 59: filer_pb.KvPutRequest
+	(*KvPutResponse)(nil),                           // 60: filer_pb.KvPutResponse
+	(*FilerConf)(nil),                               // 61: filer_pb.FilerConf
+	(*CacheRemoteObjectToLocalClusterRequest)(nil),  // 62: filer_pb.CacheRemoteObjectToLocalClusterRequest
+	(*CacheRemoteObjectToLocalClusterResponse)(nil), // 63: filer_pb.CacheRemoteObjectToLocalClusterResponse
+	(*LockRequest)(nil),                             // 64: filer_pb.LockRequest
+	(*LockResponse)(nil),                            // 65: filer_pb.LockResponse
+	(*UnlockRequest)(nil),                           // 66: filer_pb.UnlockRequest
+	(*UnlockResponse)(nil),                          // 67: filer_pb.UnlockResponse
+	(*FindLockOwnerRequest)(nil),                    // 68: filer_pb.FindLockOwnerRequest
+	(*FindLockOwnerResponse)(nil),                   // 69: filer_pb.FindLockOwnerResponse
+	(*Lock)(nil),                                    // 70: filer_pb.Lock
+	(*TransferLocksRequest)(nil),                    // 71: filer_pb.TransferLocksRequest
+	(*TransferLocksResponse)(nil),                   // 72: filer_pb.TransferLocksResponse
+	(*ReplicateLockRequest)(nil),                    // 73: filer_pb.ReplicateLockRequest
+	(*ReplicateLockResponse)(nil),                   // 74: filer_pb.ReplicateLockResponse
+	(*StreamMutateEntryRequest)(nil),                // 75: filer_pb.StreamMutateEntryRequest
+	(*StreamMutateEntryResponse)(nil),               // 76: filer_pb.StreamMutateEntryResponse
+	(*MountRegisterRequest)(nil),                    // 77: filer_pb.MountRegisterRequest
+	(*MountRegisterResponse)(nil),                   // 78: filer_pb.MountRegisterResponse
+	(*MountListRequest)(nil),                        // 79: filer_pb.MountListRequest
+	(*MountListResponse)(nil),                       // 80: filer_pb.MountListResponse
+	(*MountInfo)(nil),                               // 81: filer_pb.MountInfo
+	nil,                                             // 82: filer_pb.Entry.ExtendedEntry
+	(*WriteCondition_Clause)(nil),                   // 83: filer_pb.WriteCondition.Clause
+	nil,                                             // 84: filer_pb.UpdateEntryRequest.ExpectedExtendedEntry
+	nil,                                             // 85: filer_pb.LookupVolumeResponse.LocationsMapEntry
+	(*LocateBrokerResponse_Resource)(nil),           // 86: filer_pb.LocateBrokerResponse.Resource
+	(*FilerConf_PathConf)(nil),                      // 87: filer_pb.FilerConf.PathConf
 }
 var file_filer_proto_depIdxs = []int32{
-	7,  // 0: filer_pb.LookupDirectoryEntryResponse.entry:type_name -> filer_pb.Entry
-	7,  // 1: filer_pb.ListEntriesResponse.entry:type_name -> filer_pb.Entry
-	10, // 2: filer_pb.Entry.chunks:type_name -> filer_pb.FileChunk
-	13, // 3: filer_pb.Entry.attributes:type_name -> filer_pb.FuseAttributes
-	80, // 4: filer_pb.Entry.extended:type_name -> filer_pb.Entry.ExtendedEntry
-	6,  // 5: filer_pb.Entry.remote_entry:type_name -> filer_pb.RemoteEntry
-	7,  // 6: filer_pb.FullEntry.entry:type_name -> filer_pb.Entry
-	7,  // 7: filer_pb.EventNotification.old_entry:type_name -> filer_pb.Entry
-	7,  // 8: filer_pb.EventNotification.new_entry:type_name -> filer_pb.Entry
-	12, // 9: filer_pb.FileChunk.fid:type_name -> filer_pb.FileId
-	12, // 10: filer_pb.FileChunk.source_fid:type_name -> filer_pb.FileId
+	8,  // 0: filer_pb.LookupDirectoryEntryResponse.entry:type_name -> filer_pb.Entry
+	8,  // 1: filer_pb.ListEntriesResponse.entry:type_name -> filer_pb.Entry
+	11, // 2: filer_pb.Entry.chunks:type_name -> filer_pb.FileChunk
+	14, // 3: filer_pb.Entry.attributes:type_name -> filer_pb.FuseAttributes
+	82, // 4: filer_pb.Entry.extended:type_name -> filer_pb.Entry.ExtendedEntry
+	7,  // 5: filer_pb.Entry.remote_entry:type_name -> filer_pb.RemoteEntry
+	8,  // 6: filer_pb.FullEntry.entry:type_name -> filer_pb.Entry
+	8,  // 7: filer_pb.EventNotification.old_entry:type_name -> filer_pb.Entry
+	8,  // 8: filer_pb.EventNotification.new_entry:type_name -> filer_pb.Entry
+	13, // 9: filer_pb.FileChunk.fid:type_name -> filer_pb.FileId
+	13, // 10: filer_pb.FileChunk.source_fid:type_name -> filer_pb.FileId
 	0,  // 11: filer_pb.FileChunk.sse_type:type_name -> filer_pb.SSEType
-	10, // 12: filer_pb.FileChunkManifest.chunks:type_name -> filer_pb.FileChunk
-	7,  // 13: filer_pb.CreateEntryRequest.entry:type_name -> filer_pb.Entry
-	46, // 14: filer_pb.CreateEntryResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
-	1,  // 15: filer_pb.CreateEntryResponse.error_code:type_name -> filer_pb.FilerError
-	7,  // 16: filer_pb.UpdateEntryRequest.entry:type_name -> filer_pb.Entry
-	81, // 17: filer_pb.UpdateEntryRequest.expected_extended:type_name -> filer_pb.UpdateEntryRequest.ExpectedExtendedEntry
-	46, // 18: filer_pb.UpdateEntryResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
-	10, // 19: filer_pb.AppendToEntryRequest.chunks:type_name -> filer_pb.FileChunk
-	46, // 20: filer_pb.DeleteEntryResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
-	9,  // 21: filer_pb.StreamRenameEntryResponse.event_notification:type_name -> filer_pb.EventNotification
-	32, // 22: filer_pb.AssignVolumeResponse.location:type_name -> filer_pb.Location
-	32, // 23: filer_pb.Locations.locations:type_name -> filer_pb.Location
-	82, // 24: filer_pb.LookupVolumeResponse.locations_map:type_name -> filer_pb.LookupVolumeResponse.LocationsMapEntry
-	34, // 25: filer_pb.CollectionListResponse.collections:type_name -> filer_pb.Collection
-	9,  // 26: filer_pb.SubscribeMetadataResponse.event_notification:type_name -> filer_pb.EventNotification
-	46, // 27: filer_pb.SubscribeMetadataResponse.events:type_name -> filer_pb.SubscribeMetadataResponse
-	47, // 28: filer_pb.SubscribeMetadataResponse.log_file_refs:type_name -> filer_pb.LogFileChunkRef
-	10, // 29: filer_pb.LogFileChunkRef.chunks:type_name -> filer_pb.FileChunk
-	7,  // 30: filer_pb.TraverseBfsMetadataResponse.entry:type_name -> filer_pb.Entry
-	83, // 31: filer_pb.LocateBrokerResponse.resources:type_name -> filer_pb.LocateBrokerResponse.Resource
-	84, // 32: filer_pb.FilerConf.locations:type_name -> filer_pb.FilerConf.PathConf
-	7,  // 33: filer_pb.CacheRemoteObjectToLocalClusterResponse.entry:type_name -> filer_pb.Entry
-	46, // 34: filer_pb.CacheRemoteObjectToLocalClusterResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
-	68, // 35: filer_pb.TransferLocksRequest.locks:type_name -> filer_pb.Lock
-	14, // 36: filer_pb.StreamMutateEntryRequest.create_request:type_name -> filer_pb.CreateEntryRequest
-	16, // 37: filer_pb.StreamMutateEntryRequest.update_request:type_name -> filer_pb.UpdateEntryRequest
-	22, // 38: filer_pb.StreamMutateEntryRequest.delete_request:type_name -> filer_pb.DeleteEntryRequest
-	26, // 39: filer_pb.StreamMutateEntryRequest.rename_request:type_name -> filer_pb.StreamRenameEntryRequest
-	15, // 40: filer_pb.StreamMutateEntryResponse.create_response:type_name -> filer_pb.CreateEntryResponse
-	17, // 41: filer_pb.StreamMutateEntryResponse.update_response:type_name -> filer_pb.UpdateEntryResponse
-	23, // 42: filer_pb.StreamMutateEntryResponse.delete_response:type_name -> filer_pb.DeleteEntryResponse
-	27, // 43: filer_pb.StreamMutateEntryResponse.rename_response:type_name -> filer_pb.StreamRenameEntryResponse
-	79, // 44: filer_pb.MountListResponse.mounts:type_name -> filer_pb.MountInfo
-	31, // 45: filer_pb.LookupVolumeResponse.LocationsMapEntry.value:type_name -> filer_pb.Locations
-	2,  // 46: filer_pb.SeaweedFiler.LookupDirectoryEntry:input_type -> filer_pb.LookupDirectoryEntryRequest
-	4,  // 47: filer_pb.SeaweedFiler.ListEntries:input_type -> filer_pb.ListEntriesRequest
-	14, // 48: filer_pb.SeaweedFiler.CreateEntry:input_type -> filer_pb.CreateEntryRequest
-	16, // 49: filer_pb.SeaweedFiler.UpdateEntry:input_type -> filer_pb.UpdateEntryRequest
-	18, // 50: filer_pb.SeaweedFiler.TouchAccessTime:input_type -> filer_pb.TouchAccessTimeRequest
-	20, // 51: filer_pb.SeaweedFiler.AppendToEntry:input_type -> filer_pb.AppendToEntryRequest
-	22, // 52: filer_pb.SeaweedFiler.DeleteEntry:input_type -> filer_pb.DeleteEntryRequest
-	24, // 53: filer_pb.SeaweedFiler.AtomicRenameEntry:input_type -> filer_pb.AtomicRenameEntryRequest
-	26, // 54: filer_pb.SeaweedFiler.StreamRenameEntry:input_type -> filer_pb.StreamRenameEntryRequest
-	73, // 55: filer_pb.SeaweedFiler.StreamMutateEntry:input_type -> filer_pb.StreamMutateEntryRequest
-	28, // 56: filer_pb.SeaweedFiler.AssignVolume:input_type -> filer_pb.AssignVolumeRequest
-	30, // 57: filer_pb.SeaweedFiler.LookupVolume:input_type -> filer_pb.LookupVolumeRequest
-	35, // 58: filer_pb.SeaweedFiler.CollectionList:input_type -> filer_pb.CollectionListRequest
-	37, // 59: filer_pb.SeaweedFiler.DeleteCollection:input_type -> filer_pb.DeleteCollectionRequest
-	39, // 60: filer_pb.SeaweedFiler.Statistics:input_type -> filer_pb.StatisticsRequest
-	41, // 61: filer_pb.SeaweedFiler.Ping:input_type -> filer_pb.PingRequest
-	43, // 62: filer_pb.SeaweedFiler.GetFilerConfiguration:input_type -> filer_pb.GetFilerConfigurationRequest
-	48, // 63: filer_pb.SeaweedFiler.TraverseBfsMetadata:input_type -> filer_pb.TraverseBfsMetadataRequest
-	45, // 64: filer_pb.SeaweedFiler.SubscribeMetadata:input_type -> filer_pb.SubscribeMetadataRequest
-	45, // 65: filer_pb.SeaweedFiler.SubscribeLocalMetadata:input_type -> filer_pb.SubscribeMetadataRequest
-	55, // 66: filer_pb.SeaweedFiler.KvGet:input_type -> filer_pb.KvGetRequest
-	57, // 67: filer_pb.SeaweedFiler.KvPut:input_type -> filer_pb.KvPutRequest
-	60, // 68: filer_pb.SeaweedFiler.CacheRemoteObjectToLocalCluster:input_type -> filer_pb.CacheRemoteObjectToLocalClusterRequest
-	62, // 69: filer_pb.SeaweedFiler.DistributedLock:input_type -> filer_pb.LockRequest
-	64, // 70: filer_pb.SeaweedFiler.DistributedUnlock:input_type -> filer_pb.UnlockRequest
-	66, // 71: filer_pb.SeaweedFiler.FindLockOwner:input_type -> filer_pb.FindLockOwnerRequest
-	69, // 72: filer_pb.SeaweedFiler.TransferLocks:input_type -> filer_pb.TransferLocksRequest
-	71, // 73: filer_pb.SeaweedFiler.ReplicateLock:input_type -> filer_pb.ReplicateLockRequest
-	75, // 74: filer_pb.SeaweedFiler.MountRegister:input_type -> filer_pb.MountRegisterRequest
-	77, // 75: filer_pb.SeaweedFiler.MountList:input_type -> filer_pb.MountListRequest
-	3,  // 76: filer_pb.SeaweedFiler.LookupDirectoryEntry:output_type -> filer_pb.LookupDirectoryEntryResponse
-	5,  // 77: filer_pb.SeaweedFiler.ListEntries:output_type -> filer_pb.ListEntriesResponse
-	15, // 78: filer_pb.SeaweedFiler.CreateEntry:output_type -> filer_pb.CreateEntryResponse
-	17, // 79: filer_pb.SeaweedFiler.UpdateEntry:output_type -> filer_pb.UpdateEntryResponse
-	19, // 80: filer_pb.SeaweedFiler.TouchAccessTime:output_type -> filer_pb.TouchAccessTimeResponse
-	21, // 81: filer_pb.SeaweedFiler.AppendToEntry:output_type -> filer_pb.AppendToEntryResponse
-	23, // 82: filer_pb.SeaweedFiler.DeleteEntry:output_type -> filer_pb.DeleteEntryResponse
-	25, // 83: filer_pb.SeaweedFiler.AtomicRenameEntry:output_type -> filer_pb.AtomicRenameEntryResponse
-	27, // 84: filer_pb.SeaweedFiler.StreamRenameEntry:output_type -> filer_pb.StreamRenameEntryResponse
-	74, // 85: filer_pb.SeaweedFiler.StreamMutateEntry:output_type -> filer_pb.StreamMutateEntryResponse
-	29, // 86: filer_pb.SeaweedFiler.AssignVolume:output_type -> filer_pb.AssignVolumeResponse
-	33, // 87: filer_pb.SeaweedFiler.LookupVolume:output_type -> filer_pb.LookupVolumeResponse
-	36, // 88: filer_pb.SeaweedFiler.CollectionList:output_type -> filer_pb.CollectionListResponse
-	38, // 89: filer_pb.SeaweedFiler.DeleteCollection:output_type -> filer_pb.DeleteCollectionResponse
-	40, // 90: filer_pb.SeaweedFiler.Statistics:output_type -> filer_pb.StatisticsResponse
-	42, // 91: filer_pb.SeaweedFiler.Ping:output_type -> filer_pb.PingResponse
-	44, // 92: filer_pb.SeaweedFiler.GetFilerConfiguration:output_type -> filer_pb.GetFilerConfigurationResponse
-	49, // 93: filer_pb.SeaweedFiler.TraverseBfsMetadata:output_type -> filer_pb.TraverseBfsMetadataResponse
-	46, // 94: filer_pb.SeaweedFiler.SubscribeMetadata:output_type -> filer_pb.SubscribeMetadataResponse
-	46, // 95: filer_pb.SeaweedFiler.SubscribeLocalMetadata:output_type -> filer_pb.SubscribeMetadataResponse
-	56, // 96: filer_pb.SeaweedFiler.KvGet:output_type -> filer_pb.KvGetResponse
-	58, // 97: filer_pb.SeaweedFiler.KvPut:output_type -> filer_pb.KvPutResponse
-	61, // 98: filer_pb.SeaweedFiler.CacheRemoteObjectToLocalCluster:output_type -> filer_pb.CacheRemoteObjectToLocalClusterResponse
-	63, // 99: filer_pb.SeaweedFiler.DistributedLock:output_type -> filer_pb.LockResponse
-	65, // 100: filer_pb.SeaweedFiler.DistributedUnlock:output_type -> filer_pb.UnlockResponse
-	67, // 101: filer_pb.SeaweedFiler.FindLockOwner:output_type -> filer_pb.FindLockOwnerResponse
-	70, // 102: filer_pb.SeaweedFiler.TransferLocks:output_type -> filer_pb.TransferLocksResponse
-	72, // 103: filer_pb.SeaweedFiler.ReplicateLock:output_type -> filer_pb.ReplicateLockResponse
-	76, // 104: filer_pb.SeaweedFiler.MountRegister:output_type -> filer_pb.MountRegisterResponse
-	78, // 105: filer_pb.SeaweedFiler.MountList:output_type -> filer_pb.MountListResponse
-	76, // [76:106] is the sub-list for method output_type
-	46, // [46:76] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	11, // 12: filer_pb.FileChunkManifest.chunks:type_name -> filer_pb.FileChunk
+	8,  // 13: filer_pb.CreateEntryRequest.entry:type_name -> filer_pb.Entry
+	16, // 14: filer_pb.CreateEntryRequest.condition:type_name -> filer_pb.WriteCondition
+	83, // 15: filer_pb.WriteCondition.clauses:type_name -> filer_pb.WriteCondition.Clause
+	48, // 16: filer_pb.CreateEntryResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
+	1,  // 17: filer_pb.CreateEntryResponse.error_code:type_name -> filer_pb.FilerError
+	8,  // 18: filer_pb.UpdateEntryRequest.entry:type_name -> filer_pb.Entry
+	84, // 19: filer_pb.UpdateEntryRequest.expected_extended:type_name -> filer_pb.UpdateEntryRequest.ExpectedExtendedEntry
+	48, // 20: filer_pb.UpdateEntryResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
+	11, // 21: filer_pb.AppendToEntryRequest.chunks:type_name -> filer_pb.FileChunk
+	48, // 22: filer_pb.DeleteEntryResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
+	10, // 23: filer_pb.StreamRenameEntryResponse.event_notification:type_name -> filer_pb.EventNotification
+	34, // 24: filer_pb.AssignVolumeResponse.location:type_name -> filer_pb.Location
+	34, // 25: filer_pb.Locations.locations:type_name -> filer_pb.Location
+	85, // 26: filer_pb.LookupVolumeResponse.locations_map:type_name -> filer_pb.LookupVolumeResponse.LocationsMapEntry
+	36, // 27: filer_pb.CollectionListResponse.collections:type_name -> filer_pb.Collection
+	10, // 28: filer_pb.SubscribeMetadataResponse.event_notification:type_name -> filer_pb.EventNotification
+	48, // 29: filer_pb.SubscribeMetadataResponse.events:type_name -> filer_pb.SubscribeMetadataResponse
+	49, // 30: filer_pb.SubscribeMetadataResponse.log_file_refs:type_name -> filer_pb.LogFileChunkRef
+	11, // 31: filer_pb.LogFileChunkRef.chunks:type_name -> filer_pb.FileChunk
+	8,  // 32: filer_pb.TraverseBfsMetadataResponse.entry:type_name -> filer_pb.Entry
+	86, // 33: filer_pb.LocateBrokerResponse.resources:type_name -> filer_pb.LocateBrokerResponse.Resource
+	87, // 34: filer_pb.FilerConf.locations:type_name -> filer_pb.FilerConf.PathConf
+	8,  // 35: filer_pb.CacheRemoteObjectToLocalClusterResponse.entry:type_name -> filer_pb.Entry
+	48, // 36: filer_pb.CacheRemoteObjectToLocalClusterResponse.metadata_event:type_name -> filer_pb.SubscribeMetadataResponse
+	70, // 37: filer_pb.TransferLocksRequest.locks:type_name -> filer_pb.Lock
+	15, // 38: filer_pb.StreamMutateEntryRequest.create_request:type_name -> filer_pb.CreateEntryRequest
+	18, // 39: filer_pb.StreamMutateEntryRequest.update_request:type_name -> filer_pb.UpdateEntryRequest
+	24, // 40: filer_pb.StreamMutateEntryRequest.delete_request:type_name -> filer_pb.DeleteEntryRequest
+	28, // 41: filer_pb.StreamMutateEntryRequest.rename_request:type_name -> filer_pb.StreamRenameEntryRequest
+	17, // 42: filer_pb.StreamMutateEntryResponse.create_response:type_name -> filer_pb.CreateEntryResponse
+	19, // 43: filer_pb.StreamMutateEntryResponse.update_response:type_name -> filer_pb.UpdateEntryResponse
+	25, // 44: filer_pb.StreamMutateEntryResponse.delete_response:type_name -> filer_pb.DeleteEntryResponse
+	29, // 45: filer_pb.StreamMutateEntryResponse.rename_response:type_name -> filer_pb.StreamRenameEntryResponse
+	81, // 46: filer_pb.MountListResponse.mounts:type_name -> filer_pb.MountInfo
+	2,  // 47: filer_pb.WriteCondition.Clause.kind:type_name -> filer_pb.WriteCondition.Kind
+	33, // 48: filer_pb.LookupVolumeResponse.LocationsMapEntry.value:type_name -> filer_pb.Locations
+	3,  // 49: filer_pb.SeaweedFiler.LookupDirectoryEntry:input_type -> filer_pb.LookupDirectoryEntryRequest
+	5,  // 50: filer_pb.SeaweedFiler.ListEntries:input_type -> filer_pb.ListEntriesRequest
+	15, // 51: filer_pb.SeaweedFiler.CreateEntry:input_type -> filer_pb.CreateEntryRequest
+	18, // 52: filer_pb.SeaweedFiler.UpdateEntry:input_type -> filer_pb.UpdateEntryRequest
+	20, // 53: filer_pb.SeaweedFiler.TouchAccessTime:input_type -> filer_pb.TouchAccessTimeRequest
+	22, // 54: filer_pb.SeaweedFiler.AppendToEntry:input_type -> filer_pb.AppendToEntryRequest
+	24, // 55: filer_pb.SeaweedFiler.DeleteEntry:input_type -> filer_pb.DeleteEntryRequest
+	26, // 56: filer_pb.SeaweedFiler.AtomicRenameEntry:input_type -> filer_pb.AtomicRenameEntryRequest
+	28, // 57: filer_pb.SeaweedFiler.StreamRenameEntry:input_type -> filer_pb.StreamRenameEntryRequest
+	75, // 58: filer_pb.SeaweedFiler.StreamMutateEntry:input_type -> filer_pb.StreamMutateEntryRequest
+	30, // 59: filer_pb.SeaweedFiler.AssignVolume:input_type -> filer_pb.AssignVolumeRequest
+	32, // 60: filer_pb.SeaweedFiler.LookupVolume:input_type -> filer_pb.LookupVolumeRequest
+	37, // 61: filer_pb.SeaweedFiler.CollectionList:input_type -> filer_pb.CollectionListRequest
+	39, // 62: filer_pb.SeaweedFiler.DeleteCollection:input_type -> filer_pb.DeleteCollectionRequest
+	41, // 63: filer_pb.SeaweedFiler.Statistics:input_type -> filer_pb.StatisticsRequest
+	43, // 64: filer_pb.SeaweedFiler.Ping:input_type -> filer_pb.PingRequest
+	45, // 65: filer_pb.SeaweedFiler.GetFilerConfiguration:input_type -> filer_pb.GetFilerConfigurationRequest
+	50, // 66: filer_pb.SeaweedFiler.TraverseBfsMetadata:input_type -> filer_pb.TraverseBfsMetadataRequest
+	47, // 67: filer_pb.SeaweedFiler.SubscribeMetadata:input_type -> filer_pb.SubscribeMetadataRequest
+	47, // 68: filer_pb.SeaweedFiler.SubscribeLocalMetadata:input_type -> filer_pb.SubscribeMetadataRequest
+	57, // 69: filer_pb.SeaweedFiler.KvGet:input_type -> filer_pb.KvGetRequest
+	59, // 70: filer_pb.SeaweedFiler.KvPut:input_type -> filer_pb.KvPutRequest
+	62, // 71: filer_pb.SeaweedFiler.CacheRemoteObjectToLocalCluster:input_type -> filer_pb.CacheRemoteObjectToLocalClusterRequest
+	64, // 72: filer_pb.SeaweedFiler.DistributedLock:input_type -> filer_pb.LockRequest
+	66, // 73: filer_pb.SeaweedFiler.DistributedUnlock:input_type -> filer_pb.UnlockRequest
+	68, // 74: filer_pb.SeaweedFiler.FindLockOwner:input_type -> filer_pb.FindLockOwnerRequest
+	71, // 75: filer_pb.SeaweedFiler.TransferLocks:input_type -> filer_pb.TransferLocksRequest
+	73, // 76: filer_pb.SeaweedFiler.ReplicateLock:input_type -> filer_pb.ReplicateLockRequest
+	77, // 77: filer_pb.SeaweedFiler.MountRegister:input_type -> filer_pb.MountRegisterRequest
+	79, // 78: filer_pb.SeaweedFiler.MountList:input_type -> filer_pb.MountListRequest
+	4,  // 79: filer_pb.SeaweedFiler.LookupDirectoryEntry:output_type -> filer_pb.LookupDirectoryEntryResponse
+	6,  // 80: filer_pb.SeaweedFiler.ListEntries:output_type -> filer_pb.ListEntriesResponse
+	17, // 81: filer_pb.SeaweedFiler.CreateEntry:output_type -> filer_pb.CreateEntryResponse
+	19, // 82: filer_pb.SeaweedFiler.UpdateEntry:output_type -> filer_pb.UpdateEntryResponse
+	21, // 83: filer_pb.SeaweedFiler.TouchAccessTime:output_type -> filer_pb.TouchAccessTimeResponse
+	23, // 84: filer_pb.SeaweedFiler.AppendToEntry:output_type -> filer_pb.AppendToEntryResponse
+	25, // 85: filer_pb.SeaweedFiler.DeleteEntry:output_type -> filer_pb.DeleteEntryResponse
+	27, // 86: filer_pb.SeaweedFiler.AtomicRenameEntry:output_type -> filer_pb.AtomicRenameEntryResponse
+	29, // 87: filer_pb.SeaweedFiler.StreamRenameEntry:output_type -> filer_pb.StreamRenameEntryResponse
+	76, // 88: filer_pb.SeaweedFiler.StreamMutateEntry:output_type -> filer_pb.StreamMutateEntryResponse
+	31, // 89: filer_pb.SeaweedFiler.AssignVolume:output_type -> filer_pb.AssignVolumeResponse
+	35, // 90: filer_pb.SeaweedFiler.LookupVolume:output_type -> filer_pb.LookupVolumeResponse
+	38, // 91: filer_pb.SeaweedFiler.CollectionList:output_type -> filer_pb.CollectionListResponse
+	40, // 92: filer_pb.SeaweedFiler.DeleteCollection:output_type -> filer_pb.DeleteCollectionResponse
+	42, // 93: filer_pb.SeaweedFiler.Statistics:output_type -> filer_pb.StatisticsResponse
+	44, // 94: filer_pb.SeaweedFiler.Ping:output_type -> filer_pb.PingResponse
+	46, // 95: filer_pb.SeaweedFiler.GetFilerConfiguration:output_type -> filer_pb.GetFilerConfigurationResponse
+	51, // 96: filer_pb.SeaweedFiler.TraverseBfsMetadata:output_type -> filer_pb.TraverseBfsMetadataResponse
+	48, // 97: filer_pb.SeaweedFiler.SubscribeMetadata:output_type -> filer_pb.SubscribeMetadataResponse
+	48, // 98: filer_pb.SeaweedFiler.SubscribeLocalMetadata:output_type -> filer_pb.SubscribeMetadataResponse
+	58, // 99: filer_pb.SeaweedFiler.KvGet:output_type -> filer_pb.KvGetResponse
+	60, // 100: filer_pb.SeaweedFiler.KvPut:output_type -> filer_pb.KvPutResponse
+	63, // 101: filer_pb.SeaweedFiler.CacheRemoteObjectToLocalCluster:output_type -> filer_pb.CacheRemoteObjectToLocalClusterResponse
+	65, // 102: filer_pb.SeaweedFiler.DistributedLock:output_type -> filer_pb.LockResponse
+	67, // 103: filer_pb.SeaweedFiler.DistributedUnlock:output_type -> filer_pb.UnlockResponse
+	69, // 104: filer_pb.SeaweedFiler.FindLockOwner:output_type -> filer_pb.FindLockOwnerResponse
+	72, // 105: filer_pb.SeaweedFiler.TransferLocks:output_type -> filer_pb.TransferLocksResponse
+	74, // 106: filer_pb.SeaweedFiler.ReplicateLock:output_type -> filer_pb.ReplicateLockResponse
+	78, // 107: filer_pb.SeaweedFiler.MountRegister:output_type -> filer_pb.MountRegisterResponse
+	80, // 108: filer_pb.SeaweedFiler.MountList:output_type -> filer_pb.MountListResponse
+	79, // [79:109] is the sub-list for method output_type
+	49, // [49:79] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_filer_proto_init() }
@@ -6219,13 +6442,13 @@ func file_filer_proto_init() {
 	if File_filer_proto != nil {
 		return
 	}
-	file_filer_proto_msgTypes[71].OneofWrappers = []any{
+	file_filer_proto_msgTypes[72].OneofWrappers = []any{
 		(*StreamMutateEntryRequest_CreateRequest)(nil),
 		(*StreamMutateEntryRequest_UpdateRequest)(nil),
 		(*StreamMutateEntryRequest_DeleteRequest)(nil),
 		(*StreamMutateEntryRequest_RenameRequest)(nil),
 	}
-	file_filer_proto_msgTypes[72].OneofWrappers = []any{
+	file_filer_proto_msgTypes[73].OneofWrappers = []any{
 		(*StreamMutateEntryResponse_CreateResponse)(nil),
 		(*StreamMutateEntryResponse_UpdateResponse)(nil),
 		(*StreamMutateEntryResponse_DeleteResponse)(nil),
@@ -6236,8 +6459,8 @@ func file_filer_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_filer_proto_rawDesc), len(file_filer_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   83,
+			NumEnums:      3,
+			NumMessages:   85,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -192,6 +192,25 @@ func (fs *FilerServer) CreateEntry(ctx context.Context, req *filer_pb.CreateEntr
 	pathLock := fs.entryLockTable.AcquireLock("CreateEntry", fullpath, util.ExclusiveLock)
 	defer fs.entryLockTable.ReleaseLock(fullpath, pathLock)
 
+	// Evaluate the optional precondition against the current entry while the
+	// path lock is held, so the check and the write are atomic on this filer.
+	if conditionIsSet(req.Condition) {
+		current, findErr := fs.filer.FindEntry(ctx, fullpath)
+		if findErr != nil && findErr != filer_pb.ErrNotFound {
+			return &filer_pb.CreateEntryResponse{}, fmt.Errorf("CreateEntry condition check %s: %w", fullpath, findErr)
+		}
+		if findErr == filer_pb.ErrNotFound {
+			current = nil
+		}
+		if !writeConditionSatisfied(req.Condition, current) {
+			glog.V(3).InfofCtx(ctx, "CreateEntry %s: precondition failed: %v", fullpath, req.Condition)
+			return &filer_pb.CreateEntryResponse{
+				Error:     "precondition failed",
+				ErrorCode: filer_pb.FilerError_PRECONDITION_FAILED,
+			}, nil
+		}
+	}
+
 	ctx, eventSink := filer.WithMetadataEventSink(ctx)
 	createErr := fs.filer.CreateEntry(ctx, newEntry, req.OExcl, req.IsFromOtherCluster, req.Signatures, req.SkipCheckParentDirectory, so.MaxFileNameLength)
 

--- a/weed/server/filer_grpc_server_condition.go
+++ b/weed/server/filer_grpc_server_condition.go
@@ -1,0 +1,96 @@
+package weed_server
+
+import (
+	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+)
+
+// conditionIsSet reports whether a condition asks for any check at all.
+func conditionIsSet(cond *filer_pb.WriteCondition) bool {
+	return cond != nil && len(cond.Clauses) > 0
+}
+
+// writeConditionSatisfied reports whether the precondition holds against the
+// current entry (nil if absent), evaluated under the path lock. Every clause
+// must hold (logical AND).
+func writeConditionSatisfied(cond *filer_pb.WriteCondition, current *filer.Entry) bool {
+	for _, c := range cond.Clauses {
+		if !clauseSatisfied(c, current) {
+			return false
+		}
+	}
+	return true
+}
+
+// clauseSatisfied evaluates one primitive against the current entry. For the
+// ETag kinds, etags is a set: IF_ETAG_MATCH holds when the current ETag equals
+// any member, IF_ETAG_NOT_MATCH when it equals none.
+func clauseSatisfied(c *filer_pb.WriteCondition_Clause, current *filer.Entry) bool {
+	exists := current != nil
+	switch c.Kind {
+	case filer_pb.WriteCondition_IF_NOT_EXISTS:
+		return !exists
+	case filer_pb.WriteCondition_IF_EXISTS:
+		return exists
+	case filer_pb.WriteCondition_IF_ETAG_MATCH:
+		return exists && etagInSet(storedEntryETag(current), c.Etags, c.AllowWeak)
+	case filer_pb.WriteCondition_IF_ETAG_NOT_MATCH:
+		return !exists || !etagInSet(storedEntryETag(current), c.Etags, c.AllowWeak)
+	case filer_pb.WriteCondition_IF_UNMODIFIED_SINCE:
+		return !exists || current.Attr.Mtime.Unix() <= c.UnixTime
+	case filer_pb.WriteCondition_IF_MODIFIED_SINCE:
+		return !exists || current.Attr.Mtime.Unix() > c.UnixTime
+	default:
+		return true
+	}
+}
+
+// etagInSet reports whether stored matches any candidate. A strong comparison
+// (allowWeak false) treats a weak ETag as never equal; a weak comparison
+// ignores the W/ marker on both sides.
+func etagInSet(stored string, candidates []string, allowWeak bool) bool {
+	for _, c := range candidates {
+		if etagEqual(stored, c, allowWeak) {
+			return true
+		}
+	}
+	return false
+}
+
+func etagEqual(stored, expected string, allowWeak bool) bool {
+	sv, sWeak := canonicalETag(stored)
+	ev, eWeak := canonicalETag(expected)
+	// RFC 7232 strong comparison: a weak ETag on either side never matches.
+	if !allowWeak && (sWeak || eWeak) {
+		return false
+	}
+	return sv == ev
+}
+
+// canonicalETag splits off the weak (W/) marker before stripping quotes, so a
+// weak ETag like W/"abc" yields ("abc", true).
+func canonicalETag(etag string) (value string, weak bool) {
+	etag = strings.TrimSpace(etag)
+	if strings.HasPrefix(etag, "W/") {
+		return strings.Trim(etag[len("W/"):], `"`), true
+	}
+	return strings.Trim(etag, `"`), false
+}
+
+// storedEntryETag mirrors the S3 gateway's ETag precedence (the stored
+// Seaweed ETag extended attribute, then the chunk/Md5 fallback) so conditional
+// comparisons match what the gateway computes, without coupling the filer to
+// S3 request handling.
+func storedEntryETag(entry *filer.Entry) string {
+	if v, ok := entry.Extended[s3_constants.ExtETagKey]; ok && len(v) > 0 {
+		return normalizeETag(string(v))
+	}
+	return normalizeETag(filer.ETagEntry(entry))
+}
+
+func normalizeETag(etag string) string {
+	return strings.Trim(etag, `"`)
+}

--- a/weed/server/filer_grpc_server_condition_test.go
+++ b/weed/server/filer_grpc_server_condition_test.go
@@ -1,0 +1,161 @@
+package weed_server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func entryWithETag(etag string, mtime time.Time) *filer.Entry {
+	return &filer.Entry{
+		FullPath: "/test/obj",
+		Attr:     filer.Attr{Mtime: mtime},
+		Extended: map[string][]byte{s3_constants.ExtETagKey: []byte(etag)},
+	}
+}
+
+// one wraps a single clause into a condition.
+func one(c *filer_pb.WriteCondition_Clause) *filer_pb.WriteCondition {
+	return &filer_pb.WriteCondition{Clauses: []*filer_pb.WriteCondition_Clause{c}}
+}
+
+func TestWriteConditionSatisfied(t *testing.T) {
+	base := time.Unix(1700000000, 0)
+	present := entryWithETag("abc", base)
+
+	cases := []struct {
+		name string
+		cond *filer_pb.WriteCondition
+		cur  *filer.Entry
+		want bool
+	}{
+		{"empty-absent", &filer_pb.WriteCondition{}, nil, true},
+		{"ifnotexists-absent", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_NOT_EXISTS}), nil, true},
+		{"ifnotexists-present", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_NOT_EXISTS}), present, false},
+		{"ifexists-absent", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_EXISTS}), nil, false},
+		{"ifexists-present", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_EXISTS}), present, true},
+		{"etagmatch-hit", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{`"abc"`}}), present, true},
+		{"etagmatch-miss", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{`"zzz"`}}), present, false},
+		{"etagmatch-absent", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{`"abc"`}}), nil, false},
+		{"etagnotmatch-hit", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_NOT_MATCH, Etags: []string{`"abc"`}}), present, false},
+		{"etagnotmatch-miss", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_NOT_MATCH, Etags: []string{`"zzz"`}}), present, true},
+		{"etagnotmatch-absent", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_NOT_MATCH, Etags: []string{`"abc"`}}), nil, true},
+		{"unmodsince-ok", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_UNMODIFIED_SINCE, UnixTime: base.Unix()}), present, true},
+		{"unmodsince-fail", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_UNMODIFIED_SINCE, UnixTime: base.Unix() - 1}), present, false},
+		{"modsince-ok", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_MODIFIED_SINCE, UnixTime: base.Unix() - 1}), present, true},
+		{"modsince-fail", one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_MODIFIED_SINCE, UnixTime: base.Unix()}), present, false},
+	}
+	for _, tc := range cases {
+		if got := writeConditionSatisfied(tc.cond, tc.cur); got != tc.want {
+			t.Errorf("%s: got %v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestWriteConditionClauses(t *testing.T) {
+	base := time.Unix(1700000000, 0)
+	present := entryWithETag("abc", base)
+
+	matchAny := func(etags ...string) *filer_pb.WriteCondition {
+		return &filer_pb.WriteCondition{Clauses: []*filer_pb.WriteCondition_Clause{
+			{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: etags},
+		}}
+	}
+	noneOf := func(etags ...string) *filer_pb.WriteCondition {
+		return &filer_pb.WriteCondition{Clauses: []*filer_pb.WriteCondition_Clause{
+			{Kind: filer_pb.WriteCondition_IF_ETAG_NOT_MATCH, Etags: etags},
+		}}
+	}
+
+	cases := []struct {
+		name string
+		cond *filer_pb.WriteCondition
+		cur  *filer.Entry
+		want bool
+	}{
+		{"set-match-hit", matchAny(`"x"`, `"abc"`, `"y"`), present, true},
+		{"set-match-miss", matchAny(`"x"`, `"y"`), present, false},
+		{"set-none-clean", noneOf(`"x"`, `"y"`), present, true},
+		{"set-none-hit", noneOf(`"abc"`, `"y"`), present, false},
+		// A weak request ETag never matches under strong comparison.
+		{"weak-strong-fails", matchAny(`W/"abc"`), present, false},
+		// allow_weak compares ignoring the W/ marker.
+		{"weak-allowed", &filer_pb.WriteCondition{Clauses: []*filer_pb.WriteCondition_Clause{
+			{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{`W/"abc"`}, AllowWeak: true},
+		}}, present, true},
+		// Compound clauses are ANDed.
+		{"compound-ok", &filer_pb.WriteCondition{Clauses: []*filer_pb.WriteCondition_Clause{
+			{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{`"abc"`}},
+			{Kind: filer_pb.WriteCondition_IF_UNMODIFIED_SINCE, UnixTime: base.Unix()},
+		}}, present, true},
+		{"compound-second-fails", &filer_pb.WriteCondition{Clauses: []*filer_pb.WriteCondition_Clause{
+			{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{`"abc"`}},
+			{Kind: filer_pb.WriteCondition_IF_UNMODIFIED_SINCE, UnixTime: base.Unix() - 1},
+		}}, present, false},
+	}
+	for _, tc := range cases {
+		if got := writeConditionSatisfied(tc.cond, tc.cur); got != tc.want {
+			t.Errorf("%s: got %v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// storedEntryETag prefers the stored Seaweed ETag attribute and falls back to
+// the Md5-derived ETag, matching the S3 gateway.
+func TestStoredEntryETag(t *testing.T) {
+	withExt := entryWithETag("explicit", time.Unix(0, 0))
+	if got := storedEntryETag(withExt); got != "explicit" {
+		t.Errorf("extended etag: got %q", got)
+	}
+	md5Only := &filer.Entry{Attr: filer.Attr{Md5: []byte{0xab, 0xcd}}}
+	if got := storedEntryETag(md5Only); got != "abcd" {
+		t.Errorf("md5 fallback: got %q", got)
+	}
+}
+
+// The CreateEntry handler enforces the precondition atomically: a matching
+// If-Match overwrites, a non-matching one returns PRECONDITION_FAILED.
+func TestCreateEntryConditionEnforced(t *testing.T) {
+	store := newRenameTestStore()
+	store.entries["/test/obj"] = &filer.Entry{
+		FullPath: "/test/obj",
+		Attr:     filer.Attr{Inode: 1, Mtime: time.Unix(1700000000, 0)},
+		Extended: map[string][]byte{s3_constants.ExtETagKey: []byte("abc")},
+	}
+	f := newRenameTestFiler(store)
+	f.DirBucketsPath = "/buckets"
+	fs := &FilerServer{filer: f, option: &FilerOption{}, entryLockTable: util.NewLockTable[util.FullPath]()}
+
+	req := func(etag string) *filer_pb.CreateEntryRequest {
+		return &filer_pb.CreateEntryRequest{
+			Directory:                "/test",
+			SkipCheckParentDirectory: true,
+			Entry: &filer_pb.Entry{
+				Name:       "obj",
+				Attributes: &filer_pb.FuseAttributes{Mtime: 1700000001, FileMode: 0644, Inode: 2},
+			},
+			Condition: one(&filer_pb.WriteCondition_Clause{Kind: filer_pb.WriteCondition_IF_ETAG_MATCH, Etags: []string{etag}}),
+		}
+	}
+
+	resp, err := fs.CreateEntry(context.Background(), req(`"zzz"`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.ErrorCode != filer_pb.FilerError_PRECONDITION_FAILED {
+		t.Fatalf("mismatched etag: want PRECONDITION_FAILED, got %v (%q)", resp.ErrorCode, resp.Error)
+	}
+
+	resp, err = fs.CreateEntry(context.Background(), req(`"abc"`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("matching etag should overwrite, got error %q", resp.Error)
+	}
+}


### PR DESCRIPTION
Second of the filer-primitive stack. Stacked on #9639 (per-path lock).

Adds an optional `WriteCondition` to `CreateEntryRequest`. When set, the filer evaluates it against the current entry **while holding the per-path lock**, so the check and the write are atomic on this filer, and returns `PRECONDITION_FAILED` when it doesn't hold. The caller must route the key's writes to the owner filer for the check to be authoritative.

Two forms:
- **single primitive** — exists / not-exists / etag match / etag mismatch / [un]modified-since. Covers the common case; the client reduces request semantics to one primitive.
- **rich clauses** — a list of clauses that all must hold (logical AND). Expresses what one primitive cannot: an **ETag set** (`If-Match`/`If-None-Match` with multiple values), **weak-ETag** comparison (`allow_weak`), and **compound** conditions (e.g. `If-Match` + `If-Unmodified-Since`). Supersedes the single-primitive fields when non-empty.

ETag comparison mirrors the S3 gateway's precedence (stored Seaweed ETag attribute, then the Md5/chunk fallback) and follows RFC 7232 strong/weak rules, so results match without coupling the filer to S3 request handling.

`filer.pb.go` regenerated `--go_out` only (message-only change; no RPC added).
