### PR TITLE
s3: use oidc: prefix for trust-policy conditions in IAM example

### DIFF
--- a/test/s3/iam/STS_DISTRIBUTED.md
+++ b/test/s3/iam/STS_DISTRIBUTED.md
@@ -310,8 +310,13 @@ OIDC token's claims. The available keys are:
 | `oidc:aud` | `aud` claim |
 | `oidc:<claim>` | any other token claim, e.g. `oidc:roles`, `oidc:groups`, `oidc:email` |
 | `aws:FederatedProvider` | the provider `name` (e.g. `keycloak-oidc`) when its configured issuer matches the token, otherwise the raw issuer URL |
-| `aws:userid` | `sub` claim |
+| `aws:userid` | `sub` claim (same value as `oidc:sub` during trust-policy evaluation) |
 | `sts:DurationSeconds` | requested session duration, when supplied |
+
+During trust-policy evaluation `aws:userid` is the raw `sub` claim. Once the
+role has been assumed, the keys seen by request authorization differ: there
+`aws:userid` is a stable per-identity hash of `sub` and `iss` (see
+`ComputeParentUser`), so do not assume the two contexts carry the same value.
 
 Custom claims are always exposed under the `oidc:` prefix, so a trust policy must use
 `oidc:roles` (not a bare `roles`) to match a `roles` claim:

--- a/test/s3/iam/STS_DISTRIBUTED.md
+++ b/test/s3/iam/STS_DISTRIBUTED.md
@@ -298,6 +298,49 @@ User Request → Load Balancer → Any S3 Gateway Instance
                               Allow/Deny Request
 ```
 
+## Trust Policy Conditions
+
+Step 5 above evaluates the role's trust policy against context keys derived from the
+OIDC token's claims. The available keys are:
+
+| Condition key | Source |
+|---------------|--------|
+| `oidc:iss` | `iss` claim (issuer URL) |
+| `oidc:sub` | `sub` claim |
+| `oidc:aud` | `aud` claim |
+| `oidc:<claim>` | any other token claim, e.g. `oidc:roles`, `oidc:groups`, `oidc:email` |
+| `aws:FederatedProvider` | the provider `name` (e.g. `keycloak-oidc`) when its configured issuer matches the token, otherwise the raw issuer URL |
+| `aws:userid` | `sub` claim |
+| `sts:DurationSeconds` | requested session duration, when supplied |
+
+Custom claims are always exposed under the `oidc:` prefix, so a trust policy must use
+`oidc:roles` (not a bare `roles`) to match a `roles` claim:
+
+```json
+"Condition": {
+  "StringEquals": {
+    "oidc:roles": "s3-admin"
+  }
+}
+```
+
+A multi-valued claim (such as a `roles` array) matches when any of its values equals
+the condition value. The same `oidc:` keys can be interpolated into policy resources,
+e.g. `arn:aws:s3:::bucket/${oidc:sub}/*`.
+
+### roleMapping vs. trust policy
+
+A provider's `roleMapping` and a role's trust policy apply to two different entry
+points and are not interchangeable:
+
+- **Direct OIDC** — an S3 request carrying `Authorization: Bearer <OIDC-JWT>`. The
+  gateway applies `roleMapping` to choose the caller's role from the token claims; the
+  first matching rule (or `defaultRole`) wins.
+- **STS `AssumeRoleWithWebIdentity`** — the caller names the role explicitly via
+  `RoleArn`, and that role's trust policy decides whether the assumption is allowed.
+  `roleMapping` does not select the role on this path; instead the token claims are
+  surfaced as the `oidc:` condition keys above for the trust policy to evaluate.
+
 ## Configuration Management
 
 ### Development Environment

--- a/test/s3/iam/iam_config_docker.json
+++ b/test/s3/iam/iam_config_docker.json
@@ -37,7 +37,7 @@
             "Action": ["sts:AssumeRoleWithWebIdentity"],
             "Condition": {
               "StringEquals": {
-                "roles": "s3-admin"
+                "oidc:roles": "s3-admin"
               }
             }
           }
@@ -60,7 +60,7 @@
             "Action": ["sts:AssumeRoleWithWebIdentity"],
             "Condition": {
               "StringEquals": {
-                "roles": "s3-read-only"
+                "oidc:roles": "s3-read-only"
               }
             }
           }
@@ -83,7 +83,7 @@
             "Action": ["sts:AssumeRoleWithWebIdentity"],
             "Condition": {
               "StringEquals": {
-                "roles": "s3-read-write"
+                "oidc:roles": "s3-read-write"
               }
             }
           }


### PR DESCRIPTION
## What

OIDC trust-policy conditions for `AssumeRoleWithWebIdentity` are matched against token claims under the `oidc:` prefix (built in `validateTrustPolicyForWebIdentity`, `weed/iam/integration/iam_manager.go`). The docker IAM example used a bare `roles` key in its three trust policies. That key is never present in the evaluation context, and `EvaluateStringCondition` returns false for a missing key on a positive match, so with `defaultEffect: Deny` every web-identity assume against `S3AdminRole` / `S3ReadOnlyRole` / `S3ReadWriteRole` was denied.

This switches the three conditions to `oidc:roles` and documents the keys so the next person copying the example gets a working config.

## Changes

- `test/s3/iam/iam_config_docker.json`: `roles` -> `oidc:roles` in the three trust-policy conditions.
- `test/s3/iam/STS_DISTRIBUTED.md`: new **Trust Policy Conditions** section listing the available condition keys (`oidc:iss`, `oidc:sub`, `oidc:aud`, `oidc:<claim>`, `aws:FederatedProvider`, `aws:userid`, `sts:DurationSeconds`), and a note that `roleMapping` selects the role for direct OIDC bearer auth while STS relies on the explicit `RoleArn` plus the role's trust policy.

No engine, STS, or provider code changes; the `oidc:` convention and the roleMapping/STS split are existing intended behavior, only the example and docs were wrong/missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Trust Policy Conditions guidance describing how STS evaluates trust policies with OIDC token claims, supported condition keys, multi-valued claim behavior, custom-claim exposure, examples, and distinctions between direct OIDC requests and STS role assumption.

* **Chores**
  * Standardized IAM trust policy condition keys to use OIDC-prefixed claim keys across roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->