### PR TITLE
fix(master): notify clients after manual volume grow

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -421,6 +421,13 @@ func (ms *MasterServer) broadcastToClients(message *master_pb.KeepConnectedRespo
 	ms.clientChansLock.RUnlock()
 }
 
+// broadcastVolumeLocationsToClients notifies connected clients about newly created volume locations.
+func (ms *MasterServer) broadcastVolumeLocationsToClients(locations []*master_pb.VolumeLocation) {
+	for _, location := range locations {
+		ms.broadcastToClients(&master_pb.KeepConnectedResponse{VolumeLocation: location})
+	}
+}
+
 func (ms *MasterServer) informNewLeader(stream master_pb.Seaweed_KeepConnectedServer) error {
 	leader, err := ms.Topo.Leader()
 	if err != nil {

--- a/weed/server/master_grpc_server_test.go
+++ b/weed/server/master_grpc_server_test.go
@@ -2,8 +2,10 @@ package weed_server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/cluster"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,4 +36,39 @@ func TestInitialLockRingUpdateSkipsNonFilers(t *testing.T) {
 	ms.LockRingManager.FlushPending("group-a")
 
 	assert.Nil(t, ms.initialLockRingUpdate(cluster.BrokerType, "group-a"))
+}
+
+// TestBroadcastVolumeLocationsToClients verifies grown volume locations are sent to registered clients.
+func TestBroadcastVolumeLocationsToClients(t *testing.T) {
+	clientChan := make(chan *master_pb.KeepConnectedResponse, 2)
+	ms := &MasterServer{
+		clientChans: map[string]chan *master_pb.KeepConnectedResponse{
+			"default.filer@127.0.0.1:8888": clientChan,
+		},
+	}
+
+	ms.broadcastVolumeLocationsToClients([]*master_pb.VolumeLocation{
+		{Url: "volume-a:8080", NewVids: []uint32{7}},
+		{Url: "volume-b:8080", NewVids: []uint32{8}},
+	})
+
+	var first *master_pb.KeepConnectedResponse
+	select {
+	case first = <-clientChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first broadcast")
+	}
+	require.NotNil(t, first.GetVolumeLocation())
+	assert.Equal(t, []uint32{7}, first.GetVolumeLocation().GetNewVids())
+	assert.Equal(t, "volume-a:8080", first.GetVolumeLocation().GetUrl())
+
+	var second *master_pb.KeepConnectedResponse
+	select {
+	case second = <-clientChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second broadcast")
+	}
+	require.NotNil(t, second.GetVolumeLocation())
+	assert.Equal(t, []uint32{8}, second.GetVolumeLocation().GetNewVids())
+	assert.Equal(t, "volume-b:8080", second.GetVolumeLocation().GetUrl())
 }

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -42,9 +42,7 @@ func (ms *MasterServer) DoAutomaticVolumeGrow(req *topology.VolumeGrowRequest) {
 		glog.V(1).Infof("automatic volume grow failed: %+v", err)
 		return
 	}
-	for _, newVidLocation := range newVidLocations {
-		ms.broadcastToClients(&master_pb.KeepConnectedResponse{VolumeLocation: newVidLocation})
-	}
+	ms.broadcastVolumeLocationsToClients(newVidLocations)
 }
 
 func (ms *MasterServer) ProcessGrowRequest() {

--- a/weed/server/master_server_handlers_admin.go
+++ b/weed/server/master_server_handlers_admin.go
@@ -91,6 +91,9 @@ func (ms *MasterServer) volumeGrowHandler(w http.ResponseWriter, r *http.Request
 		} else {
 			var newVidLocations []*master_pb.VolumeLocation
 			newVidLocations, err = ms.vg.GrowByCountAndType(ms.grpcDialOption, uint32(count), option, ms.Topo)
+			if len(newVidLocations) > 0 {
+				ms.broadcastVolumeLocationsToClients(newVidLocations)
+			}
 			count = uint64(len(newVidLocations))
 		}
 	} else {


### PR DESCRIPTION
# What problem are we solving?
Manual volume growth triggered via the HTTP admin endpoint (`volumeGrowHandler`) doesn't notify connected clients (like filers) about the new volume locations. Clients are left in the dark until the next sync cycle, causing a delay in discovering new write targets. Automatic volume growth (`DoAutomaticVolumeGrow`) already broadcasts these updates correctly.


# How are we solving the problem?
* Abstracted the client notification loop into a reusable `broadcastVolumeLocationsToClients` helper on `MasterServer`.
* Called this helper inside `volumeGrowHandler` immediately after a successful manual volume allocation, ensuring clients are pushed new topology updates in real time.

# How is the PR tested?
Added `TestBroadcastVolumeLocationsToClients` in `master_grpc_server_test.go` to verify that volume locations are properly formatted into `KeepConnectedResponse` messages and successfully broadcasted to client channels without blocking.


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized broadcasting of newly added volume locations into a single helper and applied it for both automatic growth and admin-initiated volume operations, ensuring consistent client notifications.

* **Tests**
  * Added a unit test that verifies newly grown volume locations are broadcast to connected clients with the expected payload and timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->