### PR TITLE
test: wait for a writable volume before lifecycle tests' first write

### DIFF
--- a/test/s3/lifecycle/s3_lifecycle_test.go
+++ b/test/s3/lifecycle/s3_lifecycle_test.go
@@ -92,45 +92,77 @@ func ensureClusterWritable(t *testing.T, c *s3.Client) {
 		bucket := uniqueBucket("warmup")
 		deadline := time.Now().Add(60 * time.Second)
 
-		// Bound each call so a single hung request can't run past the deadline.
-		try := func(fn func(ctx context.Context) error) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		// try runs fn under a bounded context so a single hung call can't block.
+		try := func(timeout time.Duration, fn func(ctx context.Context) error) error {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 			return fn(ctx)
+		}
+		// probe is a try whose timeout is clamped to the time left before the
+		// deadline, so the whole warmup stays within the budget; ok=false means
+		// the budget is exhausted and the caller should stop.
+		probe := func(fn func(ctx context.Context) error) (err error, ok bool) {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return nil, false
+			}
+			if remaining > 10*time.Second {
+				remaining = 10 * time.Second
+			}
+			return try(remaining, fn), true
+		}
+		// backoff sleeps attempt*250ms, never past the deadline.
+		backoff := func(attempt int) {
+			d := time.Duration(attempt) * 250 * time.Millisecond
+			if left := time.Until(deadline); d > left {
+				d = left
+			}
+			if d > 0 {
+				time.Sleep(d)
+			}
 		}
 
 		// CreateBucket is a metadata op, but on a cold cluster the filer itself may
 		// not be ready yet, so retry it within the deadline rather than abandoning
 		// the whole warmup (and the PutObject probe) on the first error.
 		created := false
-		for attempt := 1; time.Now().Before(deadline); attempt++ {
-			if err := try(func(ctx context.Context) error {
+		for attempt := 1; ; attempt++ {
+			err, ok := probe(func(ctx context.Context) error {
 				_, e := c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 				return e
-			}); err == nil {
+			})
+			if !ok {
+				break
+			}
+			if err == nil {
 				created = true
 				break
 			}
-			time.Sleep(time.Duration(attempt) * 250 * time.Millisecond)
+			backoff(attempt)
 		}
 		if !created {
 			t.Logf("warmup: could not create probe bucket within 60s; proceeding")
 			return
 		}
-		defer try(func(ctx context.Context) error {
+		// Cleanup gets a fresh timeout (not the warmup budget) so teardown runs
+		// even when the probe loop used the full window.
+		defer try(10*time.Second, func(ctx context.Context) error {
 			_, e := c.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
 			return e
 		})
 
-		for attempt := 1; time.Now().Before(deadline); attempt++ {
-			err := try(func(ctx context.Context) error {
+		for attempt := 1; ; attempt++ {
+			err, ok := probe(func(ctx context.Context) error {
 				_, e := c.PutObject(ctx, &s3.PutObjectInput{
 					Bucket: aws.String(bucket), Key: aws.String("warmup"), Body: strings.NewReader("ok"),
 				})
 				return e
 			})
+			if !ok {
+				break
+			}
 			if err == nil {
-				try(func(ctx context.Context) error {
+				try(10*time.Second, func(ctx context.Context) error {
 					_, e := c.DeleteObject(ctx, &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String("warmup")})
 					return e
 				})
@@ -139,7 +171,7 @@ func ensureClusterWritable(t *testing.T, c *s3.Client) {
 				}
 				return
 			}
-			time.Sleep(time.Duration(attempt) * 250 * time.Millisecond)
+			backoff(attempt)
 		}
 		t.Logf("warmup: cluster not confirmed writable within 60s; proceeding")
 	})

--- a/test/s3/lifecycle/s3_lifecycle_test.go
+++ b/test/s3/lifecycle/s3_lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -69,7 +70,47 @@ func s3Client(t *testing.T) *s3.Client {
 			})),
 	)
 	require.NoError(t, err)
-	return s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+	ensureClusterWritable(t, client)
+	return client
+}
+
+var clusterWritableOnce sync.Once
+
+// ensureClusterWritable blocks until the cluster can actually serve a write,
+// absorbing the volume-growth warmup window after a fresh start. The Makefile
+// only waits for the server process to be up ("server up after N s"); it does
+// not wait for a writable volume, so the first PutObject can race volume growth
+// and fail with a transient 500 (assign volume: DeadlineExceeded) — the source
+// of the lifecycle-test flakes. Probing one throwaway write here, once per
+// process, warms growth so every test's first real write is past that window.
+// Best-effort: if it never becomes writable, the test's own PutObject surfaces
+// the failure normally.
+func ensureClusterWritable(t *testing.T, c *s3.Client) {
+	t.Helper()
+	clusterWritableOnce.Do(func() {
+		ctx := context.Background()
+		bucket := uniqueBucket("warmup")
+		if _, err := c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+			return // bucket create is a metadata op, not gated on volumes; leave diagnosis to the test
+		}
+		defer c.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+		deadline := time.Now().Add(60 * time.Second)
+		for attempt := 1; time.Now().Before(deadline); attempt++ {
+			_, err := c.PutObject(ctx, &s3.PutObjectInput{
+				Bucket: aws.String(bucket), Key: aws.String("warmup"), Body: strings.NewReader("ok"),
+			})
+			if err == nil {
+				c.DeleteObject(ctx, &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String("warmup")})
+				if attempt > 1 {
+					t.Logf("cluster became writable after %d probe(s)", attempt)
+				}
+				return
+			}
+			time.Sleep(time.Duration(attempt) * 250 * time.Millisecond)
+		}
+		t.Logf("warmup: cluster not confirmed writable within 60s; proceeding")
+	})
 }
 
 func filerClient(t *testing.T) (filer_pb.SeaweedFilerClient, func()) {

--- a/test/s3/lifecycle/s3_lifecycle_test.go
+++ b/test/s3/lifecycle/s3_lifecycle_test.go
@@ -89,19 +89,51 @@ var clusterWritableOnce sync.Once
 func ensureClusterWritable(t *testing.T, c *s3.Client) {
 	t.Helper()
 	clusterWritableOnce.Do(func() {
-		ctx := context.Background()
 		bucket := uniqueBucket("warmup")
-		if _, err := c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
-			return // bucket create is a metadata op, not gated on volumes; leave diagnosis to the test
-		}
-		defer c.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
 		deadline := time.Now().Add(60 * time.Second)
+
+		// Bound each call so a single hung request can't run past the deadline.
+		try := func(fn func(ctx context.Context) error) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			return fn(ctx)
+		}
+
+		// CreateBucket is a metadata op, but on a cold cluster the filer itself may
+		// not be ready yet, so retry it within the deadline rather than abandoning
+		// the whole warmup (and the PutObject probe) on the first error.
+		created := false
 		for attempt := 1; time.Now().Before(deadline); attempt++ {
-			_, err := c.PutObject(ctx, &s3.PutObjectInput{
-				Bucket: aws.String(bucket), Key: aws.String("warmup"), Body: strings.NewReader("ok"),
+			if err := try(func(ctx context.Context) error {
+				_, e := c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+				return e
+			}); err == nil {
+				created = true
+				break
+			}
+			time.Sleep(time.Duration(attempt) * 250 * time.Millisecond)
+		}
+		if !created {
+			t.Logf("warmup: could not create probe bucket within 60s; proceeding")
+			return
+		}
+		defer try(func(ctx context.Context) error {
+			_, e := c.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+			return e
+		})
+
+		for attempt := 1; time.Now().Before(deadline); attempt++ {
+			err := try(func(ctx context.Context) error {
+				_, e := c.PutObject(ctx, &s3.PutObjectInput{
+					Bucket: aws.String(bucket), Key: aws.String("warmup"), Body: strings.NewReader("ok"),
+				})
+				return e
 			})
 			if err == nil {
-				c.DeleteObject(ctx, &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String("warmup")})
+				try(func(ctx context.Context) error {
+					_, e := c.DeleteObject(ctx, &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String("warmup")})
+					return e
+				})
 				if attempt > 1 {
 					t.Logf("cluster became writable after %d probe(s)", attempt)
 				}


### PR DESCRIPTION
Fixes the intermittent `TestLifecycle*` failures where the first `PutObject` returns a transient `500 InternalError`.

## Root cause

The lifecycle suite boots a fresh cluster and writes almost immediately. The Makefile's readiness only waits for the **server process** (the log line `server up after N s`) — it does **not** wait for a **writable volume**. So the first `PutObject` can race the master's first volume growth and fail:

```
PutObject ... StatusCode: 500, api error InternalError
  (server: chunked upload failed: assign volume: all filers failed,
   last error: assign volume: DeadlineExceeded)
```

The SDK retries 3× inside the same warmup window and gives up. It's gated on runner load, so it's non-deterministic. (Confirmed: re-running the job passes — e.g. the same test went red on one attempt and `--- PASS (10.89s)` on the re-run, with no code change.)

## Fix

`s3Client` now calls `ensureClusterWritable` once per process (`sync.Once`): it creates a throwaway bucket and retries a single `PutObject` for up to 60s until it succeeds, warming volume growth before any test's first real write. Best-effort — if the cluster never becomes writable, the test's own `PutObject` still surfaces the failure normally.

Test-harness only; no product code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved S3 lifecycle test reliability by adding cluster warmup and write-readiness checks before running S3 operations. The test now performs timed retries (up to ~60s), creates and cleans up a temporary probe resource, and logs when the cluster fails to become writable to reduce transient failures after startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->