### PR TITLE
mount: keep the posix-lock hint until the release RPC succeeds

### DIFF
--- a/weed/mount/weedfs_posix_lock_routed.go
+++ b/weed/mount/weedfs_posix_lock_routed.go
@@ -287,7 +287,6 @@ func (wfs *WFS) routedReleasePosixOwner(inode, owner uint64) {
 	if !wfs.posixHint.has(inode, owner) {
 		return
 	}
-	wfs.posixHint.drop(inode, owner)
 	key, ok := wfs.posixLockKeyForInode(inode)
 	if !ok {
 		return
@@ -295,8 +294,13 @@ func (wfs *WFS) routedReleasePosixOwner(inode, owner uint64) {
 	ctx, cancel := context.WithTimeout(context.Background(), posixLockReleaseTimeout)
 	defer cancel()
 	if _, err := wfs.callPosixLock(ctx, key, filer_pb.PosixLockOp_RELEASE_POSIX_OWNER, posixlock.Range{Sid: wfs.posixSid, Owner: owner}); err != nil {
+		// Keep the hint so a later flush retries the release; dropping it on a
+		// transient failure would strand the lock until the owner filer's
+		// session-lease reaping expires it.
 		glog.Warningf("routed release posix owner %s: %v", key, err)
+		return
 	}
+	wfs.posixHint.drop(inode, owner)
 }
 
 func (wfs *WFS) routedReleaseFlockOwner(inode, owner uint64) {


### PR DESCRIPTION
Addresses a review comment on #9666 (the code landed on master via #9669).

`routedReleasePosixOwner` dropped the local owner hint *before* sending `RELEASE_POSIX_OWNER`. On a transient RPC failure the lock stays held on the owner filer, but this mount has already forgotten the owner locally — so there's nothing to retry from, and the lock is stranded until session-lease reaping expires it.

Fix: drop the hint only after a successful release. On failure, keep it so a later flush retries, with lease reaping as the backstop. (flock release has no hint, so only the POSIX-owner path is affected.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of POSIX lock release operations by allowing retry attempts on transient failures, ensuring locks are properly released even when encountering temporary network issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->