### PR TITLE
fix: avoid rclone nil close panics

### DIFF
--- a/weed/storage/backend/rclone_backend/rclone_backend.go
+++ b/weed/storage/backend/rclone_backend/rclone_backend.go
@@ -129,16 +129,10 @@ func uploadViaRclone(rfs fs.Fs, filename string, key string, fn func(progressed 
 	ctx := context.TODO()
 
 	file, err := os.Open(filename)
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
-			return
-		}
-	}(file)
-
 	if err != nil {
 		return 0, err
 	}
+	defer file.Close()
 
 	stat, err := file.Stat()
 	if err != nil {
@@ -180,24 +174,16 @@ func downloadViaRclone(fs fs.Fs, filename string, key string, fn func(progressed
 	}
 
 	rc, err := obj.Open(ctx)
-	defer func(rc io.ReadCloser) {
-		err := rc.Close()
-		if err != nil {
-			return
-		}
-	}(rc)
-
 	if err != nil {
 		return 0, err
 	}
+	defer rc.Close()
 
 	file, err := os.Create(filename)
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
-			return
-		}
-	}(file)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
 
 	tr := accounting.NewStats(ctx).NewTransfer(obj, fs)
 	defer tr.Done(ctx, err)
@@ -251,16 +237,10 @@ func (rcloneBackendStorageFile RcloneBackendStorageFile) ReadAt(p []byte, off in
 	opt := fs.RangeOption{Start: off, End: off + int64(len(p)) - 1}
 
 	rc, err := obj.Open(ctx, &opt)
-	defer func(rc io.ReadCloser) {
-		err := rc.Close()
-		if err != nil {
-			return
-		}
-	}(rc)
-
 	if err != nil {
 		return 0, err
 	}
+	defer rc.Close()
 
 	return io.ReadFull(rc, p)
 }

--- a/weed/storage/backend/rclone_backend/rclone_backend.go
+++ b/weed/storage/backend/rclone_backend/rclone_backend.go
@@ -165,6 +165,10 @@ func (s *RcloneBackendStorage) DownloadFile(filename string, key string, fn func
 	return
 }
 
+var createRcloneDownloadFile = func(filename string) (io.WriteCloser, error) {
+	return os.Create(filename)
+}
+
 func downloadViaRclone(fs fs.Fs, filename string, key string, fn func(progressed int64, percentage float32) error) (fileSize int64, err error) {
 	ctx := context.TODO()
 
@@ -179,14 +183,18 @@ func downloadViaRclone(fs fs.Fs, filename string, key string, fn func(progressed
 	}
 	defer rc.Close()
 
-	file, err := os.Create(filename)
+	file, err := createRcloneDownloadFile(filename)
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
 
 	tr := accounting.NewStats(ctx).NewTransfer(obj, fs)
-	defer tr.Done(ctx, err)
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		tr.Done(ctx, err)
+	}()
 	acc := tr.Account(ctx, rc)
 	pr := ProgressReader{acc: acc, tr: tr, fn: fn}
 

--- a/weed/storage/backend/rclone_backend/rclone_backend_test.go
+++ b/weed/storage/backend/rclone_backend/rclone_backend_test.go
@@ -51,6 +51,29 @@ func TestDownloadViaRcloneReturnsCreateErrorWithoutPanic(t *testing.T) {
 	}
 }
 
+func TestDownloadViaRcloneReturnsFileCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	rfs := newTestRcloneFs(t, &testRcloneObject{
+		remote: "key",
+		body:   "data",
+	})
+
+	previousCreateFile := createRcloneDownloadFile
+	createRcloneDownloadFile = func(string) (io.WriteCloser, error) {
+		return &closeErrorWriter{closeErr: closeErr}, nil
+	}
+	t.Cleanup(func() {
+		createRcloneDownloadFile = previousCreateFile
+	})
+
+	_, err := downloadViaRclone(rfs, "ignored", "key", func(int64, float32) error {
+		return nil
+	})
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected %v, got %v", closeErr, err)
+	}
+}
+
 func TestRcloneBackendStorageFileReadAtReturnsOpenErrorWithoutPanic(t *testing.T) {
 	openErr := errors.New("range open failed")
 	rfs := newTestRcloneFs(t, &testRcloneObject{remote: "key", openErr: openErr})
@@ -135,4 +158,16 @@ func (o *testRcloneObject) Update(context.Context, io.Reader, fs.ObjectInfo, ...
 
 func (o *testRcloneObject) Remove(context.Context) error {
 	return nil
+}
+
+type closeErrorWriter struct {
+	closeErr error
+}
+
+func (w *closeErrorWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (w *closeErrorWriter) Close() error {
+	return w.closeErr
 }

--- a/weed/storage/backend/rclone_backend/rclone_backend_test.go
+++ b/weed/storage/backend/rclone_backend/rclone_backend_test.go
@@ -1,0 +1,138 @@
+//go:build rclone
+
+package rclone_backend
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/hash"
+	"github.com/rclone/rclone/fstest/mockfs"
+)
+
+func TestUploadViaRcloneReturnsOpenErrorWithoutPanic(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.dat")
+
+	_, err := uploadViaRclone(nil, missing, "key", nil)
+	if err == nil {
+		t.Fatal("expected open error")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+}
+
+func TestDownloadViaRcloneReturnsObjectOpenErrorWithoutPanic(t *testing.T) {
+	openErr := errors.New("open failed")
+	rfs := newTestRcloneFs(t, &testRcloneObject{remote: "key", openErr: openErr})
+
+	_, err := downloadViaRclone(rfs, filepath.Join(t.TempDir(), "out.dat"), "key", nil)
+	if !errors.Is(err, openErr) {
+		t.Fatalf("expected %v, got %v", openErr, err)
+	}
+}
+
+func TestDownloadViaRcloneReturnsCreateErrorWithoutPanic(t *testing.T) {
+	rfs := newTestRcloneFs(t, &testRcloneObject{
+		remote: "key",
+		body:   "data",
+	})
+
+	_, err := downloadViaRclone(rfs, t.TempDir(), "key", nil)
+	if err == nil {
+		t.Fatal("expected create error")
+	}
+}
+
+func TestRcloneBackendStorageFileReadAtReturnsOpenErrorWithoutPanic(t *testing.T) {
+	openErr := errors.New("range open failed")
+	rfs := newTestRcloneFs(t, &testRcloneObject{remote: "key", openErr: openErr})
+	storageFile := RcloneBackendStorageFile{
+		backendStorage: &RcloneBackendStorage{fs: rfs},
+		key:            "key",
+	}
+
+	_, err := storageFile.ReadAt(make([]byte, 4), 0)
+	if !errors.Is(err, openErr) {
+		t.Fatalf("expected %v, got %v", openErr, err)
+	}
+}
+
+func newTestRcloneFs(t *testing.T, objects ...fs.Object) fs.Fs {
+	t.Helper()
+
+	rfs, err := mockfs.NewFs(context.Background(), "mock", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mfs := rfs.(*mockfs.Fs)
+	for _, obj := range objects {
+		mfs.AddObject(obj)
+	}
+	return rfs
+}
+
+type testRcloneObject struct {
+	remote  string
+	body    string
+	openErr error
+	rfs     fs.Info
+}
+
+func (o *testRcloneObject) SetFs(rfs fs.Fs) {
+	o.rfs = rfs
+}
+
+func (o *testRcloneObject) Fs() fs.Info {
+	return o.rfs
+}
+
+func (o *testRcloneObject) String() string {
+	return o.remote
+}
+
+func (o *testRcloneObject) Remote() string {
+	return o.remote
+}
+
+func (o *testRcloneObject) ModTime(context.Context) time.Time {
+	return time.Unix(0, 0)
+}
+
+func (o *testRcloneObject) Size() int64 {
+	return int64(len(o.body))
+}
+
+func (o *testRcloneObject) Hash(context.Context, hash.Type) (string, error) {
+	return "", nil
+}
+
+func (o *testRcloneObject) Storable() bool {
+	return true
+}
+
+func (o *testRcloneObject) SetModTime(context.Context, time.Time) error {
+	return nil
+}
+
+func (o *testRcloneObject) Open(context.Context, ...fs.OpenOption) (io.ReadCloser, error) {
+	if o.openErr != nil {
+		return nil, o.openErr
+	}
+	return io.NopCloser(strings.NewReader(o.body)), nil
+}
+
+func (o *testRcloneObject) Update(context.Context, io.Reader, fs.ObjectInfo, ...fs.OpenOption) error {
+	return nil
+}
+
+func (o *testRcloneObject) Remove(context.Context) error {
+	return nil
+}


### PR DESCRIPTION
# What problem are we solving?

Rclone backend may panic when `Close()` is deferred before checking errors from `os.Open`, `obj.Open`, or `os.Create`. If any of these calls returns a nil handle with an error, the deferred close attempts to close nil and causes a panic instead of returning the original error.


# How are we solving the problem?

Move `defer Close()` calls after successful error checks in rclone upload, download, and ranged read paths.
Add rclone-tagged unit tests to cover these error paths and verify they return errors without panicking.


# How is the PR tested?

go test -tags rclone ./weed/storage/backend/rclone_backend


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for the rclone storage backend to verify uploads, downloads, and range reads handle errors without panics and propagate underlying and close errors correctly, improving robustness.

* **Refactor**
  * Simplified resource cleanup and close handling in the rclone backend to surface close errors and improve reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->