### PR TITLE
redis2: apply keyPrefix in KV methods

### DIFF
--- a/weed/filer/redis2/universal_redis_store_kv.go
+++ b/weed/filer/redis2/universal_redis_store_kv.go
@@ -10,7 +10,7 @@ import (
 
 func (store *UniversalRedis2Store) KvPut(ctx context.Context, key []byte, value []byte) (err error) {
 
-	_, err = store.Client.Set(ctx, string(key), value, 0).Result()
+	_, err = store.Client.Set(ctx, store.getKey(string(key)), value, 0).Result()
 
 	if err != nil {
 		return fmt.Errorf("kv put: %w", err)
@@ -21,7 +21,7 @@ func (store *UniversalRedis2Store) KvPut(ctx context.Context, key []byte, value 
 
 func (store *UniversalRedis2Store) KvGet(ctx context.Context, key []byte) (value []byte, err error) {
 
-	data, err := store.Client.Get(ctx, string(key)).Result()
+	data, err := store.Client.Get(ctx, store.getKey(string(key))).Result()
 
 	if err == redis.Nil {
 		return nil, filer.ErrKvNotFound
@@ -32,7 +32,7 @@ func (store *UniversalRedis2Store) KvGet(ctx context.Context, key []byte) (value
 
 func (store *UniversalRedis2Store) KvDelete(ctx context.Context, key []byte) (err error) {
 
-	_, err = store.Client.Del(ctx, string(key)).Result()
+	_, err = store.Client.Del(ctx, store.getKey(string(key))).Result()
 
 	if err != nil {
 		return fmt.Errorf("kv delete: %w", err)


### PR DESCRIPTION
`KvPut`/`KvGet`/`KvDelete` in `UniversalRedis2Store` passed the raw key to Redis, ignoring the configured `keyPrefix`. Every other method on the store routes through `store.getKey()`, so entries lived under the prefix while KV values (e.g. `filer.store.id`) lived outside it.

Symptoms with a prefix-restricted Redis ACL: filer startup fails with `NOPERM No permissions to access a key` when reading `filer.store.id`. Without the ACL the key is silently created in the wrong namespace.

Fix is one call per method to route the key through `store.getKey()`, matching the rest of the store. Affects both `redis2` and `redis_cluster2` (shared store). `redis` and `redis3` stores don't expose `keyPrefix` and are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Redis key handling in the key-value store to consistently apply key transformation across put, get, and delete operations. Error handling behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->