### PR TITLE
fix(volume): avoid nil-deref when needle map loader errors (#9694)

### DIFF
--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -279,9 +279,15 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// (issue #8928). The check piggybacks on MaxNeedleEnd, which the load
 		// walks below populate without a second linear scan.
 
+		// Loader helpers below return a typed-nil pointer alongside their
+		// error; assigning that to the v.nm NeedleMapper interface yields a
+		// non-nil interface wrapping a nil concrete value, so a later
+		// `v.nm != nil` check still dispatches methods on a nil receiver.
+		// Clear v.nm explicitly so `v.nm != nil` reliably means "loaded".
 		if v.noWriteOrDelete || v.noWriteCanDelete {
 			if v.nm, err = NewSortedFileNeedleMap(v.IndexFileName(), indexFile, v.Version()); err != nil {
 				glog.V(0).Infof("loading sorted db %s error: %v", v.FileName(".sdx"), err)
+				v.nm = nil
 			}
 		} else {
 			switch needleMapKind {
@@ -293,6 +299,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					glog.V(2).Infoln("loading memory index", v.FileName(".idx"), "to memory")
 					if v.nm, err = LoadCompactNeedleMap(indexFile, v.Version()); err != nil {
 						glog.V(0).Infof("loading index %s to memory error: %v", v.FileName(".idx"), err)
+						v.nm = nil
 					}
 				}
 			case NeedleMapLevelDb:
@@ -309,6 +316,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					glog.V(0).Infoln("loading leveldb index", v.FileName(".ldb"))
 					if v.nm, err = NewLevelDbNeedleMap(v.FileName(".ldb"), indexFile, opts, v.ldbTimeout, v.Version()); err != nil {
 						glog.V(0).Infof("loading leveldb %s error: %v", v.FileName(".ldb"), err)
+						v.nm = nil
 					}
 				}
 			case NeedleMapLevelDbMedium:
@@ -325,6 +333,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					glog.V(0).Infoln("loading leveldb medium index", v.FileName(".ldb"))
 					if v.nm, err = NewLevelDbNeedleMap(v.FileName(".ldb"), indexFile, opts, v.ldbTimeout, v.Version()); err != nil {
 						glog.V(0).Infof("loading leveldb %s error: %v", v.FileName(".ldb"), err)
+						v.nm = nil
 					}
 				}
 			case NeedleMapLevelDbLarge:
@@ -341,6 +350,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					glog.V(0).Infoln("loading leveldb large index", v.FileName(".ldb"))
 					if v.nm, err = NewLevelDbNeedleMap(v.FileName(".ldb"), indexFile, opts, v.ldbTimeout, v.Version()); err != nil {
 						glog.V(0).Infof("loading leveldb %s error: %v", v.FileName(".ldb"), err)
+						v.nm = nil
 					}
 				}
 			}
@@ -351,8 +361,9 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// MaximumNeedleEnd, so this is just a numeric comparison — no extra
 		// disk I/O. A violation marks the volume read-only so a corrupt
 		// .idx left over from a crashed batched write does not silently
-		// power vacuum to drop reachable data. See issue #8928.
-		if !v.HasRemoteFile() && v.nm != nil && v.DataBackend != nil {
+		// power vacuum to drop reachable data. See issue #8928. Skip on
+		// loader error: MaximumNeedleEnd reflects a partial walk.
+		if err == nil && !v.HasRemoteFile() && v.nm != nil && v.DataBackend != nil {
 			if datSize, _, statErr := v.DataBackend.GetStat(); statErr == nil && datSize > 0 {
 				if maxEnd := v.nm.MaxNeedleEnd(); maxEnd > datSize {
 					v.noWriteOrDelete = true

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -283,11 +283,14 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// error; assigning that to the v.nm NeedleMapper interface yields a
 		// non-nil interface wrapping a nil concrete value, so a later
 		// `v.nm != nil` check still dispatches methods on a nil receiver.
-		// Clear v.nm explicitly so `v.nm != nil` reliably means "loaded".
+		// Clear v.nm explicitly so `v.nm != nil` reliably means "loaded",
+		// and close indexFile here since the defer cleanup keys off v.nm and
+		// would otherwise leak the descriptor.
 		if v.noWriteOrDelete || v.noWriteCanDelete {
 			if v.nm, err = NewSortedFileNeedleMap(v.IndexFileName(), indexFile, v.Version()); err != nil {
 				glog.V(0).Infof("loading sorted db %s error: %v", v.FileName(".sdx"), err)
 				v.nm = nil
+				indexFile.Close()
 			}
 		} else {
 			switch needleMapKind {
@@ -300,6 +303,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					if v.nm, err = LoadCompactNeedleMap(indexFile, v.Version()); err != nil {
 						glog.V(0).Infof("loading index %s to memory error: %v", v.FileName(".idx"), err)
 						v.nm = nil
+						indexFile.Close()
 					}
 				}
 			case NeedleMapLevelDb:
@@ -317,6 +321,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					if v.nm, err = NewLevelDbNeedleMap(v.FileName(".ldb"), indexFile, opts, v.ldbTimeout, v.Version()); err != nil {
 						glog.V(0).Infof("loading leveldb %s error: %v", v.FileName(".ldb"), err)
 						v.nm = nil
+						indexFile.Close()
 					}
 				}
 			case NeedleMapLevelDbMedium:
@@ -334,6 +339,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					if v.nm, err = NewLevelDbNeedleMap(v.FileName(".ldb"), indexFile, opts, v.ldbTimeout, v.Version()); err != nil {
 						glog.V(0).Infof("loading leveldb %s error: %v", v.FileName(".ldb"), err)
 						v.nm = nil
+						indexFile.Close()
 					}
 				}
 			case NeedleMapLevelDbLarge:
@@ -351,6 +357,7 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 					if v.nm, err = NewLevelDbNeedleMap(v.FileName(".ldb"), indexFile, opts, v.ldbTimeout, v.Version()); err != nil {
 						glog.V(0).Infof("loading leveldb %s error: %v", v.FileName(".ldb"), err)
 						v.nm = nil
+						indexFile.Close()
 					}
 				}
 			}

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -279,13 +279,9 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// (issue #8928). The check piggybacks on MaxNeedleEnd, which the load
 		// walks below populate without a second linear scan.
 
-		// Loader helpers below return a typed-nil pointer alongside their
-		// error; assigning that to the v.nm NeedleMapper interface yields a
-		// non-nil interface wrapping a nil concrete value, so a later
-		// `v.nm != nil` check still dispatches methods on a nil receiver.
-		// Clear v.nm explicitly so `v.nm != nil` reliably means "loaded",
-		// and close indexFile here since the defer cleanup keys off v.nm and
-		// would otherwise leak the descriptor.
+		// Loaders can return a typed-nil pointer with err set; assigning that
+		// to v.nm yields a non-nil interface over a nil receiver. Clear v.nm
+		// and close indexFile so the defer cleanup keys off v.nm cleanly.
 		if v.noWriteOrDelete || v.noWriteCanDelete {
 			if v.nm, err = NewSortedFileNeedleMap(v.IndexFileName(), indexFile, v.Version()); err != nil {
 				glog.V(0).Infof("loading sorted db %s error: %v", v.FileName(".sdx"), err)
@@ -368,8 +364,8 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// MaximumNeedleEnd, so this is just a numeric comparison — no extra
 		// disk I/O. A violation marks the volume read-only so a corrupt
 		// .idx left over from a crashed batched write does not silently
-		// power vacuum to drop reachable data. See issue #8928. Skip on
-		// loader error: MaximumNeedleEnd reflects a partial walk.
+		// power vacuum to drop reachable data. See issue #8928. err == nil
+		// guards against a partial-walk MaximumNeedleEnd.
 		if err == nil && !v.HasRemoteFile() && v.nm != nil && v.DataBackend != nil {
 			if datSize, _, statErr := v.DataBackend.GetStat(); statErr == nil && datSize > 0 {
 				if maxEnd := v.nm.MaxNeedleEnd(); maxEnd > datSize {

--- a/weed/storage/volume_loading_corrupt_idx_test.go
+++ b/weed/storage/volume_loading_corrupt_idx_test.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+)
+
+// A read-only volume whose .idx fails the size-multiple check made
+// NewSortedFileNeedleMap return a typed-nil pointer. The multi-value
+// assignment to the v.nm NeedleMapper interface stored that as a non-nil
+// interface wrapping a nil concrete value, so the post-load MaxNeedleEnd
+// structural check passed its v.nm != nil guard and then segfaulted
+// dereferencing the embedded mapMetric.
+func TestLoad_CorruptIdx_NoSegfault(t *testing.T) {
+	dir := t.TempDir()
+
+	v, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, needle.GetCurrentVersion(), 0, 0)
+	if err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	if _, _, _, err := v.writeNeedle2(newRandomNeedle(1), true, false); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	// Persist read-only so the reload picks the SortedFileNeedleMap branch.
+	v.PersistReadOnly(true)
+	v.Close()
+
+	// Truncate .idx to a non-multiple of NeedleMapEntrySize. The walk rejects
+	// that with "unexpected file size", so NewSortedFileNeedleMap returns
+	// (nil, err) — the typed-nil shape that triggered the segfault.
+	idxPath := VolumeFileName(dir, "", 1) + ".idx"
+	st, err := os.Stat(idxPath)
+	if err != nil {
+		t.Fatalf("stat idx: %v", err)
+	}
+	if err := os.Truncate(idxPath, st.Size()-1); err != nil {
+		t.Fatalf("truncate idx: %v", err)
+	}
+
+	// Pre-fix this panicked inside (*mapMetric).MaxNeedleEnd. Either an
+	// error or a clean reload is fine; what matters is no crash.
+	v2, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, needle.GetCurrentVersion(), 0, 0)
+	if err == nil {
+		v2.Close()
+	}
+}

--- a/weed/storage/volume_loading_corrupt_idx_test.go
+++ b/weed/storage/volume_loading_corrupt_idx_test.go
@@ -8,12 +8,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 )
 
-// A read-only volume whose .idx fails the size-multiple check made
-// NewSortedFileNeedleMap return a typed-nil pointer. The multi-value
-// assignment to the v.nm NeedleMapper interface stored that as a non-nil
-// interface wrapping a nil concrete value, so the post-load MaxNeedleEnd
-// structural check passed its v.nm != nil guard and then segfaulted
-// dereferencing the embedded mapMetric.
+// Corrupt .idx made NewSortedFileNeedleMap return a typed-nil into v.nm;
+// the post-load MaxNeedleEnd check then segfaulted on the nil receiver.
 func TestLoad_CorruptIdx_NoSegfault(t *testing.T) {
 	dir := t.TempDir()
 
@@ -24,13 +20,10 @@ func TestLoad_CorruptIdx_NoSegfault(t *testing.T) {
 	if _, _, _, err := v.writeNeedle2(newRandomNeedle(1), true, false); err != nil {
 		t.Fatalf("seed write: %v", err)
 	}
-	// Persist read-only so the reload picks the SortedFileNeedleMap branch.
-	v.PersistReadOnly(true)
+	v.PersistReadOnly(true) // reload goes through SortedFileNeedleMap
 	v.Close()
 
-	// Truncate .idx to a non-multiple of NeedleMapEntrySize. The walk rejects
-	// that with "unexpected file size", so NewSortedFileNeedleMap returns
-	// (nil, err) — the typed-nil shape that triggered the segfault.
+	// Truncate .idx to a non-aligned size so the walk rejects it.
 	idxPath := VolumeFileName(dir, "", 1) + ".idx"
 	st, err := os.Stat(idxPath)
 	if err != nil {
@@ -40,8 +33,7 @@ func TestLoad_CorruptIdx_NoSegfault(t *testing.T) {
 		t.Fatalf("truncate idx: %v", err)
 	}
 
-	// Pre-fix this panicked inside (*mapMetric).MaxNeedleEnd. Either an
-	// error or a clean reload is fine; what matters is no crash.
+	// Pre-fix this panicked inside (*mapMetric).MaxNeedleEnd.
 	v2, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, needle.GetCurrentVersion(), 0, 0)
 	if err == nil {
 		v2.Close()


### PR DESCRIPTION
## Summary

Fixes #9694. A corrupt `.idx` whose size is not a multiple of `NeedleMapEntrySize` sends the read-only load path into `NewSortedFileNeedleMap`, which returns `(*SortedFileNeedleMap)(nil)` when `reverseWalkIndexFile` rejects the file. The multi-value assignment

```go
if v.nm, err = NewSortedFileNeedleMap(...); err != nil {
    glog.V(0).Infof(...)
}
```

parks that typed-nil pointer in the `v.nm` `NeedleMapper` interface, so the post-load MaxNeedleEnd structural check (`volume_loading.go:357`) still passes its `v.nm != nil` guard and then dispatches `MaxNeedleEnd` through the promoted `mapMetric` accessor on a nil receiver. That dereferences `0x20` (the offset of `MaximumNeedleEnd` inside `mapMetric`) and segfaults the whole volume server at load time — matching the exact trace in the issue.

`NewLevelDbNeedleMap` has the same `return nil, err` shape, so it's fixed the same way for completeness.

## Fix

- After every needle-map loader error, set `v.nm = nil` so the interface is truly nil rather than a typed-nil wrapper.
- Gate the MaxNeedleEnd structural check on `err == nil` — on a failed load, `MaximumNeedleEnd` would reflect a partial walk anyway, and skipping is safer than acting on it.

## Test plan

- New `TestLoad_CorruptIdx_NoSegfault` in `weed/storage/volume_loading_corrupt_idx_test.go` writes a needle, persists read-only, truncates `.idx` to a non-aligned size, and reloads the volume.
  - Pre-fix: panics inside `(*SortedFileNeedleMap).MaxNeedleEnd` at `volume_loading.go:357` (same trace as the issue).
  - Post-fix: load returns an error (or succeeds), no crash.
- Full `go test ./weed/storage/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a volume-loading crash when index data is corrupted or malformed; internal mappings are now cleared on load failure and subsequent validation is skipped to prevent unsafe behavior, making loads fail gracefully instead of causing crashes.

* **Tests**
  * Added a regression test to ensure volumes with truncated or corrupted index data fail safely or reload without crashing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->