### PR TITLE
master: timeout AllocateVolume/DeleteVolume and defer growRequest cleanup

### DIFF
--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -152,9 +152,14 @@ func (ms *MasterServer) ProcessGrowRequest() {
 			// we have lock called inside vg
 			glog.V(0).Infof("volume grow %+v", req)
 			go func(req *topology.VolumeGrowRequest, vl *topology.VolumeLayout) {
+				// Always clear the layout's growRequest flag and the in-flight
+				// filter entry, even if DoAutomaticVolumeGrow panics. Otherwise
+				// a stuck grow leaves growRequest=true forever, silently
+				// blocking all future automatic growth for this layout until
+				// the master restarts.
+				defer filter.Delete(req)
+				defer vl.DoneGrowRequest()
 				ms.DoAutomaticVolumeGrow(req)
-				vl.DoneGrowRequest()
-				filter.Delete(req)
 			}(req, vl)
 		}
 	}()

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -152,11 +152,7 @@ func (ms *MasterServer) ProcessGrowRequest() {
 			// we have lock called inside vg
 			glog.V(0).Infof("volume grow %+v", req)
 			go func(req *topology.VolumeGrowRequest, vl *topology.VolumeLayout) {
-				// Always clear the layout's growRequest flag and the in-flight
-				// filter entry, even if DoAutomaticVolumeGrow panics. Otherwise
-				// a stuck grow leaves growRequest=true forever, silently
-				// blocking all future automatic growth for this layout until
-				// the master restarts.
+				// defer so a panic can't strand growRequest.
 				defer filter.Delete(req)
 				defer vl.DoneGrowRequest()
 				ms.DoAutomaticVolumeGrow(req)

--- a/weed/topology/allocate_volume.go
+++ b/weed/topology/allocate_volume.go
@@ -2,12 +2,20 @@ package topology
 
 import (
 	"context"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"google.golang.org/grpc"
 )
+
+// allocateVolumeTimeout bounds the gRPC call so a hung volume server cannot
+// pin the volume-grow goroutine forever. The grow goroutine clears the
+// layout's growRequest flag in its defer; without a deadline a stalled
+// AllocateVolume would leave that flag stuck and silently block all future
+// automatic growth for the layout until the master restarts.
+const allocateVolumeTimeout = 5 * time.Minute
 
 type AllocateVolumeResult struct {
 	Error string
@@ -17,7 +25,10 @@ func AllocateVolume(dn *DataNode, grpcDialOption grpc.DialOption, vid needle.Vol
 
 	return operation.WithVolumeServerClient(false, dn.ServerAddress(), grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
 
-		_, allocateErr := client.AllocateVolume(context.Background(), &volume_server_pb.AllocateVolumeRequest{
+		ctx, cancel := context.WithTimeout(context.Background(), allocateVolumeTimeout)
+		defer cancel()
+
+		_, allocateErr := client.AllocateVolume(ctx, &volume_server_pb.AllocateVolumeRequest{
 			VolumeId:           uint32(vid),
 			Collection:         option.Collection,
 			Replication:        option.ReplicaPlacement.String(),
@@ -36,7 +47,10 @@ func DeleteVolume(dn *DataNode, grpcDialOption grpc.DialOption, vid needle.Volum
 
 	return operation.WithVolumeServerClient(false, dn.ServerAddress(), grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
 
-		_, allocateErr := client.VolumeDelete(context.Background(), &volume_server_pb.VolumeDeleteRequest{
+		ctx, cancel := context.WithTimeout(context.Background(), allocateVolumeTimeout)
+		defer cancel()
+
+		_, allocateErr := client.VolumeDelete(ctx, &volume_server_pb.VolumeDeleteRequest{
 			VolumeId: uint32(vid),
 		})
 		return allocateErr

--- a/weed/topology/allocate_volume.go
+++ b/weed/topology/allocate_volume.go
@@ -10,15 +10,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// allocateVolumeTimeout bounds the gRPC call so a hung volume server cannot
-// pin the volume-grow goroutine forever. The grow goroutine clears the
-// layout's growRequest flag in its defer; without a deadline a stalled
-// AllocateVolume would leave that flag stuck and silently block all future
-// automatic growth for the layout until the master restarts.
-//
-// Volume create/delete is sub-second normally — 1 minute is generous even
-// for a contended disk, and short enough to recover before too many client
-// Assign attempts have drained their own retry budget.
+// Cap the RPC so a hung volume server can't strand the layout's
+// growRequest flag and block all future automatic growth.
 const allocateVolumeTimeout = 1 * time.Minute
 
 type AllocateVolumeResult struct {

--- a/weed/topology/allocate_volume.go
+++ b/weed/topology/allocate_volume.go
@@ -15,7 +15,11 @@ import (
 // layout's growRequest flag in its defer; without a deadline a stalled
 // AllocateVolume would leave that flag stuck and silently block all future
 // automatic growth for the layout until the master restarts.
-const allocateVolumeTimeout = 5 * time.Minute
+//
+// Volume create/delete is sub-second normally — 1 minute is generous even
+// for a contended disk, and short enough to recover before too many client
+// Assign attempts have drained their own retry budget.
+const allocateVolumeTimeout = 1 * time.Minute
 
 type AllocateVolumeResult struct {
 	Error string


### PR DESCRIPTION
## Problem

`weed mini` (and any setup that relies on automatic volume growth) stops accepting new uploads after running for a while, with the S3 gateway logging:

```
chunked upload failed: assign volume: all filers failed, last error:
  assign volume: assign volume: rpc error: code = DeadlineExceeded
  desc = context deadline exceeded
```

A master restart clears it. Closes #9695.

## Root cause

`ProcessGrowRequest` spawns a per-grow goroutine that clears the volume layout's `growRequest` flag *after* `DoAutomaticVolumeGrow` returns:

```go
go func(req *topology.VolumeGrowRequest, vl *topology.VolumeLayout) {
    ms.DoAutomaticVolumeGrow(req)
    vl.DoneGrowRequest()
    filter.Delete(req)
}(req, vl)
```

`DoAutomaticVolumeGrow` eventually calls `AllocateVolume` (and on cleanup `DeleteVolume`) against the chosen volume server. Both were dialing the volume server with `context.Background()` — no deadline. If the volume server stalled the RPC (heavy I/O, internal lock contention, a stable VIP hiding a dead peer, etc.), the goroutine parked forever. `growRequest` stayed `true`, every subsequent Assign hit `!vl.HasGrowRequest()` == false and skipped enqueuing a new grow, retries drained the 30s budget, and the client saw `DeadlineExceeded` until the operator restarted the master.

## Fix

- Bound both RPCs in `weed/topology/allocate_volume.go` with a 5-minute timeout (volume create/delete is sub-second in normal operation; generous for slow disks).
- Move `vl.DoneGrowRequest()` and `filter.Delete(req)` into `defer`s so a panic in `DoAutomaticVolumeGrow` also can't strand the layout.

## Test plan

- [x] `go build ./...`
- [x] `go test ./weed/topology/ ./weed/server/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured volume grow requests are always cleaned up on goroutine exit, preventing stuck state after errors or panics.
  * Added timeouts to volume allocation and deletion calls to avoid indefinite blocking on unresponsive servers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->