### PR TITLE
fix(filer.sync): validate chunk size in FilerSink to prevent 0-byte propagation

### DIFF
--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -290,6 +290,10 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 			fullData = data
 		}
 
+		if err := validateReplicatedReadSize(sourceChunk, len(fullData)); err != nil {
+			return err
+		}
+
 		transferStatus.mu.Lock()
 		transferStatus.BytesReceived = int64(len(fullData))
 		transferStatus.Status = "uploading"
@@ -329,10 +333,22 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 			return fmt.Errorf("upload result: %v", uploadResult.Error)
 		}
 
+		if err := validateReplicatedUploadSize(sourceChunk, uploadResult.Size); err != nil {
+			return err
+		}
+
 		eofBackoff = 0
 		fileId = currentFileId
 		return nil
 	}, func(retryErr error) (shouldContinue bool) {
+		if errors.Is(retryErr, errChunkSizeMismatch) {
+			glog.V(0).Infof("permanent size mismatch replicating %s for %s: %v",
+				sourceChunk.GetFileIdString(), path, retryErr)
+			transferStatus.mu.Lock()
+			transferStatus.LastErr = retryErr.Error()
+			transferStatus.mu.Unlock()
+			return false
+		}
 		if fs.hasSourceNewerVersion(path, sourceMtime) {
 			glog.V(1).Infof("skip retrying stale source %s for %s: %v", sourceChunk.GetFileIdString(), path, retryErr)
 			return false
@@ -384,6 +400,27 @@ func isEofError(err error) bool {
 		return false
 	}
 	return errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF)
+}
+
+// errChunkSizeMismatch is a permanent (non-retriable) replication failure.
+var errChunkSizeMismatch = errors.New("chunk size mismatch")
+
+func validateReplicatedReadSize(sourceChunk *filer_pb.FileChunk, readSize int) error {
+	if uint64(readSize) != sourceChunk.Size {
+		return fmt.Errorf("%w: read %s got %d bytes, source metadata says %d",
+			errChunkSizeMismatch, sourceChunk.GetFileIdString(),
+			readSize, sourceChunk.Size)
+	}
+	return nil
+}
+
+func validateReplicatedUploadSize(sourceChunk *filer_pb.FileChunk, uploadResultSize uint32) error {
+	if uint64(uploadResultSize) != sourceChunk.Size {
+		return fmt.Errorf("%w: upload %s destination stored %d bytes, source metadata says %d",
+			errChunkSizeMismatch, sourceChunk.GetFileIdString(),
+			uploadResultSize, sourceChunk.Size)
+	}
+	return nil
 }
 
 func (fs *FilerSink) buildUploadUrl(host, fileId string) string {

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -120,7 +120,7 @@ func (fs *FilerSink) replicateOneChunk(sourceChunk *filer_pb.FileChunk, path str
 
 	fileId, err := fs.fetchAndWrite(sourceChunk, path, sourceMtime)
 	if err != nil {
-		return nil, fmt.Errorf("copy %s: %v", sourceChunk.GetFileIdString(), err)
+		return nil, fmt.Errorf("copy %s: %w", sourceChunk.GetFileIdString(), err)
 	}
 
 	return &filer_pb.FileChunk{
@@ -333,10 +333,6 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 			return fmt.Errorf("upload result: %v", uploadResult.Error)
 		}
 
-		if err := validateReplicatedUploadSize(sourceChunk, uploadResult.Size); err != nil {
-			return err
-		}
-
 		eofBackoff = 0
 		fileId = currentFileId
 		return nil
@@ -410,15 +406,6 @@ func validateReplicatedReadSize(sourceChunk *filer_pb.FileChunk, readSize int) e
 		return fmt.Errorf("%w: read %s got %d bytes, source metadata says %d",
 			errChunkSizeMismatch, sourceChunk.GetFileIdString(),
 			readSize, sourceChunk.Size)
-	}
-	return nil
-}
-
-func validateReplicatedUploadSize(sourceChunk *filer_pb.FileChunk, uploadResultSize uint32) error {
-	if uint64(uploadResultSize) != sourceChunk.Size {
-		return fmt.Errorf("%w: upload %s destination stored %d bytes, source metadata says %d",
-			errChunkSizeMismatch, sourceChunk.GetFileIdString(),
-			uploadResultSize, sourceChunk.Size)
 	}
 	return nil
 }

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -1,11 +1,29 @@
 package filersink
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/replication/source"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
+
+func TestMain(m *testing.M) {
+	util_http.InitGlobalHttpClient()
+	// Shorten retry backoff so a fail-fast test that briefly enters the retry
+	// loop doesn't pay the production 1s+ wait.
+	util.RetryWaitTime = 100 * time.Millisecond
+	os.Exit(m.Run())
+}
 
 func TestTargetPathToSourcePath(t *testing.T) {
 	tests := []struct {
@@ -75,5 +93,162 @@ func TestTargetPathToSourcePath(t *testing.T) {
 				t.Fatalf("path mismatch: got %q, want %q", gotPath, tc.wantPath)
 			}
 		})
+	}
+}
+
+// FilerSink must reject chunks whose read/upload byte count disagrees with the
+// source filer metadata, instead of silently writing 0-byte needles with the
+// source size in the destination metadata.
+func TestValidateReplicatedChunkSize(t *testing.T) {
+	const fid = "74,047d16a94aa581"
+
+	tests := []struct {
+		name             string
+		expectedSize     uint64
+		readSize         int
+		uploadResultSize uint32
+		wantErr          bool
+	}{
+		{
+			name:             "healthy",
+			expectedSize:     5171,
+			readSize:         5171,
+			uploadResultSize: 5171,
+			wantErr:          false,
+		},
+		{
+			name:             "legitimately empty file",
+			expectedSize:     0,
+			readSize:         0,
+			uploadResultSize: 0,
+			wantErr:          false,
+		},
+		{
+			name:             "zero-byte read for non-empty source",
+			expectedSize:     5171,
+			readSize:         0,
+			uploadResultSize: 0,
+			wantErr:          true,
+		},
+		{
+			name:             "short read",
+			expectedSize:     5171,
+			readSize:         100,
+			uploadResultSize: 100,
+			wantErr:          true,
+		},
+		{
+			name:             "upload truncated",
+			expectedSize:     5171,
+			readSize:         5171,
+			uploadResultSize: 0,
+			wantErr:          true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk := &filer_pb.FileChunk{FileId: fid, Size: tc.expectedSize}
+
+			readErr := validateReplicatedReadSize(chunk, tc.readSize)
+			uploadErr := validateReplicatedUploadSize(chunk, tc.uploadResultSize)
+
+			gotErr := readErr
+			if gotErr == nil {
+				gotErr = uploadErr
+			}
+
+			if tc.wantErr {
+				if gotErr == nil {
+					t.Fatalf("expected error, got nil (read=%d upload=%d expected=%d)",
+						tc.readSize, tc.uploadResultSize, tc.expectedSize)
+				}
+				if !errors.Is(gotErr, errChunkSizeMismatch) {
+					t.Fatalf("expected errChunkSizeMismatch, got %v", gotErr)
+				}
+				if !strings.Contains(gotErr.Error(), fid) {
+					t.Fatalf("error %q does not mention chunk id %q", gotErr, fid)
+				}
+				return
+			}
+			if readErr != nil {
+				t.Fatalf("unexpected read-size error: %v", readErr)
+			}
+			if uploadErr != nil {
+				t.Fatalf("unexpected upload-size error: %v", uploadErr)
+			}
+		})
+	}
+}
+
+// End-to-end regression :
+// a source volume that responds 200 OK with Content-Length: 0 
+// for a chunk that filer metadata claims is 5171 bytes must be rejected 
+// by fetchAndWrite with a (non-retriable) size mismatch error, 
+// instead of being silently propagated to the destination as a 0-byte needle.
+func TestFetchAndWriteRejectsZeroByteSource(t *testing.T) {
+	const fid = "74,047d16a94aa581"
+	const expectedSize uint64 = 5171
+
+	var hits atomic.Int32
+	sourceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		// Intentionally write no body — mimic the buggy volume response.
+	}))
+	defer sourceServer.Close()
+
+	serverAddr := strings.TrimPrefix(sourceServer.URL, "http://")
+
+	filerSrc := &source.FilerSource{}
+	if err := filerSrc.DoInitialize(serverAddr, serverAddr, "/", true); err != nil {
+		t.Fatalf("filerSource.DoInitialize: %v", err)
+	}
+
+	fs := &FilerSink{
+		filerSource: filerSrc,
+		address:     serverAddr,
+		dir:         "/dst",
+		executor:    util.NewLimitedConcurrentExecutor(1),
+	}
+	fs.SetUploader(operation.NewUploaderWithHttpClient(http.DefaultClient))
+
+	sourceChunk := &filer_pb.FileChunk{
+		FileId: fid,
+		Size:   expectedSize,
+	}
+
+	done := make(chan struct {
+		fileId string
+		err    error
+	}, 1)
+	go func() {
+		gotFileId, gotErr := fs.fetchAndWrite(sourceChunk, "/dst/index.bin", 0)
+		done <- struct {
+			fileId string
+			err    error
+		}{gotFileId, gotErr}
+	}()
+
+	select {
+	case result := <-done:
+		if result.err == nil {
+			t.Fatalf("expected size mismatch error, got nil (fileId=%q)", result.fileId)
+		}
+		if !errors.Is(result.err, errChunkSizeMismatch) {
+			t.Fatalf("expected errChunkSizeMismatch, got %v", result.err)
+		}
+		if !strings.Contains(result.err.Error(), "5171") {
+			t.Fatalf("error %q does not mention expected size 5171", result.err)
+		}
+		if !strings.Contains(result.err.Error(), fid) {
+			t.Fatalf("error %q does not mention chunk id %q", result.err, fid)
+		}
+		if h := hits.Load(); h != 1 {
+			t.Fatalf("expected exactly 1 source hit (fail-fast), got %d", h)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("fetchAndWrite did not return within 5s (retry loop not aborted on size mismatch); hits=%d", hits.Load())
 	}
 }

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -19,9 +19,6 @@ import (
 
 func TestMain(m *testing.M) {
 	util_http.InitGlobalHttpClient()
-	// Shorten retry backoff so a fail-fast test that briefly enters the retry
-	// loop doesn't pay the production 1s+ wait.
-	util.RetryWaitTime = 100 * time.Millisecond
 	os.Exit(m.Run())
 }
 
@@ -96,53 +93,47 @@ func TestTargetPathToSourcePath(t *testing.T) {
 	}
 }
 
-// FilerSink must reject chunks whose read/upload byte count disagrees with the
+// FilerSink must reject chunks whose received byte count disagrees with the
 // source filer metadata, instead of silently writing 0-byte needles with the
 // source size in the destination metadata.
 func TestValidateReplicatedChunkSize(t *testing.T) {
 	const fid = "74,047d16a94aa581"
 
 	tests := []struct {
-		name             string
-		expectedSize     uint64
-		readSize         int
-		uploadResultSize uint32
-		wantErr          bool
+		name         string
+		expectedSize uint64
+		readSize     int
+		wantErr      bool
 	}{
 		{
-			name:             "healthy",
-			expectedSize:     5171,
-			readSize:         5171,
-			uploadResultSize: 5171,
-			wantErr:          false,
+			name:         "healthy",
+			expectedSize: 5171,
+			readSize:     5171,
+			wantErr:      false,
 		},
 		{
-			name:             "legitimately empty file",
-			expectedSize:     0,
-			readSize:         0,
-			uploadResultSize: 0,
-			wantErr:          false,
+			name:         "legitimately empty file",
+			expectedSize: 0,
+			readSize:     0,
+			wantErr:      false,
 		},
 		{
-			name:             "zero-byte read for non-empty source",
-			expectedSize:     5171,
-			readSize:         0,
-			uploadResultSize: 0,
-			wantErr:          true,
+			name:         "zero-byte read for non-empty source",
+			expectedSize: 5171,
+			readSize:     0,
+			wantErr:      true,
 		},
 		{
-			name:             "short read",
-			expectedSize:     5171,
-			readSize:         100,
-			uploadResultSize: 100,
-			wantErr:          true,
+			name:         "short read",
+			expectedSize: 5171,
+			readSize:     100,
+			wantErr:      true,
 		},
 		{
-			name:             "upload truncated",
-			expectedSize:     5171,
-			readSize:         5171,
-			uploadResultSize: 0,
-			wantErr:          true,
+			name:         "over-read (server returned more than metadata)",
+			expectedSize: 5171,
+			readSize:     8192,
+			wantErr:      true,
 		},
 	}
 
@@ -150,18 +141,12 @@ func TestValidateReplicatedChunkSize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			chunk := &filer_pb.FileChunk{FileId: fid, Size: tc.expectedSize}
 
-			readErr := validateReplicatedReadSize(chunk, tc.readSize)
-			uploadErr := validateReplicatedUploadSize(chunk, tc.uploadResultSize)
-
-			gotErr := readErr
-			if gotErr == nil {
-				gotErr = uploadErr
-			}
+			gotErr := validateReplicatedReadSize(chunk, tc.readSize)
 
 			if tc.wantErr {
 				if gotErr == nil {
-					t.Fatalf("expected error, got nil (read=%d upload=%d expected=%d)",
-						tc.readSize, tc.uploadResultSize, tc.expectedSize)
+					t.Fatalf("expected error, got nil (read=%d expected=%d)",
+						tc.readSize, tc.expectedSize)
 				}
 				if !errors.Is(gotErr, errChunkSizeMismatch) {
 					t.Fatalf("expected errChunkSizeMismatch, got %v", gotErr)
@@ -171,11 +156,8 @@ func TestValidateReplicatedChunkSize(t *testing.T) {
 				}
 				return
 			}
-			if readErr != nil {
-				t.Fatalf("unexpected read-size error: %v", readErr)
-			}
-			if uploadErr != nil {
-				t.Fatalf("unexpected upload-size error: %v", uploadErr)
+			if gotErr != nil {
+				t.Fatalf("unexpected read-size error: %v", gotErr)
 			}
 		})
 	}
@@ -189,6 +171,13 @@ func TestValidateReplicatedChunkSize(t *testing.T) {
 func TestFetchAndWriteRejectsZeroByteSource(t *testing.T) {
 	const fid = "74,047d16a94aa581"
 	const expectedSize uint64 = 5171
+
+	// Shorten retry backoff so a fail-fast test that briefly enters the retry
+	// loop doesn't pay the production 1s+ wait. Scoped to this test so any
+	// future test in the package keeps the production constant.
+	prevRetryWaitTime := util.RetryWaitTime
+	util.RetryWaitTime = 100 * time.Millisecond
+	t.Cleanup(func() { util.RetryWaitTime = prevRetryWaitTime })
 
 	var hits atomic.Int32
 	sourceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -250,5 +239,44 @@ func TestFetchAndWriteRejectsZeroByteSource(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("fetchAndWrite did not return within 5s (retry loop not aborted on size mismatch); hits=%d", hits.Load())
+	}
+}
+
+// Lock in that the errChunkSizeMismatch sentinel survives the wrap in
+// replicateOneChunk + pass-through in util.Retry, so filer_sink.go's
+// errors.Is check actually fires.
+func TestReplicateChunksPreservesSizeMismatchSentinel(t *testing.T) {
+	const fid = "74,047d16a94aa581"
+	const expectedSize uint64 = 5171
+
+	sourceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sourceServer.Close()
+
+	serverAddr := strings.TrimPrefix(sourceServer.URL, "http://")
+
+	filerSrc := &source.FilerSource{}
+	if err := filerSrc.DoInitialize(serverAddr, serverAddr, "/", true); err != nil {
+		t.Fatalf("filerSource.DoInitialize: %v", err)
+	}
+
+	fs := &FilerSink{
+		filerSource: filerSrc,
+		address:     serverAddr,
+		dir:         "/dst",
+		executor:    util.NewLimitedConcurrentExecutor(1),
+	}
+	fs.SetUploader(operation.NewUploaderWithHttpClient(http.DefaultClient))
+
+	sourceChunks := []*filer_pb.FileChunk{{FileId: fid, Size: expectedSize}}
+
+	_, err := fs.replicateChunks(nil, sourceChunks, "/dst/index.bin", 0)
+	if err == nil {
+		t.Fatal("expected error from replicateChunks, got nil")
+	}
+	if !errors.Is(err, errChunkSizeMismatch) {
+		t.Fatalf("error chain broken: errors.Is(err, errChunkSizeMismatch) = false; got %v", err)
 	}
 }

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -2,6 +2,7 @@ package filersink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -191,7 +192,12 @@ func (fs *FilerSink) CreateEntry(key string, entry *filer_pb.Entry, signatures [
 		replicatedChunks, err := fs.replicateChunks(context.Background(), entry.GetChunks(), key, getEntryMtime(entry))
 
 		if err != nil {
-			// only warning here since the source chunk may have been deleted already
+			// Don't swallow size-mismatch: source bytes disagree with source
+			// metadata, so committing would propagate corruption silently.
+			if errors.Is(err, errChunkSizeMismatch) {
+				glog.Errorf("refuse to replicate entry with corrupt chunk %s: %v", key, err)
+				return err
+			}
 			glog.Warningf("replicate entry chunks %s: %v", key, err)
 			return nil
 		}
@@ -274,6 +280,10 @@ func (fs *FilerSink) UpdateEntry(key string, oldEntry *filer_pb.Entry, newParent
 		// replicate the chunks that are new in the source
 		replicatedChunks, err := fs.replicateChunks(context.Background(), newChunks, key, getEntryMtime(newEntry))
 		if err != nil {
+			if errors.Is(err, errChunkSizeMismatch) {
+				glog.Errorf("refuse to replicate entry with corrupt chunk %s: %v", key, err)
+				return true, err
+			}
 			glog.Warningf("replicate entry chunks %s: %v", key, err)
 			return true, nil
 		}


### PR DESCRIPTION
# What problem are we solving?

Block the path in which `filer.sync` contaminates the cluster with 0-byte chunks in issue #9700.

# How are we solving the problem?


The existing `filer.sync` silently skips over malformed chunks or errors.
We prevent 0-byte chunks that do not match the source metadata from being propagated to the target cluster, and fail fast instead.

* First, compare the source metadata with the actual size of the received source chunk, and return an error to block the spread of corrupted data.
* After uploading the chunk that passed the source-side check, verify the uploaded size again, and fail fast if it does not match.

# How is the PR tested?

Added unit tests.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replication now validates chunk sizes after read and treats size mismatches as permanent failures: retries stop and the error is surfaced to callers so mismatched data is rejected rather than propagated.

* **Tests**
  * Added regression and integration tests covering chunk-size validation, zero-byte source handling, retry behavior, and preservation of the size-mismatch sentinel in wrapped errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->