### PR TITLE
fix(filer/postgres): default to ON CONFLICT upsert to keep tx alive

### DIFF
--- a/weed/filer/mysql/mysql_sql_gen.go
+++ b/weed/filer/mysql/mysql_sql_gen.go
@@ -13,6 +13,13 @@ type SqlGenMysql struct {
 	UpsertQueryTemplate    string
 }
 
+// DefaultUpsertQuery keeps INSERTs idempotent so the inode-index KvPut
+// after every entry write does not emit a duplicate-key roundtrip on
+// every mutation. The VALUES() form works on MariaDB and MySQL >=5.7;
+// the newer "AS new" alias from MySQL 8.0.19 errors on MariaDB, so it
+// is left for users to opt into via an explicit upsertQuery.
+const DefaultUpsertQuery = "INSERT INTO `%s` (`dirhash`,`name`,`directory`,`meta`) VALUES(?,?,?,?) ON DUPLICATE KEY UPDATE `meta` = VALUES(`meta`)"
+
 var (
 	_ = abstract_sql.SqlGenerator(&SqlGenMysql{})
 )

--- a/weed/filer/mysql/mysql_sql_gen_test.go
+++ b/weed/filer/mysql/mysql_sql_gen_test.go
@@ -1,0 +1,28 @@
+package mysql
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultUpsertQueryUsesOnDuplicateKey(t *testing.T) {
+	gen := &SqlGenMysql{UpsertQueryTemplate: DefaultUpsertQuery}
+	got := gen.GetSqlInsert("filemeta")
+	if !strings.Contains(got, "ON DUPLICATE KEY UPDATE") {
+		t.Fatalf("expected ON DUPLICATE KEY UPDATE in default upsert, got: %s", got)
+	}
+	if strings.Contains(got, "AS `new`") {
+		t.Fatalf("default should avoid MySQL 8.0.19 row-alias syntax for MariaDB compat, got: %s", got)
+	}
+	if !strings.Contains(got, "`filemeta`") {
+		t.Fatalf("expected backticked table name, got: %s", got)
+	}
+}
+
+func TestEmptyUpsertTemplateFallsBackToPlainInsert(t *testing.T) {
+	gen := &SqlGenMysql{}
+	got := gen.GetSqlInsert("filemeta")
+	if strings.Contains(got, "ON DUPLICATE KEY UPDATE") {
+		t.Fatalf("plain INSERT path should not contain ON DUPLICATE KEY UPDATE, got: %s", got)
+	}
+}

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -64,6 +64,8 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	store.SupportBucketTable = false
 	if !enableUpsert {
 		upsertQuery = ""
+	} else if upsertQuery == "" {
+		upsertQuery = DefaultUpsertQuery
 	}
 	store.SqlGenerator = &SqlGenMysql{
 		CreateTableSqlTemplate: "",

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -35,6 +35,9 @@ func (store *MysqlStore) GetName() string {
 func (store *MysqlStore) Initialize(configuration util.Configuration, prefix string) (err error) {
 	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
 	configuration.SetDefault(prefix+"connection_max_idle", 2)
+	// Default on so minimal configs avoid the duplicate-key roundtrip the
+	// inode-index KvPut would otherwise emit on every write.
+	configuration.SetDefault(prefix+"enableUpsert", true)
 	return store.initialize(
 		configuration.GetString(prefix+"dsn"),
 		configuration.GetString(prefix+"upsertQuery"),

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -35,6 +35,9 @@ func (store *MysqlStore2) GetName() string {
 func (store *MysqlStore2) Initialize(configuration util.Configuration, prefix string) (err error) {
 	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
 	configuration.SetDefault(prefix+"connection_max_idle", 2)
+	// Default on so minimal configs avoid the duplicate-key roundtrip the
+	// inode-index KvPut would otherwise emit on every write.
+	configuration.SetDefault(prefix+"enableUpsert", true)
 	return store.initialize(
 		configuration.GetString(prefix+"createTable"),
 		configuration.GetString(prefix+"upsertQuery"),

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -57,6 +57,8 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	store.SupportBucketTable = true
 	if !enableUpsert {
 		upsertQuery = ""
+	} else if upsertQuery == "" {
+		upsertQuery = mysql.DefaultUpsertQuery
 	}
 	store.SqlGenerator = &mysql.SqlGenMysql{
 		CreateTableSqlTemplate: createTable,

--- a/weed/filer/postgres/postgres_sql_gen.go
+++ b/weed/filer/postgres/postgres_sql_gen.go
@@ -13,6 +13,11 @@ type SqlGenPostgres struct {
 	UpsertQueryTemplate    string
 }
 
+// DefaultUpsertQuery keeps INSERTs idempotent so a duplicate-key failure
+// (23505) cannot poison the surrounding transaction (25P02). Used when the
+// user enables upsert but does not provide their own template.
+const DefaultUpsertQuery = `INSERT INTO "%s" (dirhash,name,directory,meta) VALUES($1,$2,$3,$4) ON CONFLICT (dirhash, name) DO UPDATE SET directory=EXCLUDED.directory, meta=EXCLUDED.meta`
+
 var (
 	_ = abstract_sql.SqlGenerator(&SqlGenPostgres{})
 )

--- a/weed/filer/postgres/postgres_sql_gen_test.go
+++ b/weed/filer/postgres/postgres_sql_gen_test.go
@@ -1,0 +1,25 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultUpsertQueryIsConflictSafe(t *testing.T) {
+	gen := &SqlGenPostgres{UpsertQueryTemplate: DefaultUpsertQuery}
+	got := gen.GetSqlInsert("filemeta")
+	if !strings.Contains(got, "ON CONFLICT") {
+		t.Fatalf("expected ON CONFLICT in default upsert, got: %s", got)
+	}
+	if !strings.Contains(got, `"filemeta"`) {
+		t.Fatalf("expected quoted table name, got: %s", got)
+	}
+}
+
+func TestEmptyUpsertTemplateFallsBackToPlainInsert(t *testing.T) {
+	gen := &SqlGenPostgres{}
+	got := gen.GetSqlInsert("filemeta")
+	if strings.Contains(got, "ON CONFLICT") {
+		t.Fatalf("plain INSERT path should not contain ON CONFLICT, got: %s", got)
+	}
+}

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -56,6 +56,8 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 	store.SupportBucketTable = false
 	if !enableUpsert {
 		upsertQuery = ""
+	} else if upsertQuery == "" {
+		upsertQuery = DefaultUpsertQuery
 	}
 	store.SqlGenerator = &SqlGenPostgres{
 		CreateTableSqlTemplate: "",

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -30,6 +30,9 @@ func (store *PostgresStore) GetName() string {
 func (store *PostgresStore) Initialize(configuration util.Configuration, prefix string) (err error) {
 	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
 	configuration.SetDefault(prefix+"connection_max_idle", 2)
+	// Default on so minimal configs are not exposed to duplicate-key tx
+	// poisoning on Postgres; an explicit false still disables it.
+	configuration.SetDefault(prefix+"enableUpsert", true)
 	return store.initialize(
 		configuration.GetString(prefix+"upsertQuery"),
 		configuration.GetBool(prefix+"enableUpsert"),

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -35,6 +35,9 @@ func (store *PostgresStore2) GetName() string {
 func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix string) (err error) {
 	// Absent key keeps a pooled default; an explicit 0 disables the idle pool.
 	configuration.SetDefault(prefix+"connection_max_idle", 2)
+	// Default on so minimal configs are not exposed to duplicate-key tx
+	// poisoning on Postgres; an explicit false still disables it.
+	configuration.SetDefault(prefix+"enableUpsert", true)
 	return store.initialize(
 		configuration.GetString(prefix+"createTable"),
 		configuration.GetString(prefix+"upsertQuery"),

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -62,6 +62,8 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 	store.SupportBucketTable = true
 	if !enableUpsert {
 		upsertQuery = ""
+	} else if upsertQuery == "" {
+		upsertQuery = postgres.DefaultUpsertQuery
 	}
 	store.SqlGenerator = &postgres.SqlGenPostgres{
 		CreateTableSqlTemplate: createTable,


### PR DESCRIPTION
## Summary

A regression introduced by the NFS-inode-index work in 4.21 made concurrent renames on the postgres filer store fail intermittently with EIO, observed in [#9704](https://github.com/seaweedfs/seaweedfs/issues/9704).

The chain:

1. Rename opens a postgres tx in `filer_grpc_server_rename.go`.
2. The new entry's `InsertEntry` triggers `recordInodeIndexWrite` -> `storeInodeIndex` -> `KvPut` on `filer.inode.path.<inode>`.
3. That row already exists from a previous write of the same file, so the bare `INSERT` in `KvPut` (`abstract_sql_store_kv.go`) returns `23505 duplicate key value violates unique constraint`.
4. Postgres aborts the surrounding tx, the next statement (source `DeleteEntry`) hits `25P02 current transaction is aborted`, rename rolls back, FUSE returns EIO.

The bug only surfaces when `KvPut` uses a plain `INSERT`. With an explicit `upsertQuery` in `filer.toml` the path becomes `INSERT ... ON CONFLICT DO UPDATE` and the conflict never throws. The scaffold provides one, but a minimal user config that just sets `enableUpsert = true` leaves it empty.

This change installs a sensible default upsert template for postgres when `enableUpsert=true` and no template was provided. The `enableUpsert=false` escape hatch is preserved for non-PG-compatible backends.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./weed/filer/postgres/... ./weed/filer/postgres2/...`
- [x] `go test ./weed/filer/postgres/...`
- [ ] Manual: reproduce the original workload (concurrent `*.writing` -> `*.temp` renames over CSI-driver FUSE mount with `[postgres2]`, `enableUpsert=true`, no explicit `upsertQuery`) and verify 23505/25P02 no longer appears in the filer log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sensible default idempotent upsert statements for Postgres and MySQL and enabled upserts by default for minimal configurations.

* **Bug Fixes**
  * Ensures default upsert is applied when enabled to avoid duplicate-key issues that can corrupt surrounding transactions.

* **Tests**
  * Added tests validating default upsert usage and fallback to plain INSERT when no template is provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->