### PR TITLE
fix(replication/s3sink): forward entry mime as ContentType

### DIFF
--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -209,7 +209,7 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 	if tags != "" {
 		uploadInput.Tagging = aws.String(tags)
 	}
-	if entry.Attributes != nil && entry.Attributes.Mime != "" {
+	if entry.Attributes.Mime != "" {
 		uploadInput.ContentType = aws.String(entry.Attributes.Mime)
 	}
 	if len(entry.Attributes.Md5) > 0 {

--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -209,7 +209,7 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 	if tags != "" {
 		uploadInput.Tagging = aws.String(tags)
 	}
-	if entry.Attributes.Mime != "" {
+	if entry.Attributes != nil && entry.Attributes.Mime != "" {
 		uploadInput.ContentType = aws.String(entry.Attributes.Mime)
 	}
 	if len(entry.Attributes.Md5) > 0 {

--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -209,6 +209,9 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 	if tags != "" {
 		uploadInput.Tagging = aws.String(tags)
 	}
+	if entry.Attributes.Mime != "" {
+		uploadInput.ContentType = aws.String(entry.Attributes.Mime)
+	}
 	if len(entry.Attributes.Md5) > 0 {
 		uploadInput.ContentMD5 = aws.String(base64.StdEncoding.EncodeToString([]byte(entry.Attributes.Md5)))
 	}

--- a/weed/replication/sink/s3sink/s3_sink_test.go
+++ b/weed/replication/sink/s3sink/s3_sink_test.go
@@ -1,11 +1,19 @@
 package S3Sink
 
 import (
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildTaggingString_ShouldStripTagPrefix(t *testing.T) {
@@ -42,6 +50,72 @@ func TestBuildTaggingString_ShouldURLEncodeValues(t *testing.T) {
 	if v := parsed.Get("path"); v != "/a/b=c&d" {
 		t.Errorf("expected tag value /a/b=c&d after decoding, got %q", v)
 	}
+}
+
+// capturePutRoundTripper records the s3manager.Uploader's PUT and replies 200
+// so the SDK is satisfied without making a real network call.
+type capturePutRoundTripper struct {
+	uploadReq *http.Request
+}
+
+func (c *capturePutRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodPut {
+		c.uploadReq = req.Clone(req.Context())
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+		_ = req.Body.Close()
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     http.Header{"ETag": []string{"\"etag\""}},
+		Request:    req,
+	}, nil
+}
+
+func newCapturingS3Sink(t *testing.T) (*S3Sink, *capturePutRoundTripper) {
+	t.Helper()
+	rt := &capturePutRoundTripper{}
+	sess, err := session.NewSession(&aws.Config{
+		Region:           aws.String("us-east-1"),
+		Endpoint:         aws.String("https://example.invalid"),
+		S3ForcePathStyle: aws.Bool(true),
+		Credentials:      credentials.NewStaticCredentials("k", "s", ""),
+		HTTPClient:       &http.Client{Transport: rt},
+	})
+	require.NoError(t, err)
+	s := &S3Sink{
+		conn:                awss3.New(sess),
+		bucket:              "bucket",
+		uploaderConcurrency: 1,
+		uploaderPartSizeMb:  5,
+	}
+	return s, rt
+}
+
+func TestS3SinkCreateEntryPassesMimeAsContentType(t *testing.T) {
+	sink, rt := newCapturingS3Sink(t)
+	entry := &filer_pb.Entry{
+		Attributes: &filer_pb.FuseAttributes{Mime: "text/html"},
+		Content:    []byte("<html></html>"),
+	}
+	require.NoError(t, sink.CreateEntry("/dir/test.html", entry, nil))
+
+	require.NotNil(t, rt.uploadReq, "uploader should have issued a PUT")
+	require.Equal(t, "text/html", rt.uploadReq.Header.Get("Content-Type"))
+}
+
+func TestS3SinkCreateEntryOmitsContentTypeWhenMimeMissing(t *testing.T) {
+	sink, rt := newCapturingS3Sink(t)
+	entry := &filer_pb.Entry{
+		Attributes: &filer_pb.FuseAttributes{},
+		Content:    []byte("data"),
+	}
+	require.NoError(t, sink.CreateEntry("/dir/test.bin", entry, nil))
+
+	require.NotNil(t, rt.uploadReq, "uploader should have issued a PUT")
+	require.Equal(t, "", rt.uploadReq.Header.Get("Content-Type"))
 }
 
 func TestBuildTaggingString_EmptyWhenNoTags(t *testing.T) {


### PR DESCRIPTION
## Summary

Companion to #9708. The `filer.replicate` S3 sink also uses `s3manager.Uploader` and never sets `ContentType`, so replicated objects on S3-compatible remotes (e.g. Backblaze B2) end up stored as `binary/octet-stream` and browsers refuse to render HTML/CSS/etc.

Forward `entry.Attributes.Mime` to `UploadInput.ContentType` in `S3Sink.CreateEntry`. Leave it unset when no Mime is recorded so the remote keeps its own default.

## Test plan
- [x] `go test ./weed/replication/sink/s3sink/...` — new tests assert `Content-Type: text/html` is sent when `Attributes.Mime` is set and no `Content-Type` header is sent when it is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * S3 file uploads now correctly set the Content-Type header based on the provided MIME type. Files with MIME type information will have the appropriate content type configured during upload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->