### PR TITLE
fix(remote_storage/gcs): forward entry mime as ContentType

### DIFF
--- a/weed/remote_storage/gcs/gcs_storage_client.go
+++ b/weed/remote_storage/gcs/gcs_storage_client.go
@@ -227,6 +227,9 @@ func (gcs *gcsRemoteStorageClient) WriteFile(loc *remote_pb.RemoteStorageLocatio
 	metadata := toMetadata(entry.Extended)
 	wc := gcs.client.Bucket(loc.Bucket).Object(key).NewWriter(context.Background())
 	wc.Metadata = metadata
+	if entry.Attributes != nil && entry.Attributes.Mime != "" {
+		wc.ContentType = entry.Attributes.Mime
+	}
 	if _, err = io.Copy(wc, reader); err != nil {
 		return nil, fmt.Errorf("upload to gcs %s/%s%s: %v", loc.Name, loc.Bucket, loc.Path, err)
 	}


### PR DESCRIPTION
## Summary

Companion to #9708 / #9710. The GCS `remote_storage` client also dropped `entry.Attributes.Mime` on upload, so `filer.remote.sync` to GCS stored objects without a ContentType and HTML/CSS/etc. didn't render correctly in browsers.

Set `wc.ContentType = entry.Attributes.Mime` when present. Mirrors the existing Azure client behavior at `weed/remote_storage/azure/azure_storage_client.go:358-359`.

## Test plan
- [x] `go build ./weed/remote_storage/gcs/...` and `go vet ./...` clean.
- [ ] GCS request capture would need a fake GCS HTTP server (the SDK doesn't expose a simple seam like `s3iface`); skipped given the fix is a one-line mirror of the established Azure pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Files stored in cloud storage now correctly preserve their MIME type information, ensuring proper content handling and display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->