### PR TITLE
fix(volume): avoid panic when URL path has a dot before the comma

### DIFF
--- a/weed/storage/needle/needle.go
+++ b/weed/storage/needle/needle.go
@@ -110,7 +110,8 @@ func CreateNeedleFromRequest(r *http.Request, fixJpgOrientation bool, sizeLimit 
 	commaSep := strings.LastIndex(r.URL.Path, ",")
 	dotSep := strings.LastIndex(r.URL.Path, ".")
 	fid := r.URL.Path[commaSep+1:]
-	if dotSep > 0 {
+	// dot must be after comma; otherwise path[commaSep+1:dotSep] panics
+	if dotSep > commaSep {
 		fid = r.URL.Path[commaSep+1 : dotSep]
 	}
 


### PR DESCRIPTION
## Summary

`CreateNeedleFromRequest` extracts the fid by locating the last `,` and last `.` in `r.URL.Path`. When the path has a dot before the last comma (for example `/vol/file.jpg,abc`), `dotSep < commaSep+1` and `path[commaSep+1:dotSep]` slices with start>end, panicking the handler goroutine.

`net/http` recovers handler panics, so the process keeps running, but the request aborts with `slice bounds out of range` in the log. Tightening the guard from `dotSep > 0` to `dotSep > commaSep` keeps the original behavior for well-formed paths and falls back to `path[commaSep+1:]` otherwise.

## Test plan

- [ ] `go test ./weed/storage/needle/... ./weed/operation/...`
- [ ] Manual: `curl -X POST http://localhost:8080/vol/file.jpg,abc` no longer panics the handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request path validation to prevent potential errors when processing requests with invalid URL formatting. Strengthened input validation now prevents failures from edge cases in malformed paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->