### PR TITLE
fix(util): guard BytesToUint{16,32,64} against short input

### DIFF
--- a/weed/util/bytes.go
+++ b/weed/util/bytes.go
@@ -33,6 +33,9 @@ func BytesToHumanReadable(b uint64) string {
 
 func BytesToUint64(b []byte) (v uint64) {
 	length := uint(len(b))
+	if length == 0 {
+		return 0
+	}
 	for i := uint(0); i < length-1; i++ {
 		v += uint64(b[i])
 		v <<= 8
@@ -42,6 +45,9 @@ func BytesToUint64(b []byte) (v uint64) {
 }
 func BytesToUint32(b []byte) (v uint32) {
 	length := uint(len(b))
+	if length == 0 {
+		return 0
+	}
 	for i := uint(0); i < length-1; i++ {
 		v += uint32(b[i])
 		v <<= 8
@@ -50,6 +56,9 @@ func BytesToUint32(b []byte) (v uint32) {
 	return
 }
 func BytesToUint16(b []byte) (v uint16) {
+	if len(b) < 2 {
+		return 0
+	}
 	v += uint16(b[0])
 	v <<= 8
 	v += uint16(b[1])

--- a/weed/util/bytes.go
+++ b/weed/util/bytes.go
@@ -56,12 +56,15 @@ func BytesToUint32(b []byte) (v uint32) {
 	return
 }
 func BytesToUint16(b []byte) (v uint16) {
-	if len(b) < 2 {
+	length := uint(len(b))
+	if length == 0 {
 		return 0
 	}
-	v += uint16(b[0])
-	v <<= 8
-	v += uint16(b[1])
+	for i := uint(0); i < length-1; i++ {
+		v += uint16(b[i])
+		v <<= 8
+	}
+	v += uint16(b[length-1])
 	return
 }
 func Uint64toBytes(b []byte, v uint64) {


### PR DESCRIPTION
## Summary

`BytesToUint64` and `BytesToUint32` compute the loop bound as `length-1` where `length` is a `uint`. On an empty slice this underflows to `MaxUint`, the loop body runs, and `b[0]` panics with `index out of range [0] with length 0`. `BytesToUint16` indexes `b[0]` and `b[1]` with no length check at all.

Every current call site guards the slice length before invoking these, so this is a latent footgun rather than a live crash; future callers (or refactors that drop the guard) would hit it. Return `0` on short input, matching the existing variable-length contract.

## Test plan

- [ ] `go test ./weed/util/...`
- [ ] `go build ./weed/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced byte conversion utilities to safely handle empty input slices, preventing indexing errors and returning appropriate zero values.
  * Improved byte-to-integer conversions to correctly process variable-length inputs with proper big-endian value accumulation, eliminating assumptions about fixed input sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->