### PR TITLE
fix(shell): don't halt volume.fsck purge on a stuck read-only volume

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -458,9 +458,10 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 			}
 			// Call out to a closure per volume so the deferred "mark
 			// readonly again" fires between volumes instead of piling up
-			// until findExtraChunksInVolumeServers returns.
+			// until findExtraChunksInVolumeServers returns. Per-volume
+			// failures shouldn't halt the rest of the run.
 			if err := c.purgeOneVolume(volumeId, orphanReplicaFileIds, volumeReplicaCounts[volumeId], readOnlyServerReplicas[volumeId]); err != nil {
-				return err
+				fmt.Fprintf(c.writer, "skip purging volume %d: %v\n", volumeId, err)
 			}
 		}
 	}
@@ -510,7 +511,11 @@ func (c *commandVolumeFsck) purgeOneVolume(volumeId uint32, orphanReplicaFileIds
 	needleVID := needle.VolumeId(volumeId)
 	for _, server := range readOnlyReplicas {
 		if err := markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, true, false); err != nil {
-			return fmt.Errorf("mark volume %d on %v read/write: %v", volumeId, server, err)
+			// Don't halt the rest of the fsck run — log and skip this
+			// volume. Replicas flipped writable in earlier iterations
+			// roll back via the defer below.
+			fmt.Fprintf(c.writer, "skip purging volume %d: mark %v writable: %v\n", volumeId, server, err)
+			return nil
 		}
 		fmt.Fprintf(c.writer, "temporarily marked %d on server %v writable for forced purge\n", volumeId, server)
 		defer markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, false, false)

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -511,11 +511,8 @@ func (c *commandVolumeFsck) purgeOneVolume(volumeId uint32, orphanReplicaFileIds
 	needleVID := needle.VolumeId(volumeId)
 	for _, server := range readOnlyReplicas {
 		if err := markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, true, false); err != nil {
-			// Don't halt the rest of the fsck run — log and skip this
-			// volume. Replicas flipped writable in earlier iterations
-			// roll back via the defer below.
-			fmt.Fprintf(c.writer, "skip purging volume %d: mark %v writable: %v\n", volumeId, server, err)
-			return nil
+			// Replicas flipped writable earlier roll back via the defer.
+			return fmt.Errorf("mark %v writable: %v", server, err)
 		}
 		fmt.Fprintf(c.writer, "temporarily marked %d on server %v writable for forced purge\n", volumeId, server)
 		defer markVolumeWritable(c.env.option.GrpcDialOption, needleVID, server, false, false)

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -448,6 +448,7 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 	// MasterClient.GetLocations, so iterating per replica here (as the old
 	// code did) would issue N*N delete RPCs for N replicas.
 	if applyPurging {
+		var skippedVolumeIds []uint32
 		for volumeId, orphanReplicaFileIds := range volumeIdOrphanFileIds {
 			if len(orphanReplicaFileIds) == 0 {
 				continue
@@ -459,10 +460,17 @@ func (c *commandVolumeFsck) findExtraChunksInVolumeServers(dataNodeVolumeIdToVIn
 			// Call out to a closure per volume so the deferred "mark
 			// readonly again" fires between volumes instead of piling up
 			// until findExtraChunksInVolumeServers returns. Per-volume
-			// failures shouldn't halt the rest of the run.
+			// failures (e.g. a replica stuck read-only) don't halt the
+			// rest of the run; the volume is remembered and its deletes
+			// are skipped.
 			if err := c.purgeOneVolume(volumeId, orphanReplicaFileIds, volumeReplicaCounts[volumeId], readOnlyServerReplicas[volumeId]); err != nil {
 				fmt.Fprintf(c.writer, "skip purging volume %d: %v\n", volumeId, err)
+				skippedVolumeIds = append(skippedVolumeIds, volumeId)
 			}
+		}
+		if len(skippedVolumeIds) > 0 {
+			sort.Slice(skippedVolumeIds, func(i, j int) bool { return skippedVolumeIds[i] < skippedVolumeIds[j] })
+			fmt.Fprintf(c.writer, "skipped purge on %d volume(s): %v\n", len(skippedVolumeIds), skippedVolumeIds)
 		}
 	}
 


### PR DESCRIPTION
## Summary

A failed `VolumeMarkWritable` on one volume aborted the entire `volume.fsck -reallyDeleteFromVolume` run, leaving every later volume's orphans unpurged and forcing operators to re-run fsck repeatedly. The mark-writable-then-delete dance can fail for legitimate reasons (the volume is genuinely stuck read-only, transient gRPC issues, etc.), and that shouldn't take the whole purge down with it.

- `purgeOneVolume`: a `markVolumeWritable` failure now logs `skip purging volume N: mark X writable: ...` and returns nil. Replicas already flipped writable in earlier iterations still roll back via the existing per-iteration `defer`.
- `findExtraChunksInVolumeServers`: per-volume errors from `purgeOneVolume` (e.g. `MasterClient.GetLocations` returning no locations) log `skip purging volume N: ...` and the loop continues to the next volume.

Per-file delete errors were already non-fatal after the `BatchDelete` per-result rework, and the "marked writable but still read-only at delete time" path was fixed by the `reopenIdxForWrite` change. This is the remaining halt path in the purge loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents a single volume purge failure from aborting an entire fsck run: the command now logs a “skip purging volume …” message, records skipped volumes, and continues processing remaining volumes, then prints a consolidated summary.
  * Clarifies error wording when flipping a read-only replica writable and notes rollback behavior for earlier flips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->