### PR TITLE
chore(weed/storage/backend/s3_backend): remove unused function

### DIFF
--- a/weed/storage/backend/s3_backend/s3_sessions.go
+++ b/weed/storage/backend/s3_backend/s3_sessions.go
@@ -18,14 +18,6 @@ var (
 	sessionsLock sync.RWMutex
 )
 
-func getSession(region string) (s3iface.S3API, bool) {
-	sessionsLock.RLock()
-	defer sessionsLock.RUnlock()
-
-	sess, found := s3Sessions[region]
-	return sess, found
-}
-
 func createSession(awsAccessKeyId, awsSecretAccessKey, region, endpoint string, forcePathStyle bool) (s3iface.S3API, error) {
 
 	sessionsLock.Lock()

--- a/weed/storage/backend/s3_backend/s3_sessions.go
+++ b/weed/storage/backend/s3_backend/s3_sessions.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	s3Sessions   = make(map[string]s3iface.S3API)
-	sessionsLock sync.RWMutex
+	sessionsLock sync.Mutex
 )
 
 func createSession(awsAccessKeyId, awsSecretAccessKey, region, endpoint string, forcePathStyle bool) (s3iface.S3API, error) {
@@ -48,7 +48,7 @@ func createSession(awsAccessKeyId, awsSecretAccessKey, region, endpoint string, 
 
 	t := s3.New(sess)
 
-	s3Sessions[region] = t
+	s3Sessions[cacheKey] = t
 
 	return t, nil
 


### PR DESCRIPTION
This removes the unused `getSession()` function from `weed/storage/backend/s3_backend`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified storage backend session management for improved reliability.
  * Improved session caching to distinguish across region/endpoint combinations, reducing incorrect client reuse and making S3 connections more reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->