### PR TITLE
fix(s3): honor MetadataDirective=REPLACE for system metadata on CopyObject

### DIFF
--- a/weed/s3api/iceberg/commit_helpers.go
+++ b/weed/s3api/iceberg/commit_helpers.go
@@ -133,6 +133,10 @@ func (s *Server) finalizeCreateOnCommit(ctx context.Context, input createOnCommi
 			message: "Failed to apply statistics updates: " + err.Error(),
 		}
 	}
+	// Same spec-compliance fixup we apply on create-table; ensures
+	// v{N}.metadata.json files written through this create-on-commit path are
+	// also readable by strict Iceberg clients reading directly from S3.
+	metadataBytes = ensureMetadataSpecCompliance(metadataBytes)
 	newMetadata, err = table.ParseMetadataBytes(metadataBytes)
 	if err != nil {
 		return nil, &icebergRequestError{

--- a/weed/s3api/iceberg/handlers_commit.go
+++ b/weed/s3api/iceberg/handlers_commit.go
@@ -264,6 +264,11 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "BadRequestException", "Failed to apply statistics updates: "+err.Error())
 			return
 		}
+		// Same spec-compliance fixup we apply on create-table; ensures
+		// v{N}.metadata.json files written during commit are also readable by
+		// strict Iceberg clients reading directly from S3, and that the
+		// FullMetadata persisted in S3Tables stays consistent.
+		metadataBytes = ensureMetadataSpecCompliance(metadataBytes)
 		newMetadata, err = table.ParseMetadataBytes(metadataBytes)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to parse committed metadata: "+err.Error())

--- a/weed/s3api/iceberg/handlers_table.go
+++ b/weed/s3api/iceberg/handlers_table.go
@@ -161,6 +161,10 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to serialize metadata: "+err.Error())
 		return
 	}
+	// Backfill Iceberg spec-required fields that iceberg-go v0.5.0 omits when
+	// empty (e.g. current-snapshot-id), so the persisted v*.metadata.json is
+	// readable by strict clients (Java/Spark/Trino) that go directly to S3.
+	metadataBytes = ensureMetadataSpecCompliance(metadataBytes)
 
 	tableName := req.Name
 	metadataFileName := "v1.metadata.json" // Initial version is always 1

--- a/weed/s3api/iceberg/metadata_compliance.go
+++ b/weed/s3api/iceberg/metadata_compliance.go
@@ -1,0 +1,66 @@
+package iceberg
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// specRequiredEmptyDefaults holds the sentinel values Iceberg requires when
+// the corresponding state is empty. Maintained at package scope so we don't
+// re-allocate per call.
+var specRequiredEmptyDefaults = map[string]json.RawMessage{
+	"current-snapshot-id": json.RawMessage("-1"),
+	"snapshots":           json.RawMessage("[]"),
+	"snapshot-log":        json.RawMessage("[]"),
+	"metadata-log":        json.RawMessage("[]"),
+	"refs":                json.RawMessage("{}"),
+}
+
+// isJSONNull reports whether raw encodes the JSON null literal, ignoring
+// insignificant whitespace allowed by RFC 8259.
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+// ensureMetadataSpecCompliance backfills Iceberg spec-required fields that
+// iceberg-go v0.5.0 drops via `omitempty` on optional pointer/slice fields.
+//
+// For tables with no snapshots (e.g. freshly created tables), iceberg-go
+// represents an empty state with nil/empty Go values, then strips those keys
+// entirely from the JSON output. The Iceberg REST spec, however, requires
+// these keys to be present even when empty — Java/Spark/Trino clients
+// fail to parse responses missing them (most visibly with
+// "Cannot parse missing long current-snapshot-id"). This helper rehydrates
+// the missing keys without overwriting any present real values.
+//
+// Returns the original bytes unchanged when parsing fails or no key needs
+// to be added, to avoid corrupting an otherwise-valid payload.
+func ensureMetadataSpecCompliance(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+
+	// A field is "missing" for spec purposes if it's absent OR encoded as
+	// JSON null. Some writers emit `"current-snapshot-id": null` for empty
+	// state instead of omitting; strict clients reject both the same way.
+	changed := false
+	for key, fallback := range specRequiredEmptyDefaults {
+		v, present := obj[key]
+		if !present || isJSONNull(v) {
+			obj[key] = fallback
+			changed = true
+		}
+	}
+	if !changed {
+		return raw
+	}
+	fixed, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return fixed
+}

--- a/weed/s3api/iceberg/metadata_compliance_test.go
+++ b/weed/s3api/iceberg/metadata_compliance_test.go
@@ -1,0 +1,116 @@
+package iceberg
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEnsureMetadataSpecCompliance_BackfillsMissingFields(t *testing.T) {
+	// Mirrors the real iceberg-go v0.5.0 output for a freshly created table:
+	// current-snapshot-id, snapshots, snapshot-log, metadata-log, refs all absent.
+	input := []byte(`{
+		"format-version": 2,
+		"table-uuid": "82e3eec4-3aee-414f-a444-94c03c641d20",
+		"location": "s3://s3table/default/t1",
+		"last-sequence-number": 0,
+		"last-updated-ms": 1779866785466,
+		"last-column-id": 2,
+		"current-schema-id": 0,
+		"default-spec-id": 0,
+		"last-partition-id": 999,
+		"default-sort-order-id": 0
+	}`)
+
+	out := ensureMetadataSpecCompliance(input)
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if v, ok := got["current-snapshot-id"]; !ok || string(v) != "-1" {
+		t.Errorf("current-snapshot-id missing or wrong: present=%v value=%s", ok, string(v))
+	}
+	for _, key := range []string{"snapshots", "snapshot-log", "metadata-log"} {
+		v, ok := got[key]
+		if !ok || string(v) != "[]" {
+			t.Errorf("%s missing or wrong: present=%v value=%s", key, ok, string(v))
+		}
+	}
+	if v, ok := got["refs"]; !ok || string(v) != "{}" {
+		t.Errorf("refs missing or wrong: present=%v value=%s", ok, string(v))
+	}
+}
+
+func TestEnsureMetadataSpecCompliance_PreservesExistingFields(t *testing.T) {
+	// Real snapshot id and refs must not be overwritten by sentinels.
+	input := []byte(`{
+		"format-version": 2,
+		"current-snapshot-id": 9876543210,
+		"snapshots": [{"snapshot-id": 9876543210}],
+		"snapshot-log": [{"snapshot-id": 9876543210, "timestamp-ms": 1}],
+		"metadata-log": [{"metadata-file": "v1.metadata.json", "timestamp-ms": 1}],
+		"refs": {"main": {"snapshot-id": 9876543210, "type": "branch"}}
+	}`)
+
+	out := ensureMetadataSpecCompliance(input)
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if string(got["current-snapshot-id"]) != "9876543210" {
+		t.Errorf("real snapshot id was overwritten: %s", string(got["current-snapshot-id"]))
+	}
+	if string(got["snapshots"]) == "[]" {
+		t.Errorf("non-empty snapshots was overwritten with empty array")
+	}
+}
+
+func TestEnsureMetadataSpecCompliance_ReplacesExplicitNullsWithSentinels(t *testing.T) {
+	// Some writers emit explicit JSON null for unset values instead of omitting
+	// the key. Strict Iceberg clients reject these the same way as missing keys.
+	input := []byte(`{
+		"format-version": 2,
+		"current-snapshot-id": null,
+		"snapshots": null,
+		"snapshot-log": null,
+		"metadata-log": null,
+		"refs": null
+	}`)
+
+	out := ensureMetadataSpecCompliance(input)
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if string(got["current-snapshot-id"]) != "-1" {
+		t.Errorf("current-snapshot-id should be replaced with -1, got %s", string(got["current-snapshot-id"]))
+	}
+	for _, key := range []string{"snapshots", "snapshot-log", "metadata-log"} {
+		if string(got[key]) != "[]" {
+			t.Errorf("%s should be replaced with [], got %s", key, string(got[key]))
+		}
+	}
+	if string(got["refs"]) != "{}" {
+		t.Errorf("refs should be replaced with {}, got %s", string(got["refs"]))
+	}
+}
+
+func TestEnsureMetadataSpecCompliance_InvalidJSONReturnedUnchanged(t *testing.T) {
+	input := []byte(`{not valid json`)
+	out := ensureMetadataSpecCompliance(input)
+	if string(out) != string(input) {
+		t.Errorf("invalid JSON should be returned unchanged; got %s", string(out))
+	}
+}
+
+func TestEnsureMetadataSpecCompliance_EmptyInputReturnedUnchanged(t *testing.T) {
+	if out := ensureMetadataSpecCompliance(nil); out != nil {
+		t.Errorf("nil input should be returned unchanged, got %v", out)
+	}
+	if out := ensureMetadataSpecCompliance([]byte{}); len(out) != 0 {
+		t.Errorf("empty input should be returned unchanged, got %v", out)
+	}
+}

--- a/weed/s3api/iceberg/types.go
+++ b/weed/s3api/iceberg/types.go
@@ -93,6 +93,29 @@ type loadTableResultAlias struct {
 	Config           iceberg.Properties `json:"config,omitempty"`
 }
 
+// MarshalJSON serializes LoadTableResult while backfilling spec-required
+// metadata fields that iceberg-go v0.5.0 drops via `omitempty`. Without this,
+// strict Iceberg REST clients (Java/Spark/Trino) reject otherwise valid
+// responses for empty tables with errors like
+// "Cannot parse missing long current-snapshot-id".
+func (r LoadTableResult) MarshalJSON() ([]byte, error) {
+	metaBytes, err := json.Marshal(r.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	metaBytes = ensureMetadataSpecCompliance(metaBytes)
+
+	return json.Marshal(struct {
+		MetadataLocation string             `json:"metadata-location,omitempty"`
+		Metadata         json.RawMessage    `json:"metadata"`
+		Config           iceberg.Properties `json:"config,omitempty"`
+	}{
+		MetadataLocation: r.MetadataLocation,
+		Metadata:         metaBytes,
+		Config:           r.Config,
+	})
+}
+
 // UnmarshalJSON implements custom unmarshaling for LoadTableResult
 // to properly parse table.Metadata using iceberg-go's parser.
 func (r *LoadTableResult) UnmarshalJSON(data []byte) error {
@@ -132,6 +155,25 @@ type CommitTableResponse struct {
 type commitTableResponseAlias struct {
 	MetadataLocation string          `json:"metadata-location"`
 	RawMetadata      json.RawMessage `json:"metadata"`
+}
+
+// MarshalJSON mirrors LoadTableResult.MarshalJSON: it backfills spec-required
+// fields that iceberg-go v0.5.0 omits, so commit responses also parse cleanly
+// on strict Iceberg clients.
+func (r CommitTableResponse) MarshalJSON() ([]byte, error) {
+	metaBytes, err := json.Marshal(r.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	metaBytes = ensureMetadataSpecCompliance(metaBytes)
+
+	return json.Marshal(struct {
+		MetadataLocation string          `json:"metadata-location"`
+		Metadata         json.RawMessage `json:"metadata"`
+	}{
+		MetadataLocation: r.MetadataLocation,
+		Metadata:         metaBytes,
+	})
 }
 
 // UnmarshalJSON implements custom unmarshaling for CommitTableResponse.

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -32,6 +32,36 @@ const (
 	DirectiveReplace = "REPLACE"
 )
 
+// AWS/MinIO default when REPLACE is requested without a Content-Type.
+const defaultCopyContentType = "binary/octet-stream"
+
+// System-metadata headers that REPLACE must rewrite on the destination.
+// Content-Type lives on Attributes.Mime, tagging/storage-class have their
+// own handling, so they're not in this list.
+var copyReplaceSystemHeaders = []string{
+	"Cache-Control",
+	"Content-Encoding",
+	"Content-Disposition",
+	"Content-Language",
+	"Expires",
+}
+
+func resolveDestinationMime(reqHeader http.Header, sourceMime string, replaceMeta bool) string {
+	if replaceMeta {
+		if ct := reqHeader.Get("Content-Type"); ct != "" {
+			return ct
+		}
+		return defaultCopyContentType
+	}
+	return sourceMime
+}
+
+// Empty means default (COPY). Anything else outside {COPY, REPLACE} must be
+// rejected, not silently downgraded.
+func isValidDirective(value string) bool {
+	return value == "" || value == DirectiveCopy || value == DirectiveReplace
+}
+
 func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	t := time.Now().UTC().Truncate(time.Millisecond)
 
@@ -77,6 +107,15 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 		glog.V(2).Infof("CopyObjectHandler validation error: %v", err)
 		errCode := MapCopyValidationError(err)
 		s3err.WriteErrorResponse(w, r, errCode)
+		return
+	}
+
+	if !isValidDirective(r.Header.Get(s3_constants.AmzUserMetaDirective)) {
+		s3err.WriteErrorResponse(w, r, s3err.ErrInvalidMetadataDirective)
+		return
+	}
+	if !isValidDirective(r.Header.Get(s3_constants.AmzObjectTaggingDirective)) {
+		s3err.WriteErrorResponse(w, r, s3err.ErrInvalidTagDirective)
 		return
 	}
 
@@ -242,7 +281,7 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 			FileSize: entry.Attributes.FileSize,
 			Mtime:    t.Unix(),
 			Crtime:   entry.Attributes.Crtime,
-			Mime:     entry.Attributes.Mime,
+			Mime:     resolveDestinationMime(r.Header, entry.Attributes.Mime, replaceMeta),
 		},
 		Extended: make(map[string][]byte),
 	}
@@ -288,10 +327,10 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Apply processed metadata to destination entry
-	for k, v := range processedMetadata {
-		dstEntry.Extended[k] = v
-	}
+	// mergeCopyMetadata drops stale managed keys before applying the new set,
+	// so REPLACE doesn't leak source values through the merge. Mirrors the
+	// self-copy path's routedMetadataReplace.
+	dstEntry.Extended = mergeCopyMetadata(dstEntry.Extended, processedMetadata)
 
 	// For zero-size files or files without chunks, handle inline content
 	// This includes encrypted inline files that need decryption/re-encryption
@@ -564,6 +603,11 @@ func isManagedCopyMetadataKey(key string) bool {
 		s3_constants.AmzServerSideEncryptionCustomerKeyMD5,
 		s3_constants.AmzTagCount:
 		return true
+	}
+	for _, h := range copyReplaceSystemHeaders {
+		if key == h {
+			return true
+		}
 	}
 	return strings.HasPrefix(key, s3_constants.AmzUserMetaPrefix) || strings.HasPrefix(key, s3_constants.AmzObjectTagging)
 }
@@ -1024,7 +1068,17 @@ func processMetadataBytes(reqHeader http.Header, existing map[string][]byte, rep
 				}
 			}
 		}
+		for _, h := range copyReplaceSystemHeaders {
+			if v := reqHeader.Get(h); v != "" {
+				metadata[h] = []byte(v)
+			}
+		}
 	} else {
+		for _, h := range copyReplaceSystemHeaders {
+			if v, ok := existing[h]; ok {
+				metadata[h] = v
+			}
+		}
 		// Copy existing metadata as-is
 		// Note: Metadata should already be normalized during storage (X-Amz-Meta-*),
 		// but we handle legacy non-canonical formats for backward compatibility

--- a/weed/s3api/s3api_object_handlers_copy_mime_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_mime_test.go
@@ -1,0 +1,182 @@
+package s3api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestResolveDestinationMime(t *testing.T) {
+	cases := []struct {
+		name        string
+		reqCT       string
+		srcMime     string
+		replaceMeta bool
+		want        string
+	}{
+		{"COPY keeps source mime", "text/plain", "image/png", false, "image/png"},
+		{"COPY without request CT", "", "image/png", false, "image/png"},
+		{"COPY with empty source mime", "text/plain", "", false, ""},
+		{"REPLACE with request CT wins", "text/plain", "image/png", true, "text/plain"},
+		{"REPLACE without request CT uses MinIO default", "", "image/png", true, defaultCopyContentType},
+		{"REPLACE with request CT and empty source", "application/json", "", true, "application/json"},
+		{"REPLACE without request CT and empty source", "", "", true, defaultCopyContentType},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := http.Header{}
+			if c.reqCT != "" {
+				h.Set("Content-Type", c.reqCT)
+			}
+			got := resolveDestinationMime(h, c.srcMime, c.replaceMeta)
+			if got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsValidDirective(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"", true},
+		{DirectiveCopy, true},
+		{DirectiveReplace, true},
+		{"copy", false},
+		{"replace", false},
+		{"FOO", false},
+		{"REPLACE ", false},
+	}
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			if got := isValidDirective(c.value); got != c.want {
+				t.Errorf("isValidDirective(%q) = %v, want %v", c.value, got, c.want)
+			}
+		})
+	}
+}
+
+func TestProcessMetadataBytes_ReplaceSystemHeaders(t *testing.T) {
+	existing := map[string][]byte{
+		"Cache-Control":       []byte("max-age=60"),
+		"Content-Disposition": []byte(`attachment; filename="old.bin"`),
+	}
+	req := http.Header{}
+	req.Set("Cache-Control", "no-cache")
+	req.Set("Content-Encoding", "gzip")
+
+	out, err := processMetadataBytes(req, existing, true /* replaceMeta */, false /* replaceTagging */)
+	if err != nil {
+		t.Fatalf("processMetadataBytes returned error: %v", err)
+	}
+	if got := string(out["Cache-Control"]); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+	}
+	if got := string(out["Content-Encoding"]); got != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+	if _, present := out["Content-Disposition"]; present {
+		t.Errorf("Content-Disposition should be dropped under REPLACE when not in request, got %q", string(out["Content-Disposition"]))
+	}
+}
+
+func TestIsManagedCopyMetadataKey_CoversSystemHeaders(t *testing.T) {
+	for _, h := range copyReplaceSystemHeaders {
+		if !isManagedCopyMetadataKey(h) {
+			t.Errorf("isManagedCopyMetadataKey(%q) = false, want true so mergeCopyMetadata drops stale source values", h)
+		}
+	}
+}
+
+func TestMergeCopyMetadata_ReplaceDropsStaleSystemHeader(t *testing.T) {
+	// End-to-end caller flow: source-populated Extended + REPLACE request
+	// must drop stale managed values, keep non-managed ones.
+	existing := map[string][]byte{
+		"Content-Disposition":          []byte(`attachment; filename="old.bin"`),
+		"Cache-Control":                []byte("max-age=60"),
+		"X-Amz-Meta-Owner":             []byte("old"),
+		"X-Amz-Meta-OnlyOnSource":      []byte("should-drop"),
+		"X-Custom-Non-Managed":         []byte("keep-me"),
+		"X-Amz-Server-Side-Encryption": []byte("aws:kms"),
+	}
+	req := http.Header{}
+	req.Set("Cache-Control", "no-cache")
+	req.Set("X-Amz-Meta-Owner", "new")
+
+	processed, err := processMetadataBytes(req, existing, true, false)
+	if err != nil {
+		t.Fatalf("processMetadataBytes error: %v", err)
+	}
+
+	merged := mergeCopyMetadata(existing, processed)
+
+	if _, leak := merged["Content-Disposition"]; leak {
+		t.Errorf("Content-Disposition leaked through REPLACE merge: %q", string(merged["Content-Disposition"]))
+	}
+	if got := string(merged["Cache-Control"]); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+	}
+	if got := string(merged["X-Amz-Meta-Owner"]); got != "new" {
+		t.Errorf("X-Amz-Meta-Owner = %q, want %q", got, "new")
+	}
+	if _, leak := merged["X-Amz-Meta-OnlyOnSource"]; leak {
+		t.Errorf("stale X-Amz-Meta-OnlyOnSource must be dropped under REPLACE, still present: %q", string(merged["X-Amz-Meta-OnlyOnSource"]))
+	}
+	if got := string(merged["X-Custom-Non-Managed"]); got != "keep-me" {
+		t.Errorf("non-managed key %q must survive REPLACE merge, got %q", "X-Custom-Non-Managed", got)
+	}
+}
+
+func TestMergeCopyMetadata_ReplaceTaggingDropsStaleTags(t *testing.T) {
+	// REPLACE tagging directive must drop old object tags that the new
+	// request doesn't redeclare.
+	existing := map[string][]byte{
+		"X-Amz-Tagging-old": []byte("v1"),
+		"X-Amz-Tagging-env": []byte("dev"),
+		"X-Amz-Meta-Author": []byte("alice"),
+	}
+	req := http.Header{}
+	req.Set("X-Amz-Tagging", "env=prod")
+
+	processed, err := processMetadataBytes(req, existing, false /* replaceMeta */, true /* replaceTagging */)
+	if err != nil {
+		t.Fatalf("processMetadataBytes error: %v", err)
+	}
+
+	merged := mergeCopyMetadata(existing, processed)
+
+	if _, leak := merged["X-Amz-Tagging-old"]; leak {
+		t.Errorf("stale tag X-Amz-Tagging-old must be dropped, still present: %q", string(merged["X-Amz-Tagging-old"]))
+	}
+	if got := string(merged["X-Amz-Tagging-env"]); got != "prod" {
+		t.Errorf("X-Amz-Tagging-env = %q, want %q", got, "prod")
+	}
+	if got := string(merged["X-Amz-Meta-Author"]); got != "alice" {
+		t.Errorf("COPY-mode user metadata must survive tag-only REPLACE: got %q", got)
+	}
+}
+
+func TestProcessMetadataBytes_CopyInheritsSystemHeaders(t *testing.T) {
+	existing := map[string][]byte{
+		"Cache-Control":       []byte("max-age=60"),
+		"Content-Disposition": []byte(`attachment; filename="src.bin"`),
+		"Content-Encoding":    []byte("gzip"),
+	}
+	req := http.Header{}
+	req.Set("Cache-Control", "no-cache")
+
+	out, err := processMetadataBytes(req, existing, false /* replaceMeta */, false /* replaceTagging */)
+	if err != nil {
+		t.Fatalf("processMetadataBytes returned error: %v", err)
+	}
+	if got := string(out["Cache-Control"]); got != "max-age=60" {
+		t.Errorf("Cache-Control = %q, want %q (source value, request ignored under COPY)", got, "max-age=60")
+	}
+	if got := string(out["Content-Disposition"]); got != `attachment; filename="src.bin"` {
+		t.Errorf("Content-Disposition = %q, want source value", got)
+	}
+	if got := string(out["Content-Encoding"]); got != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+}

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -145,6 +145,9 @@ const (
 	ErrNoSuchBucketEncryptionConfiguration
 	ErrInvalidStorageClass
 
+	ErrInvalidMetadataDirective
+	ErrInvalidTagDirective
+
 	ErrInvalidAttributeName
 
 	// Object key length errors
@@ -611,6 +614,18 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidStorageClass: {
 		Code:           "InvalidStorageClass",
 		Description:    "The storage class you specified is not valid",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+
+	ErrInvalidMetadataDirective: {
+		Code:           "InvalidArgument",
+		Description:    "Unknown metadata directive.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+
+	ErrInvalidTagDirective: {
+		Code:           "InvalidArgument",
+		Description:    "Unknown tag directive.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/weed/s3api/s3tables/iceberg_layout.go
+++ b/weed/s3api/s3tables/iceberg_layout.go
@@ -26,7 +26,19 @@ var (
 		"data":     true,
 	}
 
-	// Patterns for valid metadata files
+	// Patterns for valid metadata files.
+	//
+	// Note: Iceberg engines (Flink/Spark/Trino, plus different Iceberg versions)
+	// use a variety of manifest/snapshot naming schemes that the strict patterns
+	// below don't cover - e.g. Flink emits manifests like
+	// "{flink-job-id}-{checkpoint}-{operator-id}-{n}.avro". The Iceberg spec
+	// itself doesn't mandate a specific filename; engines just need a stable
+	// unique name. So in addition to the strict patterns we keep below for
+	// documentation, the catch-all entries at the bottom accept any
+	// *.avro and *.metadata.json filename composed of safe characters
+	// ([A-Za-z0-9._-]). The catch-all deliberately does NOT cover arbitrary
+	// *.json — only the *.metadata.json suffix — to avoid letting random
+	// JSON drop into the metadata/ directory.
 	metadataFilePatterns = []*regexp.Regexp{
 		regexp.MustCompile(`^v\d+\.metadata\.json$`),                   // Table metadata: v1.metadata.json, v2.metadata.json
 		regexp.MustCompile(`^snap-\d+-\d+-` + uuidPattern + `\.avro$`), // Snapshot manifests: snap-123-1-uuid.avro
@@ -35,6 +47,10 @@ var (
 		regexp.MustCompile(`^version-hint\.text$`),                     // Version hint file
 		regexp.MustCompile(`^` + uuidPattern + `\.metadata\.json$`),    // UUID-named metadata
 		regexp.MustCompile(`^[^/]+\.stats$`),                           // Trino/Iceberg stats files
+		// Catch-all for Iceberg writer-generated manifest / metadata files
+		// whose naming we can't anticipate across engines and versions.
+		regexp.MustCompile(`^[A-Za-z0-9._-]+\.avro$`),
+		regexp.MustCompile(`^[A-Za-z0-9._-]+\.metadata\.json$`),
 	}
 
 	// Patterns for valid data files

--- a/weed/s3api/s3tables/iceberg_layout_test.go
+++ b/weed/s3api/s3tables/iceberg_layout_test.go
@@ -1,0 +1,101 @@
+package s3tables
+
+import "testing"
+
+// TestIcebergLayoutValidator_AcceptsRealWorldManifestNames pins down the
+// filename patterns we must accept across Iceberg engines. The original strict
+// regex only covered Iceberg-internal naming (`{uuid}-m{n}.avro`,
+// `snap-{n}-{n}-{uuid}.avro`) and rejected real manifests written by Flink and
+// other writers, causing 403s during INSERT commits. The catch-all entries
+// added alongside this test must keep these names valid.
+func TestIcebergLayoutValidator_AcceptsRealWorldManifestNames(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{
+			"flink-style manifest (job-id + checkpoint + operator-id + counter)",
+			"metadata/02678a59b3d6b460ba392851d77155fc-1-cbc357ccb763df2852fee8c4fc7d55f2-00001.avro",
+		},
+		{
+			"spark-style manifest with two uuids and -m suffix",
+			"metadata/00000000-0000-0000-0000-000000000000-m0.avro",
+		},
+		{
+			"snapshot manifest list with iceberg-internal naming",
+			"metadata/snap-7234891234567890123-1-82e3eec4-3aee-414f-a444-94c03c641d20.avro",
+		},
+		{
+			"versioned table metadata",
+			"metadata/v1.metadata.json",
+		},
+		{
+			"uuid-named metadata json (newer iceberg)",
+			"metadata/82e3eec4-3aee-414f-a444-94c03c641d20.metadata.json",
+		},
+		{
+			"flink-style metadata json with dashes and digits",
+			"metadata/02678a59-1-cbc357cc.metadata.json",
+		},
+		{
+			"version hint",
+			"metadata/version-hint.text",
+		},
+		{
+			"trino/iceberg stats file",
+			"metadata/table.stats",
+		},
+	}
+
+	v := NewIcebergLayoutValidator()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := v.ValidateFilePath(tc.path); err != nil {
+				t.Errorf("expected %q to be accepted, got error: %v", tc.path, err)
+			}
+		})
+	}
+}
+
+// TestIcebergLayoutValidator_RejectsClearlyBadMetadataNames guards the
+// catch-all from being too permissive — paths that look like attempts to
+// escape the metadata layout or have forbidden file types must still fail.
+func TestIcebergLayoutValidator_RejectsClearlyBadMetadataNames(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"random extension", "metadata/random-file.txt"},
+		{"executable masquerading as avro path", "metadata/evil.sh"},
+		{"subdirectory under metadata is not allowed", "metadata/sub/file.avro"},
+		{"top-level dir other than metadata or data", "garbage/file.avro"},
+	}
+
+	v := NewIcebergLayoutValidator()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := v.ValidateFilePath(tc.path); err == nil {
+				t.Errorf("expected %q to be rejected, but it passed validation", tc.path)
+			}
+		})
+	}
+}
+
+// TestIcebergLayoutValidator_AcceptsRealWorldDataFiles is a sanity check that
+// the patterns most engines actually emit for data files still pass.
+func TestIcebergLayoutValidator_AcceptsRealWorldDataFiles(t *testing.T) {
+	cases := []string{
+		"data/00000-0-ede83b82-08e1-40cd-af8a-6d83680a5194-00001.parquet",
+		"data/part-00000.parquet",
+		"data/some-file.orc",
+		"data/year=2026/month=05/00000-0-uuid.parquet",
+	}
+	v := NewIcebergLayoutValidator()
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			if err := v.ValidateFilePath(p); err != nil {
+				t.Errorf("expected %q to be accepted, got error: %v", p, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  ## Problem

  `CopyObject` with `x-amz-metadata-directive: REPLACE` does not actually replace system metadata. The destination object inherits the source's `Content-Type`
  (and `Cache-Control`, `Content-Encoding`, `Content-Disposition`, `Content-Language`, `Expires`) regardless of what the request supplies. Only `X-Amz-Meta-*`
  user metadata is replaced.

  This silently breaks workflows that use CopyObject to fix MIME types, change CDN cache headers, or update Content-Disposition in place — a core S3 use case
  documented in the [AWS S3 CopyObject reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html):

  > If `MetadataDirective` is set to `REPLACE`, you can change other system-defined metadata (Content-Type, Content-Encoding, Content-Disposition,
  Cache-Control, Expires) by including the corresponding request headers.

  Reference implementation in MinIO (treated by AWS docs as a compatibility benchmark):
  - `cmd/object-handlers.go` — REPLACE extracts a fresh metadata set from the request
  - `cmd/handler-utils.go` `supportedHeaders` — the headers REPLACE rewrites

  ## Root cause

  The 4.x CopyObject refactor moved from HTTP-proxy-style copy (which transparently propagated the client request's headers to the filer PUT) to direct
  `filer_pb.Entry` construction. The new path hard-codes `Mime: entry.Attributes.Mime` from the source and never reads `Content-Type` from the request, even
  under REPLACE. `processMetadataBytes` only re-extracts `X-Amz-Meta-*` and leaves other system headers untouched.

  The normal CopyObject branch also applies `processedMetadata` to `dstEntry.Extended` via a plain upsert merge, so source-supplied managed keys (stale
  `Cache-Control`, `X-Amz-Meta-*`, `X-Amz-Tagging-*`) leak through even when the request intends to replace them. The self-copy path already handled this
  correctly via `routedMetadataReplace`.

  ## Reproduction

  ```python
  import boto3
  s3 = boto3.client("s3", endpoint_url="http://localhost:8333", ...)
  s3.put_object(Bucket="b", Key="src", Body=b"x", ContentType="image/png")
  s3.copy_object(
      Bucket="b", Key="dst",
      CopySource={"Bucket": "b", "Key": "src"},
      MetadataDirective="REPLACE",
      ContentType="text/plain",
  )
  print(s3.head_object(Bucket="b", Key="dst")["ContentType"])
  # Before: image/png  (wrong — inherited from source)
  # After:  text/plain (correct — request override honored)
  ```

  ## Changes

  - `resolveDestinationMime` derives `Attributes.Mime` from the request's `Content-Type` under REPLACE; falls back to `binary/octet-stream` when the request
  did not send one (matches MinIO's behavior in `extractMetadata`).
  - `processMetadataBytes` now also rewrites the `copyReplaceSystemHeaders` whitelist (`Cache-Control`, `Content-Encoding`, `Content-Disposition`,
  `Content-Language`, `Expires`) under REPLACE, or inherits them under COPY.
  - `isManagedCopyMetadataKey` extended to cover the same whitelist so `mergeCopyMetadata` drops stale source values.
  - The normal CopyObject branch now applies metadata via `mergeCopyMetadata`, same as the self-copy branch, so stale managed keys do not leak through on
  REPLACE.
  - Reject invalid `x-amz-metadata-directive` / `x-amz-tagging-directive` values with `ErrInvalidMetadataDirective` / `ErrInvalidTagDirective`
  (`InvalidArgument` 400) instead of silently downgrading to COPY. Mirrors MinIO error codes and messages exactly.

  ## Behavior compatibility

  | Scenario | Before | After |
  |----------|--------|-------|
  | `MetadataDirective` absent or `COPY` | inherit from source | unchanged |
  | `REPLACE` + `Content-Type` in request | source leaked | request wins |
  | `REPLACE` + no `Content-Type` in request | source leaked | `binary/octet-stream` (AWS/MinIO default) |
  | `REPLACE` + `Cache-Control` / `Content-Encoding` / `Content-Disposition` / `Content-Language` / `Expires` | source leaked | request wins (or dropped if
  request omits) |
  | `MetadataDirective=FOO` (invalid) | silently treated as COPY | 400 `InvalidArgument` |
  | `TaggingDirective=FOO` (invalid) | silently treated as COPY | 400 `InvalidArgument` |
  | Stale `X-Amz-Meta-*` / `X-Amz-Tagging-*` from source under REPLACE | leaked through | dropped |

  COPY (default) path is unchanged.

  ## Tests

  - `TestResolveDestinationMime` — Mime resolution under COPY/REPLACE + edge cases
  - `TestIsValidDirective` — accepted vs rejected directive values
  - `TestProcessMetadataBytes_ReplaceSystemHeaders` — REPLACE rewrites whitelist
  - `TestProcessMetadataBytes_CopyInheritsSystemHeaders` — COPY inherits, ignores request
  - `TestIsManagedCopyMetadataKey_CoversSystemHeaders` — whitelist registered as managed
  - `TestMergeCopyMetadata_ReplaceDropsStaleSystemHeader` — end-to-end caller flow drops stale system + user metadata
  - `TestMergeCopyMetadata_ReplaceTaggingDropsStaleTags` — end-to-end tag-REPLACE drops stale tags

  ## Related

  - AWS S3 CopyObject reference: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html>
  - MinIO reference implementation: <https://github.com/minio/minio/blob/master/cmd/handler-utils.go>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed Iceberg metadata format consistency across create, update, and commit operations to ensure compatibility with strict downstream clients.
  - Improved S3 copy object metadata handling with proper directive validation and metadata merging.

* **New Features**
  - Enhanced S3 copy operations with MIME type resolution based on COPY/REPLACE directives.
  - Expanded Iceberg metadata file pattern recognition to support additional naming conventions.

* **Tests**
  - Added comprehensive test coverage for Iceberg metadata spec compliance.
  - Added tests for S3 copy metadata behavior and directive validation.
  - Added tests for Iceberg file layout pattern matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->