### PR TITLE
fix(s3): allow anonymous unsigned-streaming PutObject

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -1388,9 +1388,21 @@ func (iam *IdentityAccessManagement) authenticateRequestInternal(r *http.Request
 		identity, s3Err = iam.reqSignatureV4Verify(r)
 		amzAuthType = "SigV4"
 	case authTypeStreamingUnsigned:
-		glog.V(4).Infof("unsigned streaming upload")
-		identity, s3Err = iam.reqSignatureV4Verify(r)
-		amzAuthType = "SigV4"
+		// An unsigned-streaming PUT may still be SigV4-signed (header/presigned) or
+		// fully anonymous; modern botocore adds a CRC32 trailer to plain PUTs, so an
+		// anonymous upload also lands here. Verify a signature only when one is present.
+		if isRequestSignatureV4(r) || isRequestPresignedSignatureV4(r) {
+			glog.V(4).Infof("unsigned streaming upload, signed request")
+			identity, s3Err = iam.reqSignatureV4Verify(r)
+			amzAuthType = "SigV4"
+		} else {
+			glog.V(4).Infof("unsigned streaming upload, anonymous request")
+			amzAuthType = "Anonymous"
+			if identity, found = iam.LookupAnonymous(); !found {
+				r.Header.Set(s3_constants.AmzAuthType, amzAuthType)
+				return identity, s3err.ErrAccessDenied, reqAuthType
+			}
+		}
 	case authTypeJWT:
 		glog.V(4).Infof("jwt auth type detected, iamIntegration != nil? %t", iam.iamIntegration != nil)
 		r.Header.Set(s3_constants.AmzAuthType, "Jwt")

--- a/weed/s3api/auth_security_test.go
+++ b/weed/s3api/auth_security_test.go
@@ -29,6 +29,11 @@ func signRawHTTPRequest(ctx context.Context, req *http.Request, accessKey, secre
 }
 
 func TestReproIssue7912(t *testing.T) {
+	// This test asserts behavior for a config with no anonymous identity; reset
+	// the shared in-memory store so a leaked anonymous identity from another test
+	// does not satisfy the unsigned-streaming auth path.
+	resetMemoryStore()
+
 	// Create a temporary s3.json
 	configContent := `{
   "identities": [
@@ -196,6 +201,52 @@ func TestReproIssue7912(t *testing.T) {
 		assert.Equal(t, s3err.ErrAccessDenied, errCode, "Should be denied with unsigned streaming if no auth header")
 		assert.Nil(t, identity)
 	})
+}
+
+// TestAnonymousStreamingUnsignedUpload is a regression test for issue #9725.
+// Modern botocore/aiobotocore attaches a CRC32 trailer to plain PutObject calls,
+// turning the payload into STREAMING-UNSIGNED-PAYLOAD-TRAILER. An anonymous
+// (anon=True) upload then carries that header but no Authorization, which used to
+// be routed straight to SigV4 verification and rejected as AccessDenied. It must
+// instead fall back to the configured anonymous identity, just like a plain
+// anonymous PUT does.
+func TestAnonymousStreamingUnsignedUpload(t *testing.T) {
+	// This test loads an anonymous identity into the shared in-memory credential
+	// store; reset before and after so it neither inherits nor leaks state.
+	resetMemoryStore()
+	defer resetMemoryStore()
+
+	configContent := `{
+  "identities": [
+    {
+      "name": "anonymous",
+      "actions": ["Read", "Write", "List"]
+    }
+  ]
+}`
+	tmpFile, err := os.CreateTemp("", "s3-config-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.Write([]byte(configContent))
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: tmpFile.Name()}, nil, "memory")
+	require.True(t, iam.isEnabled(), "Auth should be enabled")
+
+	r := httptest.NewRequest(http.MethodPut, "http://localhost:8333/somebucket/someobject", nil)
+	r.Header.Set("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+	r.Header.Set("x-amz-trailer", "x-amz-checksum-crc32")
+	// No Authorization header: anonymous upload with a checksum trailer.
+
+	// The request must stay classified as unsigned-streaming so getRequestDataReader
+	// still decodes the chunked body; only the auth resolution falls back to anonymous.
+	assert.Equal(t, authTypeStreamingUnsigned, getRequestAuthType(r))
+
+	identity, errCode := iam.authRequest(r, s3_constants.ACTION_WRITE)
+	assert.Equal(t, s3err.ErrNone, errCode, "anonymous unsigned-streaming PUT should resolve to the anonymous identity")
+	require.NotNil(t, identity)
+	assert.Equal(t, s3_constants.AccountAnonymousId, identity.Name)
 }
 
 // TestExternalUrlSignatureVerification tests that S3 signature verification works


### PR DESCRIPTION
Fixes #9725

### Problem

Anonymous `PutObject` (`s3fs` with `anon=True`) intermittently fails with `Access Denied`, while explicit credentials always work. The split is the client's botocore version: it reproduces with newer botocore/aiobotocore (the "when_supported" data-integrity default) and not with older ones — which is why it showed up in a GitLab CI runner but not locally. Same class of regression as #9557.

### Root cause

Newer botocore attaches a CRC32 checksum trailer to plain `PutObject`, which sets `x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`. For an anonymous request (no `Authorization` header):

- `getRequestAuthType` classifies it as `authTypeStreamingUnsigned` instead of `authTypeAnonymous`.
- `authenticateRequestInternal` then unconditionally ran `reqSignatureV4Verify`, which returns `AccessDenied` when there is no signature to verify.

Explicit credentials work because the SigV4 signature satisfies the verifier. The chunked-body decoder (`newChunkedReader`) already handled the anonymous unsigned case — only the auth classification was wrong.

### Fix

In the `authTypeStreamingUnsigned` branch, verify a signature only when one is actually present (`Authorization` header or presigned query); otherwise fall back to the anonymous identity, mirroring the plain anonymous path. The request stays classified as unsigned-streaming so `getRequestDataReader` still decodes the chunked body (reclassifying it as anonymous would have stored the raw chunk framing).

### Security

With no anonymous identity configured, `LookupAnonymous` returns not-found and the request is still denied, so the #7912 anti-bypass property holds. The new behavior only honors an explicitly configured anonymous identity — which a plain (non-streaming) anonymous PUT already does.

### Tests

- `TestAnonymousStreamingUnsignedUpload`: a configured anonymous identity + unsigned-streaming PUT with no auth header now resolves to the anonymous identity, and the request stays classified as unsigned-streaming so the body is still decoded. Verified to fail on the pre-fix code (AccessDenied) and pass after.
- `TestReproIssue7912` now resets the shared in-memory credential store at its start; the behavior change surfaced a pre-existing cross-test leak of an anonymous identity from another test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 API authentication to properly handle anonymous uploads with streaming payloads by correctly distinguishing between signed and unsigned requests.

* **Tests**
  * Added regression test for anonymous streaming uploads to prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->