### PR TITLE
fix: return immediately on first error in DistributedOperation

### DIFF
--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -191,18 +191,35 @@ type RemoteResult struct {
 
 func DistributedOperation(locations []operation.Location, op func(location operation.Location) error) error {
 	length := len(locations)
-	results := make(chan RemoteResult)
-	for _, location := range locations {
-		go func(location operation.Location, results chan RemoteResult) {
-			results <- RemoteResult{location.Url, op(location)}
-		}(location, results)
-	}
-	ret := DistributedOperationResult(make(map[string]error))
-	for i := 0; i < length; i++ {
-		result := <-results
-		ret[result.Host] = result.Error
+	if length == 0 {
+		return nil
 	}
 
+	resultCh := make(chan RemoteResult, length)
+	errCh := make(chan error, 1)
+
+	for _, location := range locations {
+		go func(location operation.Location) {
+			err := op(location)
+			if err != nil {
+				select {
+				case errCh <- fmt.Errorf("[%s]: %v", location.Url, err):
+				default:
+				}
+			}
+			resultCh <- RemoteResult{location.Url, err}
+		}(location)
+	}
+
+	ret := DistributedOperationResult(make(map[string]error))
+	for i := 0; i < length; i++ {
+		select {
+		case err := <-errCh:
+			return err
+		case result := <-resultCh:
+			ret[result.Host] = result.Error
+		}
+	}
 	return ret.Error()
 }
 

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -195,29 +195,22 @@ func DistributedOperation(locations []operation.Location, op func(location opera
 		return nil
 	}
 
+	// buffered so a straggler (e.g. a replica stalled on a TCP dial timeout) can
+	// still deliver its result and exit after we have already returned.
 	resultCh := make(chan RemoteResult, length)
-	errCh := make(chan error, 1)
-
 	for _, location := range locations {
 		go func(location operation.Location) {
-			err := op(location)
-			if err != nil {
-				select {
-				case errCh <- fmt.Errorf("[%s]: %v", location.Url, err):
-				default:
-				}
-			}
-			resultCh <- RemoteResult{location.Url, err}
+			resultCh <- RemoteResult{location.Url, op(location)}
 		}(location)
 	}
 
 	ret := DistributedOperationResult(make(map[string]error))
 	for i := 0; i < length; i++ {
-		select {
-		case err := <-errCh:
-			return err
-		case result := <-resultCh:
-			ret[result.Host] = result.Error
+		result := <-resultCh
+		ret[result.Host] = result.Error
+		if result.Error != nil {
+			// fail fast on the first error instead of waiting for slow replicas
+			return ret.Error()
 		}
 	}
 	return ret.Error()


### PR DESCRIPTION
When a replica is unreachable, DistributedOperation previously blocked
waiting for ALL goroutines to complete before returning any error to the
caller. With a dead replica the goroutine would stall on the underlying
TCP dial timeout (~10-30s), and during that window the filer upload loop
(slot-limited to 4 concurrent goroutines) would also stall, turning a
single failed replica into a full upload stall of 129s or more.

Now DistributedOperation returns as soon as the first error is reported
by any goroutine, while still draining remaining goroutines so they
complete normally. This makes replica failures visible to the caller
immediately rather than after the slowest goroutine times out.

No change to the all-or-nothing consistency model - a single replica
failure still causes the write to fail. No change to the function
signature. The only behavioral difference is the speed at which the
error is delivered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote failures are detected and reported promptly, avoiding background stalls.
  * Per-host errors are collected and presented together for clearer failure diagnosis.

* **Performance**
  * Operations return immediately when there are no targets, reducing unnecessary work and latency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->