### PR TITLE
perf(s3.iam.GetUser): Make the API default to the request username if not specified

### DIFF
--- a/weed/s3api/s3api_embedded_iam.go
+++ b/weed/s3api/s3api_embedded_iam.go
@@ -2854,7 +2854,7 @@ func (e *EmbeddedIamApi) DoActions(w http.ResponseWriter, r *http.Request) {
 
 	// Handle implicit username for HTTP requests
 	switch r.Form.Get("Action") {
-	case "ListAccessKeys", "CreateAccessKey", "DeleteAccessKey", "UpdateAccessKey", "ListUserPolicies":
+	case "ListAccessKeys", "CreateAccessKey", "DeleteAccessKey", "UpdateAccessKey", "ListUserPolicies", "GetUser":
 		e.handleImplicitUsername(r, values)
 	case "CreateServiceAccount":
 		createdBy := s3_constants.GetIdentityNameFromContext(r)

--- a/weed/s3api/s3api_embedded_iam_test.go
+++ b/weed/s3api/s3api_embedded_iam_test.go
@@ -339,6 +339,46 @@ func TestEmbeddedIamGetUser(t *testing.T) {
 	assert.Equal(t, "TestUser", *out.GetUserResult.User.UserName)
 }
 
+// TestEmbeddedIamGetUserImplicitUsername verifies GetUser without a UserName defaults
+// to the user that signed the request rather than returning NoSuchEntity for an empty
+// username, matching documented AWS IAM behavior.
+func TestEmbeddedIamGetUserImplicitUsername(t *testing.T) {
+	const accessKey = UserAccessKeyPrefix + "TESTFAKEKEY000001"
+
+	api := NewEmbeddedIamApiForTest()
+	api.mockConfig = &iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{
+			{
+				Name: "TestUser",
+				Credentials: []*iam_pb.Credential{
+					{AccessKey: accessKey, SecretKey: "testsecretfake"},
+				},
+			},
+		},
+	}
+	// handleImplicitUsername resolves the username via iam.LookupByAccessKey,
+	// so the iam state must know about the credential.
+	if err := api.iam.LoadS3ApiConfigurationFromBytes(mustMarshalJSON(api.mockConfig)); err != nil {
+		t.Fatalf("failed to load iam config: %v", err)
+	}
+
+	// GetUser request with NO UserName, but signed by accessKey.
+	form := url.Values{}
+	form.Set("Action", "GetUser")
+	req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+accessKey+
+		"/20220420/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=fakesig")
+
+	out := iamGetUserResponse{}
+	rr, err := executeEmbeddedIamRequest(api, req, &out)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+
+	require.NotNil(t, out.GetUserResult.User.UserName)
+	assert.Equal(t, "TestUser", *out.GetUserResult.User.UserName)
+}
+
 // TestEmbeddedIamCreatePolicy tests creating a policy via the embedded IAM API
 func TestEmbeddedIamCreatePolicy(t *testing.T) {
 	api := NewEmbeddedIamApiForTest()


### PR DESCRIPTION

This makes the Embedded S3 IAM API align with the documented behavior of the AWS IAM API as per AWS Docs: https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUser.html

BREAKING CHANGE: This changes the default behavior of the Embedded IAM API to use the username of the user holding the accesskey used to make the request in the GetUsername request handler.

Closes #9745 

# What problem are we solving?
See issue #9745 

The IAM API should return information on the current user if there is no username parameter specified in the request. 


# How are we solving the problem?
Add the GetUser endpoint to the case executing `e.handleImplicitUsername(r, values)` in `weed/s3api/s3api_embedded_iam.go`

# How is the PR tested?
One manual test to validate the solution, otherwise not yet.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

> [!NOTE]
> This is intended to be a reference for a proper PR, I'm not intending for this to be merged, unless you are just fine with it. 
> I wanted to do a bit more than just drop an issue, and this is probably the best way to provide a clear description of how this could be fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **IAM GetUser Action**: Enhanced the GetUser action to automatically resolve the user based on the caller's signing access key when no explicit username is provided, ensuring consistency with AWS IAM behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->