### PR TITLE
s3: short-circuit filer failover on ErrNotFound

### DIFF
--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -47,13 +47,13 @@ func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(file
 		return nil
 	}
 
-	// ErrNotFound is a valid application-level response (entry doesn't exist on this filer),
-	// not a filer health issue. Only record true failures (transport errors, timeouts, etc.)
-	// in the health tracker to avoid poisoning the circuit breaker with normal "not found"
-	// responses in multi-filer setups.
-	if !errors.Is(err, filer_pb.ErrNotFound) {
-		s3a.filerClient.RecordFilerFailure(currentFiler)
+	// A reachable filer answering ErrNotFound is authoritative; failover is for
+	// unreachable/unhealthy filers, not for re-asking about an absent entry.
+	if errors.Is(err, filer_pb.ErrNotFound) {
+		return err
 	}
+
+	s3a.filerClient.RecordFilerFailure(currentFiler)
 
 	// Current filer failed - try all other filers with health-aware selection
 	filers := s3a.filerClient.GetAllFilers()
@@ -83,10 +83,12 @@ func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(file
 			return nil
 		}
 
-		// Only record real failures, not ErrNotFound
-		if !errors.Is(err, filer_pb.ErrNotFound) {
-			s3a.filerClient.RecordFilerFailure(filer)
+		// Authoritative not-found - stop failing over.
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return err
 		}
+
+		s3a.filerClient.RecordFilerFailure(filer)
 		glog.V(2).Infof("WithFilerClient: failover to %s failed: %v", filer, err)
 		lastErr = err
 	}


### PR DESCRIPTION
## Problem

`withFilerClientFailover` treated a filer's `ErrNotFound` the same as a transport failure. On a not-found it:

1. Did **not** return early — it fell through to the failover loop and re-queried **every other filer**, each also returning not-found.
2. Wrapped the authoritative not-found in a misleading error: `all filers failed, last error: filer: no entry is found in filer store`.

For S3 workloads with many legitimate misses this is expensive and noisy. A concrete example is `GET object?versionId=X` for a version that was deleted or expired: each such 404 fans out to N filers and logs as if every filer were broken. We observed hundreds of these on a versioned (Veeam) workload.

## Change

A reachable filer that answers `ErrNotFound` has given an **authoritative** answer. Failover exists to route around unreachable/unhealthy filers (transport errors, timeouts) — not to look harder for an entry the store already reports as absent.

- Short-circuit on `ErrNotFound` from the current filer: return it directly instead of fanning out.
- Same short-circuit inside the failover loop: once a healthy filer answers not-found, stop and return it.
- `ErrNotFound` is still never recorded as a filer health failure (unchanged intent).

Callers that need read-after-write behaviour already retry at the S3 semantic layer (e.g. `getLatestObjectVersion`'s retry loop), so that concern stays where it belongs rather than being masked by transport-level fan-out.

## Compatibility

Callers detect not-found with `errors.Is(err, filer_pb.ErrNotFound)`, which still holds — the result is now the unwrapped `ErrNotFound` instead of a `%w`-wrapped one. Suffix-based checks elsewhere (e.g. `command_fs_verify`) match on `"no entry is found in filer store"`, which is still present.

## Test plan

- `go build ./weed/s3api/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 API handling of "not found" results so missing objects return immediately, reducing unnecessary retries and speeding responses.
  * Prevents healthy backends from being marked as failed when they legitimately report "not found," improving accuracy of backend health behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->