### PR TITLE
s3: return NoSuchVersion (not NoSuchKey) for a missing versionId

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -641,7 +641,11 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 			entry, err = s3a.getSpecificObjectVersion(bucket, object, versionId)
 			if err != nil {
 				glog.Errorf("Failed to get specific version %s: %v", versionId, err)
-				s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
+				if errors.Is(err, filer_pb.ErrNotFound) {
+					s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchVersion)
+				} else {
+					s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+				}
 				return
 			}
 			targetVersionId = versionId
@@ -2149,7 +2153,11 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 			entry, err = s3a.getSpecificObjectVersion(bucket, object, versionId)
 			if err != nil {
 				glog.Errorf("Failed to get specific version %s for %s/%s: %v", versionId, bucket, object, err)
-				s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
+				if errors.Is(err, filer_pb.ErrNotFound) {
+					s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchVersion)
+				} else {
+					s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+				}
 				return
 			}
 			targetVersionId = versionId

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -984,7 +984,7 @@ func (s3a *S3ApiServer) getSpecificObjectVersion(bucket, object, versionId strin
 		bucketDir := s3a.bucketDir(bucket)
 		entry, err := s3a.getEntry(bucketDir, normalizedObject)
 		if err != nil {
-			return nil, fmt.Errorf("null version object %s not found: %v", normalizedObject, err)
+			return nil, fmt.Errorf("null version object %s not found: %w", normalizedObject, err)
 		}
 		return entry, nil
 	}
@@ -995,7 +995,7 @@ func (s3a *S3ApiServer) getSpecificObjectVersion(bucket, object, versionId strin
 
 	entry, err := s3a.getEntry(versionsDir, versionFile)
 	if err != nil {
-		return nil, fmt.Errorf("version %s not found: %v", versionId, err)
+		return nil, fmt.Errorf("version %s not found: %w", versionId, err)
 	}
 
 	return entry, nil

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -57,6 +57,7 @@ const (
 	ErrNoSuchCORSConfiguration
 	ErrNoSuchLifecycleConfiguration
 	ErrNoSuchKey
+	ErrNoSuchVersion
 	ErrNoSuchUpload
 	ErrInvalidBucketName
 	ErrInvalidBucketState
@@ -279,6 +280,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrNoSuchKey: {
 		Code:           "NoSuchKey",
 		Description:    "The specified key does not exist.",
+		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrNoSuchVersion: {
+		Code:           "NoSuchVersion",
+		Description:    "The specified version does not exist.",
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrNoSuchUpload: {


### PR DESCRIPTION
## Problem

`GET`/`HEAD object?versionId=X` where version `X` does not exist returned the S3 error code `NoSuchKey`. AWS S3 returns `NoSuchVersion` (HTTP 404) for a missing version. Clients and tooling that distinguish "the key is gone" from "this particular version is gone" rely on the correct code.

## Change

- Add the `ErrNoSuchVersion` error code (`NoSuchVersion`, HTTP 404, "The specified version does not exist.").
- Return it from the `GetObjectHandler` and `HeadObjectHandler` specific-version lookups instead of `ErrNoSuchKey`.

Both codes map to HTTP 404, so the status code is unchanged — only the S3 error code in the response body is corrected to match AWS.

## Test plan

- `go build ./weed/s3api/...`
- `go test ./weed/s3api/s3err/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for versioned object operations: requesting a non-existent object version now returns a clear "version not found" (NoSuchVersion) response and consistent 404 behavior, improving S3 API compatibility and making version-related failures easier to diagnose for clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->