### PR TITLE
admin: store file browser uploads in volumes, not inline

### DIFF
--- a/weed/admin/handlers/file_browser_grpc.go
+++ b/weed/admin/handlers/file_browser_grpc.go
@@ -19,13 +19,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-// Admin file browser upload chunk sizing — kept in sync with the values
-// s3api uses so files end up split into the same fid-sized pieces the rest of
-// the cluster expects.
-const (
-	adminUploadChunkSize      = 8 * 1024 * 1024
-	adminUploadSmallFileLimit = 256 * 1024
-)
+// Admin upload chunk size, matching s3api so files split into the same fid-sized pieces.
+const adminUploadChunkSize = 8 * 1024 * 1024
 
 // File browser handlers backed by the filer gRPC service. They bypass the
 // filer's HTTP listener so the UI keeps working when the filer is started
@@ -100,11 +95,9 @@ func (h *FileBrowserHandlers) downloadFileGrpc(ctx context.Context, filePath str
 	return h.streamEntryContent(ctx, entry, size, w)
 }
 
-// uploadFileGrpc streams the upload to volume servers in 8 MiB chunks via the
-// shared chunked-upload helper, then registers the assembled entry through the
-// filer gRPC service. Bytes never enter the admin process's heap as a whole —
-// each chunk is sized to adminUploadChunkSize. Small files (< 256 KiB) are
-// stored inline on the entry, matching the S3 server's behaviour.
+// uploadFileGrpc streams the upload to volumes in 8 MiB chunks via the shared
+// chunked-upload helper, then registers the entry over the filer gRPC service.
+// Content always lands in volumes, never inlined on the entry.
 func (h *FileBrowserHandlers) uploadFileGrpc(ctx context.Context, filePath string, fileName string, mimeType string, reader io.Reader) error {
 	cleanFilePath, err := h.validateAndCleanFilePath(filePath)
 	if err != nil {
@@ -152,11 +145,9 @@ func (h *FileBrowserHandlers) uploadFileGrpc(ctx context.Context, filePath strin
 	}
 
 	chunkResult, err := operation.UploadReaderInChunks(ctx, reader, &operation.ChunkedUploadOption{
-		ChunkSize:       adminUploadChunkSize,
-		SmallFileLimit:  adminUploadSmallFileLimit,
-		SaveSmallInline: true,
-		MimeType:        mimeType,
-		AssignFunc:      assignFunc,
+		ChunkSize:  adminUploadChunkSize,
+		MimeType:   mimeType,
+		AssignFunc: assignFunc,
 	})
 	if err != nil {
 		// Partial chunks come back even on error so we can clean them up rather
@@ -178,11 +169,7 @@ func (h *FileBrowserHandlers) uploadFileGrpc(ctx context.Context, filePath strin
 			Mime:     mimeType,
 		},
 	}
-	if len(chunkResult.SmallContent) > 0 {
-		entry.Content = chunkResult.SmallContent
-	} else {
-		entry.Chunks = chunkResult.FileChunks
-	}
+	entry.Chunks = chunkResult.FileChunks
 
 	err = h.adminServer.WithFilerClient(func(client filer_pb.SeaweedFilerClient) error {
 		_, createErr := client.CreateEntry(ctx, &filer_pb.CreateEntryRequest{


### PR DESCRIPTION
Files uploaded via the admin file browser were stored in the `entry.Content` field (filer metadata store) instead of a volume whenever they were under 256 KiB.

`uploadFileGrpc` passed `SaveSmallInline: true` with a 256 KiB limit to the chunked uploader. The filer's own upload path never inlines unless `saveToFilerLimit` is set (default 0), and the S3 server shares that path, so this diverged from the rest of the cluster.

Drop the inline options so admin uploads always land in volumes.

This has been the behavior since the file browser upload was switched to the filer gRPC + volume HTTP path; before that it proxied to the filer HTTP endpoint, which stores to volumes by default. Existing entries already written inline are unaffected; only new uploads change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Admin file uploads simplified to always use the chunked upload path; separate small-file inline storage handling removed.
  * Upload behavior now consistently produces file chunk metadata and applies orphaned-chunk cleanup uniformly across uploads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs/pull/9752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->