### PR TITLE
s3: reject reserved bucket name "filemeta"

### DIFF
--- a/weed/s3api/s3bucket/s3api_bucket.go
+++ b/weed/s3api/s3bucket/s3api_bucket.go
@@ -7,10 +7,18 @@ import (
 	"unicode"
 )
 
+// Reserved because it is the default table/collection name of the filer
+// store; a bucket of the same name collides with it and wedges the bucket
+// (cannot be deleted, breaks fsck) on SQL backends with per-bucket tables.
+const reservedBucketName = "filemeta"
+
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 func VerifyS3BucketName(name string) (err error) {
 	if len(name) < 3 || len(name) > 63 {
 		return fmt.Errorf("bucket name must between [3, 63] characters")
+	}
+	if name == reservedBucketName {
+		return fmt.Errorf("bucket name %q is reserved", name)
 	}
 	for idx, ch := range name {
 		if !(unicode.IsLower(ch) || ch == '.' || ch == '-' || unicode.IsNumber(ch)) {

--- a/weed/s3api/s3bucket/s3api_bucket_test.go
+++ b/weed/s3api/s3bucket/s3api_bucket_test.go
@@ -17,6 +17,7 @@ func Test_verifyBucketName(t *testing.T) {
 		"grehtrry-",
 		"----------",
 		"x@fdsgr032",
+		"filemeta",
 	}
 	for _, invalidName := range invalidS3BucketNames {
 		err := VerifyS3BucketName(invalidName)


### PR DESCRIPTION
`filemeta` is the default table name of the SQL filer store (`DEFAULT_TABLE`). When a SQL backend runs with per-bucket tables, a bucket named `filemeta` collides with that table — but the two bucket-name validators disagree:

- creation goes through `VerifyS3BucketName`, which accepts `filemeta` (valid S3 name)
- every store operation goes through `isValidBucket`, which rejects `filemeta` (`!= DEFAULT_TABLE`)

So the bucket creates and lists fine, but every subsequent operation fails with `invalid bucket name filemeta`. The bucket is wedged: it can't be deleted (`DeleteFolderChildren` resolves the bucket to `filemeta` and errors), and it breaks `volume.fsck`, which sweeps all buckets through the filer store.

This reconciles the two checks by reserving `filemeta` in `VerifyS3BucketName`, so it is rejected uniformly at the shell command, the S3 API `PutBucket`, and filer dir creation under `/buckets`. Harmless for non-SQL backends — just a reserved word.

Note: this prevents the bad state going forward; an already-stuck `filemeta` bucket still needs manual cleanup at the store level.

Fixes #9758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * S3 bucket name validation has been updated. The system now rejects "filemeta" as an invalid bucket name. Attempting to create a bucket with this name will result in an error message. This prevents conflicts and ensures proper operation of S3 bucket management features throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->