### PR TITLE
fix(http): handle invalid gzip stream errors

### DIFF
--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -397,6 +397,9 @@ func ReadUrlAsStream(ctx context.Context, fileUrl, jwt string, cipherKey []byte,
 	switch contentEncoding {
 	case "gzip":
 		reader, err = gzip.NewReader(r.Body)
+		if err != nil {
+			return true, err
+		}
 		defer reader.Close()
 	default:
 		reader = r.Body

--- a/weed/util/http/http_global_client_util_test.go
+++ b/weed/util/http/http_global_client_util_test.go
@@ -1,6 +1,11 @@
 package http
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestAppendQueryParameter(t *testing.T) {
 	testCases := []struct {
@@ -68,5 +73,22 @@ func TestAppendQueryParameter(t *testing.T) {
 				t.Fatalf("expected %q, got %q", tc.expected, actual)
 			}
 		})
+	}
+}
+
+func TestReadUrlAsStreamReturnsGzipReaderError(t *testing.T) {
+	InitGlobalHttpClient()
+	defer GetGlobalHttpClient().Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not gzip"))
+	}))
+	defer server.Close()
+
+	_, err := ReadUrlAsStream(context.Background(), server.URL, "", nil, false, true, 0, 0, func(data []byte) {})
+	if err == nil {
+		t.Fatal("ReadUrlAsStream returned nil error for invalid gzip response")
 	}
 }

--- a/weed/util/http/http_global_client_util_test.go
+++ b/weed/util/http/http_global_client_util_test.go
@@ -78,7 +78,6 @@ func TestAppendQueryParameter(t *testing.T) {
 
 func TestReadUrlAsStreamReturnsGzipReaderError(t *testing.T) {
 	InitGlobalHttpClient()
-	defer GetGlobalHttpClient().Close()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Encoding", "gzip")


### PR DESCRIPTION
# What problem are we solving?

`ReadUrlAsStream` could panic when an HTTP response declares `Content-Encoding: gzip` but returns a body that is not a valid gzip stream. In that case `gzip.NewReader` returns an error, but the previous code continued to defer and read from the nil reader.

# How are we solving the problem?

Return the `gzip.NewReader` error immediately before registering `Close` or reading from the gzip reader. This preserves the existing behavior for valid gzip and non-gzip responses while turning invalid gzip responses into a normal error path instead of a panic.

A regression test was added with an `httptest` server that returns `Content-Encoding: gzip` and an invalid gzip payload.

# How is the PR tested?

- `go test ./weed/util/http -run TestReadUrlAsStreamReturnsGzipReaderError -count=1`

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for gzip-compressed HTTP responses during streaming reads so decompression failures are detected and reported immediately, reducing silent failures and enabling safer retries.

* **Tests**
  * Added test coverage that validates behavior when a response claims gzip encoding but contains invalid gzip data, ensuring errors are surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->