### PR TITLE
fix(s3api): Fix multipart upload ETag compatibility with Hadoop S3A

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -1007,7 +1007,6 @@ func (s3a *S3ApiServer) listObjectParts(input *s3.ListPartsInput) (output *ListP
 				glog.Errorf("listObjectParts %s %s parse %s: %v", *input.Bucket, *input.UploadId, entry.Name, err)
 				continue
 			}
-			// partETag := filer.ETag(entry)
 			partETag := getEtagFromEntry(entry)
 			part := &s3.Part{
 				PartNumber:   aws.Int64(int64(partNumber)),

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -467,7 +467,6 @@ func (s3a *S3ApiServer) prepareMultipartCompletionState(r *http.Request, input *
 			}
 
 			partStartChunk := len(finalParts)
-			// partETag := filer.ETag(entry)
 			partETag := getEtagFromEntry(entry)
 
 			for _, chunk := range entry.GetChunks() {

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -467,7 +467,8 @@ func (s3a *S3ApiServer) prepareMultipartCompletionState(r *http.Request, input *
 			}
 
 			partStartChunk := len(finalParts)
-			partETag := filer.ETag(entry)
+			// partETag := filer.ETag(entry)
+			partETag := getEtagFromEntry(entry)
 
 			for _, chunk := range entry.GetChunks() {
 				finalChunk, chunkErr := completedMultipartChunk(chunk, offset, sses3Info)
@@ -1007,7 +1008,8 @@ func (s3a *S3ApiServer) listObjectParts(input *s3.ListPartsInput) (output *ListP
 				glog.Errorf("listObjectParts %s %s parse %s: %v", *input.Bucket, *input.UploadId, entry.Name, err)
 				continue
 			}
-			partETag := filer.ETag(entry)
+			// partETag := filer.ETag(entry)
+			partETag := getEtagFromEntry(entry)
 			part := &s3.Part{
 				PartNumber:   aws.Int64(int64(partNumber)),
 				LastModified: aws.Time(time.Unix(entry.Attributes.Mtime, 0).UTC()),

--- a/weed/s3api/filer_multipart_etag_test.go
+++ b/weed/s3api/filer_multipart_etag_test.go
@@ -1,0 +1,117 @@
+package s3api
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+)
+
+func TestGetEtagFromEntryPrefersStoredExtendedETag(t *testing.T) {
+	storedETag := "11111111111111111111111111111111"
+	computedMD5 := mustDecodeHexETagForTest(t, "22222222222222222222222222222222")
+
+	entry := &filer_pb.Entry{
+		Name: "0001.part",
+		Attributes: &filer_pb.FuseAttributes{
+			Md5: computedMD5,
+		},
+		Extended: map[string][]byte{
+			s3_constants.ExtETagKey: []byte(storedETag),
+		},
+	}
+
+	if got, want := getEtagFromEntry(entry), `"`+storedETag+`"`; got != want {
+		t.Fatalf("getEtagFromEntry() = %q, want stored extended ETag %q", got, want)
+	}
+
+	match, invalid, normalizedPartETag, normalizedEntryETag := validateCompletePartETag(storedETag, entry)
+	if invalid || !match {
+		t.Fatalf("validateCompletePartETag() = match:%v invalid:%v part:%q entry:%q, want stored ETag match", match, invalid, normalizedPartETag, normalizedEntryETag)
+	}
+
+	computedETag := hex.EncodeToString(computedMD5)
+	match, invalid, normalizedPartETag, normalizedEntryETag = validateCompletePartETag(computedETag, entry)
+	if invalid || match {
+		t.Fatalf("validateCompletePartETag() = match:%v invalid:%v part:%q entry:%q, want computed filer ETag mismatch", match, invalid, normalizedPartETag, normalizedEntryETag)
+	}
+}
+
+func TestGetEtagFromEntryFallbacksToFilerETag(t *testing.T) {
+	computedETag := "33333333333333333333333333333333"
+	entry := &filer_pb.Entry{
+		Name: "0001.part",
+		Attributes: &filer_pb.FuseAttributes{
+			Md5: mustDecodeHexETagForTest(t, computedETag),
+		},
+		Extended: map[string][]byte{
+			s3_constants.ExtETagKey: []byte(""),
+		},
+	}
+
+	if got, want := getEtagFromEntry(entry), `"`+computedETag+`"`; got != want {
+		t.Fatalf("getEtagFromEntry() = %q, want fallback filer ETag %q", got, want)
+	}
+}
+
+func TestCalculateMultipartETagUsesStoredPartETags(t *testing.T) {
+	storedPart1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	storedPart2 := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	computedPart1 := "cccccccccccccccccccccccccccccccc"
+	computedPart2 := "dddddddddddddddddddddddddddddddd"
+
+	partEntries := map[int][]*filer_pb.Entry{
+		1: {newMultipartETagTestEntry(t, "0001.part", storedPart1, computedPart1)},
+		2: {newMultipartETagTestEntry(t, "0002.part", storedPart2, computedPart2)},
+	}
+
+	got := calculateMultipartETag(partEntries, []int{1, 2})
+	want := expectedMultipartETagForTest(t, storedPart1, storedPart2)
+	if got != want {
+		t.Fatalf("calculateMultipartETag() = %q, want %q", got, want)
+	}
+
+	legacyComputedETag := expectedMultipartETagForTest(t, computedPart1, computedPart2)
+	if got == legacyComputedETag {
+		t.Fatalf("calculateMultipartETag() = %q, still used filer.ETag-derived part ETags", got)
+	}
+}
+
+func newMultipartETagTestEntry(t *testing.T, name, storedETag, computedETag string) *filer_pb.Entry {
+	t.Helper()
+	return &filer_pb.Entry{
+		Name: name,
+		Attributes: &filer_pb.FuseAttributes{
+			Md5: mustDecodeHexETagForTest(t, computedETag),
+		},
+		Extended: map[string][]byte{
+			s3_constants.ExtETagKey: []byte(storedETag),
+		},
+	}
+}
+
+func expectedMultipartETagForTest(t *testing.T, partETags ...string) string {
+	t.Helper()
+	var combined []byte
+	for _, partETag := range partETags {
+		partETag = strings.Trim(partETag, `"`)
+		if before, _, found := strings.Cut(partETag, "-"); found {
+			partETag = before
+		}
+		combined = append(combined, mustDecodeHexETagForTest(t, partETag)...)
+	}
+	return fmt.Sprintf("%x-%d", md5.Sum(combined), len(partETags))
+}
+
+func mustDecodeHexETagForTest(t *testing.T, etag string) []byte {
+	t.Helper()
+	decoded, err := hex.DecodeString(etag)
+	if err != nil {
+		t.Fatalf("decode hex ETag %q: %v", etag, err)
+	}
+	return decoded
+}


### PR DESCRIPTION
# What problem are we solving?
When completing a multipart upload, part ETags were computed using `filer.ETag(entry)`, which calculates from internal SeaweedFS chunks or `Attributes.Md5`. This produces incorrect results when a single S3 part is split into multiple SeaweedFS chunks, because the composite chunk ETag differs from the client-visible S3 part ETag stored in `Extended` metadata by `PutObjectPart`. This caused the final multipart ETag to mismatch what S3 clients (e.g. hadoop-aws) expect, breaking ETag validation on `CompleteMultipartUpload` and `ListParts`.

# How are we solving the problem?
Replace `filer.ETag(entry)` with `getEtagFromEntry(entry)` in two places:
- `prepareMultipartCompletionState` — used when computing the final multipart ETag
- `listObjectParts` — used when returning part ETags to the client
- `getEtagFromEntry` prefers the persisted `ExtETagKey` in `entry.Extended` (the client-visible S3 part ETag written by `PutObjectPart`) over the internally computed filer ETag, falling back to `filer.ETag` only when no Extended ETag is present.

# How is the PR tested?
- `TestGetEtagFromEntryPrefersStoredExtendedETag`: verifies that `getEtagFromEntry` returns the stored Extended ETag when present, and that `validateCompletePartETag` matches against the stored ETag but not the internally computed one.
- `TestGetEtagFromEntryFallbacksToFilerETag`: verifies fallback to `filer.ETag` when Extended ETag is empty.
- `TestCalculateMultipartETagUsesStoredPartETags`: verifies end-to-end that `calculateMultipartETag` uses stored Extended ETags from all parts, and explicitly asserts the result differs from the legacy `filer.ETag`-derived computation.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure multipart upload parts report and complete using stored/normalized per-part ETags when available, with fallback to computed ETags for consistency.

* **Tests**
  * Added tests validating preference for stored per-part ETags, correct fallback to computed ETags, and accurate multipart ETag calculation using stored part ETags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->