### PR TITLE
fix(topology): restore active count after vacuum recovery

### DIFF
--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -788,9 +788,15 @@ func (vl *VolumeLayout) SetVolumeUnavailable(dn *DataNode, vid needle.VolumeId) 
 	}
 	return false
 }
-func (vl *VolumeLayout) SetVolumeAvailable(dn *DataNode, vid needle.VolumeId, isReadOnly, isFullCapacity bool) bool {
+func (vl *VolumeLayout) SetVolumeAvailable(dn *DataNode, vid needle.VolumeId, isReadOnly, isFullCapacity bool) (becameWritable bool) {
+	restoreActiveVolumeCount := false
 	vl.accessLock.Lock()
-	defer vl.accessLock.Unlock()
+	defer func() {
+		vl.accessLock.Unlock()
+		if restoreActiveVolumeCount {
+			vl.adjustActiveVolumeCount(vid, +1)
+		}
+	}()
 
 	vInfo, err := dn.GetVolumesById(vid)
 	if err != nil {
@@ -804,9 +810,17 @@ func (vl *VolumeLayout) SetVolumeAvailable(dn *DataNode, vid needle.VolumeId, is
 	}
 
 	if vl.enoughCopies(vid) {
-		return vl.setVolumeWritable(vid)
+		becameWritable = vl.setVolumeWritable(vid)
+		if becameWritable {
+			if st := vl.sizeTracking[vid]; st != nil && !st.fullSince.IsZero() {
+				// fullSince marks a prior capacity-full removal that already
+				// decremented activeVolumeCount. Re-adding must pair it once.
+				st.fullSince = time.Time{}
+				restoreActiveVolumeCount = true
+			}
+		}
 	}
-	return false
+	return becameWritable
 }
 
 func (vl *VolumeLayout) enoughCopies(vid needle.VolumeId) bool {

--- a/weed/topology/volume_layout_capacity_recovery_test.go
+++ b/weed/topology/volume_layout_capacity_recovery_test.go
@@ -67,3 +67,52 @@ func TestSetVolumeCapacityFullStampsFullSinceAndRecovers(t *testing.T) {
 		t.Fatalf("expected fullSince cleared after recovery")
 	}
 }
+
+func TestSetVolumeAvailableRestoresActiveCountForCapacityFullVolume(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":4000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	topo, vl := setupPickTest(t, layout, 10000)
+
+	initialActive := topo.diskUsages.usages[types.HardDriveType].activeVolumeCount
+	if !vl.SetVolumeCapacityFull(1) {
+		t.Fatalf("SetVolumeCapacityFull should report the volume was writable")
+	}
+	vl.AdjustActiveVolumeCountForFull(1)
+	if got := topo.diskUsages.usages[types.HardDriveType].activeVolumeCount; got != initialActive-1 {
+		t.Fatalf("expected activeVolumeCount decremented to %d, got %d", initialActive-1, got)
+	}
+
+	vl.accessLock.RLock()
+	dn := vl.vid2location[1].list[0]
+	vl.accessLock.RUnlock()
+
+	if !vl.SetVolumeAvailable(dn, 1, false, false) {
+		t.Fatalf("SetVolumeAvailable should report the volume became writable")
+	}
+	if got := topo.diskUsages.usages[types.HardDriveType].activeVolumeCount; got != initialActive {
+		t.Fatalf("expected SetVolumeAvailable to restore activeVolumeCount to %d, got %d", initialActive, got)
+	}
+	if !vl.sizeTracking[1].fullSince.IsZero() {
+		t.Fatalf("expected SetVolumeAvailable to clear fullSince after restoring activeVolumeCount")
+	}
+
+	advanceSizeTrackingClock(vl, 1, capacityRecoveryDelay+time.Second)
+	if vl.UpdateVolumeSize(1, 4000, 0) {
+		t.Fatalf("heartbeat recovery should not fire after SetVolumeAvailable already restored the volume")
+	}
+	if got := topo.diskUsages.usages[types.HardDriveType].activeVolumeCount; got != initialActive {
+		t.Fatalf("expected activeVolumeCount to remain %d, got %d", initialActive, got)
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

When a volume is marked capacity full, the master removes it from the writable list and decrements `activeVolumeCount`.

The heartbeat recovery path restores `activeVolumeCount` when the volume later shrinks and becomes writable again. However, vacuum commit can also make a capacity-full volume writable again through `SetVolumeAvailable()`. Before this PR, that path re-added the volume to `writables` but did not restore `activeVolumeCount`.

This could leave `activeVolumeCount` lower than the actual writable volume count, and repeated full/vacuum cycles could make the count drift further.

# How are we solving the problem?

When `SetVolumeAvailable()` successfully re-adds a volume to the writable list, it now restores `activeVolumeCount` only if the volume has a non-zero `fullSince` marker.

`fullSince` indicates that the volume was previously removed by the capacity-full path, which already decremented `activeVolumeCount`. After restoring the count, the PR clears `fullSince` so the heartbeat recovery path will not try to recover the same capacity-full event again.

The change is intentionally limited to the vacuum recovery path and keeps the active-count adjustment paired with actual writable-state recovery.

# How is the PR tested?

Added a regression test covering the vacuum recovery path:

1. mark a writable volume as capacity full
2. verify `activeVolumeCount` is decremented
3. call `SetVolumeAvailable()`
4. verify the volume becomes writable and `activeVolumeCount` is restored
5. verify later heartbeat recovery does not fire again for the same event

Tested with:

```sh
go test ./weed/topology -run 'TestSetVolumeAvailableRestoresActiveCountForCapacityFullVolume|TestSetVolumeCapacityFullStampsFullSinceAndRecovers|TestUpdateVolumeSizeRecoversEagerlyRemovedVolume|TestVolumeReadOnlyStatusChange|TestVolumeReadOnlyAndRemoteStatusChange' -count=1
go test ./weed/topology -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed volume capacity management to properly restore active volume counts when a previously full volume becomes available again, clearing its full-capacity timestamp.

* **Tests**
  * Added test to verify volume capacity recovery and active count restoration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->