### PR TITLE
filer: name the read-only path in the write rejection

### DIFF
--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -98,7 +98,7 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 		query.Get("saveInside"),
 	)
 	if err != nil {
-		if err == ErrReadOnly {
+		if errors.Is(err, ErrReadOnly) {
 			w.WriteHeader(http.StatusInsufficientStorage)
 		} else {
 			glog.V(1).InfolnCtx(ctx, "post", r.RequestURI, ":", err.Error())
@@ -255,7 +255,13 @@ func (fs *FilerServer) detectStorageOption(ctx context.Context, requestURI, qCol
 	rule := fs.filer.FilerConf.MatchStorageRule(requestURI)
 
 	if rule.ReadOnly {
-		return nil, ErrReadOnly
+		// Name the read-only prefix so the caller knows which path is locked and why.
+		// MatchStorageRule leaves LocationPrefix empty when several rules merge; fall back to the request path.
+		prefix := rule.LocationPrefix
+		if prefix == "" {
+			prefix = requestURI
+		}
+		return nil, fmt.Errorf("%w: %s (e.g. bucket over quota)", ErrReadOnly, prefix)
 	}
 
 	// Use local variable instead of mutating shared rule

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -99,7 +99,7 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 	)
 	if err != nil {
 		if errors.Is(err, ErrReadOnly) {
-			w.WriteHeader(http.StatusInsufficientStorage)
+			writeJsonError(w, r, http.StatusInsufficientStorage, err)
 		} else {
 			glog.V(1).InfolnCtx(ctx, "post", r.RequestURI, ":", err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
@@ -259,7 +259,8 @@ func (fs *FilerServer) detectStorageOption(ctx context.Context, requestURI, qCol
 		// MatchStorageRule leaves LocationPrefix empty when several rules merge; fall back to the request path.
 		prefix := rule.LocationPrefix
 		if prefix == "" {
-			prefix = requestURI
+			// requestURI may carry a query string on the HTTP path; keep only the path.
+			prefix, _, _ = strings.Cut(requestURI, "?")
 		}
 		return nil, fmt.Errorf("%w: %s (e.g. bucket over quota)", ErrReadOnly, prefix)
 	}


### PR DESCRIPTION
Writes under a read-only path rule were rejected with a flat `read only`, with no indication of which path was locked or why. A FUSE `mkdir` surfaced it as `rpc error: code = Unknown desc = read only`, and there was no way to tell it apart from a transient failure.

Wrap the error with the matched location prefix and a quota hint:

```
read only: /buckets/k8s-2-101/ (e.g. bucket over quota)
```

The prefix comes from the matched rule's `LocationPrefix`, falling back to the request path in the rare case where several rules merge and leave it blank.

The error still wraps the `ErrReadOnly` sentinel, so the S3 put/copy handlers keep mapping it via `errors.Is`; the HTTP write handler's `==` check is switched to `errors.Is` to match.

Closes #9766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of read-only storage restrictions. Read-only conditions are now surfaced in responses (with explanatory messages) even when wrapped, and include contextual locked-path prefixes (e.g., "bucket over quota") to clarify which location is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->