### PR TITLE
volume: keep volume writable after a deletion-tail compaction

### DIFF
--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -3071,11 +3071,15 @@ impl Volume {
                 let bytes = fake_del_needle.write_bytes(version);
                 dst_dat.write_all(&bytes)?;
 
+                // Record the tombstone's real .dat offset, like the normal delete path,
+                // so a deletion left at the .dat tail stays visible to the integrity
+                // check on reload. Offset 0 hid the trailing tombstone and falsely
+                // flipped the volume read-only.
                 let mut idx_entry_buf = [0u8; NEEDLE_MAP_ENTRY_SIZE];
                 crate::storage::types::idx_entry_to_bytes(
                     &mut idx_entry_buf,
                     key,
-                    Offset::from_actual_offset(0),
+                    Offset::from_actual_offset(dat_offset as i64),
                     Size(crate::storage::types::TOMBSTONE_FILE_SIZE.into()),
                 );
                 dst_idx.write_all(&idx_entry_buf)?;

--- a/weed/storage/volume_vacuum.go
+++ b/weed/storage/volume_vacuum.go
@@ -389,11 +389,15 @@ func (v *Volume) makeupDiff(newDatFileName, newIdxFileName, oldDatFileName, oldI
 			fakeDelNeedle.Id = key
 			fakeDelNeedle.Cookie = 0x12345678
 			fakeDelNeedle.AppendAtNs = uint64(time.Now().UnixNano())
-			_, _, _, err = fakeDelNeedle.Append(dstDatBackend, v.Version())
-			if err != nil {
-				return fmt.Errorf("append deleted %d failed: %v", key, err)
+			fakeDelOffset, _, _, appendErr := fakeDelNeedle.Append(dstDatBackend, v.Version())
+			if appendErr != nil {
+				return fmt.Errorf("append deleted %d failed: %v", key, appendErr)
 			}
-			util.Uint32toBytes(idxEntryBytes[8:12], uint32(0))
+			// Record the tombstone's real .dat offset, like the normal delete path,
+			// so a deletion left at the .dat tail stays visible to the integrity
+			// check on reload. Offset 0 hid the trailing tombstone and falsely
+			// flipped the volume read-only.
+			idxEntryBytes = needle_map.ToBytes(key, ToOffset(int64(fakeDelOffset)), increIdxEntry.size)
 		}
 
 		if _, err := idx.Seek(0, 2); err != nil {

--- a/weed/storage/volume_vacuum_test.go
+++ b/weed/storage/volume_vacuum_test.go
@@ -151,6 +151,54 @@ func testCompactionByIndex(t *testing.T, needleMapKind NeedleMapKind) {
 
 }
 
+// A deletion replayed by makeupDiff appends a tombstone to the compacted .dat.
+// When that tombstone is the .dat tail, its .idx entry must carry the real
+// offset, not 0, or the post-commit integrity check can't see the trailing
+// tombstone and wrongly flips the volume read-only — loading a
+// SortedFileNeedleMap instead of the writable LevelDb map.
+func TestCommitCompactDeletionTailKeepsWritable(t *testing.T) {
+	dir := t.TempDir()
+
+	v, err := NewVolume(dir, dir, "", 1, NeedleMapLevelDb, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, needle.GetCurrentVersion(), 0, 0)
+	if err != nil {
+		t.Fatalf("volume creation: %v", err)
+	}
+
+	for i := uint64(1); i <= 5; i++ {
+		if _, _, _, err := v.writeNeedle2(newRandomNeedle(i), true, false); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	v.CompactByIndex(nil)
+
+	// The sole change in the commit window is a deletion, so makeupDiff appends
+	// its tombstone last, putting it at the .dat tail.
+	if _, err := v.deleteNeedle2(newEmptyNeedle(3)); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if err := v.CommitCompact(); err != nil {
+		t.Fatalf("commit compact: %v", err)
+	}
+
+	if _, ok := v.nm.(*LevelDbNeedleMap); !ok {
+		t.Fatalf("after compaction v.nm is %T, want *LevelDbNeedleMap (volume wrongly marked read-only)", v.nm)
+	}
+	v.Close()
+
+	// Reload from disk to confirm the integrity check passes and the volume
+	// stays writable.
+	v, err = NewVolume(dir, dir, "", 1, NeedleMapLevelDb, nil, nil, 0, needle.GetCurrentVersion(), 0, 0)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	defer v.Close()
+	if v.noWriteOrDelete {
+		t.Fatal("volume reloaded read-only after a deletion-tail compaction")
+	}
+}
+
 func TestCompactVolumeFilesOffline(t *testing.T) {
 	dir := t.TempDir()
 	location := NewDiskLocation(dir, 10, util.MinFreeSpace{}, dir, "", nil)


### PR DESCRIPTION
## Problem

`TestLDBIndexCompaction` panics intermittently:

```
panic: interface conversion: interface {} is *storage.SortedFileNeedleMap, not *storage.LevelDbNeedleMap
```

The test uses unseeded `rand`, so it only trips on ~3% of runs. The panic is a symptom of a real correctness bug in compaction commit.

`makeupDiff` replays the changes that happened during the compaction window onto the newly compacted volume. For a replayed **deletion** it appends a tombstone to the new `.dat` but records the `.idx` entry with **offset 0**. `incrementedHasUpdatedIndexEntry` is a map, so the replay order is random — when a deletion is appended last, the tombstone sits at the `.dat` tail.

On the reload inside `CommitCompact`, the data-integrity check finds the `.dat` tail by scanning the `.idx` for the highest offset, **skipping offset-0 entries**. It therefore can't see the trailing 32-byte tombstone, reports `actual N != expected N-32`, and marks the volume read-only — which reloads it as a `SortedFileNeedleMap` instead of the writable needle map. The test's type assertion then panics.

Outside the test, this means a normal compaction whose last replayed change is a delete wrongly flips the volume read-only on its next load.

## Fix

Record the tombstone's real `.dat` offset in the `.idx` entry, exactly like the normal delete path (`appendToIndexFile` with the appended offset). The needle map still treats the entry as deleted because it keys off the negative size, so lookups are unchanged; only the integrity check can now find the trailing tombstone.

Mirrored the same one-line fix into the Rust volume server, which had the identical `offset 0`.

Added `TestCommitCompactDeletionTailKeepsWritable`: a deterministic regression test (one deletion as the only commit-window change, so the tombstone is always the `.dat` tail). It fails reliably without the fix and passes with it.

`TestLDBIndexCompaction` runs clean over 200 iterations with the fix; the full `weed/storage` suite and the Rust compaction tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed volumes being incorrectly marked read-only after compaction when deletion entries appear at the end of the data file. Volumes now maintain writeability and proper integrity verification on reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->