### PR TITLE
fix(seaweed-volume): bound request body and stored-content expansion to prevent OOM under load

### DIFF
--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -23,6 +23,17 @@ use crate::pb::volume_server_pb;
 use crate::storage::needle::needle::Needle;
 use crate::storage::types::*;
 
+/// Slack added over the configured file-size limit when bounding the raw
+/// request body, to allow for multipart/form-data framing overhead. The exact
+/// per-file limit is still enforced on the parsed data after multipart parsing.
+const UPLOAD_BODY_OVERHEAD: usize = 16 * 1024 * 1024; // 16 MiB
+
+/// Upper bound on bytes we will materialize in memory for a single request when
+/// expanding stored content (gzip decompression or chunk-manifest assembly).
+/// Guards against gzip bombs and crafted/oversized manifest sizes OOM-killing
+/// the server; legitimate large objects are read via client-side chunk fetches.
+const MAX_EXPANSION_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
+
 // ============================================================================
 // Inflight Throttle Guard
 // ============================================================================
@@ -1452,11 +1463,7 @@ async fn get_or_head_handler_inner(
     if is_compressed {
         if needs_image_ops {
             // Always decompress for image operations (Go decompresses before resize/crop)
-            use flate2::read::GzDecoder;
-            use std::io::Read as _;
-            let mut decoder = GzDecoder::new(&data[..]);
-            let mut decompressed = Vec::new();
-            if decoder.read_to_end(&mut decompressed).is_ok() {
+            if let Some(decompressed) = maybe_decompress_gzip(&data) {
                 data = decompressed;
             }
         } else {
@@ -1474,11 +1481,7 @@ async fn get_or_head_handler_inner(
                 response_headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
             } else {
                 // Decompress for client
-                use flate2::read::GzDecoder;
-                use std::io::Read as _;
-                let mut decoder = GzDecoder::new(&data[..]);
-                let mut decompressed = Vec::new();
-                if decoder.read_to_end(&mut decompressed).is_ok() {
+                if let Some(decompressed) = maybe_decompress_gzip(&data) {
                     data = decompressed;
                 }
             }
@@ -2134,15 +2137,26 @@ pub async fn post_handler(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    // Read body
-    let body = match axum::body::to_bytes(request.into_body(), usize::MAX).await {
+    // Read body, bounded by the configured file-size limit so a single upload
+    // cannot buffer unbounded memory and OOM-kill the server (mirrors Go's
+    // io.LimitReader(r.Body, sizeLimit+1)). A margin covers multipart framing;
+    // the exact per-file limit is still enforced on the parsed data below.
+    let body_limit = if state.file_size_limit_bytes > 0 {
+        (state.file_size_limit_bytes as usize).saturating_add(UPLOAD_BODY_OVERHEAD)
+    } else {
+        usize::MAX
+    };
+    let body = match axum::body::to_bytes(request.into_body(), body_limit).await {
         Ok(b) => b,
         Err(e) => {
-            return json_error_with_query(
-                StatusCode::BAD_REQUEST,
-                format!("read body: {}", e),
-                Some(&query),
-            )
+            // With a limit configured, an error here means the body exceeded it
+            // before we buffered the whole thing; report it like the size check.
+            let msg = if state.file_size_limit_bytes > 0 {
+                format!("file over the limited {} bytes", state.file_size_limit_bytes)
+            } else {
+                format!("read body: {}", e)
+            };
+            return json_error_with_query(StatusCode::BAD_REQUEST, msg, Some(&query));
         }
     };
 
@@ -2761,15 +2775,7 @@ pub async fn delete_handler(
     // If this is a chunk manifest, delete child chunks first
     if n.is_chunk_manifest() {
         let manifest_data = if n.is_compressed() {
-            use flate2::read::GzDecoder;
-            use std::io::Read as _;
-            let mut decoder = GzDecoder::new(&n.data[..]);
-            let mut decompressed = Vec::new();
-            if decoder.read_to_end(&mut decompressed).is_ok() {
-                decompressed
-            } else {
-                n.data.clone()
-            }
+            maybe_decompress_gzip(&n.data).unwrap_or_else(|| n.data.clone())
         } else {
             n.data.clone()
         };
@@ -3124,14 +3130,7 @@ fn try_expand_chunk_manifest(
     last_modified_str: &Option<String>,
 ) -> Option<Response> {
     let data = if n.is_compressed() {
-        use flate2::read::GzDecoder;
-        use std::io::Read as _;
-        let mut decoder = GzDecoder::new(&n.data[..]);
-        let mut decompressed = Vec::new();
-        if decoder.read_to_end(&mut decompressed).is_err() {
-            return None;
-        }
-        decompressed
+        maybe_decompress_gzip(&n.data)?
     } else {
         n.data.clone()
     };
@@ -3140,6 +3139,13 @@ fn try_expand_chunk_manifest(
         Ok(m) => m,
         Err(_) => return None,
     };
+
+    // Guard the attacker-controlled manifest size before allocating: a negative
+    // value would wrap to a huge usize (capacity-overflow panic) and an oversized
+    // one would OOM-kill the server.
+    if manifest.size < 0 || manifest.size as u64 > MAX_EXPANSION_BYTES {
+        return None;
+    }
 
     // Read and concatenate all chunks
     let mut result = vec![0u8; manifest.size as usize];
@@ -3175,15 +3181,7 @@ fn try_expand_chunk_manifest(
             }
         }
         let chunk_data = if chunk_needle.is_compressed() {
-            use flate2::read::GzDecoder;
-            use std::io::Read as _;
-            let mut decoder = GzDecoder::new(&chunk_needle.data[..]);
-            let mut decompressed = Vec::new();
-            if decoder.read_to_end(&mut decompressed).is_ok() {
-                decompressed
-            } else {
-                chunk_needle.data.clone()
-            }
+            maybe_decompress_gzip(&chunk_needle.data).unwrap_or_else(|| chunk_needle.data.clone())
         } else {
             chunk_needle.data.clone()
         };
@@ -3567,9 +3565,15 @@ fn try_gzip_data(data: &[u8]) -> Option<Vec<u8>> {
 fn maybe_decompress_gzip(data: &[u8]) -> Option<Vec<u8>> {
     use flate2::read::GzDecoder;
     use std::io::Read;
-    let mut decoder = GzDecoder::new(data);
+    // Cap the output so a crafted, highly-compressible (gzip-bomb) needle cannot
+    // OOM the server when decompressed on read or upload. take(limit+1) lets us
+    // tell "exactly at the limit" apart from "over it".
+    let mut decoder = GzDecoder::new(data).take(MAX_EXPANSION_BYTES + 1);
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).ok()?;
+    if decompressed.len() as u64 > MAX_EXPANSION_BYTES {
+        return None;
+    }
     Some(decompressed)
 }
 

--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -3267,10 +3267,11 @@ fn try_expand_chunk_manifest(
             use flate2::read::GzDecoder;
             use std::io::Read as _;
             let mut decoder = GzDecoder::new(&chunk_needle.data[..]);
+            let window = &mut result[offset..];
             let mut written = 0usize;
             let mut decode_failed = false;
-            while offset + written < result.len() {
-                match decoder.read(&mut result[offset + written..]) {
+            while written < window.len() {
+                match decoder.read(&mut window[written..]) {
                     Ok(0) => break,
                     Ok(n) => written += n,
                     Err(_) => {
@@ -3279,11 +3280,12 @@ fn try_expand_chunk_manifest(
                     }
                 }
             }
-            // If the chunk wasn't decodable gzip at all, fall back to its raw
-            // bytes (truncated to the window), preserving prior behavior.
-            if written == 0 && decode_failed {
-                let copy_len = chunk_needle.data.len().min(result.len() - offset);
-                result[offset..offset + copy_len].copy_from_slice(&chunk_needle.data[..copy_len]);
+            // On any decode failure, drop the partial output and fall back to the
+            // chunk's raw bytes (truncated to the window), preserving prior behavior.
+            if decode_failed {
+                window[..written].fill(0);
+                let copy_len = chunk_needle.data.len().min(window.len());
+                window[..copy_len].copy_from_slice(&chunk_needle.data[..copy_len]);
             }
         } else {
             let copy_len = chunk_needle.data.len().min(result.len() - offset);

--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -3242,25 +3242,9 @@ fn try_expand_chunk_manifest(
                 )
             }
         }
-        let chunk_data = if chunk_needle.is_compressed() {
-            match maybe_decompress_gzip(&chunk_needle.data) {
-                Ok(d) => d,
-                Err(GunzipError::TooLarge) => {
-                    return Some(
-                        (
-                            StatusCode::PAYLOAD_TOO_LARGE,
-                            "compressed chunk exceeds decompression limit",
-                        )
-                            .into_response(),
-                    )
-                }
-                Err(GunzipError::Decode) => chunk_needle.data.clone(),
-            }
-        } else {
-            chunk_needle.data.clone()
-        };
         // Validate the attacker-controlled chunk offset before indexing: a
-        // negative value would wrap to a huge usize and underflow `end - offset`.
+        // negative value would wrap to a huge usize, and an out-of-range one has
+        // nowhere to land.
         if chunk.offset < 0 {
             return Some(
                 (
@@ -3274,10 +3258,36 @@ fn try_expand_chunk_manifest(
         if offset >= result.len() {
             continue;
         }
-        let end = offset.saturating_add(chunk_data.len()).min(result.len());
-        let copy_len = end.saturating_sub(offset);
-        if copy_len > 0 {
-            result[offset..offset + copy_len].copy_from_slice(&chunk_data[..copy_len]);
+        // Write the chunk into its window in `result`. Compressed chunks inflate
+        // directly into the destination slice (bounded by the remaining window),
+        // so a chunk never allocates a second large buffer — peak memory stays at
+        // ~manifest.size instead of doubling. Bytes past the window are dropped,
+        // matching the prior truncation behavior.
+        if chunk_needle.is_compressed() {
+            use flate2::read::GzDecoder;
+            use std::io::Read as _;
+            let mut decoder = GzDecoder::new(&chunk_needle.data[..]);
+            let mut written = 0usize;
+            let mut decode_failed = false;
+            while offset + written < result.len() {
+                match decoder.read(&mut result[offset + written..]) {
+                    Ok(0) => break,
+                    Ok(n) => written += n,
+                    Err(_) => {
+                        decode_failed = true;
+                        break;
+                    }
+                }
+            }
+            // If the chunk wasn't decodable gzip at all, fall back to its raw
+            // bytes (truncated to the window), preserving prior behavior.
+            if written == 0 && decode_failed {
+                let copy_len = chunk_needle.data.len().min(result.len() - offset);
+                result[offset..offset + copy_len].copy_from_slice(&chunk_needle.data[..copy_len]);
+            }
+        } else {
+            let copy_len = chunk_needle.data.len().min(result.len() - offset);
+            result[offset..offset + copy_len].copy_from_slice(&chunk_needle.data[..copy_len]);
         }
     }
 

--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -34,6 +34,16 @@ const UPLOAD_BODY_OVERHEAD: usize = 16 * 1024 * 1024; // 16 MiB
 /// the server; legitimate large objects are read via client-side chunk fetches.
 const MAX_EXPANSION_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
 
+/// Why `maybe_decompress_gzip` failed, so callers can distinguish a recoverable
+/// "not valid gzip, use the raw bytes" from "the bomb cap was hit, reject it".
+#[derive(Debug)]
+enum GunzipError {
+    /// Input was not valid gzip / decode failed — callers may fall back to raw.
+    Decode,
+    /// Decompressed output would exceed `MAX_EXPANSION_BYTES` — must be rejected.
+    TooLarge,
+}
+
 // ============================================================================
 // Inflight Throttle Guard
 // ============================================================================
@@ -1463,8 +1473,16 @@ async fn get_or_head_handler_inner(
     if is_compressed {
         if needs_image_ops {
             // Always decompress for image operations (Go decompresses before resize/crop)
-            if let Some(decompressed) = maybe_decompress_gzip(&data) {
-                data = decompressed;
+            match maybe_decompress_gzip(&data) {
+                Ok(decompressed) => data = decompressed,
+                Err(GunzipError::TooLarge) => {
+                    return (
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "compressed object exceeds decompression limit",
+                    )
+                        .into_response()
+                }
+                Err(GunzipError::Decode) => {} // not valid gzip; keep raw bytes
             }
         } else {
             let accept_encoding = headers
@@ -1481,8 +1499,16 @@ async fn get_or_head_handler_inner(
                 response_headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
             } else {
                 // Decompress for client
-                if let Some(decompressed) = maybe_decompress_gzip(&data) {
-                    data = decompressed;
+                match maybe_decompress_gzip(&data) {
+                    Ok(decompressed) => data = decompressed,
+                    Err(GunzipError::TooLarge) => {
+                        return (
+                            StatusCode::PAYLOAD_TOO_LARGE,
+                            "compressed object exceeds decompression limit",
+                        )
+                            .into_response()
+                    }
+                    Err(GunzipError::Decode) => {} // not valid gzip; keep raw bytes
                 }
             }
         }
@@ -2142,7 +2168,11 @@ pub async fn post_handler(
     // io.LimitReader(r.Body, sizeLimit+1)). A margin covers multipart framing;
     // the exact per-file limit is still enforced on the parsed data below.
     let body_limit = if state.file_size_limit_bytes > 0 {
-        (state.file_size_limit_bytes as usize).saturating_add(UPLOAD_BODY_OVERHEAD)
+        // try_from (not `as usize`) so a >usize::MAX limit on 32-bit caps at
+        // usize::MAX instead of silently truncating/wrapping to a tiny value.
+        usize::try_from(state.file_size_limit_bytes)
+            .unwrap_or(usize::MAX)
+            .saturating_add(UPLOAD_BODY_OVERHEAD)
     } else {
         usize::MAX
     };
@@ -2296,7 +2326,17 @@ pub async fn post_handler(
     };
 
     let uncompressed_data = if is_gzipped {
-        maybe_decompress_gzip(&body_data_raw).unwrap_or_else(|| body_data_raw.clone())
+        match maybe_decompress_gzip(&body_data_raw) {
+            Ok(d) => d,
+            Err(GunzipError::TooLarge) => {
+                return json_error_with_query(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "compressed object exceeds decompression limit",
+                    Some(&query),
+                );
+            }
+            Err(GunzipError::Decode) => body_data_raw.clone(),
+        }
     } else {
         body_data_raw.clone()
     };
@@ -2775,7 +2815,17 @@ pub async fn delete_handler(
     // If this is a chunk manifest, delete child chunks first
     if n.is_chunk_manifest() {
         let manifest_data = if n.is_compressed() {
-            maybe_decompress_gzip(&n.data).unwrap_or_else(|| n.data.clone())
+            match maybe_decompress_gzip(&n.data) {
+                Ok(d) => d,
+                Err(GunzipError::TooLarge) => {
+                    return json_error_with_query(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "compressed manifest exceeds decompression limit",
+                        Some(&del_query),
+                    );
+                }
+                Err(GunzipError::Decode) => n.data.clone(),
+            }
         } else {
             n.data.clone()
         };
@@ -3130,7 +3180,19 @@ fn try_expand_chunk_manifest(
     last_modified_str: &Option<String>,
 ) -> Option<Response> {
     let data = if n.is_compressed() {
-        maybe_decompress_gzip(&n.data)?
+        match maybe_decompress_gzip(&n.data) {
+            Ok(d) => d,
+            Err(GunzipError::TooLarge) => {
+                return Some(
+                    (
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "compressed manifest exceeds decompression limit",
+                    )
+                        .into_response(),
+                )
+            }
+            Err(GunzipError::Decode) => return None,
+        }
     } else {
         n.data.clone()
     };
@@ -3181,13 +3243,39 @@ fn try_expand_chunk_manifest(
             }
         }
         let chunk_data = if chunk_needle.is_compressed() {
-            maybe_decompress_gzip(&chunk_needle.data).unwrap_or_else(|| chunk_needle.data.clone())
+            match maybe_decompress_gzip(&chunk_needle.data) {
+                Ok(d) => d,
+                Err(GunzipError::TooLarge) => {
+                    return Some(
+                        (
+                            StatusCode::PAYLOAD_TOO_LARGE,
+                            "compressed chunk exceeds decompression limit",
+                        )
+                            .into_response(),
+                    )
+                }
+                Err(GunzipError::Decode) => chunk_needle.data.clone(),
+            }
         } else {
             chunk_needle.data.clone()
         };
+        // Validate the attacker-controlled chunk offset before indexing: a
+        // negative value would wrap to a huge usize and underflow `end - offset`.
+        if chunk.offset < 0 {
+            return Some(
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("invalid negative chunk offset in {}", chunk.fid),
+                )
+                    .into_response(),
+            );
+        }
         let offset = chunk.offset as usize;
-        let end = std::cmp::min(offset + chunk_data.len(), result.len());
-        let copy_len = end - offset;
+        if offset >= result.len() {
+            continue;
+        }
+        let end = offset.saturating_add(chunk_data.len()).min(result.len());
+        let copy_len = end.saturating_sub(offset);
         if copy_len > 0 {
             result[offset..offset + copy_len].copy_from_slice(&chunk_data[..copy_len]);
         }
@@ -3562,19 +3650,22 @@ fn try_gzip_data(data: &[u8]) -> Option<Vec<u8>> {
     encoder.finish().ok()
 }
 
-fn maybe_decompress_gzip(data: &[u8]) -> Option<Vec<u8>> {
+fn maybe_decompress_gzip(data: &[u8]) -> Result<Vec<u8>, GunzipError> {
     use flate2::read::GzDecoder;
     use std::io::Read;
     // Cap the output so a crafted, highly-compressible (gzip-bomb) needle cannot
     // OOM the server when decompressed on read or upload. take(limit+1) lets us
-    // tell "exactly at the limit" apart from "over it".
+    // tell "exactly at the limit" apart from "over it", which we reject as
+    // TooLarge so callers fail the request instead of silently using raw bytes.
     let mut decoder = GzDecoder::new(data).take(MAX_EXPANSION_BYTES + 1);
     let mut decompressed = Vec::new();
-    decoder.read_to_end(&mut decompressed).ok()?;
+    decoder
+        .read_to_end(&mut decompressed)
+        .map_err(|_| GunzipError::Decode)?;
     if decompressed.len() as u64 > MAX_EXPANSION_BYTES {
-        return None;
+        return Err(GunzipError::TooLarge);
     }
-    Some(decompressed)
+    Ok(decompressed)
 }
 
 fn compute_md5_base64(data: &[u8]) -> String {
@@ -3816,7 +3907,11 @@ mod tests {
         let compressed = try_gzip_data(data).unwrap();
         let decompressed = maybe_decompress_gzip(&compressed).unwrap();
         assert_eq!(decompressed, data);
-        assert!(maybe_decompress_gzip(data).is_none());
+        // Non-gzip input is reported as a decode error (callers fall back to raw).
+        assert!(matches!(
+            maybe_decompress_gzip(data),
+            Err(GunzipError::Decode)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Rust volume server (`seaweed-volume/`) can be OOM-killed under load. `post_handler` reads the entire upload body with:

```rust
let body = axum::body::to_bytes(request.into_body(), usize::MAX).await;
```

i.e. **no upper bound** — and the `fileSizeLimitMB` check happens *after* the whole body is already buffered. Because the in-flight upload/download byte throttle defaults to `0` (unlimited), there is no global cap either, so:

- a single multi-GB upload, or
- many concurrent uploads,

buffer unbounded memory (multipart amplifies it ~3×) until the OS OOM-killer terminates the process.

The read path has two more single-request OOM vectors:
- `let mut result = vec![0u8; manifest.size as usize];` in `try_expand_chunk_manifest` allocates from an **attacker-controlled** chunk-manifest size (a stored `cm=1` needle), and a negative `size` wraps to a huge `usize` (capacity-overflow panic).
- gzip decompression (`maybe_decompress_gzip` and several inline `GzDecoder` sites) was unbounded — a small highly-compressible needle could decompress to an arbitrary size (gzip bomb).

## Fix

- **Bound the upload body read** by `file_size_limit_bytes` (plus a 16 MiB margin for multipart framing), mirroring Go's `io.LimitReader(r.Body, sizeLimit+1)`. Oversize bodies are rejected before the whole body is buffered; the exact per-file limit is still enforced on the parsed data. When the limit is `0` (explicitly unlimited) behavior is unchanged.
- **Validate `manifest.size`** (reject negative / oversized) before the allocation.
- **Cap gzip output** in `maybe_decompress_gzip` (`MAX_EXPANSION_BYTES`, 2 GiB) and route the duplicated inline `GzDecoder` blocks through it (also de-dupes 5 copies).

No new config/flags. The existing `concurrentUploadLimitMB`/`concurrentDownloadLimitMB` throttles remain the way to bound *aggregate* concurrent memory; this PR ensures a single request can't blow past `fileSizeLimitMB` regardless.

## Notes / review focus
- The 16 MiB margin over `fileSizeLimitMB` covers multipart boundary/field framing; the precise file-size limit is still enforced post-parse, so the margin only affects how much raw body is buffered before rejection.
- The default `fileSizeLimitMB` is 256, so the common deployment is now bounded out of the box; `fileSizeLimitMB=0` remains opt-out/unlimited.

## Testing
- `cargo build` clean; `cargo test --lib` → 299 passed.
- No new clippy warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced server-side caps on buffered uploads and decompression to prevent unbounded memory/CPU use.
  * Uploads now respect configured size limits and return clear errors when exceeded.
  * Read/serve and image operations now consistently handle compressed payloads: over-limit expansions are rejected; invalid gzip falls back to raw bytes.
  * Manifest/chunk expansion validates sizes/offsets and avoids extra large allocations or partial corrupt output.

* **Tests**
  * Updated tests to expect the new decompression error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->