### PR TITLE
fix(http): check delete request errors before auth

### DIFF
--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -144,10 +144,10 @@ func maybeAddAuth(req *http.Request, jwt string) {
 
 func Delete(url string, jwt string) error {
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
-	maybeAddAuth(req, jwt)
 	if err != nil {
 		return err
 	}
+	maybeAddAuth(req, jwt)
 	resp, e := GetGlobalHttpClient().Do(req)
 	if e != nil {
 		return e
@@ -172,10 +172,10 @@ func Delete(url string, jwt string) error {
 
 func DeleteProxied(url string, jwt string) (body []byte, httpStatus int, err error) {
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
-	maybeAddAuth(req, jwt)
 	if err != nil {
 		return
 	}
+	maybeAddAuth(req, jwt)
 	resp, err := GetGlobalHttpClient().Do(req)
 	if err != nil {
 		return

--- a/weed/util/http/http_global_client_util_test.go
+++ b/weed/util/http/http_global_client_util_test.go
@@ -70,3 +70,27 @@ func TestAppendQueryParameter(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteReturnsInvalidRequestErrorBeforeAddingAuth(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Delete panicked before returning the request error: %v", r)
+		}
+	}()
+
+	if err := Delete("http://[::1", "jwt"); err == nil {
+		t.Fatal("expected invalid request error")
+	}
+}
+
+func TestDeleteProxiedReturnsInvalidRequestErrorBeforeAddingAuth(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DeleteProxied panicked before returning the request error: %v", r)
+		}
+	}()
+
+	if _, _, err := DeleteProxied("http://[::1", "jwt"); err == nil {
+		t.Fatal("expected invalid request error")
+	}
+}


### PR DESCRIPTION
Fix HTTP delete helpers to return invalid request errors before adding auth. Delete and DeleteProxied now check http.NewRequest errors before calling maybeAddAuth, preventing a nil request panic when malformed URLs are used with JWT auth. The change adds regression tests for both delete paths.

# What problem are we solving?

Delete and DeleteProxied could panic on malformed URLs when a JWT was provided. http.NewRequest can return a nil request with an error, but the code called maybeAddAuth before checking that error.


# How are we solving the problem?

Return the request construction error first, then add the Authorization header only after a valid request exists. This preserves existing delete behavior while avoiding the nil request panic.



# How is the PR tested?

go test ./weed/util/http -run 'TestDelete(ReturnsInvalidRequestErrorBeforeAddingAuth|ProxiedReturnsInvalidRequestErrorBeforeAddingAuth)' -count=1

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP delete error handling so malformed requests are detected and reported immediately, preventing further processing.

* **Tests**
  * Added tests to confirm delete and proxied delete calls return an error (and do not crash) when given invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->