### PR TITLE
fix(s3/lifecycle): report success to admin via JobCompleted

### DIFF
--- a/weed/worker/tasks/s3_lifecycle/handler.go
+++ b/weed/worker/tasks/s3_lifecycle/handler.go
@@ -256,7 +256,27 @@ func (h *Handler) Execute(ctx context.Context, request *plugin_pb.ExecuteJobRequ
 	defer s3Conn.Close()
 	rpc := s3_lifecycle_pb.NewSeaweedS3LifecycleInternalClient(s3Conn)
 
-	return h.executeDailyReplay(runCtx, request, bucketsPath, filerClient, rpc, cfg, sender)
+	if err := h.executeDailyReplay(runCtx, request, bucketsPath, filerClient, rpc, cfg, sender); err != nil {
+		return err
+	}
+
+	return sendSuccessCompletion(request, sender)
+}
+
+const dailyReplaySuccessSummary = "s3 lifecycle daily replay completed"
+
+// JobCompleted must set JobType to the handler's jobType constant;
+// routed requests may leave request.Job.JobType empty, and the admin
+// ignores completions with empty JobType.
+func sendSuccessCompletion(request *plugin_pb.ExecuteJobRequest, sender pluginworker.ExecutionSender) error {
+	return sender.SendCompleted(&plugin_pb.JobCompleted{
+		JobId:   request.Job.JobId,
+		JobType: jobType,
+		Success: true,
+		Result: &plugin_pb.JobResult{
+			Summary: dailyReplaySuccessSummary,
+		},
+	})
 }
 
 // executeDailyReplay runs one bounded daily-replay pass via

--- a/weed/worker/tasks/s3_lifecycle/handler_test.go
+++ b/weed/worker/tasks/s3_lifecycle/handler_test.go
@@ -371,8 +371,9 @@ func TestDescriptor_AdminRuntimeDefaultsEnabledByDefault(t *testing.T) {
 // the handler refuses malformed jobs early instead of waiting on a
 // 30s dial timeout.
 type recordingExecSender struct {
-	progress  []*plugin_pb.JobProgressUpdate
-	completed []*plugin_pb.JobCompleted
+	progress     []*plugin_pb.JobProgressUpdate
+	completed    []*plugin_pb.JobCompleted
+	completedErr error
 }
 
 func (r *recordingExecSender) SendProgress(p *plugin_pb.JobProgressUpdate) error {
@@ -380,6 +381,9 @@ func (r *recordingExecSender) SendProgress(p *plugin_pb.JobProgressUpdate) error
 	return nil
 }
 func (r *recordingExecSender) SendCompleted(c *plugin_pb.JobCompleted) error {
+	if r.completedErr != nil {
+		return r.completedErr
+	}
 	r.completed = append(r.completed, c)
 	return nil
 }
@@ -462,6 +466,36 @@ func TestExecute_EmptyJobTypeAccepted(t *testing.T) {
 	}, &recordingExecSender{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no s3 servers", "validation flowed past the type check")
+}
+
+// ---------- sendSuccessCompletion ----------
+
+func TestSendSuccessCompletion_EmitsCanonicalCompletion(t *testing.T) {
+	sender := &recordingExecSender{}
+	request := &plugin_pb.ExecuteJobRequest{
+		Job: &plugin_pb.JobSpec{JobId: "job-123"}, // empty JobType (broadcast routing)
+	}
+
+	require.NoError(t, sendSuccessCompletion(request, sender))
+
+	require.Len(t, sender.completed, 1, "exactly one completion must be sent")
+	c := sender.completed[0]
+	assert.Equal(t, jobType, c.JobType, "completion must use the canonical jobType, not request.Job.JobType")
+	assert.NotEmpty(t, c.JobType, "an empty JobType is dropped by the admin")
+	assert.Equal(t, "job-123", c.JobId, "completion must echo the original JobId")
+	assert.True(t, c.Success, "a clean replay is a success completion")
+	require.NotNil(t, c.Result)
+	assert.NotEmpty(t, c.Result.Summary, "admin UI surfaces a non-empty Result.Summary")
+}
+
+func TestSendSuccessCompletion_PropagatesSendError(t *testing.T) {
+	sentinel := errors.New("stream closed")
+	sender := &recordingExecSender{completedErr: sentinel}
+	request := &plugin_pb.ExecuteJobRequest{Job: &plugin_pb.JobSpec{JobId: "job-456"}}
+
+	err := sendSuccessCompletion(request, sender)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
 }
 
 // ---------- lookupBucketsPath ----------


### PR DESCRIPTION
# What problem are we solving?
S3 lifecycle jobs could finish successfully on the worker but stay running in the admin UI.
The `s3_lifecycle` handler returned `nil` after a successful daily replay. The plugin worker framework only sends `JobCompleted` automatically for the error path, so admin never saw a successful completion. Those jobs then sat around until stale monitoring eventually marked them failed.

# How are we solving the problem?
After `executeDailyReplay` succeeds, the handler now sends an explicit successful `JobCompleted`.
The completion uses the canonical `s3_lifecycle` job type instead of `request.Job.JobType`, because routed/broadcast execute requests may have an empty job type and admin ignores completions with an empty `JobType`.
The failure path is left alone: if `executeDailyReplay` returns an error, `Execute` still returns it and the existing worker framework reports the failed completion.

# How is the PR tested?
```bash
go test ./weed/worker/tasks/s3_lifecycle
```
Added focused unit coverage for the success completion payload and for propagating SendCompleted errors.

Also validated manually on a 4.30-based cluster. Before this change, scheduled lifecycle jobs in our cluster were observed failing with stale-monitor messages such as `job expired after 24h0m0s without progress`. After deploying this patch, the same scheduled lifecycle jobs completed as `job_state_succeeded`.


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 lifecycle task completion reporting to ensure successful job executions are properly confirmed and acknowledged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->