### PR TITLE
fix(admin): make scheduler pruning lane-aware

### DIFF
--- a/weed/admin/plugin/plugin_scheduler.go
+++ b/weed/admin/plugin/plugin_scheduler.go
@@ -186,8 +186,8 @@ func (r *Plugin) runLaneSchedulerIterationLocked(ls *schedulerLaneState, jobType
 		}
 	}
 
-	r.pruneSchedulerState(active)
-	r.pruneDetectorLeases(active)
+	r.pruneSchedulerState(ls.lane, active)
+	r.pruneDetectorLeases(ls.lane, active)
 	r.setLaneLoopState(ls, "", "idle")
 	return hadJobs
 }
@@ -213,8 +213,8 @@ func (r *Plugin) runLaneSchedulerIterationConcurrent(ls *schedulerLaneState, job
 	}
 	wg.Wait()
 
-	r.pruneSchedulerState(active)
-	r.pruneDetectorLeases(active)
+	r.pruneSchedulerState(ls.lane, active)
+	r.pruneDetectorLeases(ls.lane, active)
 	r.setLaneLoopState(ls, "", "idle")
 	return hadJobs.Load()
 }
@@ -746,11 +746,16 @@ func (r *Plugin) finishDetection(jobType string) {
 	r.schedulerMu.Unlock()
 }
 
-func (r *Plugin) pruneSchedulerState(activeJobTypes map[string]struct{}) {
+// pruneSchedulerState removes next-detection state for inactive job types
+// in lane only. Prune must not touch other lanes' entries in the global map.
+func (r *Plugin) pruneSchedulerState(lane SchedulerLane, activeJobTypes map[string]struct{}) {
 	r.schedulerMu.Lock()
 	defer r.schedulerMu.Unlock()
 
 	for jobType := range r.nextDetectionAt {
+		if JobTypeLane(jobType) != lane {
+			continue
+		}
 		if _, ok := activeJobTypes[jobType]; !ok {
 			delete(r.nextDetectionAt, jobType)
 			delete(r.detectionInFlight, jobType)
@@ -766,11 +771,15 @@ func (r *Plugin) clearSchedulerJobType(jobType string) {
 	r.clearDetectorLease(jobType, "")
 }
 
-func (r *Plugin) pruneDetectorLeases(activeJobTypes map[string]struct{}) {
+// pruneDetectorLeases removes detector leases for inactive job types in lane only.
+func (r *Plugin) pruneDetectorLeases(lane SchedulerLane, activeJobTypes map[string]struct{}) {
 	r.detectorLeaseMu.Lock()
 	defer r.detectorLeaseMu.Unlock()
 
 	for jobType := range r.detectorLeases {
+		if JobTypeLane(jobType) != lane {
+			continue
+		}
 		if _, ok := activeJobTypes[jobType]; !ok {
 			delete(r.detectorLeases, jobType)
 		}

--- a/weed/admin/plugin/plugin_scheduler_test.go
+++ b/weed/admin/plugin/plugin_scheduler_test.go
@@ -673,3 +673,118 @@ func TestRunLaneSchedulerIterationLockBehavior(t *testing.T) {
 		})
 	}
 }
+
+// ---------- lane-scoped prune ----------
+
+func TestPruneSchedulerState_DefaultLaneKeepsForeignLanesAndPrunesOwnStale(t *testing.T) {
+	p, err := New(Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Shutdown()
+
+	now := time.Now().UTC()
+	p.schedulerMu.Lock()
+	p.nextDetectionAt["s3_lifecycle"] = now.Add(24 * time.Hour) // lifecycle lane
+	p.nextDetectionAt["vacuum"] = now.Add(time.Minute)          // default lane, active
+	p.nextDetectionAt["ec_balance"] = now.Add(time.Minute)      // default lane, stale
+	p.detectionInFlight["ec_balance"] = true
+	p.schedulerMu.Unlock()
+
+	// Default-lane iteration prunes with only its own active job types.
+	p.pruneSchedulerState(LaneDefault, map[string]struct{}{"vacuum": {}})
+
+	p.schedulerMu.Lock()
+	defer p.schedulerMu.Unlock()
+	if _, ok := p.nextDetectionAt["s3_lifecycle"]; !ok {
+		t.Fatal("default-lane prune must not delete lifecycle-lane nextDetectionAt[s3_lifecycle]")
+	}
+	if _, ok := p.nextDetectionAt["vacuum"]; !ok {
+		t.Fatal("active default-lane job (vacuum) must be kept")
+	}
+	if _, ok := p.nextDetectionAt["ec_balance"]; ok {
+		t.Fatal("stale default-lane job (ec_balance) must still be pruned within its own lane")
+	}
+	if _, ok := p.detectionInFlight["ec_balance"]; ok {
+		t.Fatal("pruned job must also drop its detectionInFlight entry")
+	}
+}
+
+func TestPruneSchedulerState_LifecycleLaneLeavesDefaultLane(t *testing.T) {
+	p, err := New(Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Shutdown()
+
+	now := time.Now().UTC()
+	p.schedulerMu.Lock()
+	p.nextDetectionAt["vacuum"] = now.Add(time.Minute)          // default lane
+	p.nextDetectionAt["s3_lifecycle"] = now.Add(24 * time.Hour) // lifecycle lane, active
+	p.schedulerMu.Unlock()
+
+	p.pruneSchedulerState(LaneLifecycle, map[string]struct{}{"s3_lifecycle": {}})
+
+	p.schedulerMu.Lock()
+	defer p.schedulerMu.Unlock()
+	if _, ok := p.nextDetectionAt["vacuum"]; !ok {
+		t.Fatal("lifecycle-lane prune must not delete default-lane nextDetectionAt[vacuum]")
+	}
+	if _, ok := p.nextDetectionAt["s3_lifecycle"]; !ok {
+		t.Fatal("active lifecycle job (s3_lifecycle) must be kept")
+	}
+}
+
+func TestPruneDetectorLeases_IsLaneScoped(t *testing.T) {
+	p, err := New(Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Shutdown()
+
+	p.detectorLeaseMu.Lock()
+	p.detectorLeases["s3_lifecycle"] = "worker-a" // lifecycle lane
+	p.detectorLeases["vacuum"] = "worker-b"       // default lane, active
+	p.detectorLeases["ec_balance"] = "worker-c"   // default lane, stale
+	p.detectorLeaseMu.Unlock()
+
+	p.pruneDetectorLeases(LaneDefault, map[string]struct{}{"vacuum": {}})
+
+	p.detectorLeaseMu.Lock()
+	defer p.detectorLeaseMu.Unlock()
+	if _, ok := p.detectorLeases["s3_lifecycle"]; !ok {
+		t.Fatal("default-lane prune must not delete lifecycle-lane detector lease")
+	}
+	if _, ok := p.detectorLeases["vacuum"]; !ok {
+		t.Fatal("active default-lane detector lease (vacuum) must be kept")
+	}
+	if _, ok := p.detectorLeases["ec_balance"]; ok {
+		t.Fatal("stale default-lane detector lease (ec_balance) must still be pruned within its own lane")
+	}
+}
+
+func TestLaneStatus_LifecycleNextDetectionSurvivesDefaultLanePrune(t *testing.T) {
+	p, err := New(Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Shutdown()
+
+	now := time.Now().UTC()
+	expected := now.Add(24 * time.Hour)
+	p.schedulerMu.Lock()
+	p.nextDetectionAt["s3_lifecycle"] = expected
+	p.nextDetectionAt["vacuum"] = now.Add(time.Minute)
+	p.schedulerMu.Unlock()
+
+	p.pruneSchedulerState(LaneDefault, map[string]struct{}{"vacuum": {}})
+
+	status := p.GetLaneSchedulerStatus(LaneLifecycle)
+	if status.NextDetectionAt == nil {
+		t.Fatal("lifecycle lane status lost next_detection_at after a default-lane prune")
+	}
+	if !status.NextDetectionAt.Equal(expected) {
+		t.Fatalf("next_detection_at = %v, want %v (must be the 24h schedule, not the idle-sleep fallback)",
+			status.NextDetectionAt, expected)
+	}
+}


### PR DESCRIPTION
# What problem are we solving?
The plugin scheduler has separate lanes (`default`, `lifecycle`, `iceberg`), but pruning was done against shared scheduler maps using only the active job types from the current lane.

So one lane could delete state owned by another lane. In our cluster, the default lane cleared `nextDetectionAt["s3_lifecycle"]` because `s3_lifecycle` is not active in the default lane. After that, the lifecycle lane treated it as not scheduled and ran it again on the short idle loop instead of the configured 24h detection interval.

This was visible in `/api/plugin/scheduler-status?lane=lifecycle`: `next_detection_at` fell back to the short scheduler sleep instead of staying at the real lifecycle schedule.

# How are we solving the problem?
Make pruning lane-aware.

`pruneSchedulerState` and `pruneDetectorLeases` now get the current lane and skip entries where `JobTypeLane(jobType) != lane`. Each lane still prunes inactive job types owned by that lane, but it no longer touches state owned by other lanes.

# How is the PR tested?
```bash
go test ./weed/admin/plugin -run 'TestPruneSchedulerState|TestPruneDetectorLeases|TestLaneStatus_LifecycleNextDetectionSurvivesDefaultLanePrune'
```

Added tests for:
- default-lane pruning preserving lifecycle state;
- lifecycle-lane pruning preserving default state;
- detector leases using the same lane scope;
- lifecycle status keeping the 24h next_detection_at after a default-lane prune.

Also validated manually on a 4.30-based cluster. Before this change, s3_lifecycle was scheduled every few minutes despite a 1440 minute detection interval. After deploying this patch, lifecycle next_detection_at stayed on the expected 24h schedule.


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler cleanup behavior to properly scope pruning operations to individual lanes, preventing inadvertent removal of scheduling state and detector leases from other lanes. This improves scheduling reliability by ensuring each lane maintains independent cleanup cycles without interfering with other active lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->