### PR TITLE
test(s3/iam): scope ListBucket isolation via s3:prefix condition

### DIFF
--- a/test/s3/iam/s3_policy_variables_test.go
+++ b/test/s3/iam/s3_policy_variables_test.go
@@ -210,10 +210,21 @@ func TestS3PolicyVariablesUsernameIsolation(t *testing.T) {
 			"Sid": "DenyOtherFolders",
 			"Effect": "Deny",
 			"Principal": "*",
-			"Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+			"Action": ["s3:GetObject", "s3:PutObject"],
 			"NotResource": "arn:aws:s3:::%s/${aws:username}/*"
+		}, {
+			"Sid": "DenyListOtherPrefixes",
+			"Effect": "Deny",
+			"Principal": "*",
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::%s",
+			"Condition": {
+				"StringNotLike": {
+					"s3:prefix": ["${aws:username}/*", "${aws:username}"]
+				}
+			}
 		}]
-	}`, bucketName, bucketName, bucketName)
+	}`, bucketName, bucketName, bucketName, bucketName)
 
 	_, err = adminClient.PutBucketPolicy(&s3.PutBucketPolicyInput{
 		Bucket: aws.String(bucketName),


### PR DESCRIPTION
## What

`TestS3PolicyVariablesUsernameIsolation` fails on current master. Bisected to #9792 ("keep ListBucket resource ARN at bucket level"):

| binary | result |
|---|---|
| parent of #9792 (`8e4022d5c`) | PASS 3/3 |
| master (incl. #9792) | FAIL 3/3 |

The isolation policy denied `s3:ListBucket` through an object-path `NotResource`:

```json
{ "Effect": "Deny",
  "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
  "NotResource": "arn:aws:s3:::bucket/${aws:username}/*" }
```

#9792 keeps `ListBucket` bucket-level (resource ARN = `arn:aws:s3:::bucket`) and moves prefix scoping to the `s3:prefix` condition — by design. With a bucket-level resource, the object-path `NotResource` can never match, so the Deny always fires and a user can no longer list their own prefix.

## Fix

Express the per-user List scope the way #9792 intends and the way the matching `Allow` already does — with an `s3:prefix` condition. `GetObject`/`PutObject` keep the object-path `NotResource` (still correct, since those stay object-scoped):

```json
{ "Sid": "DenyListOtherPrefixes", "Effect": "Deny", "Action": "s3:ListBucket",
  "Resource": "arn:aws:s3:::bucket",
  "Condition": { "StringNotLike": { "s3:prefix": ["${aws:username}/*", "${aws:username}"] } } }
```

This is the AWS-canonical per-user-folder isolation pattern. The test workflow is path-filtered and hadn't run on the master commits since #9792 merged, so the regression surfaced on an unrelated PR rather than on #9792 itself.

## Verification

Against a master build (with #9792):
- `TestS3PolicyVariablesUsernameIsolation` — PASS 3/3
- `go test -run TestS3PolicyVariables` — PASS
- `go test -run 'TestS3PolicyVariables|TestS3IAMContextual'` — PASS

Note: this is the only test in `test/s3/iam` that scoped `ListBucket` via object-path `NotResource`. If preserving that pre-#9792 behavior for existing user policies is desired instead, that would be an engine-level change rather than a test fix — happy to take that direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated S3 bucket policy validation for username isolation scenarios to use more granular deny statements with proper access control conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->