### PR TITLE
s3: route object reads to the key's owner filer

### DIFF
--- a/weed/cluster/lock_client.go
+++ b/weed/cluster/lock_client.go
@@ -29,10 +29,9 @@ type LockClient struct {
 	ring        *lock_manager.HashRing
 	ringVersion int64
 
-	// priorRing is the ring in effect before the most recent change, retained for
-	// priorWindow after ringChangedAt so a route-by-key caller can consult the
-	// previous owner of a just-moved key during a rebalance. Mirrors the master's
-	// lock_manager.LockRing.PriorOwner cooling-off.
+	// priorRing is the ring before the most recent change, kept for priorWindow so a
+	// route-by-key caller can consult a just-moved key's previous owner during a
+	// rebalance. Mirrors the master's lock_manager.LockRing.PriorOwner cooling-off.
 	priorRing     *lock_manager.HashRing
 	ringChangedAt time.Time
 	priorWindow   time.Duration
@@ -59,10 +58,10 @@ func (lc *LockClient) SetRing(servers []pb.ServerAddress, version int64) {
 		return
 	}
 	lc.ringVersion = version
+	// Build a fresh ring (not an in-place mutation) so the outgoing ring survives as
+	// priorRing with its own servers for the cooling-off window.
 	newRing := lock_manager.NewHashRing(lock_manager.DefaultVnodeCount)
 	newRing.SetServers(servers)
-	// Retain the outgoing ring as the prior view (a fresh ring, not an in-place
-	// mutation, so the prior keeps its own servers) for the cooling-off window.
 	if lc.ring != nil {
 		lc.priorRing = lc.ring
 		lc.ringChangedAt = time.Now()
@@ -96,12 +95,10 @@ func (lc *LockClient) PrimaryForKey(key string) pb.ServerAddress {
 	return lc.ring.GetPrimary(key)
 }
 
-// PriorOwnerForKey returns key's owner from the ring in effect before the most
-// recent change, but only while that change is within the cooling-off window and
-// the owner actually moved; otherwise "". It mirrors lock_manager.LockRing.PriorOwner
-// so a route-by-key reader can consult a just-moved key's previous owner before
-// treating the new owner's NotFound as authoritative — during a rebalance the new
-// owner may not have replicated the key yet.
+// PriorOwnerForKey returns key's owner from the prior ring while a rebalance is
+// within the cooling-off window and ownership actually moved, else "". Lets a
+// route-by-key reader consult a just-moved key's previous owner before the new
+// owner's NotFound is final (the new owner may not have replicated the key yet).
 func (lc *LockClient) PriorOwnerForKey(key string) pb.ServerAddress {
 	lc.ringMu.RLock()
 	defer lc.ringMu.RUnlock()

--- a/weed/cluster/lock_client.go
+++ b/weed/cluster/lock_client.go
@@ -28,6 +28,14 @@ type LockClient struct {
 	ringMu      sync.RWMutex
 	ring        *lock_manager.HashRing
 	ringVersion int64
+
+	// priorRing is the ring in effect before the most recent change, retained for
+	// priorWindow after ringChangedAt so a route-by-key caller can consult the
+	// previous owner of a just-moved key during a rebalance. Mirrors the master's
+	// lock_manager.LockRing.PriorOwner cooling-off.
+	priorRing     *lock_manager.HashRing
+	ringChangedAt time.Time
+	priorWindow   time.Duration
 }
 
 func NewLockClient(grpcDialOption grpc.DialOption, seedFiler pb.ServerAddress) *LockClient {
@@ -36,6 +44,7 @@ func NewLockClient(grpcDialOption grpc.DialOption, seedFiler pb.ServerAddress) *
 		maxLockDuration: 5 * time.Second,
 		sleepDuration:   2473 * time.Millisecond,
 		seedFiler:       seedFiler,
+		priorWindow:     5 * time.Second,
 	}
 }
 
@@ -50,10 +59,15 @@ func (lc *LockClient) SetRing(servers []pb.ServerAddress, version int64) {
 		return
 	}
 	lc.ringVersion = version
-	if lc.ring == nil {
-		lc.ring = lock_manager.NewHashRing(lock_manager.DefaultVnodeCount)
+	newRing := lock_manager.NewHashRing(lock_manager.DefaultVnodeCount)
+	newRing.SetServers(servers)
+	// Retain the outgoing ring as the prior view (a fresh ring, not an in-place
+	// mutation, so the prior keeps its own servers) for the cooling-off window.
+	if lc.ring != nil {
+		lc.priorRing = lc.ring
+		lc.ringChangedAt = time.Now()
 	}
-	lc.ring.SetServers(servers)
+	lc.ring = newRing
 }
 
 // hostForKey returns the filer that should own key per the current ring view,
@@ -80,6 +94,29 @@ func (lc *LockClient) PrimaryForKey(key string) pb.ServerAddress {
 		return ""
 	}
 	return lc.ring.GetPrimary(key)
+}
+
+// PriorOwnerForKey returns key's owner from the ring in effect before the most
+// recent change, but only while that change is within the cooling-off window and
+// the owner actually moved; otherwise "". It mirrors lock_manager.LockRing.PriorOwner
+// so a route-by-key reader can consult a just-moved key's previous owner before
+// treating the new owner's NotFound as authoritative — during a rebalance the new
+// owner may not have replicated the key yet.
+func (lc *LockClient) PriorOwnerForKey(key string) pb.ServerAddress {
+	lc.ringMu.RLock()
+	defer lc.ringMu.RUnlock()
+	if lc.ring == nil || lc.priorRing == nil {
+		return ""
+	}
+	if time.Since(lc.ringChangedAt) > lc.priorWindow {
+		return ""
+	}
+	current := lc.ring.GetPrimary(key)
+	prior := lc.priorRing.GetPrimary(key)
+	if prior != "" && prior != current {
+		return prior
+	}
+	return ""
 }
 
 type LiveLock struct {

--- a/weed/cluster/lock_client_test.go
+++ b/weed/cluster/lock_client_test.go
@@ -93,15 +93,14 @@ func TestLockClientPrimaryForKey(t *testing.T) {
 	}
 }
 
-// During a rebalance, a key whose ownership moved should report its previous owner
-// for the cooling-off window (so a route-by-key reader can consult it), while a key
-// whose ownership did not move reports none.
+// A moved key reports its previous owner within the cooling-off window; an unmoved
+// key reports none.
 func TestLockClientPriorOwnerForKey(t *testing.T) {
 	lc := NewLockClient(nil, "seed:8888")
 
 	setA := []pb.ServerAddress{"filer-a:8888", "filer-b:8888", "filer-c:8888"}
 	lc.SetRing(setA, 1)
-	// Only one ring so far: nothing to fall back to.
+	// One ring: nothing to fall back to.
 	if got := lc.PriorOwnerForKey("any"); got != "" {
 		t.Fatalf("single ring should have no prior owner, got %q", got)
 	}

--- a/weed/cluster/lock_client_test.go
+++ b/weed/cluster/lock_client_test.go
@@ -1,7 +1,9 @@
 package cluster
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/cluster/lock_manager"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -88,5 +90,64 @@ func TestLockClientPrimaryForKey(t *testing.T) {
 	}
 	if got != lc.hostForKey("k") {
 		t.Errorf("PrimaryForKey %q disagrees with hostForKey %q", got, lc.hostForKey("k"))
+	}
+}
+
+// During a rebalance, a key whose ownership moved should report its previous owner
+// for the cooling-off window (so a route-by-key reader can consult it), while a key
+// whose ownership did not move reports none.
+func TestLockClientPriorOwnerForKey(t *testing.T) {
+	lc := NewLockClient(nil, "seed:8888")
+
+	setA := []pb.ServerAddress{"filer-a:8888", "filer-b:8888", "filer-c:8888"}
+	lc.SetRing(setA, 1)
+	// Only one ring so far: nothing to fall back to.
+	if got := lc.PriorOwnerForKey("any"); got != "" {
+		t.Fatalf("single ring should have no prior owner, got %q", got)
+	}
+
+	priorRing := lock_manager.NewHashRing(lock_manager.DefaultVnodeCount)
+	priorRing.SetServers(setA)
+
+	// Add a server so some keys' ownership moves.
+	setB := []pb.ServerAddress{"filer-a:8888", "filer-b:8888", "filer-c:8888", "filer-d:8888"}
+	lc.SetRing(setB, 2)
+
+	var moved, stable string
+	for i := 0; i < 2000 && (moved == "" || stable == ""); i++ {
+		key := fmt.Sprintf("key-%d", i)
+		if lc.PrimaryForKey(key) != priorRing.GetPrimary(key) {
+			if moved == "" {
+				moved = key
+			}
+		} else if stable == "" {
+			stable = key
+		}
+	}
+	if moved == "" || stable == "" {
+		t.Skip("could not find both a moved and a stable key")
+	}
+
+	if got, want := lc.PriorOwnerForKey(moved), priorRing.GetPrimary(moved); got != want {
+		t.Fatalf("PriorOwnerForKey(moved)=%q, want %q", got, want)
+	}
+	if got := lc.PriorOwnerForKey(stable); got != "" {
+		t.Fatalf("unmoved key should have no prior owner, got %q", got)
+	}
+}
+
+// The prior owner is only offered within the cooling-off window.
+func TestLockClientPriorOwnerForKeyExpires(t *testing.T) {
+	lc := NewLockClient(nil, "seed:8888")
+	lc.priorWindow = 20 * time.Millisecond
+
+	lc.SetRing([]pb.ServerAddress{"filer-a:8888", "filer-b:8888", "filer-c:8888"}, 1)
+	lc.SetRing([]pb.ServerAddress{"filer-a:8888", "filer-b:8888", "filer-c:8888", "filer-d:8888"}, 2)
+
+	time.Sleep(40 * time.Millisecond)
+	for i := 0; i < 2000; i++ {
+		if got := lc.PriorOwnerForKey(fmt.Sprintf("key-%d", i)); got != "" {
+			t.Fatalf("prior owner should expire after the cooling window, got %q", got)
+		}
 	}
 }

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -20,7 +20,7 @@ var _ = filer_pb.FilerClient(&S3ApiServer{})
 func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	// Use filerClient for proper connection management and failover
 	if s3a.filerClient != nil {
-		return s3a.withFilerClientFailover(streamingMode, fn)
+		return s3a.withFilerClientFailover("", streamingMode, fn)
 	}
 
 	// Fallback to direct connection if filerClient not initialized
@@ -32,69 +32,74 @@ func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.Sea
 
 }
 
-// withFilerClientFailover attempts to execute fn with automatic failover to other filers
-func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
-	// Get current filer as starting point
+// withFilerClientFailover runs fn against an ordered set of filers, failing over
+// only on transport errors. A NotFound from a reached filer is authoritative: it
+// stops failover, so an absent entry is never re-asked elsewhere (no fan-out, and
+// no resurrecting a peer's not-yet-replicated tombstone).
+//
+// Order: preferred (if set), then the gateway's current filer, then the rest.
+// preferred lets a caller route a read to a key's ring owner — where routed writes
+// land — for read-after-write across gateways. It may be a group filer outside the
+// static -filer list; the health and current-filer bookkeeping no-op for untracked
+// addresses. A successful failover updates the current filer for later requests, but
+// a successful preferred read does not (its owner is per-key, not a new default).
+func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	currentFiler := s3a.filerClient.GetCurrentFiler()
 
-	// Try current filer first (fast path)
-	err := pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
-		client := filer_pb.NewSeaweedFilerClient(grpcConnection)
-		return fn(client)
-	}, currentFiler.ToGrpcAddress(), false, s3a.option.GrpcDialOption)
-
-	if err == nil {
-		s3a.filerClient.RecordFilerSuccess(currentFiler)
-		return nil
-	}
-
-	// A reachable filer answering ErrNotFound is authoritative; failover is for
-	// unreachable/unhealthy filers, not for re-asking about an absent entry.
-	if errors.Is(err, filer_pb.ErrNotFound) {
-		return err
-	}
-
-	s3a.filerClient.RecordFilerFailure(currentFiler)
-
-	// Current filer failed - try all other filers with health-aware selection
-	filers := s3a.filerClient.GetAllFilers()
-	var lastErr error = err
-
-	for _, filer := range filers {
-		if filer == currentFiler {
-			continue // Already tried this one
+	// Build an ordered, de-duplicated candidate list.
+	candidates := make([]pb.ServerAddress, 0, 2+len(s3a.option.Filers))
+	seen := make(map[pb.ServerAddress]bool)
+	addCandidate := func(filer pb.ServerAddress) {
+		if filer == "" || seen[filer] {
+			return
 		}
+		seen[filer] = true
+		candidates = append(candidates, filer)
+	}
+	addCandidate(preferred)
+	addCandidate(currentFiler)
+	for _, filer := range s3a.filerClient.GetAllFilers() {
+		addCandidate(filer)
+	}
 
-		// Skip filers known to be unhealthy (circuit breaker pattern)
-		if s3a.filerClient.ShouldSkipUnhealthyFiler(filer) {
+	var lastErr error
+	for i, filer := range candidates {
+		// Always attempt the first candidate so a request makes progress even when
+		// every filer is flagged unhealthy; skip flagged ones only when failing over.
+		if i > 0 && s3a.filerClient.ShouldSkipUnhealthyFiler(filer) {
 			glog.V(2).Infof("WithFilerClient: skipping unhealthy filer %s", filer)
 			continue
 		}
 
-		err = pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
-			client := filer_pb.NewSeaweedFilerClient(grpcConnection)
-			return fn(client)
+		err := pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
+			return fn(filer_pb.NewSeaweedFilerClient(grpcConnection))
 		}, filer.ToGrpcAddress(), false, s3a.option.GrpcDialOption)
 
 		if err == nil {
-			// Success! Record success and update current filer for future requests
 			s3a.filerClient.RecordFilerSuccess(filer)
-			s3a.filerClient.SetCurrentFiler(filer)
-			glog.V(1).Infof("WithFilerClient: failover from %s to %s succeeded", currentFiler, filer)
+			// Prefer a healthy filer we failed over to for future requests, but don't
+			// let a per-key preferred owner become the gateway's default.
+			if filer != currentFiler && filer != preferred {
+				s3a.filerClient.SetCurrentFiler(filer)
+				glog.V(1).Infof("WithFilerClient: failover from %s to %s succeeded", currentFiler, filer)
+			}
 			return nil
 		}
 
-		// Authoritative not-found - stop failing over.
+		// A reachable filer answering ErrNotFound is authoritative; failover is for
+		// unreachable/unhealthy filers, not for re-asking about an absent entry.
 		if errors.Is(err, filer_pb.ErrNotFound) {
 			return err
 		}
 
 		s3a.filerClient.RecordFilerFailure(filer)
-		glog.V(2).Infof("WithFilerClient: failover to %s failed: %v", filer, err)
+		glog.V(2).Infof("WithFilerClient: filer %s failed: %v", filer, err)
 		lastErr = err
 	}
 
-	// All filers failed
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no filer available")
+	}
 	return fmt.Errorf("all filers failed, last error: %w", lastErr)
 }
 

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -32,9 +32,10 @@ func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.Sea
 
 }
 
-// withFilerClientFailover runs fn against preferred (if set), then the current
-// filer, then the rest, trying healthy filers before unhealthy ones. Failover is
-// for transport errors only: a reached filer's ErrNotFound is authoritative (no
+// withFilerClientFailover runs fn against preferred (if set) first, then the
+// remaining filers (current, then the rest) with healthy ones before unhealthy.
+// Failover is for transport errors only: a reached filer's ErrNotFound is
+// authoritative (no
 // fan-out, no resurrecting a peer's not-yet-replicated tombstone). preferred lets a
 // caller route to a key's ring owner for read-after-write; it may be a filer outside
 // the static list (the bookkeeping no-ops for untracked addresses). A failover
@@ -57,19 +58,30 @@ func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, stre
 		addCandidate(filer)
 	}
 
-	// Healthy filers first (keeping their priority), unhealthy ones only as a last
-	// resort so a request still progresses when all are flagged.
+	// An explicit preferred owner is tried first even if health-flagged: demoting it
+	// behind a healthy replica would let that replica's authoritative NotFound mask a
+	// write that has only reached the owner. Health-order the rest, unhealthy ones
+	// last so a request still progresses when all are flagged.
 	var healthy, unhealthy []pb.ServerAddress
 	for _, filer := range candidates {
+		if filer == preferred {
+			continue
+		}
 		if s3a.filerClient.ShouldSkipUnhealthyFiler(filer) {
 			unhealthy = append(unhealthy, filer)
 		} else {
 			healthy = append(healthy, filer)
 		}
 	}
+	ordered := make([]pb.ServerAddress, 0, len(candidates))
+	if preferred != "" {
+		ordered = append(ordered, preferred)
+	}
+	ordered = append(ordered, healthy...)
+	ordered = append(ordered, unhealthy...)
 
 	var lastErr error
-	for _, filer := range append(healthy, unhealthy...) {
+	for _, filer := range ordered {
 		err := pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
 			return fn(filer_pb.NewSeaweedFilerClient(grpcConnection))
 		}, filer.ToGrpcAddress(), false, s3a.option.GrpcDialOption)

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -32,21 +32,16 @@ func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.Sea
 
 }
 
-// withFilerClientFailover runs fn against an ordered set of filers, failing over
-// only on transport errors. A NotFound from a reached filer is authoritative: it
-// stops failover, so an absent entry is never re-asked elsewhere (no fan-out, and
-// no resurrecting a peer's not-yet-replicated tombstone).
-//
-// Order: preferred (if set), then the gateway's current filer, then the rest.
-// preferred lets a caller route a read to a key's ring owner — where routed writes
-// land — for read-after-write across gateways. It may be a group filer outside the
-// static -filer list; the health and current-filer bookkeeping no-op for untracked
-// addresses. A successful failover updates the current filer for later requests, but
-// a successful preferred read does not (its owner is per-key, not a new default).
+// withFilerClientFailover runs fn against preferred (if set), then the current
+// filer, then the rest, trying healthy filers before unhealthy ones. Failover is
+// for transport errors only: a reached filer's ErrNotFound is authoritative (no
+// fan-out, no resurrecting a peer's not-yet-replicated tombstone). preferred lets a
+// caller route to a key's ring owner for read-after-write; it may be a filer outside
+// the static list (the bookkeeping no-ops for untracked addresses). A failover
+// updates the current filer; a preferred read does not, as its owner is per-key.
 func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	currentFiler := s3a.filerClient.GetCurrentFiler()
 
-	// Build an ordered, de-duplicated candidate list.
 	candidates := make([]pb.ServerAddress, 0, 2+len(s3a.option.Filers))
 	seen := make(map[pb.ServerAddress]bool)
 	addCandidate := func(filer pb.ServerAddress) {
@@ -62,32 +57,31 @@ func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, stre
 		addCandidate(filer)
 	}
 
-	var lastErr error
-	for i, filer := range candidates {
-		// Always attempt the first candidate so a request makes progress even when
-		// every filer is flagged unhealthy; skip flagged ones only when failing over.
-		if i > 0 && s3a.filerClient.ShouldSkipUnhealthyFiler(filer) {
-			glog.V(2).Infof("WithFilerClient: skipping unhealthy filer %s", filer)
-			continue
+	// Healthy filers first (keeping their priority), unhealthy ones only as a last
+	// resort so a request still progresses when all are flagged.
+	var healthy, unhealthy []pb.ServerAddress
+	for _, filer := range candidates {
+		if s3a.filerClient.ShouldSkipUnhealthyFiler(filer) {
+			unhealthy = append(unhealthy, filer)
+		} else {
+			healthy = append(healthy, filer)
 		}
+	}
 
+	var lastErr error
+	for _, filer := range append(healthy, unhealthy...) {
 		err := pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
 			return fn(filer_pb.NewSeaweedFilerClient(grpcConnection))
 		}, filer.ToGrpcAddress(), false, s3a.option.GrpcDialOption)
 
 		if err == nil {
 			s3a.filerClient.RecordFilerSuccess(filer)
-			// Prefer a healthy filer we failed over to for future requests, but don't
-			// let a per-key preferred owner become the gateway's default.
 			if filer != currentFiler && filer != preferred {
 				s3a.filerClient.SetCurrentFiler(filer)
 				glog.V(1).Infof("WithFilerClient: failover from %s to %s succeeded", currentFiler, filer)
 			}
 			return nil
 		}
-
-		// A reachable filer answering ErrNotFound is authoritative; failover is for
-		// unreachable/unhealthy filers, not for re-asking about an absent entry.
 		if errors.Is(err, filer_pb.ErrNotFound) {
 			return err
 		}

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -87,6 +87,11 @@ func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, stre
 		}
 
 		s3a.filerClient.RecordFilerFailure(filer)
+		// A preferred owner is often outside the static filer list, where the health
+		// tracking above no-ops; flag it so route-by-key reads skip it briefly.
+		if filer == preferred {
+			s3a.markOwnerUnreachable(filer)
+		}
 		glog.V(2).Infof("WithFilerClient: filer %s failed: %v", filer, err)
 		lastErr = err
 	}

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -2408,8 +2408,7 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 // fetchObjectEntry fetches the filer entry for an object
 // Returns nil if not found (not an error), or propagates other errors
 func (s3a *S3ApiServer) fetchObjectEntry(bucket, object string) (*filer_pb.Entry, error) {
-	objectPath := fmt.Sprintf("%s/%s", s3a.bucketDir(bucket), object)
-	fetchedEntry, fetchErr := s3a.getEntry("", objectPath)
+	fetchedEntry, fetchErr := s3a.getObjectEntryRoutedByKey(bucket, object)
 	if fetchErr != nil {
 		if errors.Is(fetchErr, filer_pb.ErrNotFound) {
 			return nil, nil // Not found is not an error for SSE check
@@ -2422,8 +2421,7 @@ func (s3a *S3ApiServer) fetchObjectEntry(bucket, object string) (*filer_pb.Entry
 // fetchObjectEntryRequired fetches the filer entry for an object
 // Returns an error if the object is not found or any other error occurs
 func (s3a *S3ApiServer) fetchObjectEntryRequired(bucket, object string) (*filer_pb.Entry, error) {
-	objectPath := fmt.Sprintf("%s/%s", s3a.bucketDir(bucket), object)
-	fetchedEntry, fetchErr := s3a.getEntry("", objectPath)
+	fetchedEntry, fetchErr := s3a.getObjectEntryRoutedByKey(bucket, object)
 	if fetchErr != nil {
 		return nil, fetchErr // Return error for both not-found and other errors
 	}

--- a/weed/s3api/s3api_object_routed_read.go
+++ b/weed/s3api/s3api_object_routed_read.go
@@ -2,7 +2,9 @@ package s3api
 
 import (
 	"context"
+	"errors"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
@@ -19,6 +21,12 @@ import (
 // an object created via the non-routed lock path on another filer can briefly read
 // as absent until it replicates to the owner.
 //
+// During a rebalance the new owner may not have replicated a just-moved key yet, so
+// on the owner's NotFound — and only while the ring change is within the cooling-off
+// window — it consults the key's previous owner once. That trades the transient
+// scale-up 404 for a transient stale read if a delete routed to the new owner races
+// the same window.
+//
 // When no owner is resolvable (single filer, lock client unavailable) it behaves
 // exactly like getEntry.
 func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer_pb.Entry, error) {
@@ -32,6 +40,42 @@ func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer
 	dir, name := fullPath.DirAndName()
 	var entry *filer_pb.Entry
 	err := s3a.withFilerClientFailover(owner, false, func(client filer_pb.SeaweedFilerClient) error {
+		resp, lookupErr := filer_pb.LookupEntry(context.Background(), client, &filer_pb.LookupDirectoryEntryRequest{
+			Directory: dir,
+			Name:      name,
+		})
+		if lookupErr != nil {
+			return lookupErr
+		}
+		entry = resp.Entry
+		return nil
+	})
+
+	if errors.Is(err, filer_pb.ErrNotFound) {
+		if prior := s3a.priorWriteOwner(bucket, object); prior != "" && prior != owner {
+			if priorEntry, priorErr := s3a.lookupEntryOnFiler(prior, dir, name); priorErr == nil {
+				return priorEntry, nil
+			}
+		}
+	}
+	return entry, err
+}
+
+// priorWriteOwner returns the object key's previous ring owner during the
+// cooling-off window after a rebalance, or "" outside it. See
+// LockClient.PriorOwnerForKey.
+func (s3a *S3ApiServer) priorWriteOwner(bucket, object string) pb.ServerAddress {
+	if object == "" || s3a.objectWriteLockClient == nil {
+		return ""
+	}
+	return s3a.objectWriteLockClient.PriorOwnerForKey(s3a.objectRouteKey(bucket, object))
+}
+
+// lookupEntryOnFiler resolves dir/name against a single filer, without failover —
+// a targeted probe used to consult a key's prior owner during a rebalance.
+func (s3a *S3ApiServer) lookupEntryOnFiler(filer pb.ServerAddress, dir, name string) (*filer_pb.Entry, error) {
+	var entry *filer_pb.Entry
+	err := pb.WithFilerClient(false, 0, filer, s3a.option.GrpcDialOption, func(client filer_pb.SeaweedFilerClient) error {
 		resp, lookupErr := filer_pb.LookupEntry(context.Background(), client, &filer_pb.LookupDirectoryEntryRequest{
 			Directory: dir,
 			Name:      name,

--- a/weed/s3api/s3api_object_routed_read.go
+++ b/weed/s3api/s3api_object_routed_read.go
@@ -1,0 +1,46 @@
+package s3api
+
+import (
+	"context"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// getObjectEntryRoutedByKey resolves an object's entry, preferring the filer that
+// owns the object's key on the write ring — where routed writes land — so a read
+// observes a just-written object without waiting for cross-filer metadata
+// replication. It reuses the same route key as the write path, so reader and writer
+// resolve the same owner.
+//
+// Failover to the gateway's filer set happens only on transport errors; a NotFound
+// from the owner is authoritative (no fan-out, no resurrecting a peer's
+// not-yet-replicated tombstone). The owner is the home of the routed-write path, so
+// an object created via the non-routed lock path on another filer can briefly read
+// as absent until it replicates to the owner.
+//
+// When no owner is resolvable (single filer, lock client unavailable) it behaves
+// exactly like getEntry.
+func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer_pb.Entry, error) {
+	fullPath := util.NewFullPath(s3a.bucketDir(bucket), object)
+
+	owner := s3a.routableWriteOwner(bucket, object)
+	if owner == "" || s3a.filerClient == nil {
+		return filer_pb.GetEntry(context.Background(), s3a, fullPath)
+	}
+
+	dir, name := fullPath.DirAndName()
+	var entry *filer_pb.Entry
+	err := s3a.withFilerClientFailover(owner, false, func(client filer_pb.SeaweedFilerClient) error {
+		resp, lookupErr := filer_pb.LookupEntry(context.Background(), client, &filer_pb.LookupDirectoryEntryRequest{
+			Directory: dir,
+			Name:      name,
+		})
+		if lookupErr != nil {
+			return lookupErr
+		}
+		entry = resp.Entry
+		return nil
+	})
+	return entry, err
+}

--- a/weed/s3api/s3api_object_routed_read.go
+++ b/weed/s3api/s3api_object_routed_read.go
@@ -3,11 +3,17 @@ package s3api
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
+
+// unreachableOwnerTTL is how long a route-by-key owner that just failed a read is
+// skipped before being retried — long enough to spare a dead owner per-request
+// dials, short enough to resume owner-first reads soon after it (or the ring) recovers.
+const unreachableOwnerTTL = 2 * time.Second
 
 // getObjectEntryRoutedByKey resolves an object's entry preferring the key's write
 // owner (the same route key the write path hashes), so a read sees a just-written
@@ -22,9 +28,16 @@ func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer
 		return filer_pb.GetEntry(context.Background(), s3a, fullPath)
 	}
 
+	// Skip an owner whose recent read hit a transport error; read local-first until
+	// it (or the ring) recovers, rather than re-dialing a dead owner every request.
+	preferred := owner
+	if s3a.ownerRecentlyUnreachable(owner) {
+		preferred = ""
+	}
+
 	dir, name := fullPath.DirAndName()
 	var entry *filer_pb.Entry
-	err := s3a.withFilerClientFailover(owner, false, func(client filer_pb.SeaweedFilerClient) error {
+	err := s3a.withFilerClientFailover(preferred, false, func(client filer_pb.SeaweedFilerClient) error {
 		resp, lookupErr := filer_pb.LookupEntry(context.Background(), client, &filer_pb.LookupDirectoryEntryRequest{
 			Directory: dir,
 			Name:      name,
@@ -53,6 +66,17 @@ func (s3a *S3ApiServer) priorWriteOwner(bucket, object string) pb.ServerAddress 
 		return ""
 	}
 	return s3a.objectWriteLockClient.PriorOwnerForKey(s3a.objectRouteKey(bucket, object))
+}
+
+func (s3a *S3ApiServer) markOwnerUnreachable(owner pb.ServerAddress) {
+	s3a.unreachableOwners.Store(owner, time.Now().Add(unreachableOwnerTTL))
+}
+
+func (s3a *S3ApiServer) ownerRecentlyUnreachable(owner pb.ServerAddress) bool {
+	if v, ok := s3a.unreachableOwners.Load(owner); ok {
+		return time.Now().Before(v.(time.Time))
+	}
+	return false
 }
 
 // lookupEntryOnFiler resolves dir/name against a single filer, without failover.

--- a/weed/s3api/s3api_object_routed_read.go
+++ b/weed/s3api/s3api_object_routed_read.go
@@ -9,26 +9,11 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-// getObjectEntryRoutedByKey resolves an object's entry, preferring the filer that
-// owns the object's key on the write ring — where routed writes land — so a read
-// observes a just-written object without waiting for cross-filer metadata
-// replication. It reuses the same route key as the write path, so reader and writer
-// resolve the same owner.
-//
-// Failover to the gateway's filer set happens only on transport errors; a NotFound
-// from the owner is authoritative (no fan-out, no resurrecting a peer's
-// not-yet-replicated tombstone). The owner is the home of the routed-write path, so
-// an object created via the non-routed lock path on another filer can briefly read
-// as absent until it replicates to the owner.
-//
-// During a rebalance the new owner may not have replicated a just-moved key yet, so
-// on the owner's NotFound — and only while the ring change is within the cooling-off
-// window — it consults the key's previous owner once. That trades the transient
-// scale-up 404 for a transient stale read if a delete routed to the new owner races
-// the same window.
-//
-// When no owner is resolvable (single filer, lock client unavailable) it behaves
-// exactly like getEntry.
+// getObjectEntryRoutedByKey resolves an object's entry preferring the key's write
+// owner (the same route key the write path hashes), so a read sees a just-written
+// object without waiting for cross-filer replication. On the owner's ErrNotFound it
+// probes the key's prior owner once during a rebalance window; falls back to
+// getEntry when no owner is resolvable.
 func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer_pb.Entry, error) {
 	fullPath := util.NewFullPath(s3a.bucketDir(bucket), object)
 
@@ -51,6 +36,8 @@ func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer
 		return nil
 	})
 
+	// A just-moved key may not have replicated to the new owner yet; consult its
+	// prior owner once while the ring change is within the cooling-off window.
 	if errors.Is(err, filer_pb.ErrNotFound) {
 		if prior := s3a.priorWriteOwner(bucket, object); prior != "" && prior != owner {
 			if priorEntry, priorErr := s3a.lookupEntryOnFiler(prior, dir, name); priorErr == nil {
@@ -61,9 +48,6 @@ func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer
 	return entry, err
 }
 
-// priorWriteOwner returns the object key's previous ring owner during the
-// cooling-off window after a rebalance, or "" outside it. See
-// LockClient.PriorOwnerForKey.
 func (s3a *S3ApiServer) priorWriteOwner(bucket, object string) pb.ServerAddress {
 	if object == "" || s3a.objectWriteLockClient == nil {
 		return ""
@@ -71,8 +55,7 @@ func (s3a *S3ApiServer) priorWriteOwner(bucket, object string) pb.ServerAddress 
 	return s3a.objectWriteLockClient.PriorOwnerForKey(s3a.objectRouteKey(bucket, object))
 }
 
-// lookupEntryOnFiler resolves dir/name against a single filer, without failover —
-// a targeted probe used to consult a key's prior owner during a rebalance.
+// lookupEntryOnFiler resolves dir/name against a single filer, without failover.
 func (s3a *S3ApiServer) lookupEntryOnFiler(filer pb.ServerAddress, dir, name string) (*filer_pb.Entry, error) {
 	var entry *filer_pb.Entry
 	err := pb.WithFilerClient(false, 0, filer, s3a.option.GrpcDialOption, func(client filer_pb.SeaweedFilerClient) error {

--- a/weed/s3api/s3api_object_routed_read_test.go
+++ b/weed/s3api/s3api_object_routed_read_test.go
@@ -1,0 +1,24 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+)
+
+// A flagged owner reads back as recently unreachable; an unflagged one does not.
+func TestOwnerRecentlyUnreachable(t *testing.T) {
+	s3a := &S3ApiServer{}
+	owner := pb.ServerAddress("127.0.0.1:8888.18888")
+
+	if s3a.ownerRecentlyUnreachable(owner) {
+		t.Fatal("unmarked owner should not be flagged")
+	}
+	s3a.markOwnerUnreachable(owner)
+	if !s3a.ownerRecentlyUnreachable(owner) {
+		t.Fatal("marked owner should be flagged within the TTL")
+	}
+	if s3a.ownerRecentlyUnreachable(pb.ServerAddress("127.0.0.1:9999.19999")) {
+		t.Fatal("a different owner should not be flagged")
+	}
+}

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -98,6 +98,12 @@ type S3ApiServer struct {
 	newObjectWriteLock    func(bucket, object string) objectWriteLock
 	// objectWriteLockClient resolves a key's owner filer for route-by-key.
 	objectWriteLockClient *cluster.LockClient
+	// unreachableOwners holds owners (pb.ServerAddress -> expiry time.Time) whose
+	// last owner-first read hit a transport error, so route-by-key reads briefly
+	// skip them instead of re-dialing a dead owner every request until the ring
+	// drops it. Bypasses the gateway's filer health tracking, which no-ops for an
+	// owner outside the static -filer list.
+	unreachableOwners sync.Map
 	// Shared ReaderCache used by the S3 GET streaming path. It lives for the
 	// lifetime of the server so that concurrent and repeat reads share a
 	// single in-flight download per chunk, and so that no per-request


### PR DESCRIPTION
## Problem

S3 writes already route by key to the owner filer on the lock ring, where the entry is created. Reads, though, go to the gateway's local filer and treat its `NotFound` as authoritative (no failover on `NotFound`). So a `GET`/`HEAD` on one gateway can miss an object another gateway has just written, until the filers' `MetaAggregator` metadata replication catches up. This is the root cause behind the intermittent `404 NoSuchKey` in the `S3 Distributed Lock Regression Tests` job: the routed conditional `PUT` lands on the owner filer, but the read-back through the other gateway hits its local filer and races replication.

## Change

Resolve an object's entry from the key's **owner filer first** (the same route key the write path uses, so reader and writer agree on the owner), and fail over to the gateway's filer set **only on transport errors**.

- An owner `NotFound` stays authoritative: no fan-out across filers, and no resurrecting a peer's not-yet-replicated tombstone. A delete routed to the owner is visible immediately, and a genuine miss costs one lookup.
- Keys owned by the gateway's local filer are unchanged (the candidate list de-dups, so it's the current local fast path).
- A successful owner read does not move the gateway's sticky current filer (the owner is per-key, not a new default); a genuine failover still does.

`withFilerClientFailover` now takes a preferred start filer. The object-entry read fetchers (`fetchObjectEntry`, `fetchObjectEntryRequired` — covering `GET`, `HEAD`, `GetObjectAttributes`, ACL, and retention reads) pass the owner; every other caller passes `""` and keeps the existing current-filer behavior.

## Behavior during a cluster transition (ring churn)

The ring is versioned and monotonic — both the gateway's `LockClient.SetRing` and the master's `LockRing.SetSnapshot` reject stale/reordered updates. Before any ring arrives, `PrimaryForKey` returns `""` and reads fall back to plain local-first `getEntry`, so a starting gateway is unchanged.

- **Filer leaves / crashes:** a still-stale owner resolves to the dead filer → transport error → failover to a surviving filer (all carry eventually-consistent full copies). Availability preserved.
- **Stale ring / gateway version skew:** degrades to the eventual-consistency window reads already had; lock-path forwarding still guarantees exactly-one-winner for concurrent writes, so only read freshness softens.
- **Filer joins (ownership shifts to a not-yet-synced new owner):** the new owner can `NotFound` a just-moved key. To avoid a transient scale-up 404, the gateway `LockClient` now retains the previous ring for a cooling-off window (`PriorOwnerForKey`, mirroring the master's `LockRing.PriorOwner`); on the owner's `NotFound` it probes the key's **previous owner** once before treating the miss as final. Scoped to keys whose ownership actually moved and only within the window, so steady-state reads are untouched. This trades the transient 404 for a transient stale read if a delete routed to the new owner races the same window — the same authoritative-NotFound tradeoff, narrowed to the rebalance.

Invariant across all transitions: every filer a read can land on holds an eventually-consistent full copy, so the worst case is a transient, self-healing miss — never a hard failure, lost write, or stale-data-as-truth.

## Scope and trade-offs

- Single-object entry reads only. `LIST` spans many keys with different owners and can't be routed to one owner, so it stays eventually consistent.
- The shared `resolveObjectEntry` (used by write/delete preconditions, where the lock-path write lands on the local filer) is intentionally left local-first, so a precondition read can't diverge from where its write applies.
- Residual window: objects written through the non-routed lock path land on a gateway's local filer, so they can still read as absent on the owner until they replicate. This is the eventual-consistency tail shrunk to the minority of writes that bypass the owner.

## Testing

- `go test ./weed/s3api/` and `go test ./weed/cluster/...` pass; new `LockClient.PriorOwnerForKey` unit tests (move + expiry) cover the cooling-off window.
- `TestConditionalPutIfNoneMatchDistributedLockAcrossS3Gateways` (the previously flaky job) now passes deterministically — the cross-gateway read-back resolves on the owner without waiting for replication. Ran the cross-filer read path 5x with an immediate (non-retried) read; green every time. No test change was needed: the fix removes the race at its root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 failover: prefers a routed owner, orders healthy candidates first, treats authoritative "not found" as terminal, records per-filer successes/failures, and returns clearer final errors.

* **Performance**
  * Faster and more accurate object metadata resolution by routing reads to the appropriate filer owner.

* **New Features**
  * Route-by-key reads can probe a prior owner during rebalances and temporarily skip recently-unreachable owners.

* **Tests**
  * Added tests for prior-owner reporting, expiry, and owner-reachability TTL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->