### PR TITLE
s3: defer a recently-unreachable owner that is also the current filer

### DIFF
--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -58,16 +58,16 @@ func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, stre
 		addCandidate(filer)
 	}
 
-	// An explicit preferred owner is tried first even if health-flagged: demoting it
-	// behind a healthy replica would let that replica's authoritative NotFound mask a
-	// write that has only reached the owner. Health-order the rest, unhealthy ones
-	// last so a request still progresses when all are flagged.
+	// preferred (the routed owner) is tried first even when health-flagged, so a
+	// replica's authoritative NotFound can't mask a write that only reached the owner.
+	// A recently-unreachable filer counts as unhealthy, deferring a dead owner that is
+	// also the current filer to the tail rather than dialing it before healthy replicas.
 	var healthy, unhealthy []pb.ServerAddress
 	for _, filer := range candidates {
 		if filer == preferred {
 			continue
 		}
-		if s3a.filerClient.ShouldSkipUnhealthyFiler(filer) {
+		if s3a.filerClient.ShouldSkipUnhealthyFiler(filer) || s3a.ownerRecentlyUnreachable(filer) {
 			unhealthy = append(unhealthy, filer)
 		} else {
 			healthy = append(healthy, filer)


### PR DESCRIPTION
Follow-up to #9806, addressing a review comment that landed after it merged.

## Problem

Owner-first reads skip a recently-unreachable owner by blanking `preferred` in `getObjectEntryRoutedByKey`. But that only removes the owner from the *preferred* slot — `withFilerClientFailover` always re-adds the gateway's current filer to the candidate list. So when the key's owner **is** the gateway's current filer, the flagged owner stayed in the list and got dialed anyway, defeating the dead-owner skip (and a healthy replica's authoritative `NotFound` could be accepted ahead of it).

## Change

Treat a recently-unreachable filer (`ownerRecentlyUnreachable`) as unhealthy in the failover health partition, alongside `ShouldSkipUnhealthyFiler`. A flagged owner re-added as the current filer is then deferred to the last-resort tail instead of tried before healthy replicas.

- `preferred` is still pulled out and tried first, so a live, non-flagged owner is unaffected (read-after-write preserved).
- The read path still blanks `preferred` for a flagged owner, so the flagged owner is never the first attempt; this change handles the case where it re-enters as the current filer.
- Deferring to the tail (rather than hard-excluding) keeps last-resort progress: if every healthy replica is also down, the owner — which may have recovered within the window — is still tried.

When the owner is flagged and skipped, its keys read local-first and may see a replica's `NotFound` until the owner (or the ring) recovers — the intended eventual-consistency tradeoff of the dead-owner circuit breaker, bounded by the short TTL.

## Testing

- `go build ./weed/...`, `gofmt`, `go test ./weed/s3api/` pass.
- The `distributed_lock` integration test passes (steady state: owners are never flagged, so unaffected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved failover candidate ordering to ensure a preferred candidate is tried first even if flagged unhealthy.
  * Adjusted handling for recently-unreachable nodes when building the dial list.
  * Clarified in-line documentation and made minor formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->