### PR TITLE
fix(s3api): use request context for listing

### DIFF
--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -311,7 +311,9 @@ func InvalidateGrpcConnection(address string) {
 
 // grpcMarshalErrorPrefix is the library-owned prefix gRPC prepends to every
 // client-side proto marshal failure; see grpc-go rpc_util.go encode():
-//   status.Errorf(codes.Internal, "grpc: error while marshaling: %v", ...)
+//
+//	status.Errorf(codes.Internal, "grpc: error while marshaling: %v", ...)
+//
 // The "grpc:" token is reserved for gRPC internal diagnostics and will not
 // collide with user-produced Internal statuses.
 const grpcMarshalErrorPrefix = "grpc: error while marshaling"
@@ -352,9 +354,39 @@ func isClientSideMarshalError(err error) bool {
 	return s.Code() == codes.Internal && strings.HasPrefix(s.Message(), grpcMarshalErrorPrefix)
 }
 
+type noConnectionInvalidationError struct {
+	err error
+}
+
+func (e noConnectionInvalidationError) Error() string {
+	return e.err.Error()
+}
+
+func (e noConnectionInvalidationError) Unwrap() error {
+	return e.err
+}
+
+// WithoutConnectionInvalidation marks a per-request callback error so it does
+// not poison a shared cached ClientConn.
+func WithoutConnectionInvalidation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return noConnectionInvalidationError{err: err}
+}
+
+func shouldSkipConnectionInvalidation(err error) bool {
+	var noInvalidate noConnectionInvalidationError
+	return errors.As(err, &noInvalidate)
+}
+
 // shouldInvalidateConnection checks if an error indicates the cached connection should be invalidated
 func shouldInvalidateConnection(err error) bool {
 	if err == nil {
+		return false
+	}
+
+	if shouldSkipConnectionInvalidation(err) {
 		return false
 	}
 
@@ -423,7 +455,7 @@ func WithGrpcClient(streamingMode bool, signature int32, fn func(*grpc.ClientCon
 	}
 	defer grpcConnection.Close()
 	executionErr := fn(grpcConnection)
-	if executionErr != nil {
+	if executionErr != nil && !shouldSkipConnectionInvalidation(executionErr) {
 		// The streaming channel is dedicated to this caller, but unrelated
 		// request-path callers share a cached non-streaming ClientConn to the
 		// same peer. When the stream fails, drop that cached channel so the

--- a/weed/pb/grpc_client_server_test.go
+++ b/weed/pb/grpc_client_server_test.go
@@ -30,6 +30,23 @@ func TestShouldInvalidateConnection_MarshalErrorIsPerRequest(t *testing.T) {
 	}
 }
 
+func TestShouldInvalidateConnection_NoInvalidateWrapper(t *testing.T) {
+	canceledErr := status.Error(codes.Canceled, "caller request canceled")
+	wrapped := WithoutConnectionInvalidation(canceledErr)
+
+	if status.Code(wrapped) != codes.Canceled {
+		t.Fatalf("wrapped error status code = %v, want %v", status.Code(wrapped), codes.Canceled)
+	}
+	if shouldInvalidateConnection(wrapped) {
+		t.Fatalf("caller request cancellation must not invalidate the shared connection")
+	}
+
+	deadlineErr := status.Error(codes.DeadlineExceeded, "caller request timed out")
+	if shouldInvalidateConnection(WithoutConnectionInvalidation(deadlineErr)) {
+		t.Fatalf("caller request deadline must not invalidate the shared connection")
+	}
+}
+
 // TestShouldInvalidateConnection_GenuineInternalStillInvalidates ensures the
 // marshal-error carve-out does not swallow real server-side Internal errors,
 // which previously caused — and should continue to cause — connection

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -17,34 +18,39 @@ import (
 var _ = filer_pb.FilerClient(&S3ApiServer{})
 
 func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+	return s3a.WithFilerClientContext(context.Background(), streamingMode, fn)
+}
+
+func (s3a *S3ApiServer) WithFilerClientContext(ctx context.Context, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	// Use filerClient for proper connection management and failover
 	if s3a.filerClient != nil {
-		return s3a.withFilerClientFailover(streamingMode, fn)
+		return s3a.withFilerClientFailover(ctx, streamingMode, fn)
 	}
 
 	// Fallback to direct connection if filerClient not initialized
 	// This should only happen during initialization or testing
-	return pb.WithGrpcClient(streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
-		client := filer_pb.NewSeaweedFilerClient(grpcConnection)
-		return fn(client)
-	}, s3a.getFilerAddress().ToGrpcAddress(), false, s3a.option.GrpcDialOption)
-
+	return s3a.withGrpcFilerClient(ctx, streamingMode, s3a.getFilerAddress().ToGrpcAddress(), fn)
 }
 
 // withFilerClientFailover attempts to execute fn with automatic failover to other filers
-func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+func (s3a *S3ApiServer) withFilerClientFailover(ctx context.Context, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	// Get current filer as starting point
 	currentFiler := s3a.filerClient.GetCurrentFiler()
 
 	// Try current filer first (fast path)
-	err := pb.WithGrpcClient(streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
-		client := filer_pb.NewSeaweedFilerClient(grpcConnection)
-		return fn(client)
-	}, currentFiler.ToGrpcAddress(), false, s3a.option.GrpcDialOption)
+	err := s3a.withGrpcFilerClient(ctx, streamingMode, currentFiler.ToGrpcAddress(), fn)
 
 	if err == nil {
 		s3a.filerClient.RecordFilerSuccess(currentFiler)
 		return nil
+	}
+
+	if shouldStopFilerFailover(ctx, err) {
+		return err
 	}
 
 	// A reachable filer answering ErrNotFound is authoritative; failover is for
@@ -70,10 +76,7 @@ func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(file
 			continue
 		}
 
-		err = pb.WithGrpcClient(streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
-			client := filer_pb.NewSeaweedFilerClient(grpcConnection)
-			return fn(client)
-		}, filer.ToGrpcAddress(), false, s3a.option.GrpcDialOption)
+		err = s3a.withGrpcFilerClient(ctx, streamingMode, filer.ToGrpcAddress(), fn)
 
 		if err == nil {
 			// Success! Record success and update current filer for future requests
@@ -81,6 +84,10 @@ func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(file
 			s3a.filerClient.SetCurrentFiler(filer)
 			glog.V(1).Infof("WithFilerClient: failover from %s to %s succeeded", currentFiler, filer)
 			return nil
+		}
+
+		if shouldStopFilerFailover(ctx, err) {
+			return err
 		}
 
 		// Authoritative not-found - stop failing over.
@@ -95,6 +102,20 @@ func (s3a *S3ApiServer) withFilerClientFailover(streamingMode bool, fn func(file
 
 	// All filers failed
 	return fmt.Errorf("all filers failed, last error: %w", lastErr)
+}
+
+func (s3a *S3ApiServer) withGrpcFilerClient(ctx context.Context, streamingMode bool, address string, fn func(filer_pb.SeaweedFilerClient) error) error {
+	return pb.WithGrpcClient(streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
+		err := fn(filer_pb.NewSeaweedFilerClient(grpcConnection))
+		if shouldStopFilerFailover(ctx, err) {
+			return pb.WithoutConnectionInvalidation(err)
+		}
+		return err
+	}, address, false, s3a.option.GrpcDialOption)
+}
+
+func shouldStopFilerFailover(ctx context.Context, err error) bool {
+	return err != nil && ctx.Err() != nil && isRequestDoneError(err)
 }
 
 func (s3a *S3ApiServer) AdjustedUrl(location *filer_pb.Location) string {

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -254,6 +254,10 @@ func isCanceledStreamingError(err error) bool {
 	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
 }
 
+func isRequestDoneError(err error) bool {
+	return isCanceledStreamingError(err) || errors.Is(err, context.DeadlineExceeded) || status.Code(err) == codes.DeadlineExceeded
+}
+
 func shouldWriteStreamingErrorResponse(err error) bool {
 	return err != nil && !isCanceledStreamingError(err)
 }
@@ -332,15 +336,16 @@ func (s3a *S3ApiServer) hasChildren(ctx context.Context, bucket, prefix string) 
 	bucketDir := s3a.bucketDir(bucket)
 	fullPath := bucketDir + "/" + cleanPrefix
 
-	// List one child object. filer_pb.List cancels the underlying ListEntries
-	// stream when it returns, so gRPC's per-stream client goroutine is not leaked.
-	// The caller's request context is propagated so the probe is cancelled if the
-	// client disconnects.
+	// List one child object. The caller's request context is used both for the
+	// RPC and for filer failover/connection-invalidation decisions, so client
+	// disconnects are treated as per-request cancellations.
 	found := false
-	err := filer_pb.List(ctx, s3a, fullPath, "", func(*filer_pb.Entry, bool) error {
-		found = true
-		return nil
-	}, "", true, 1)
+	err := s3a.WithFilerClientContext(ctx, false, func(client filer_pb.SeaweedFilerClient) error {
+		return filer_pb.SeaweedList(ctx, client, fullPath, "", func(*filer_pb.Entry, bool) error {
+			found = true
+			return nil
+		}, "", true, 1)
+	})
 
 	if err == nil {
 		return found

--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -112,6 +112,10 @@ func (s3a *S3ApiServer) ListObjectsV2Handler(w http.ResponseWriter, r *http.Requ
 	response, err := s3a.listFilerEntries(r.Context(), bucket, originalPrefix, maxKeys, marker, delimiter, encodingTypeUrl, fetchOwner)
 
 	if err != nil {
+		if shouldSuppressListEntriesRequestDoneError(r.Context(), err) {
+			glog.V(3).Infof("ListObjectsV2Handler: request ended while listing %s: %v", bucket, err)
+			return
+		}
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return
 	}
@@ -176,6 +180,10 @@ func (s3a *S3ApiServer) ListObjectsV1Handler(w http.ResponseWriter, r *http.Requ
 	response, err := s3a.listFilerEntries(r.Context(), bucket, originalPrefix, uint16(maxKeys), marker, delimiter, encodingTypeUrl, true)
 
 	if err != nil {
+		if shouldSuppressListEntriesRequestDoneError(r.Context(), err) {
+			glog.V(3).Infof("ListObjectsV1Handler: request ended while listing %s: %v", bucket, err)
+			return
+		}
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return
 	}
@@ -270,7 +278,7 @@ func (s3a *S3ApiServer) listFilerEntries(ctx context.Context, bucket string, ori
 	}
 
 	// check filer
-	err = s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+	err = s3a.WithFilerClientContext(ctx, false, func(client filer_pb.SeaweedFilerClient) error {
 		var lastEntryWasCommonPrefix bool
 		var lastCommonPrefixName string
 
@@ -298,7 +306,7 @@ func (s3a *S3ApiServer) listFilerEntries(ctx context.Context, bucket string, ori
 		for {
 			empty := true
 
-			nextMarker, doErr = s3a.doListFilerEntries(client, reqDir, prefix, cursor, marker, delimiter, false, bucket, func(dir string, entry *filer_pb.Entry) {
+			nextMarker, doErr = s3a.doListFilerEntriesWithContext(ctx, client, reqDir, prefix, cursor, marker, delimiter, false, bucket, func(dir string, entry *filer_pb.Entry) {
 				empty = false
 				dirName, entryName, _ := entryUrlEncode(dir, entry.Name, encodingTypeUrl)
 				if entry.IsDirectory {
@@ -558,6 +566,21 @@ func buildTruncatedNextMarker(requestDir, prefix, nextMarker string, lastEntryWa
 }
 
 func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, dir, prefix string, cursor *ListingCursor, marker, delimiter string, inclusiveStartFrom bool, bucket string, eachEntryFn func(dir string, entry *filer_pb.Entry)) (nextMarker string, err error) {
+	return s3a.doListFilerEntriesWithContext(context.Background(), client, dir, prefix, cursor, marker, delimiter, inclusiveStartFrom, bucket, eachEntryFn)
+}
+
+func isListEntriesRequestDoneError(err error) bool {
+	return isRequestDoneError(err)
+}
+
+func shouldSuppressListEntriesRequestDoneError(ctx context.Context, err error) bool {
+	return isListEntriesRequestDoneError(err) && ctx.Err() != nil
+}
+
+func (s3a *S3ApiServer) doListFilerEntriesWithContext(ctx context.Context, client filer_pb.SeaweedFilerClient, dir, prefix string, cursor *ListingCursor, marker, delimiter string, inclusiveStartFrom bool, bucket string, eachEntryFn func(dir string, entry *filer_pb.Entry)) (nextMarker string, err error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	// invariants
 	//   prefix and marker should be under dir, marker may contain "/"
 	//   maxKeys should be updated for each recursion
@@ -571,7 +594,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 	if strings.Contains(marker, "/") {
 		subDir, subMarker := toParentAndDescendants(marker)
 		// println("doListFilerEntries dir", dir+"/"+subDir, "subMarker", subMarker)
-		subNextMarker, subErr := s3a.doListFilerEntries(client, dir+"/"+subDir, "", cursor, subMarker, delimiter, false, bucket, eachEntryFn)
+		subNextMarker, subErr := s3a.doListFilerEntriesWithContext(ctx, client, dir+"/"+subDir, "", cursor, subMarker, delimiter, false, bucket, eachEntryFn)
 		if subErr != nil {
 			err = subErr
 			return
@@ -593,9 +616,13 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 		InclusiveStartFrom: inclusiveStartFrom,
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	listCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	stream, listErr := client.ListEntries(ctx, request)
+	stream, listErr := client.ListEntries(listCtx, request)
 	if listErr != nil {
 		if errors.Is(listErr, filer_pb.ErrNotFound) {
 			return
@@ -610,7 +637,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 			if recvErr == io.EOF {
 				break
 			} else {
-				err = fmt.Errorf("iterating entries %+v: %v", request, recvErr)
+				err = fmt.Errorf("iterating entries %+v: %w", request, recvErr)
 				return
 			}
 		}
@@ -693,7 +720,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 				// Recurse into subdirectory to list any children, noting whether the
 				// subtree produced any entries.
 				childEmitted := false
-				subNextMarker, subErr := s3a.doListFilerEntries(client, dir+"/"+entry.Name, "", cursor, "", delimiter, false, bucket, func(d string, e *filer_pb.Entry) {
+				subNextMarker, subErr := s3a.doListFilerEntriesWithContext(ctx, client, dir+"/"+entry.Name, "", cursor, "", delimiter, false, bucket, func(d string, e *filer_pb.Entry) {
 					childEmitted = true
 					eachEntryFn(d, e)
 				})

--- a/weed/s3api/s3api_object_handlers_list_test.go
+++ b/weed/s3api/s3api_object_handlers_list_test.go
@@ -3,16 +3,22 @@ package s3api
 import (
 	"context"
 	"io"
+	"net"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/seaweedfs/seaweedfs/weed/wdclient"
 	"github.com/stretchr/testify/assert"
 	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 type testListEntriesStream struct {
@@ -63,6 +69,88 @@ func (c *testFilerClient) ListEntries(ctx context.Context, in *filer_pb.ListEntr
 
 	return &testListEntriesStream{entries: entries}, nil
 }
+
+type contextCaptureFilerClient struct {
+	filer_pb.SeaweedFilerClient
+	captured context.Context
+}
+
+func (c *contextCaptureFilerClient) ListEntries(ctx context.Context, in *filer_pb.ListEntriesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[filer_pb.ListEntriesResponse], error) {
+	c.captured = ctx
+	return &testListEntriesStream{}, nil
+}
+
+type listEntriesErrorFilerClient struct {
+	filer_pb.SeaweedFilerClient
+	err    error
+	called bool
+}
+
+func (c *listEntriesErrorFilerClient) ListEntries(ctx context.Context, in *filer_pb.ListEntriesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[filer_pb.ListEntriesResponse], error) {
+	c.called = true
+	return nil, c.err
+}
+
+type recvErrorFilerClient struct {
+	filer_pb.SeaweedFilerClient
+	err error
+}
+
+func (c *recvErrorFilerClient) ListEntries(ctx context.Context, in *filer_pb.ListEntriesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[filer_pb.ListEntriesResponse], error) {
+	return &recvErrorListEntriesStream{err: c.err}, nil
+}
+
+type cancelingListEntriesFilerServer struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	cancel context.CancelFunc
+}
+
+func (s *cancelingListEntriesFilerServer) ListEntries(_ *filer_pb.ListEntriesRequest, _ grpc.ServerStreamingServer[filer_pb.ListEntriesResponse]) error {
+	s.cancel()
+	return status.Error(codes.Canceled, "client disconnected")
+}
+
+func startCancelingListEntriesFilerServer(t *testing.T, cancel context.CancelFunc) pb.ServerAddress {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(grpcServer, &cancelingListEntriesFilerServer{cancel: cancel})
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		listener.Close()
+	})
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	host, grpcPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener address: %v", err)
+	}
+	return pb.ServerAddress(host + ":1." + grpcPort)
+}
+
+type recvErrorListEntriesStream struct {
+	err error
+}
+
+func (s *recvErrorListEntriesStream) Recv() (*filer_pb.ListEntriesResponse, error) {
+	return nil, s.err
+}
+
+func (s *recvErrorListEntriesStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *recvErrorListEntriesStream) Trailer() metadata.MD         { return metadata.MD{} }
+func (s *recvErrorListEntriesStream) Close() error                 { return nil }
+func (s *recvErrorListEntriesStream) Context() context.Context     { return context.Background() }
+func (s *recvErrorListEntriesStream) SendMsg(m interface{}) error  { return nil }
+func (s *recvErrorListEntriesStream) RecvMsg(m interface{}) error  { return nil }
+func (s *recvErrorListEntriesStream) CloseSend() error             { return nil }
 
 type markerEchoFilerClient struct {
 	filer_pb.SeaweedFilerClient
@@ -884,4 +972,208 @@ func TestListObjectsV2_PrefixEndingWithSlash_WithDelimiter(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"fileA"}, results, "Should only return files under directory '1', not '1000'")
+}
+
+func TestDoListFilerEntriesUsesCallerContext(t *testing.T) {
+	type testKey string
+	ctx := context.WithValue(context.Background(), testKey("key"), "value")
+	client := &contextCaptureFilerClient{}
+	cursor := &ListingCursor{maxKeys: 1}
+
+	_, err := (&S3ApiServer{}).doListFilerEntriesWithContext(ctx, client, "/buckets/test-bucket", "", cursor, "", "", false, "test-bucket", func(dir string, entry *filer_pb.Entry) {})
+	assert.NoError(t, err)
+	if client.captured == nil {
+		t.Fatal("ListEntries was not called")
+	}
+	assert.Equal(t, "value", client.captured.Value(testKey("key")))
+}
+
+func TestDoListFilerEntriesReturnsCanceledContextBeforeListEntries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client := &listEntriesErrorFilerClient{err: context.Canceled}
+	cursor := &ListingCursor{maxKeys: 1}
+
+	_, err := (&S3ApiServer{}).doListFilerEntriesWithContext(ctx, client, "/buckets/test-bucket", "", cursor, "", "", false, "test-bucket", func(dir string, entry *filer_pb.Entry) {})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, client.called)
+}
+
+func TestDoListFilerEntriesClassifiesCanceledListEntriesErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "context canceled", err: context.Canceled},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded},
+		{name: "grpc canceled", err: status.Error(codes.Canceled, "client connection is closing")},
+		{name: "grpc deadline exceeded", err: status.Error(codes.DeadlineExceeded, "deadline exceeded")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &listEntriesErrorFilerClient{err: tt.err}
+			cursor := &ListingCursor{maxKeys: 1}
+
+			_, err := (&S3ApiServer{}).doListFilerEntriesWithContext(context.Background(), client, "/buckets/test-bucket", "", cursor, "", "", false, "test-bucket", func(dir string, entry *filer_pb.Entry) {})
+
+			assert.Error(t, err)
+			assert.True(t, isListEntriesRequestDoneError(err))
+			assert.True(t, client.called)
+		})
+	}
+}
+
+func TestDoListFilerEntriesClassifiesCanceledRecvErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "context canceled", err: context.Canceled},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded},
+		{name: "grpc canceled", err: status.Error(codes.Canceled, "client connection is closing")},
+		{name: "grpc deadline exceeded", err: status.Error(codes.DeadlineExceeded, "deadline exceeded")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &recvErrorFilerClient{err: tt.err}
+			cursor := &ListingCursor{maxKeys: 1}
+
+			_, err := (&S3ApiServer{}).doListFilerEntriesWithContext(context.Background(), client, "/buckets/test-bucket", "", cursor, "", "", false, "test-bucket", func(dir string, entry *filer_pb.Entry) {})
+
+			assert.Error(t, err)
+			assert.True(t, isListEntriesRequestDoneError(err))
+		})
+	}
+}
+
+func TestListEntriesRequestDoneSuppressionRequiresEndedRequestContext(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "grpc canceled", err: status.Error(codes.Canceled, "filer stream canceled")},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded},
+		{name: "grpc deadline exceeded", err: status.Error(codes.DeadlineExceeded, "filer deadline exceeded")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, isListEntriesRequestDoneError(tt.err))
+			assert.False(t, shouldSuppressListEntriesRequestDoneError(context.Background(), tt.err))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			assert.True(t, shouldSuppressListEntriesRequestDoneError(ctx, tt.err))
+		})
+	}
+}
+
+func TestWithFilerClientFailoverRetriesRequestDoneErrorsWhenCallerContextActive(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "grpc canceled", err: status.Error(codes.Canceled, "filer stream canceled")},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded},
+		{name: "grpc deadline exceeded", err: status.Error(codes.DeadlineExceeded, "filer deadline exceeded")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filers := []pb.ServerAddress{"127.0.0.1:17171", "127.0.0.1:17172"}
+			dialOption := grpc.WithTransportCredentials(insecure.NewCredentials())
+			filerClient := wdclient.NewFilerClient(filers, dialOption, "")
+			defer filerClient.Close()
+			for _, filer := range filers {
+				defer pb.InvalidateGrpcConnection(filer.ToGrpcAddress())
+			}
+
+			s3a := &S3ApiServer{
+				option:      &S3ApiServerOption{GrpcDialOption: dialOption},
+				filerClient: filerClient,
+			}
+
+			calls := 0
+			err := s3a.withFilerClientFailover(context.Background(), false, func(client filer_pb.SeaweedFilerClient) error {
+				calls++
+				if calls == 1 {
+					return tt.err
+				}
+				return nil
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, 2, calls)
+		})
+	}
+}
+
+func TestWithFilerClientFailoverStopsWhenCallerContextDone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "context canceled", err: context.Canceled},
+		{name: "grpc canceled", err: status.Error(codes.Canceled, "client disconnected")},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded},
+		{name: "grpc deadline exceeded", err: status.Error(codes.DeadlineExceeded, "request timed out")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filers := []pb.ServerAddress{"127.0.0.1:17173", "127.0.0.1:17174"}
+			dialOption := grpc.WithTransportCredentials(insecure.NewCredentials())
+			filerClient := wdclient.NewFilerClient(filers, dialOption, "")
+			defer filerClient.Close()
+			for _, filer := range filers {
+				defer pb.InvalidateGrpcConnection(filer.ToGrpcAddress())
+			}
+
+			s3a := &S3ApiServer{
+				option:      &S3ApiServerOption{GrpcDialOption: dialOption},
+				filerClient: filerClient,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			calls := 0
+			err := s3a.withFilerClientFailover(ctx, false, func(client filer_pb.SeaweedFilerClient) error {
+				calls++
+				return tt.err
+			})
+
+			assert.Error(t, err)
+			assert.True(t, isRequestDoneError(err))
+			assert.Equal(t, 1, calls)
+		})
+	}
+}
+
+func TestHasChildrenDoesNotMarkFilerUnhealthyWhenCallerContextEnds(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	filer := startCancelingListEntriesFilerServer(t, cancel)
+	dialOption := grpc.WithTransportCredentials(insecure.NewCredentials())
+	filerClient := wdclient.NewFilerClient([]pb.ServerAddress{filer}, dialOption, "", &wdclient.FilerClientOption{
+		FailureThreshold: 1,
+	})
+	defer filerClient.Close()
+	defer pb.InvalidateGrpcConnection(filer.ToGrpcAddress())
+
+	s3a := &S3ApiServer{
+		option: &S3ApiServerOption{
+			BucketsPath:    "/buckets",
+			GrpcDialOption: dialOption,
+		},
+		filerClient: filerClient,
+	}
+
+	s3a.hasChildren(ctx, "bucket", "dir")
+
+	assert.True(t, ctx.Err() != nil)
+	assert.False(t, filerClient.ShouldSkipUnhealthyFiler(filer))
 }


### PR DESCRIPTION
Use the incoming S3 list request context when opening filer ListEntries streams. This lets ListObjectsV1 and ListObjectsV2 stop filer listing work when the HTTP request is canceled or times out. The change keeps the existing direct doListFilerEntries helper as a background-context wrapper, propagates the request context through recursive listing calls, and adds a unit test for ListEntries context propagation.

# What problem are we solving?

S3 list object requests already receive an HTTP request context, but filer ListEntries calls were opened with context.Background. Large or recursive listings could continue doing filer work after the client disconnected or the request was canceled.



# How are we solving the problem?

ListObjectsV1 and ListObjectsV2 pass r.Context() into listFilerEntries, which now calls a context-aware internal doListFilerEntriesWithContext helper. Recursive listing calls reuse the same caller context, while the old doListFilerEntries signature remains as a compatibility wrapper for existing direct callers and tests.


# How is the PR tested?

go test -count=1 ./weed/s3api -run 'TestDoListFilerEntriesUsesCallerContext|TestListObjectsV2_PrefixEndingWithSlash'
go test -count=1 ./weed/s3api


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-request opt-out to avoid invalidating cached gRPC connections and a context-aware filer client API so caller cancellation propagates through listing and failover.

* **Bug Fixes**
  * Suppress internal errors for ended requests (canceled/deadline) across ListObjects, nested listings and failover, preventing unnecessary retries and connection invalidation.

* **Tests**
  * Added tests covering context propagation, canceled/deadline classification, request-done suppression, and failover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->