### PR TITLE
filer: bound TraverseBfsMetadata memory by queuing directory paths

### DIFF
--- a/weed/server/filer_grpc_server_traverse_meta.go
+++ b/weed/server/filer_grpc_server_traverse_meta.go
@@ -22,34 +22,55 @@ func (fs *FilerServer) TraverseBfsMetadata(req *filer_pb.TraverseBfsMetadataRequ
 
 	ctx := stream.Context()
 
-	queue := util.NewQueue[*filer.Entry]()
+	isExcluded := func(path util.FullPath) bool {
+		return excludedTrie.MatchPrefix([]byte(path), func(key []byte, value bool) bool {
+			return true
+		})
+	}
+
+	// Send each entry as it is visited and queue only directory paths to
+	// descend into. Queuing the entries themselves would hold the whole
+	// subtree in memory, including every file's chunk list, and can exhaust
+	// the filer on large trees (e.g. during a peer's first-time bootstrap).
+	sendEntry := func(entry *filer.Entry) error {
+		parent, _ := entry.FullPath.DirAndName()
+		if err := stream.Send(&filer_pb.TraverseBfsMetadataResponse{
+			Directory: parent,
+			Entry:     entry.ToProtoEntry(),
+		}); err != nil {
+			return fmt.Errorf("send traverse bfs metadata response: %w", err)
+		}
+		return nil
+	}
+
 	dirEntry, err := fs.filer.FindEntry(ctx, util.FullPath(req.Directory))
 	if err != nil {
 		return fmt.Errorf("find dir %s: %v", req.Directory, err)
 	}
-	queue.Enqueue(dirEntry)
+	if isExcluded(dirEntry.FullPath) {
+		return nil
+	}
+	if err := sendEntry(dirEntry); err != nil {
+		return err
+	}
 
-	for item := queue.Dequeue(); item != nil; item = queue.Dequeue() {
-		if excludedTrie.MatchPrefix([]byte(item.FullPath), func(key []byte, value bool) bool {
-			return true
-		}) {
-			// println("excluded", item.FullPath)
-			continue
-		}
-		parent, _ := item.FullPath.DirAndName()
-		if err := stream.Send(&filer_pb.TraverseBfsMetadataResponse{
-			Directory: parent,
-			Entry:     item.ToProtoEntry(),
-		}); err != nil {
-			return fmt.Errorf("send traverse bfs metadata response: %w", err)
-		}
+	queue := util.NewQueue[util.FullPath]()
+	if dirEntry.IsDirectory() {
+		queue.Enqueue(dirEntry.FullPath)
+	}
 
-		if !item.IsDirectory() {
-			continue
-		}
-
-		if err := fs.iterateDirectory(ctx, item.FullPath, func(entry *filer.Entry) error {
-			queue.Enqueue(entry)
+	for queue.Len() > 0 {
+		dirPath := queue.Dequeue()
+		if err := fs.iterateDirectory(ctx, dirPath, func(entry *filer.Entry) error {
+			if isExcluded(entry.FullPath) {
+				return nil
+			}
+			if err := sendEntry(entry); err != nil {
+				return err
+			}
+			if entry.IsDirectory() {
+				queue.Enqueue(entry.FullPath)
+			}
 			return nil
 		}); err != nil {
 			return err

--- a/weed/server/filer_grpc_server_traverse_meta.go
+++ b/weed/server/filer_grpc_server_traverse_meta.go
@@ -23,9 +23,17 @@ func (fs *FilerServer) TraverseBfsMetadata(req *filer_pb.TraverseBfsMetadataRequ
 	ctx := stream.Context()
 
 	isExcluded := func(path util.FullPath) bool {
-		return excludedTrie.MatchPrefix([]byte(path), func(key []byte, value bool) bool {
+		excluded := false
+		excludedTrie.MatchPrefix([]byte(path), func(key []byte, value bool) bool {
+			// Only exclude when the prefix ends on a path-component boundary,
+			// so /a/b does not also exclude a sibling like /a/bc.
+			if len(path) == len(key) || path[len(key)] == '/' {
+				excluded = true
+				return false
+			}
 			return true
 		})
+		return excluded
 	}
 
 	// Send each entry as it is visited and queue only directory paths to

--- a/weed/server/filer_grpc_server_traverse_meta_test.go
+++ b/weed/server/filer_grpc_server_traverse_meta_test.go
@@ -54,10 +54,12 @@ func (s *captureTraverseStream) Send(resp *filer_pb.TraverseBfsMetadataResponse)
 
 func TestTraverseBfsMetadata(t *testing.T) {
 	store := newRenameTestStore()
-	for _, dir := range []string{"/", "/a", "/a/sub", "/b", "/.system"} {
+	// "/.system-data" shares the "/.system" byte prefix but is a different
+	// path component, so it must not be excluded.
+	for _, dir := range []string{"/", "/a", "/a/sub", "/b", "/.system", "/.system-data"} {
 		store.entries[dir] = newDirectoryEntry(dir, 1)
 	}
-	for _, file := range []string{"/a/f1", "/a/sub/f2", "/b/f3", "/.system/secret"} {
+	for _, file := range []string{"/a/f1", "/a/sub/f2", "/b/f3", "/.system/secret", "/.system-data/keep"} {
 		store.entries[file] = newFileEntry(file, 2)
 	}
 
@@ -70,8 +72,12 @@ func TestTraverseBfsMetadata(t *testing.T) {
 	}, stream)
 	assert.NoError(t, err)
 
-	// The excluded subtree is skipped; everything else is visited exactly once.
-	assert.ElementsMatch(t, []string{"/", "/a", "/a/f1", "/a/sub", "/a/sub/f2", "/b", "/b/f3"}, stream.visited)
+	// The excluded subtree is skipped; everything else (including the
+	// /.system-data sibling) is visited exactly once.
+	assert.ElementsMatch(t, []string{
+		"/", "/a", "/a/f1", "/a/sub", "/a/sub/f2", "/b", "/b/f3",
+		"/.system-data", "/.system-data/keep",
+	}, stream.visited)
 
 	// Each entry's parent must be streamed before the entry itself, so a
 	// consumer can apply the tree top-down.

--- a/weed/server/filer_grpc_server_traverse_meta_test.go
+++ b/weed/server/filer_grpc_server_traverse_meta_test.go
@@ -1,10 +1,14 @@
 package weed_server
 
 import (
+	"context"
 	"testing"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/viant/ptrie"
+	"google.golang.org/grpc"
 )
 
 func TestPtrie(t *testing.T) {
@@ -30,3 +34,55 @@ func TestPtrie(t *testing.T) {
 
 	assert.False(t, excludedTrie.Has(b))
 }
+
+type captureTraverseStream struct {
+	grpc.ServerStream
+	ctx     context.Context
+	visited []string
+}
+
+func (s *captureTraverseStream) Context() context.Context { return s.ctx }
+
+func (s *captureTraverseStream) Send(resp *filer_pb.TraverseBfsMetadataResponse) error {
+	dir := resp.Directory
+	if dir != "/" {
+		dir += "/"
+	}
+	s.visited = append(s.visited, dir+resp.Entry.Name)
+	return nil
+}
+
+func TestTraverseBfsMetadata(t *testing.T) {
+	store := newRenameTestStore()
+	for _, dir := range []string{"/", "/a", "/a/sub", "/b", "/.system"} {
+		store.entries[dir] = newDirectoryEntry(dir, 1)
+	}
+	for _, file := range []string{"/a/f1", "/a/sub/f2", "/b/f3", "/.system/secret"} {
+		store.entries[file] = newFileEntry(file, 2)
+	}
+
+	server := &FilerServer{filer: newRenameTestFiler(store)}
+	stream := &captureTraverseStream{ctx: context.Background()}
+
+	err := server.TraverseBfsMetadata(&filer_pb.TraverseBfsMetadataRequest{
+		Directory:        "/",
+		ExcludedPrefixes: []string{"/.system"},
+	}, stream)
+	assert.NoError(t, err)
+
+	// The excluded subtree is skipped; everything else is visited exactly once.
+	assert.ElementsMatch(t, []string{"/", "/a", "/a/f1", "/a/sub", "/a/sub/f2", "/b", "/b/f3"}, stream.visited)
+
+	// Each entry's parent must be streamed before the entry itself, so a
+	// consumer can apply the tree top-down.
+	seen := make(map[string]bool)
+	for _, path := range stream.visited {
+		if path != "/" {
+			parent, _ := util.FullPath(path).DirAndName()
+			assert.Truef(t, seen[parent], "parent %s of %s not streamed first", parent, path)
+		}
+		seen[path] = true
+	}
+}
+
+var _ filer_pb.SeaweedFiler_TraverseBfsMetadataServer = (*captureTraverseStream)(nil)


### PR DESCRIPTION
## Summary

`TraverseBfsMetadata` runs a BFS that enqueues **every entry in the tree** into an in-memory queue, with each `filer.Entry` carrying its full chunk list:

```go
queue := util.NewQueue[*filer.Entry]()
...
fs.iterateDirectory(ctx, item.FullPath, func(entry *filer.Entry) error {
    queue.Enqueue(entry) // every file AND dir, with its full chunk list
    return nil
})
```

`iterateDirectory` pages the listing 1024 rows at a time, but the callback pushes every entry into the queue, so the queue can grow to hold (close to) the whole filesystem at once — files with large chunk manifests are multi-MB each. On a large tree this can exhaust the filer serving the traversal.

This RPC is used by filer-to-filer bootstrap (#8979) and by the admin file browser. Note: bootstrap/aggregation only runs when filers use **separate** stores; a shared store (Postgres/MySQL/etc.) gives every filer the same store signature, so aggregation is skipped and this path is never hit there.

## Fix

Send each entry as it is visited and queue only directory paths to descend into. Memory is bounded by the number of directories rather than the entire tree; file entries (with their chunk lists) are never buffered. Streamed output order is unchanged, and excluded subtrees are skipped before being queued.

## Scope

Found while investigating #9813, but that deployment uses a shared Postgres store, so bootstrap never runs there — **this is not the fix for #9813**. Filing as standalone hardening for separate-store clusters and the admin file browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized BFS traversal metadata functionality for improved performance.
  * Enhanced excluded-path handling with centralized prefix matching.
  * Improved error reporting with additional context information.

* **Tests**
  * Added comprehensive test coverage for BFS traversal functionality with exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->