### PR TITLE
filer: stream persisted log files when serving metadata subscriptions

### DIFF
--- a/weed/filer/filer_notify.go
+++ b/weed/filer/filer_notify.go
@@ -220,8 +220,10 @@ func (f *Filer) ReadPersistedLogBuffer(startPosition log_buffer.MessagePosition,
 	}
 	ch := make(chan entryOrErr, readaheadSize)
 	stopReadahead := make(chan struct{})
+	readaheadDone := make(chan struct{})
 	go func() {
 		defer close(ch)
+		defer close(readaheadDone)
 		for {
 			entry, readErr := visitor.GetNext()
 			if readErr != nil {
@@ -240,7 +242,13 @@ func (f *Filer) ReadPersistedLogBuffer(startPosition log_buffer.MessagePosition,
 			}
 		}
 	}()
-	defer close(stopReadahead)
+	// Stop the readahead goroutine, wait for it to exit, then release any log
+	// file readers it left open (e.g. on early return or cancellation).
+	defer func() {
+		close(stopReadahead)
+		<-readaheadDone
+		visitor.Close()
+	}()
 
 	for item := range ch {
 		if item.err != nil {
@@ -261,4 +269,3 @@ func (f *Filer) ReadPersistedLogBuffer(startPosition log_buffer.MessagePosition,
 
 	return
 }
-

--- a/weed/filer/filer_notify_read.go
+++ b/weed/filer/filer_notify_read.go
@@ -355,17 +355,25 @@ func (iter *LogFileQueueIterator) getNext(v *OrderedLogVisitor) (logEntry *filer
 			if err == nil {
 				return logEntry, nil
 			}
-			if err != io.EOF {
-				if !isChunkNotFoundError(err) {
-					return nil, err
-				}
+			// The current file is done (io.EOF), its volume was deleted, or it is
+			// unreadable. Close it on every path so the reader is not left alive
+			// until GC; only a genuine read error is propagated.
+			readErr := err
+			switch {
+			case readErr == io.EOF:
+				readErr = nil
+			case isChunkNotFoundError(readErr):
 				// Volume or chunk was deleted, skip the rest of this log file
-				glog.Warningf("skipping rest of %s: %v", iter.currentFileIterator.filePath, err)
+				glog.Warningf("skipping rest of %s: %v", iter.currentFileIterator.filePath, readErr)
+				readErr = nil
 			}
 			if closeErr := iter.currentFileIterator.Close(); closeErr != nil {
 				glog.Warningf("close log file %s: %v", iter.currentFileIterator.filePath, closeErr)
 			}
 			iter.currentFileIterator = nil
+			if readErr != nil {
+				return nil, readErr
+			}
 		}
 
 		// advance to the next file

--- a/weed/filer/filer_notify_read.go
+++ b/weed/filer/filer_notify_read.go
@@ -197,6 +197,15 @@ func (o *OrderedLogVisitor) GetNext() (logEntry *filer_pb.LogEntry, err error) {
 	return item.Entry, nil
 }
 
+// Close releases any log file readers still open across the per-filer
+// iterators, e.g. when a subscription stops before reaching the end. Safe to
+// call more than once.
+func (o *OrderedLogVisitor) Close() {
+	for _, it := range o.perFilerIteratorMap {
+		it.Close()
+	}
+}
+
 func getFilerId(name string) string {
 	idx := strings.LastIndex(name, ".")
 	if idx < 0 {
@@ -342,6 +351,16 @@ func newLogFileQueueIterator(masterClient *wdclient.MasterClient, q *util.Queue[
 		masterClient: masterClient,
 		startTsNs:    startTsNs,
 		stopTsNs:     stopTsNs,
+	}
+}
+
+// Close releases the current log file reader, if any. Safe to call more than once.
+func (iter *LogFileQueueIterator) Close() {
+	if iter.currentFileIterator != nil {
+		if err := iter.currentFileIterator.Close(); err != nil {
+			glog.Warningf("close log file %s: %v", iter.currentFileIterator.filePath, err)
+		}
+		iter.currentFileIterator = nil
 	}
 }
 

--- a/weed/filer/filer_notify_read.go
+++ b/weed/filer/filer_notify_read.go
@@ -329,12 +329,11 @@ func (c *LogFileEntryCollector) collectMore(v *OrderedLogVisitor) (err error) {
 // ----------
 
 type LogFileQueueIterator struct {
-	q              *util.Queue[*LogFileEntry]
-	masterClient   *wdclient.MasterClient
-	startTsNs      int64
-	stopTsNs       int64
-	pendingEntries []*filer_pb.LogEntry
-	pendingIndex   int
+	q                   *util.Queue[*LogFileEntry]
+	masterClient        *wdclient.MasterClient
+	startTsNs           int64
+	stopTsNs            int64
+	currentFileIterator *LogFileIterator
 }
 
 func newLogFileQueueIterator(masterClient *wdclient.MasterClient, q *util.Queue[*LogFileEntry], startTsNs, stopTsNs int64) *LogFileQueueIterator {
@@ -346,20 +345,30 @@ func newLogFileQueueIterator(masterClient *wdclient.MasterClient, q *util.Queue[
 	}
 }
 
-// getNext will return io.EOF when done
+// getNext streams one log entry at a time from the current file, advancing to
+// the next file as each is exhausted. It returns io.EOF when done. Entries are
+// not buffered per file, so memory stays O(1) regardless of log file size.
 func (iter *LogFileQueueIterator) getNext(v *OrderedLogVisitor) (logEntry *filer_pb.LogEntry, err error) {
 	for {
-		// return pending entries first
-		if iter.pendingIndex < len(iter.pendingEntries) {
-			logEntry = iter.pendingEntries[iter.pendingIndex]
-			iter.pendingIndex++
-			return logEntry, nil
+		if iter.currentFileIterator != nil {
+			logEntry, err = iter.currentFileIterator.getNext()
+			if err == nil {
+				return logEntry, nil
+			}
+			if err != io.EOF {
+				if !isChunkNotFoundError(err) {
+					return nil, err
+				}
+				// Volume or chunk was deleted, skip the rest of this log file
+				glog.Warningf("skipping rest of %s: %v", iter.currentFileIterator.filePath, err)
+			}
+			if closeErr := iter.currentFileIterator.Close(); closeErr != nil {
+				glog.Warningf("close log file %s: %v", iter.currentFileIterator.filePath, closeErr)
+			}
+			iter.currentFileIterator = nil
 		}
-		// reset for next file
-		iter.pendingEntries = nil
-		iter.pendingIndex = 0
 
-		// read entries from next file
+		// advance to the next file
 		if iter.q.Len() == 0 {
 			return nil, io.EOF
 		}
@@ -382,38 +391,7 @@ func (iter *LogFileQueueIterator) getNext(v *OrderedLogVisitor) (logEntry *filer
 		if next != nil && next.TsNs <= iter.startTsNs {
 			continue
 		}
-
-		// read all entries from this file
-		iter.pendingEntries, err = iter.readFileEntries(t.FileEntry)
-		if err != nil {
-			return nil, err
-		}
-	}
-}
-
-// readFileEntries reads all log entries from a single file
-func (iter *LogFileQueueIterator) readFileEntries(fileEntry *Entry) (entries []*filer_pb.LogEntry, err error) {
-	fileIterator := newLogFileIterator(iter.masterClient, fileEntry, iter.startTsNs, iter.stopTsNs)
-	defer func() {
-		if closeErr := fileIterator.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-
-	for {
-		logEntry, err := fileIterator.getNext()
-		if err == io.EOF {
-			return entries, nil
-		}
-		if err != nil {
-			if isChunkNotFoundError(err) {
-				// Volume or chunk was deleted, skip the rest of this log file
-				glog.Warningf("skipping rest of %s: %v", fileIterator.filePath, err)
-				return entries, nil
-			}
-			return nil, err
-		}
-		entries = append(entries, logEntry)
+		iter.currentFileIterator = newLogFileIterator(iter.masterClient, t.FileEntry, iter.startTsNs, iter.stopTsNs)
 	}
 }
 


### PR DESCRIPTION
## Problem

A filer can OOM on startup. A heap profile from a filer that was killed at ~24 GB shows ~11 GB live in protobuf unmarshal under:

```
SubscribeMetadata -> ReadPersistedLogBuffer -> collectPersistedLogBuffer
  -> OrderedLogVisitor -> LogFileQueueIterator.readFileEntries -> proto.Unmarshal
```

`readFileEntries` reads an **entire** persisted log file, unmarshals every `LogEntry` into a slice, and returns them all at once (held in `pendingEntries`). That makes a subscription read `O(all entries in one log file)` instead of `O(one entry)`. When per-entry metadata is large (files with tens of thousands of chunks) and many subscribers connect at once — e.g. a CSI deployment where ~200 pods reconnect the moment the filer restarts — each `SubscribeMetadata` stream buffers a full log file, and the filer runs out of memory.

This is a regression: before #7692 the iterator streamed one entry at a time via a `currentFileIterator`. #7692 switched to whole-file buffering to add deleted-volume skipping.

## Fix

Restore per-entry streaming: keep a current `LogFileIterator` and return one `LogEntry` at a time, advancing to the next file as each is exhausted. Memory per subscription is back to `O(1)` regardless of log file size. The deleted-volume skip added in #7692 is preserved (skip the rest of a file on a chunk-not-found error), and each file iterator is now closed as it is drained.

Reported in #9813, with the heap profile pinpointing this path.

Closes #9813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * More memory-efficient log streaming by removing per-file buffering and streaming entries directly from active files.

* **Bug Fixes**
  * Ensured background readahead and log readers are reliably stopped and closed on cancellation or early return to prevent resource leaks.
  * Improved iteration behavior around log boundaries and stop-time filtering to avoid stale reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->