### PR TITLE
filer: keep S3 list order byte-lexicographic regardless of SQL name column collation

### DIFF
--- a/weed/filer/mysql/mysql_collation.go
+++ b/weed/filer/mysql/mysql_collation.go
@@ -1,0 +1,41 @@
+package mysql
+
+import (
+	"database/sql"
+	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+)
+
+// ConfigureListOrdering switches the list queries to BINARY byte ordering when
+// the live filemeta.name collation is not binary, so S3 ListObjectsV2 stays
+// lexicographic. The fallback costs a filesort, so warn the operator to fix it.
+func ConfigureListOrdering(db *sql.DB, gen *SqlGenMysql) {
+	collation, isBinary, err := nameColumnCollation(db)
+	if err != nil {
+		glog.V(1).Infof("mysql: skip filemeta.name collation check: %v", err)
+		return
+	}
+	if isBinary {
+		return
+	}
+	gen.ForceBinaryCollation = true
+	glog.Warningf("mysql: filemeta.name collation %q is not binary, so S3 list order is not byte-lexicographic and clients that merge sorted listings may report spurious diffs. Falling back to a slower BINARY sort; convert the name column to a *_bin collation (e.g. utf8mb4_bin) for correct, indexed ordering.", collation)
+}
+
+func nameColumnCollation(db *sql.DB) (collation string, isBinary bool, err error) {
+	row := db.QueryRow("SELECT COLLATION_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'name'", abstract_sql.DEFAULT_TABLE)
+	var c sql.NullString
+	if err = row.Scan(&c); err != nil {
+		return "", false, err
+	}
+	return c.String, isBinaryCollation(c.String), nil
+}
+
+// isBinaryCollation reports whether a collation orders by byte value: a NULL
+// collation (BINARY column) or any *_bin collation.
+func isBinaryCollation(collation string) bool {
+	c := strings.ToLower(strings.TrimSpace(collation))
+	return c == "" || c == "binary" || strings.HasSuffix(c, "_bin")
+}

--- a/weed/filer/mysql/mysql_sql_gen.go
+++ b/weed/filer/mysql/mysql_sql_gen.go
@@ -11,6 +11,8 @@ type SqlGenMysql struct {
 	CreateTableSqlTemplate string
 	DropTableSqlTemplate   string
 	UpsertQueryTemplate    string
+	// Force byte ordering on a non-binary name column; see ConfigureListOrdering.
+	ForceBinaryCollation bool
 }
 
 // DefaultUpsertQuery keeps INSERTs idempotent so the inode-index KvPut
@@ -48,12 +50,22 @@ func (gen *SqlGenMysql) GetSqlDeleteFolderChildren(tableName string) string {
 	return fmt.Sprintf("DELETE FROM `%s` WHERE `dirhash` = ? AND `directory` = ?", tableName)
 }
 
+// nameExpr forces byte ordering on a non-binary column at the cost of a filesort.
+func (gen *SqlGenMysql) nameExpr() string {
+	if gen.ForceBinaryCollation {
+		return "BINARY `name`"
+	}
+	return "`name`"
+}
+
 func (gen *SqlGenMysql) GetSqlListExclusive(tableName string) string {
-	return fmt.Sprintf("SELECT `name`, `meta` FROM `%s` WHERE `dirhash` = ? AND `name` > ? AND `directory` = ? AND `name` LIKE ? ORDER BY `name` ASC LIMIT ?", tableName)
+	name := gen.nameExpr()
+	return fmt.Sprintf("SELECT `name`, `meta` FROM `%s` WHERE `dirhash` = ? AND %s > ? AND `directory` = ? AND %s LIKE ? ORDER BY %s ASC LIMIT ?", tableName, name, name, name)
 }
 
 func (gen *SqlGenMysql) GetSqlListInclusive(tableName string) string {
-	return fmt.Sprintf("SELECT `name`, `meta` FROM `%s` WHERE `dirhash` = ? AND `name` >= ? AND `directory` = ? AND `name` LIKE ? ORDER BY `name` ASC LIMIT ?", tableName)
+	name := gen.nameExpr()
+	return fmt.Sprintf("SELECT `name`, `meta` FROM `%s` WHERE `dirhash` = ? AND %s >= ? AND `directory` = ? AND %s LIKE ? ORDER BY %s ASC LIMIT ?", tableName, name, name, name)
 }
 
 func (gen *SqlGenMysql) GetSqlCreateTable(tableName string) string {

--- a/weed/filer/mysql/mysql_sql_gen_test.go
+++ b/weed/filer/mysql/mysql_sql_gen_test.go
@@ -26,3 +26,45 @@ func TestEmptyUpsertTemplateFallsBackToPlainInsert(t *testing.T) {
 		t.Fatalf("plain INSERT path should not contain ON DUPLICATE KEY UPDATE, got: %s", got)
 	}
 }
+
+func TestListSqlDefaultOrderingFollowsColumn(t *testing.T) {
+	gen := &SqlGenMysql{}
+	for _, got := range []string{gen.GetSqlListExclusive("filemeta"), gen.GetSqlListInclusive("filemeta")} {
+		if strings.Contains(got, "BINARY") {
+			t.Fatalf("default list query should not force BINARY, got: %s", got)
+		}
+		if !strings.Contains(got, "ORDER BY `name` ASC") {
+			t.Fatalf("expected plain name ordering, got: %s", got)
+		}
+	}
+}
+
+func TestListSqlBinaryOrderingOnNonBinaryColumn(t *testing.T) {
+	gen := &SqlGenMysql{ForceBinaryCollation: true}
+	for _, got := range []string{gen.GetSqlListExclusive("filemeta"), gen.GetSqlListInclusive("filemeta")} {
+		if !strings.Contains(got, "ORDER BY BINARY `name` ASC") {
+			t.Fatalf("expected BINARY ordering, got: %s", got)
+		}
+		if !strings.Contains(got, "BINARY `name` LIKE ?") {
+			t.Fatalf("expected BINARY prefix filter, got: %s", got)
+		}
+		if strings.Contains(got, "AND `name` > ?") || strings.Contains(got, "AND `name` >= ?") {
+			t.Fatalf("pagination comparison must also be BINARY, got: %s", got)
+		}
+	}
+}
+
+func TestIsBinaryCollation(t *testing.T) {
+	binary := []string{"", "binary", "utf8mb4_bin", "utf8mb3_bin", "latin1_bin", "UTF8MB4_BIN"}
+	for _, c := range binary {
+		if !isBinaryCollation(c) {
+			t.Fatalf("expected %q to be treated as binary", c)
+		}
+	}
+	ci := []string{"utf8mb4_general_ci", "utf8mb3_general_ci", "utf8mb4_0900_ai_ci", "latin1_swedish_ci"}
+	for _, c := range ci {
+		if isBinaryCollation(c) {
+			t.Fatalf("expected %q to be treated as non-binary", c)
+		}
+	}
+}

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -70,11 +70,12 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	} else if upsertQuery == "" {
 		upsertQuery = DefaultUpsertQuery
 	}
-	store.SqlGenerator = &SqlGenMysql{
+	gen := &SqlGenMysql{
 		CreateTableSqlTemplate: "",
 		DropTableSqlTemplate:   "DROP TABLE `%s`",
 		UpsertQueryTemplate:    upsertQuery,
 	}
+	store.SqlGenerator = gen
 
 	store.RetryableErrorCallback = func(err error) bool {
 		var mysqlError *mysql.MySQLError
@@ -154,6 +155,8 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	if err = store.DB.Ping(); err != nil {
 		return fmt.Errorf("connect to %s error:%v", maskedDSN(cfg), err)
 	}
+
+	ConfigureListOrdering(store.DB, gen)
 
 	return nil
 }

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -63,11 +63,12 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	} else if upsertQuery == "" {
 		upsertQuery = mysql.DefaultUpsertQuery
 	}
-	store.SqlGenerator = &mysql.SqlGenMysql{
+	gen := &mysql.SqlGenMysql{
 		CreateTableSqlTemplate: createTable,
 		DropTableSqlTemplate:   "DROP TABLE `%s`",
 		UpsertQueryTemplate:    upsertQuery,
 	}
+	store.SqlGenerator = gen
 
 	sqlUrl := fmt.Sprintf(CONNECTION_URL_PATTERN, user, password, hostname, port, database)
 	adaptedSqlUrl := fmt.Sprintf(CONNECTION_URL_PATTERN, user, "<ADAPTED>", hostname, port, database)
@@ -95,6 +96,8 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil && !strings.Contains(err.Error(), "table already exist") {
 		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 	}
+
+	mysql.ConfigureListOrdering(store.DB, gen)
 
 	return nil
 }

--- a/weed/filer/postgres/postgres_collation.go
+++ b/weed/filer/postgres/postgres_collation.go
@@ -1,0 +1,53 @@
+package postgres
+
+import (
+	"database/sql"
+	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+)
+
+// ConfigureListOrdering switches the list queries to COLLATE "C" when the live
+// filemeta.name collation is locale-aware, so S3 ListObjectsV2 stays
+// lexicographic. The fallback costs a sort, so warn the operator to fix it.
+func ConfigureListOrdering(db *sql.DB, gen *SqlGenPostgres) {
+	collation, isBinary, err := nameColumnCollation(db)
+	if err != nil {
+		glog.V(1).Infof("postgres: skip filemeta.name collation check: %v", err)
+		return
+	}
+	if isBinary {
+		return
+	}
+	gen.ForceBinaryCollation = true
+	glog.Warningf(`postgres: filemeta.name collation %q is not byte-ordered, so S3 list order is not byte-lexicographic and clients that merge sorted listings may report spurious diffs. Falling back to a slower COLLATE "C" sort; declare the name column COLLATE "C" (or use a C/C.UTF-8 database collation) for correct, indexed ordering.`, collation)
+}
+
+func nameColumnCollation(db *sql.DB) (collation string, isBinary bool, err error) {
+	// information_schema reports NULL for a column on the database default, so
+	// fall back to datcollate for the effective ordering.
+	row := db.QueryRow(`SELECT
+		(SELECT collation_name FROM information_schema.columns
+			WHERE table_schema = current_schema() AND table_name = $1 AND column_name = 'name'),
+		(SELECT datcollate FROM pg_database WHERE datname = current_database())`, abstract_sql.DEFAULT_TABLE)
+	var columnCollation, dbCollate sql.NullString
+	if err = row.Scan(&columnCollation, &dbCollate); err != nil {
+		return "", false, err
+	}
+	effective := columnCollation.String
+	if !columnCollation.Valid || effective == "" {
+		effective = dbCollate.String
+	}
+	return effective, isByteOrderedCollation(effective), nil
+}
+
+// isByteOrderedCollation reports whether a Postgres locale sorts by byte value
+// (C, POSIX, C.UTF-8) rather than locale order (en_US.UTF-8, ICU, ...).
+func isByteOrderedCollation(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "c", "posix", "c.utf-8", "c.utf8":
+		return true
+	}
+	return false
+}

--- a/weed/filer/postgres/postgres_sql_gen.go
+++ b/weed/filer/postgres/postgres_sql_gen.go
@@ -11,6 +11,8 @@ type SqlGenPostgres struct {
 	CreateTableSqlTemplate string
 	DropTableSqlTemplate   string
 	UpsertQueryTemplate    string
+	// Force byte ordering on a locale-aware name column; see ConfigureListOrdering.
+	ForceBinaryCollation bool
 }
 
 // DefaultUpsertQuery keeps INSERTs idempotent so a duplicate-key failure
@@ -46,12 +48,22 @@ func (gen *SqlGenPostgres) GetSqlDeleteFolderChildren(tableName string) string {
 	return fmt.Sprintf(`DELETE FROM "%s" WHERE dirhash=$1 AND directory=$2`, tableName)
 }
 
+// nameExpr forces byte ordering on a locale-aware column via COLLATE "C".
+func (gen *SqlGenPostgres) nameExpr() string {
+	if gen.ForceBinaryCollation {
+		return `name COLLATE "C"`
+	}
+	return "name"
+}
+
 func (gen *SqlGenPostgres) GetSqlListExclusive(tableName string) string {
-	return fmt.Sprintf(`SELECT NAME, meta FROM "%s" WHERE dirhash=$1 AND name>$2 AND directory=$3 AND name like $4 ORDER BY NAME ASC LIMIT $5`, tableName)
+	name := gen.nameExpr()
+	return fmt.Sprintf(`SELECT NAME, meta FROM "%s" WHERE dirhash=$1 AND %s>$2 AND directory=$3 AND %s like $4 ORDER BY %s ASC LIMIT $5`, tableName, name, name, name)
 }
 
 func (gen *SqlGenPostgres) GetSqlListInclusive(tableName string) string {
-	return fmt.Sprintf(`SELECT NAME, meta FROM "%s" WHERE dirhash=$1 AND name>=$2 AND directory=$3 AND name like $4 ORDER BY NAME ASC LIMIT $5`, tableName)
+	name := gen.nameExpr()
+	return fmt.Sprintf(`SELECT NAME, meta FROM "%s" WHERE dirhash=$1 AND %s>=$2 AND directory=$3 AND %s like $4 ORDER BY %s ASC LIMIT $5`, tableName, name, name, name)
 }
 
 func (gen *SqlGenPostgres) GetSqlCreateTable(tableName string) string {

--- a/weed/filer/postgres/postgres_sql_gen_test.go
+++ b/weed/filer/postgres/postgres_sql_gen_test.go
@@ -23,3 +23,45 @@ func TestEmptyUpsertTemplateFallsBackToPlainInsert(t *testing.T) {
 		t.Fatalf("plain INSERT path should not contain ON CONFLICT, got: %s", got)
 	}
 }
+
+func TestListSqlDefaultOrderingFollowsColumn(t *testing.T) {
+	gen := &SqlGenPostgres{}
+	for _, got := range []string{gen.GetSqlListExclusive("filemeta"), gen.GetSqlListInclusive("filemeta")} {
+		if strings.Contains(got, "COLLATE") {
+			t.Fatalf("default list query should not force a collation, got: %s", got)
+		}
+		if !strings.Contains(got, "ORDER BY name ASC") {
+			t.Fatalf("expected plain name ordering, got: %s", got)
+		}
+	}
+}
+
+func TestListSqlBinaryOrderingOnNonBinaryColumn(t *testing.T) {
+	gen := &SqlGenPostgres{ForceBinaryCollation: true}
+	for _, got := range []string{gen.GetSqlListExclusive("filemeta"), gen.GetSqlListInclusive("filemeta")} {
+		if !strings.Contains(got, `ORDER BY name COLLATE "C" ASC`) {
+			t.Fatalf(`expected COLLATE "C" ordering, got: %s`, got)
+		}
+		if !strings.Contains(got, `name COLLATE "C" like $4`) {
+			t.Fatalf(`expected COLLATE "C" prefix filter, got: %s`, got)
+		}
+		if strings.Contains(got, "AND name>$2") || strings.Contains(got, "AND name>=$2") {
+			t.Fatalf("pagination comparison must also be byte-ordered, got: %s", got)
+		}
+	}
+}
+
+func TestIsByteOrderedCollation(t *testing.T) {
+	byteOrdered := []string{"C", "POSIX", "c", "C.UTF-8", "C.utf8"}
+	for _, c := range byteOrdered {
+		if !isByteOrderedCollation(c) {
+			t.Fatalf("expected %q to be treated as byte-ordered", c)
+		}
+	}
+	locale := []string{"en_US.UTF-8", "en_US.utf8", "en-US-x-icu", "und-x-icu", ""}
+	for _, c := range locale {
+		if isByteOrderedCollation(c) {
+			t.Fatalf("expected %q to be treated as locale-aware", c)
+		}
+	}
+}

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -62,11 +62,12 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 	} else if upsertQuery == "" {
 		upsertQuery = DefaultUpsertQuery
 	}
-	store.SqlGenerator = &SqlGenPostgres{
+	gen := &SqlGenPostgres{
 		CreateTableSqlTemplate: "",
 		DropTableSqlTemplate:   `drop table "%s"`,
 		UpsertQueryTemplate:    upsertQuery,
 	}
+	store.SqlGenerator = gen
 
 	// pgx-optimized connection string with better timeouts and connection handling
 	sqlUrl := "connect_timeout=30"
@@ -115,6 +116,8 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 		return openErr
 	}
 	store.DB = db
+
+	ConfigureListOrdering(store.DB, gen)
 
 	return nil
 }

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,11 +68,12 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 	} else if upsertQuery == "" {
 		upsertQuery = postgres.DefaultUpsertQuery
 	}
-	store.SqlGenerator = &postgres.SqlGenPostgres{
+	gen := &postgres.SqlGenPostgres{
 		CreateTableSqlTemplate: createTable,
 		DropTableSqlTemplate:   `drop table "%s"`,
 		UpsertQueryTemplate:    upsertQuery,
 	}
+	store.SqlGenerator = gen
 
 	// pgx-optimized connection string with better timeouts and connection handling
 	sqlUrl := "connect_timeout=30"
@@ -125,6 +126,8 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
 		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 	}
+
+	postgres.ConfigureListOrdering(store.DB, gen)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #9819

## Problem

The SQL filer list queries order by the `name` column and paginate with a `name > ?` predicate, both of which follow the **column/database collation**:

- **MySQL**: a case-insensitive column collation (e.g. `utf8mb3_general_ci`) returns S3 keys out of byte order.
- **Postgres**: a locale-aware collation (e.g. the common `en_US.UTF-8` database default) does the same.

S3 `ListObjectsV2` then returns keys in non-byte-lexicographic order, so clients that merge two sorted listings report existing objects as both source-only and target-only and overwrite them unnecessarily.

The scaffolds already recommend byte-ordered collations (`utf8mb4_bin` / `COLLATE "C"`), but S3 correctness shouldn't silently depend on the existing table being configured exactly right.

## Why detect instead of always forcing byte order

- MySQL `BINARY name` is a cast that matches no index, so applying it unconditionally would force a filesort on the correctly configured majority. `COLLATE utf8mb4_bin` also can't be applied to a `utf8mb3` column (the reporter's case) - it errors.
- Postgres `name COLLATE "C"` only costs an index-less sort when the column isn't already byte-ordered.

So each store detects the live `filemeta.name` collation once at startup:

- Already byte-ordered (`*_bin` / true `BINARY`; `C` / `POSIX` / `C.UTF-8`): nothing changes - the SQL is unchanged and stays index-ordered.
- Otherwise: wrap the comparison, the `LIKE` prefix, and the `ORDER BY` in `BINARY name` (MySQL) / `name COLLATE "C"` (Postgres) - kept consistent so ordering, pagination, and prefix filtering match - and log a warning to convert the column (which restores both correctness and indexed performance).

Applies to `mysql`, `mysql2`, `postgres`, and `postgres2`. If the table doesn't exist yet or the catalog is unreachable, the default ordering is kept.

## Other MySQL flavors

The MySQL detection uses `information_schema.COLUMNS.COLLATION_NAME` + `DATABASE()`, the `BINARY` operator, and `*_bin` collations - all supported by MariaDB and TiDB, so the same path works there. TiDB's collations are byte-ordered (`utf8mb4_bin`) and detect as binary, so nothing changes. Any flavor where the probe fails just logs at V(1) and falls back to the prior `ORDER BY name` behavior, so nothing breaks.

## Tests

Unit tests per store for default vs. byte-ordered SQL generation (comparison/prefix/order switch together) and the collation classifier. `go build ./...`, `go vet`, and the package tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of DB collation for MySQL and PostgreSQL; enforces byte-lexicographic ordering for file listings when needed.
* **Bug Fixes / Reliability**
  * Safer fallback: if collation cannot be determined, ordering is left unchanged and a log/warning is emitted; enforced ordering may be slower when used.
* **Tests**
  * Added tests for SQL generation and collation-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->