### PR TITLE
fix(master): advance maxVolumeId when registering EC shards

### DIFF
--- a/weed/topology/topology_ec.go
+++ b/weed/topology/topology_ec.go
@@ -129,6 +129,10 @@ func (loc *EcShardLocations) DeleteShard(shardId erasure_coding.ShardId, dn *Dat
 
 func (t *Topology) RegisterEcShards(ecvi *erasure_coding.EcVolumeInfo, dn *DataNode) {
 
+	// EC-only volumes (source volume deleted after encoding) must bump
+	// maxVolumeId too, or a heartbeat-rebuilt master could re-issue their id.
+	t.UpAdjustMaxVolumeId(ecvi.VolumeId)
+
 	t.ecShardMapLock.Lock()
 	defer t.ecShardMapLock.Unlock()
 

--- a/weed/topology/topology_ec_max_volume_id_test.go
+++ b/weed/topology/topology_ec_max_volume_id_test.go
@@ -1,0 +1,33 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+)
+
+// TestRegisterEcShardsAdvancesMaxVolumeId guards against volume-id reuse: an
+// EC-only volume must advance maxVolumeId so a heartbeat-rebuilt master cannot
+// re-issue its id.
+func TestRegisterEcShardsAdvancesMaxVolumeId(t *testing.T) {
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+	dc := topo.GetOrCreateDataCenter("dc1")
+	rack := dc.GetOrCreateRack("rack1")
+	dn := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", map[string]uint32{"": 100})
+
+	const ecVid = uint32(39848)
+	if got := topo.GetMaxVolumeId(); uint32(got) >= ecVid {
+		t.Fatalf("precondition: maxVolumeId already %d, want < %d", got, ecVid)
+	}
+
+	// Full-sync heartbeat reporting an EC-only volume.
+	msg := buildEcShardMessage(ecVid, "prefeitura", "", 0, []erasure_coding.ShardId{0, 1, 2, 3})
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{msg}, dn)
+
+	if got := topo.GetMaxVolumeId(); got != needle.VolumeId(ecVid) {
+		t.Fatalf("maxVolumeId after EC registration = %d, want %d", got, ecVid)
+	}
+}

--- a/weed/topology/topology_ec_max_volume_id_test.go
+++ b/weed/topology/topology_ec_max_volume_id_test.go
@@ -31,3 +31,20 @@ func TestRegisterEcShardsAdvancesMaxVolumeId(t *testing.T) {
 		t.Fatalf("maxVolumeId after EC registration = %d, want %d", got, ecVid)
 	}
 }
+
+// TestIncrementalSyncDataNodeEcShardsAdvancesMaxVolumeId locks the same
+// invariant on the incremental heartbeat path.
+func TestIncrementalSyncDataNodeEcShardsAdvancesMaxVolumeId(t *testing.T) {
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+	dc := topo.GetOrCreateDataCenter("dc1")
+	rack := dc.GetOrCreateRack("rack1")
+	dn := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", map[string]uint32{"": 100})
+
+	const ecVid = uint32(39849)
+	msg := buildEcShardMessage(ecVid, "prefeitura", "", 0, []erasure_coding.ShardId{0, 1, 2, 3})
+	topo.IncrementalSyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{msg}, nil, dn)
+
+	if got := topo.GetMaxVolumeId(); got != needle.VolumeId(ecVid) {
+		t.Fatalf("maxVolumeId after incremental EC registration = %d, want %d", got, ecVid)
+	}
+}


### PR DESCRIPTION
## Problem

EC volume reads can fail with `404 Not Found` for chunks the filer clearly references, breaking object reads (seen in the field as Veeam restore failures: "restore chain is corrupted" / "Failed to download disk"). On the affected volumes:

- the EC `.ecx` index only contains an **old** range of needle ids, while the requested needle id is **newer** and out of range; and
- the object's filer metadata `Created` time is **after** the `.ec*` files were generated — impossible for a sealed, read-only EC volume to contain.

## Root cause: volume-id reuse

The master can re-hand-out a volume id that EC shards still occupy:

1. `maxVolumeId` is persisted in raft, but when the master starts without resuming raft state it is rebuilt from volume-server heartbeats.
2. Regular volumes advance `maxVolumeId` (`Disk.doAddOrUpdateVolume` → `UpAdjustMaxVolumeId`), but **EC shard registration never did**.
3. After EC encoding, the original normal volume is deleted, so a high-numbered volume can exist **only** as EC shards. Those ids are invisible to the rebuilt `maxVolumeId`, which collapses to the highest remaining *normal* volume.
4. `NextVolumeId()` (= `maxVolumeId + 1`) then re-issues ids that EC volumes still hold. A new volume is created on top of an existing EC volume id.
5. New writes land on the new volume and the filer stores chunk references to them; reads route to the old EC shards, whose `.ecx` never contained the new needle → `404`.

This matches the field signature exactly: the affected EC `.ecx` ranges are narrow/old, the requested needle is newer than the encoding, the object is newer than the `.ec*` files, and whole contiguous **bands** of high ids are affected (one max-collapse re-issues a contiguous range).

## Fix

Advance `maxVolumeId` when EC shards are registered, mirroring the regular-volume path. `RegisterEcShards` is the single chokepoint both the full (`SyncDataNodeEcShards`) and incremental (`IncrementalSyncDataNodeEcShards`) heartbeat paths funnel through, so a heartbeat-rebuilt master now accounts for EC-only volume ids and can never re-issue one.

This is the durable fix independent of `resumeState`: keeping raft state on restart reduces how often the max is rebuilt from heartbeats, but any state loss (snapshot loss, re-bootstrap, raft backend change) would otherwise still trigger the reuse.

## Test

`TestRegisterEcShardsAdvancesMaxVolumeId` registers an EC-only volume via a full-sync heartbeat and asserts `maxVolumeId` advances to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the cluster's max volume ID is advanced when EC-only shards are registered, avoiding reuse of previously issued EC volume IDs during cluster state rebuilds.

* **Tests**
  * Added tests verifying the max volume ID advances after EC shard synchronization on both full-sync and incremental heartbeat paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->