### PR TITLE
feat(filer.backup): -initialSnapshot re-seeds a reinitialized destination

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -41,6 +41,7 @@ type FilerBackupOptions struct {
 	timeAgo             *time.Duration
 	retentionDays       *int
 	initialSnapshot     *bool
+	resetCheckpoint     *bool
 }
 
 var (
@@ -64,6 +65,7 @@ func init() {
 	filerBackupOptions.disableErrorRetry = cmdFilerBackup.Flag.Bool("disableErrorRetry", false, "disables errors retry, only logs will print")
 	filerBackupOptions.ignore404Error = cmdFilerBackup.Flag.Bool("ignore404Error", true, "ignore 404 errors from filer")
 	filerBackupOptions.initialSnapshot = cmdFilerBackup.Flag.Bool("initialSnapshot", false, "before subscribing to metadata updates, walk the live filer tree under -filerPath and seed the destination. Only runs on a fresh sync (no prior checkpoint and -timeAgo is 0). After the walk, subscription starts from the walk-start timestamp so concurrent changes are still captured.")
+	filerBackupOptions.resetCheckpoint = cmdFilerBackup.Flag.Bool("resetCheckpoint", false, "clear the persisted resume checkpoint for this sink before starting, forcing a fresh sync from the beginning (re-runs -initialSnapshot). Only effective when -timeAgo is 0. The checkpoint lives in the source filer's KV under a per-sink key.")
 }
 
 var cmdFilerBackup = &Command{
@@ -138,6 +140,22 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	isFreshSync := true
 	sinkId := util.HashStringToLong(dataSink.GetName() + dataSink.GetSinkToDirectory())
 	if timeAgo.Milliseconds() == 0 {
+		// resetCheckpoint clears the persisted resume offset so getOffset below
+		// returns 0 → isFreshSync stays true → -initialSnapshot re-runs a full
+		// walk. Writing 0 is equivalent to deleting the key for getOffset's
+		// purposes (it only resumes when lastOffsetTsNs > 0).
+		if *backupOption.resetCheckpoint {
+			if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId), 0); err != nil {
+				return fmt.Errorf("resetCheckpoint: clear offset for sinkId %d: %w", sinkId, err)
+			}
+			// Clear only once. runFilerBackup retries doFilerBackup forever on
+			// error; leaving this set would re-zero the checkpoint on every retry
+			// and never make forward progress after a transient failure. Once the
+			// offset is cleared, later retries must resume from the persisted
+			// checkpoint.
+			*backupOption.resetCheckpoint = false
+			glog.V(0).Infof("resetCheckpoint: cleared checkpoint for sinkId %d — starting fresh", sinkId)
+		}
 		lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
 		if err != nil {
 			// A KV read failure is ambiguous — a checkpoint may well exist but the

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -144,6 +144,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		// returns 0 → isFreshSync stays true → -initialSnapshot re-runs a full
 		// walk. Writing 0 is equivalent to deleting the key for getOffset's
 		// purposes (it only resumes when lastOffsetTsNs > 0).
+		didReset := false
 		if *backupOption.resetCheckpoint {
 			if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId), 0); err != nil {
 				return fmt.Errorf("resetCheckpoint: clear offset for sinkId %d: %w", sinkId, err)
@@ -154,16 +155,25 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 			// offset is cleared, later retries must resume from the persisted
 			// checkpoint.
 			*backupOption.resetCheckpoint = false
+			didReset = true
 			glog.V(0).Infof("resetCheckpoint: cleared checkpoint for sinkId %d — starting fresh", sinkId)
 		}
 		lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
 		if err != nil {
-			// A KV read failure is ambiguous — a checkpoint may well exist but the
-			// source filer is temporarily unreachable. Don't treat that as a fresh
-			// sync; otherwise runFilerBackup's retry loop would redo the full
-			// -initialSnapshot walk on every transient error.
-			isFreshSync = false
-			glog.V(0).Infof("starting from %v (offset read failed: %v)", startFrom, err)
+			if didReset {
+				// We just wrote offset 0, so this is authoritatively a fresh sync.
+				// A read-back failure must not flip isFreshSync to false here —
+				// that would skip the -initialSnapshot walk the reset explicitly
+				// requested. Keep isFreshSync=true.
+				glog.V(0).Infof("starting from %v (offset read failed after reset, treating as fresh: %v)", startFrom, err)
+			} else {
+				// A KV read failure is ambiguous — a checkpoint may well exist but
+				// the source filer is temporarily unreachable. Don't treat that as
+				// a fresh sync; otherwise runFilerBackup's retry loop would redo
+				// the full -initialSnapshot walk on every transient error.
+				isFreshSync = false
+				glog.V(0).Infof("starting from %v (offset read failed: %v)", startFrom, err)
+			}
 		} else if lastOffsetTsNs > 0 {
 			startFrom = time.Unix(0, lastOffsetTsNs)
 			isFreshSync = false

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -140,46 +140,37 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	isFreshSync := true
 	sinkId := util.HashStringToLong(dataSink.GetName() + dataSink.GetSinkToDirectory())
 	if timeAgo.Milliseconds() == 0 {
-		// resetCheckpoint clears the persisted resume offset so getOffset below
-		// returns 0 → isFreshSync stays true → -initialSnapshot re-runs a full
-		// walk. Writing 0 is equivalent to deleting the key for getOffset's
-		// purposes (it only resumes when lastOffsetTsNs > 0).
-		didReset := false
 		if *backupOption.resetCheckpoint {
+			// Clear the persisted resume offset, then start fresh. We just wrote
+			// 0, so this is authoritatively a fresh sync: leave isFreshSync=true
+			// and startFrom at epoch 0 and skip the read-back entirely (reading it
+			// back could fail transiently and wrongly flip isFreshSync, skipping
+			// the -initialSnapshot walk the reset explicitly requested).
 			if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId), 0); err != nil {
 				return fmt.Errorf("resetCheckpoint: clear offset for sinkId %d: %w", sinkId, err)
 			}
-			// Clear only once. runFilerBackup retries doFilerBackup forever on
-			// error; leaving this set would re-zero the checkpoint on every retry
-			// and never make forward progress after a transient failure. Once the
-			// offset is cleared, later retries must resume from the persisted
-			// checkpoint.
+			// Clear only once: runFilerBackup retries doFilerBackup forever on
+			// error, so leaving this set would re-zero the checkpoint on every
+			// retry and never make progress after a transient failure. Later
+			// retries take the else branch and resume from the persisted offset.
 			*backupOption.resetCheckpoint = false
-			didReset = true
 			glog.V(0).Infof("resetCheckpoint: cleared checkpoint for sinkId %d — starting fresh", sinkId)
-		}
-		lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
-		if err != nil {
-			if didReset {
-				// We just wrote offset 0, so this is authoritatively a fresh sync.
-				// A read-back failure must not flip isFreshSync to false here —
-				// that would skip the -initialSnapshot walk the reset explicitly
-				// requested. Keep isFreshSync=true.
-				glog.V(0).Infof("starting from %v (offset read failed after reset, treating as fresh: %v)", startFrom, err)
-			} else {
+		} else {
+			lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
+			if err != nil {
 				// A KV read failure is ambiguous — a checkpoint may well exist but
 				// the source filer is temporarily unreachable. Don't treat that as
 				// a fresh sync; otherwise runFilerBackup's retry loop would redo
 				// the full -initialSnapshot walk on every transient error.
 				isFreshSync = false
 				glog.V(0).Infof("starting from %v (offset read failed: %v)", startFrom, err)
+			} else if lastOffsetTsNs > 0 {
+				startFrom = time.Unix(0, lastOffsetTsNs)
+				isFreshSync = false
+				glog.V(0).Infof("resuming from %v", startFrom)
+			} else {
+				glog.V(0).Infof("starting from %v (no prior checkpoint)", startFrom)
 			}
-		} else if lastOffsetTsNs > 0 {
-			startFrom = time.Unix(0, lastOffsetTsNs)
-			isFreshSync = false
-			glog.V(0).Infof("resuming from %v", startFrom)
-		} else {
-			glog.V(0).Infof("starting from %v (no prior checkpoint)", startFrom)
 		}
 	} else {
 		startFrom = time.Now().Add(-timeAgo)

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -41,7 +41,6 @@ type FilerBackupOptions struct {
 	timeAgo             *time.Duration
 	retentionDays       *int
 	initialSnapshot     *bool
-	resetCheckpoint     *bool
 }
 
 var (
@@ -64,8 +63,7 @@ func init() {
 	filerBackupOptions.retentionDays = cmdFilerBackup.Flag.Int("retentionDays", 0, "incremental backup retention days")
 	filerBackupOptions.disableErrorRetry = cmdFilerBackup.Flag.Bool("disableErrorRetry", false, "disables errors retry, only logs will print")
 	filerBackupOptions.ignore404Error = cmdFilerBackup.Flag.Bool("ignore404Error", true, "ignore 404 errors from filer")
-	filerBackupOptions.initialSnapshot = cmdFilerBackup.Flag.Bool("initialSnapshot", false, "before subscribing to metadata updates, walk the live filer tree under -filerPath and seed the destination. Only runs on a fresh sync (no prior checkpoint and -timeAgo is 0). After the walk, subscription starts from the walk-start timestamp so concurrent changes are still captured.")
-	filerBackupOptions.resetCheckpoint = cmdFilerBackup.Flag.Bool("resetCheckpoint", false, "clear the persisted resume checkpoint for this sink before starting, forcing a fresh sync from the beginning (re-runs -initialSnapshot). Only effective when -timeAgo is 0. The checkpoint lives in the source filer's KV under a per-sink key.")
+	filerBackupOptions.initialSnapshot = cmdFilerBackup.Flag.Bool("initialSnapshot", false, "before subscribing to metadata updates, walk the live filer tree under -filerPath and seed the destination, then subscribe from the walk-start timestamp so concurrent changes are still captured. Runs on every start when -timeAgo is 0 and overwrites the saved checkpoint, so it also re-seeds a reinitialized destination. Remove it once the backup is caught up, otherwise it re-walks the whole tree on each restart.")
 }
 
 var cmdFilerBackup = &Command{
@@ -77,12 +75,13 @@ var cmdFilerBackup = &Command{
 	and write to the destination. This is to replace filer.replicate command since additional message queue is not needed.
 
 	If restarted and "-timeAgo" is not set, the synchronization will resume from the previous checkpoints, persisted every minute.
-	A fresh sync will start from the earliest metadata logs. To reset the checkpoints, just set "-timeAgo" to a high value.
+	A fresh sync will start from the earliest metadata logs.
 
 	On a fresh sync the metadata event log only re-materializes files that still exist on the source; entries that were
 	created and later deleted are replayed as a create-then-delete pair and therefore never appear on the destination.
 	Pass "-initialSnapshot" to walk the live filer tree first and seed the destination with the current tree, then
-	subscribe from the walk-start timestamp. The walk only runs when there is no prior checkpoint.
+	subscribe from the walk-start timestamp. This also re-seeds a reinitialized destination: it overwrites the saved
+	checkpoint and re-walks on every start, so remove it once the backup is caught up.
 
 `,
 }
@@ -137,36 +136,18 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 
 	// get start time for the data sink
 	startFrom := time.Unix(0, 0)
-	isFreshSync := true
 	sinkId := util.HashStringToLong(dataSink.GetName() + dataSink.GetSinkToDirectory())
-	if timeAgo.Milliseconds() == 0 {
-		if *backupOption.resetCheckpoint {
-			// Clear the persisted resume offset, then start fresh. We just wrote
-			// 0, so this is authoritatively a fresh sync: leave isFreshSync=true
-			// and startFrom at epoch 0 and skip the read-back entirely (reading it
-			// back could fail transiently and wrongly flip isFreshSync, skipping
-			// the -initialSnapshot walk the reset explicitly requested).
-			if err := setOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId), 0); err != nil {
-				return fmt.Errorf("resetCheckpoint: clear offset for sinkId %d: %w", sinkId, err)
-			}
-			// Clear only once: runFilerBackup retries doFilerBackup forever on
-			// error, so leaving this set would re-zero the checkpoint on every
-			// retry and never make progress after a transient failure. Later
-			// retries take the else branch and resume from the persisted offset.
-			*backupOption.resetCheckpoint = false
-			glog.V(0).Infof("resetCheckpoint: cleared checkpoint for sinkId %d — starting fresh", sinkId)
+	runSnapshot := *backupOption.initialSnapshot && timeAgo == 0
+	if timeAgo == 0 {
+		if runSnapshot {
+			// snapshot below sets the start point; no checkpoint read needed
+			glog.V(0).Infof("initialSnapshot requested — walking live tree before subscribing")
 		} else {
 			lastOffsetTsNs, err := getOffset(grpcDialOption, sourceFiler, BackupKeyPrefix, int32(sinkId))
 			if err != nil {
-				// A KV read failure is ambiguous — a checkpoint may well exist but
-				// the source filer is temporarily unreachable. Don't treat that as
-				// a fresh sync; otherwise runFilerBackup's retry loop would redo
-				// the full -initialSnapshot walk on every transient error.
-				isFreshSync = false
 				glog.V(0).Infof("starting from %v (offset read failed: %v)", startFrom, err)
 			} else if lastOffsetTsNs > 0 {
 				startFrom = time.Unix(0, lastOffsetTsNs)
-				isFreshSync = false
 				glog.V(0).Infof("resuming from %v", startFrom)
 			} else {
 				glog.V(0).Infof("starting from %v (no prior checkpoint)", startFrom)
@@ -174,7 +155,6 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		}
 	} else {
 		startFrom = time.Now().Add(-timeAgo)
-		isFreshSync = false
 		glog.V(0).Infof("start time is set to %v", startFrom)
 	}
 
@@ -193,13 +173,11 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	}
 	dataSink.SetSourceFiler(filerSource)
 
-	// When the destination has no prior checkpoint and the user opted in to an
-	// initial snapshot, walk the live filer tree first and seed the destination
-	// with the current entries. This avoids the "only new files appear" pitfall
-	// of replaying the metadata event log: entries created-then-deleted before
-	// the walk leave no trace, so a re-backup after wiping the destination
-	// reflects what is actually live on the source instead of an empty tree.
-	if *backupOption.initialSnapshot && isFreshSync {
+	// Walk and seed the live tree, then subscribe from the walk-start watermark:
+	// replaying the event log alone misses entries created-then-deleted before
+	// the walk. The watermark overwrites any stale checkpoint, re-seeding a wiped
+	// destination.
+	if runSnapshot {
 		snapshotTsNs, err := runInitialSnapshot(sourceFiler.ToGrpcAddress(), filerSource, sourcePath, targetPath, excludePaths, reExcludeFileName, excludeFileNames, excludePathPatterns, dataSink, *backupOption.ignore404Error)
 		if err != nil {
 			return fmt.Errorf("initial snapshot: %w", err)
@@ -212,6 +190,8 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 			return fmt.Errorf("persist initial snapshot offset: %w", err)
 		}
 		startFrom = time.Unix(0, snapshotTsNs)
+		// walk once per process; retries resume from the persisted checkpoint
+		*backupOption.initialSnapshot = false
 		glog.V(0).Infof("initialSnapshot done; subscribing from %v", startFrom)
 	}
 


### PR DESCRIPTION
# What problem are we solving?

filer.backup resumes from a per-sink offset persisted in the source filer's KV. 

**There was no first-class way to discard that checkpoint** and re-run from the beginning short of guessing a large -timeAgo, which also skips -initialSnapshot. (Files with missing file metadata event logs must be synchronized using -initialSnapshot.)

# How are we solving the problem?

**Add -resetCheckpoint: before reading the offset, write 0 for this sink** 
so getOffset returns 0, isFreshSync stays true, and -initialSnapshot re-runs a full walk. 

Effective only when -timeAgo is 0.

When reinitializing the directory of the same sink and running filer.backup from scratch, using the -resetCheckpoint option ensures that even older files whose metadata event logs have been lost on the source cluster are synchronized without being missed.

# How is the PR tested?
1. The **real-green** cluster contains older files whose metadata event logs are no longer available.
2. `filer.backup` is configured to synchronize data from **real-green** to **real-blue**.
3. During a SeaweedFS upgrade on the **real-blue** cluster, the data became inconsistent, requiring the cluster data to be reinitialized.
4. After reinitialization, `filer.backup` is run again to synchronize data from **real-green** to **real-blue**.

If the `-resetCheckpoint` option is not used, older files whose metadata event logs are no longer available will be skipped during synchronization and will not be included in the backup.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `-initialSnapshot` now runs on every start when `-timeAgo 0`, overwrites the saved checkpoint and re-walks to re-seed the destination.

* **Bug Fixes**
  * Startup resume logic clarified: when not running an initial snapshot the command will read and resume from saved checkpoints when present; offset read errors are logged without altering the default start time.

* **Documentation**
  * Updated CLI help and command description to reflect the above behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->