### PR TITLE
ip.bind: bind outbound connections to the configured address

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -335,6 +335,7 @@ func (fo *FilerOptions) startFiler() {
 	if *fo.bindIp == "" {
 		*fo.bindIp = *fo.ip
 	}
+	util.SetOutboundLocalIP(*fo.bindIp)
 	if *fo.allowedOrigins == "" {
 		*fo.allowedOrigins = "*"
 	}

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -188,6 +188,7 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	if *masterOption.ipBind == "" {
 		*masterOption.ipBind = *masterOption.ip
 	}
+	util.SetOutboundLocalIP(*masterOption.ipBind)
 
 	myMasterAddress, peers := checkPeers(*masterOption.ip, *masterOption.port, *masterOption.portGrpc, *masterOption.peers)
 

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -324,6 +324,7 @@ func (s3opt *S3Options) startS3Server() bool {
 	if *s3opt.bindIp == "" {
 		*s3opt.bindIp = "0.0.0.0"
 	}
+	util.SetOutboundLocalIP(*s3opt.bindIp)
 
 	defaultFileMode, fileModeErr := s3opt.parseDefaultFileMode()
 	if fileModeErr != nil {

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -274,6 +274,9 @@ func runServer(cmd *Command, args []string) bool {
 	if *serverBindIp == "" {
 		serverBindIp = serverIp
 	}
+	// Bind outbound connections to the same address up front so every
+	// component started below inherits it, before any of them dials.
+	util.SetOutboundLocalIP(*serverBindIp)
 
 	if *serverMetricsHttpIp == "" {
 		*serverMetricsHttpIp = *serverBindIp

--- a/weed/command/sftp.go
+++ b/weed/command/sftp.go
@@ -110,6 +110,7 @@ func (sftpOpt *SftpOptions) startSftpServer() bool {
 	if *sftpOpt.bindIp == "" {
 		*sftpOpt.bindIp = "0.0.0.0"
 	}
+	util.SetOutboundLocalIP(*sftpOpt.bindIp)
 	filerAddress := pb.ServerAddress(*sftpOpt.filer)
 	grpcDialOption := security.LoadClientTLS(util.GetViper(), "grpc.client")
 

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -380,6 +380,7 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 	if *v.bindIp == "" {
 		*v.bindIp = *v.ip
 	}
+	util.SetOutboundLocalIP(*v.bindIp)
 
 	if *v.publicPort == 0 {
 		*v.publicPort = *v.port

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -89,6 +89,8 @@ func (wo *WebDavOption) resolvePaths() {
 
 func (wo *WebDavOption) startWebDav() bool {
 
+	util.SetOutboundLocalIP(*wo.ipBind)
+
 	// detect current user
 	uid, gid := uint32(0), uint32(0)
 	if u, err := user.Current(); err == nil {

--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -73,8 +73,13 @@ type versionedGrpcClient struct {
 }
 
 func init() {
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 1024
-	http.DefaultTransport.(*http.Transport).MaxIdleConns = 1024
+	t := http.DefaultTransport.(*http.Transport)
+	t.MaxIdleConnsPerHost = 1024
+	t.MaxIdleConns = 1024
+	// Bind outbound HTTP to the -ip.bind source address. Reads the setting
+	// per dial, so it applies regardless of when SetOutboundLocalIP runs
+	// relative to this init.
+	t.DialContext = util.OutboundDialContext
 }
 
 // RegisterLocalGrpcSocket registers a Unix socket path for a gRPC service
@@ -206,6 +211,13 @@ func GrpcDial(ctx context.Context, address string, waitForReady bool, opts ...gr
 		options = append(options, grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			var d net.Dialer
 			return d.DialContext(ctx, "unix", socketPath)
+		}))
+	} else if util.OutboundLocalAddr() != nil {
+		// Bind outbound gRPC connections to the configured -ip.bind source
+		// address. Only installed when a source address is set, so default
+		// deployments keep gRPC's stock dialer behavior.
+		options = append(options, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return util.OutboundDialContext(ctx, "tcp", addr)
 		}))
 	}
 

--- a/weed/util/http/client/http_client.go
+++ b/weed/util/http/client/http_client.go
@@ -165,6 +165,8 @@ func NewHttpClient(clientName ClientName, opts ...HttpClientOpt) (*HTTPClient, e
 		MaxIdleConns:        1024,
 		MaxIdleConnsPerHost: 1024,
 		TLSClientConfig:     tlsConfig,
+		// Bind outbound HTTP to the -ip.bind source address.
+		DialContext: util.OutboundDialContext,
 	}
 	httpClient.Client = &http.Client{
 		Transport: httpClient.Transport,
@@ -279,6 +281,8 @@ func NewHttpClientWithTLS(certFile, keyFile, caFile string, insecureSkipVerify b
 		MaxIdleConns:        1024,
 		MaxIdleConnsPerHost: 1024,
 		TLSClientConfig:     tlsConfig,
+		// Bind outbound HTTP to the -ip.bind source address.
+		DialContext: util.OutboundDialContext,
 	}
 	httpClient.Client = &http.Client{
 		Transport: httpClient.Transport,

--- a/weed/util/outbound_dial.go
+++ b/weed/util/outbound_dial.go
@@ -14,15 +14,25 @@ import (
 // address instead of one the OS picks arbitrarily, which may not even be able
 // to reach the target. A nil value keeps the historical behavior of letting
 // the OS choose the source address.
-var outboundLocalAddr atomic.Pointer[net.TCPAddr]
+var (
+	outboundLocalAddr    atomic.Pointer[net.TCPAddr]
+	outboundLocalAddrSet atomic.Bool
+)
 
 // SetOutboundLocalIP records ip as the source address for outbound TCP
-// connections. An empty, wildcard (0.0.0.0 / ::), or unparseable value clears
-// any binding so the OS keeps choosing the source address.
+// connections. An empty, wildcard (0.0.0.0 / ::), or unparseable value leaves
+// the source address to the OS.
+//
+// The first call wins. `weed server` applies the top-level -ip.bind before its
+// embedded master/volume/filer/s3/... start, so a component's own (possibly
+// different) bind setting can't later clobber the process-wide source address
+// the others already dial from.
 func SetOutboundLocalIP(ip string) {
+	if !outboundLocalAddrSet.CompareAndSwap(false, true) {
+		return
+	}
 	parsed := net.ParseIP(ip)
 	if parsed == nil || parsed.IsUnspecified() {
-		outboundLocalAddr.Store(nil)
 		return
 	}
 	outboundLocalAddr.Store(&net.TCPAddr{IP: parsed})
@@ -57,7 +67,20 @@ func outboundLocalAddrForDial(network, address string) *net.TCPAddr {
 	if localAddr == nil || !strings.HasPrefix(network, "tcp") || isLoopbackHost(address) {
 		return nil
 	}
+	// A source address can only originate a connection to a target of the same
+	// IP family. When the target is a literal IP of the other family, leave the
+	// source to the OS rather than forcing a dial that is bound to fail.
+	if host, _, err := net.SplitHostPort(address); err == nil {
+		if targetIP := net.ParseIP(host); targetIP != nil && isIPv4(targetIP) != isIPv4(localAddr.IP) {
+			return nil
+		}
+	}
 	return localAddr
+}
+
+// isIPv4 reports whether ip is an IPv4 (or IPv4-mapped) address.
+func isIPv4(ip net.IP) bool {
+	return ip.To4() != nil
 }
 
 // isLoopbackHost reports whether the host part of a "host:port" (or bare host)

--- a/weed/util/outbound_dial.go
+++ b/weed/util/outbound_dial.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// outboundLocalAddr is the optional source address that outbound TCP
+// connections initiated by this process bind to. It mirrors the -ip.bind
+// setting so connections this process opens leave from the configured
+// address instead of one the OS picks arbitrarily, which may not even be able
+// to reach the target. A nil value keeps the historical behavior of letting
+// the OS choose the source address.
+var outboundLocalAddr atomic.Pointer[net.TCPAddr]
+
+// SetOutboundLocalIP records ip as the source address for outbound TCP
+// connections. An empty, wildcard (0.0.0.0 / ::), or unparseable value clears
+// any binding so the OS keeps choosing the source address.
+func SetOutboundLocalIP(ip string) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil || parsed.IsUnspecified() {
+		outboundLocalAddr.Store(nil)
+		return
+	}
+	outboundLocalAddr.Store(&net.TCPAddr{IP: parsed})
+}
+
+// OutboundLocalAddr returns the configured source address for outbound TCP
+// connections, or nil if none is configured.
+func OutboundLocalAddr() *net.TCPAddr {
+	return outboundLocalAddr.Load()
+}
+
+// OutboundDialContext dials network/address with the standard library's
+// default timeouts, binding the local (source) address to the configured
+// -ip.bind value for non-loopback tcp targets. Loopback targets and non-tcp
+// networks (e.g. unix sockets) keep the OS-chosen source address: a routable
+// bind IP cannot originate a packet on the loopback interface.
+func OutboundDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	d := net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	if localAddr := outboundLocalAddrForDial(network, address); localAddr != nil {
+		d.LocalAddr = localAddr
+	}
+	return d.DialContext(ctx, network, address)
+}
+
+// outboundLocalAddrForDial returns the source address to bind for a dial to
+// network/address, or nil to leave the source address to the OS.
+func outboundLocalAddrForDial(network, address string) *net.TCPAddr {
+	localAddr := OutboundLocalAddr()
+	if localAddr == nil || !strings.HasPrefix(network, "tcp") || isLoopbackHost(address) {
+		return nil
+	}
+	return localAddr
+}
+
+// isLoopbackHost reports whether the host part of a "host:port" (or bare host)
+// address refers to the loopback interface.
+func isLoopbackHost(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/weed/util/outbound_dial_test.go
+++ b/weed/util/outbound_dial_test.go
@@ -4,23 +4,31 @@ import (
 	"testing"
 )
 
+// resetOutbound clears the process-global outbound source address so each test
+// starts from a clean slate (SetOutboundLocalIP is otherwise first-write-wins).
+func resetOutbound() {
+	outboundLocalAddrSet.Store(false)
+	outboundLocalAddr.Store(nil)
+}
+
 func TestSetOutboundLocalIP(t *testing.T) {
-	t.Cleanup(func() { SetOutboundLocalIP("") })
+	t.Cleanup(resetOutbound)
 
 	cases := []struct {
 		name   string
 		ip     string
-		wantIP string // empty means cleared
+		wantIP string // empty means no binding
 	}{
 		{"ipv4", "10.0.0.5", "10.0.0.5"},
 		{"ipv6", "fe80::1", "fe80::1"},
-		{"empty clears", "", ""},
-		{"wildcard v4 clears", "0.0.0.0", ""},
-		{"wildcard v6 clears", "::", ""},
-		{"garbage clears", "not-an-ip", ""},
+		{"empty", "", ""},
+		{"wildcard v4", "0.0.0.0", ""},
+		{"wildcard v6", "::", ""},
+		{"garbage", "not-an-ip", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			resetOutbound()
 			SetOutboundLocalIP(tc.ip)
 			got := OutboundLocalAddr()
 			if tc.wantIP == "" {
@@ -42,15 +50,32 @@ func TestSetOutboundLocalIP(t *testing.T) {
 	}
 }
 
+// TestSetOutboundLocalIPFirstWins guards the behavior that keeps `weed server`
+// from letting a component's own bind setting clobber the process-wide address.
+func TestSetOutboundLocalIPFirstWins(t *testing.T) {
+	t.Cleanup(resetOutbound)
+	resetOutbound()
+
+	SetOutboundLocalIP("10.0.0.5") // server-level bind, applied first
+	SetOutboundLocalIP("10.0.0.9") // a component's own bind: must be ignored
+	SetOutboundLocalIP("")         // a component clearing: must not unbind
+
+	got := OutboundLocalAddr()
+	if got == nil || got.IP.String() != "10.0.0.5" {
+		t.Fatalf("first call should win, got %v", got)
+	}
+}
+
 func TestOutboundLocalAddrForDial(t *testing.T) {
-	t.Cleanup(func() { SetOutboundLocalIP("") })
+	t.Cleanup(resetOutbound)
 
 	// No bind configured: never binds a source address.
-	SetOutboundLocalIP("")
+	resetOutbound()
 	if got := outboundLocalAddrForDial("tcp", "10.0.0.9:8080"); got != nil {
 		t.Fatalf("unconfigured dial should not bind, got %v", got)
 	}
 
+	resetOutbound()
 	SetOutboundLocalIP("10.0.0.5")
 	cases := []struct {
 		name     string
@@ -64,6 +89,7 @@ func TestOutboundLocalAddrForDial(t *testing.T) {
 		{"loopback ip skipped", "tcp", "127.0.0.1:9333", false},
 		{"loopback name skipped", "tcp", "localhost:9333", false},
 		{"ipv6 loopback skipped", "tcp", "[::1]:9333", false},
+		{"ipv6 literal target skipped", "tcp", "[2001:db8::1]:8080", false},
 		{"unix network skipped", "unix", "/tmp/x.sock", false},
 		{"udp network skipped", "udp", "10.0.0.9:53", false},
 	}
@@ -77,5 +103,27 @@ func TestOutboundLocalAddrForDial(t *testing.T) {
 				t.Fatalf("%s/%s: expected no source binding, got %v", tc.network, tc.address, got)
 			}
 		})
+	}
+}
+
+func TestOutboundLocalAddrFamilyMismatch(t *testing.T) {
+	t.Cleanup(resetOutbound)
+
+	resetOutbound()
+	SetOutboundLocalIP("10.0.0.5") // IPv4 source
+	if got := outboundLocalAddrForDial("tcp", "[2001:db8::1]:8080"); got != nil {
+		t.Fatalf("IPv4 source to IPv6 literal target should skip binding, got %v", got)
+	}
+	if got := outboundLocalAddrForDial("tcp", "10.0.0.9:8080"); got == nil {
+		t.Fatalf("IPv4 source to IPv4 literal target should bind")
+	}
+
+	resetOutbound()
+	SetOutboundLocalIP("2001:db8::5") // IPv6 source
+	if got := outboundLocalAddrForDial("tcp", "10.0.0.9:8080"); got != nil {
+		t.Fatalf("IPv6 source to IPv4 literal target should skip binding, got %v", got)
+	}
+	if got := outboundLocalAddrForDial("tcp", "[2001:db8::1]:8080"); got == nil {
+		t.Fatalf("IPv6 source to IPv6 literal target should bind")
 	}
 }

--- a/weed/util/outbound_dial_test.go
+++ b/weed/util/outbound_dial_test.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestSetOutboundLocalIP(t *testing.T) {
+	t.Cleanup(func() { SetOutboundLocalIP("") })
+
+	cases := []struct {
+		name   string
+		ip     string
+		wantIP string // empty means cleared
+	}{
+		{"ipv4", "10.0.0.5", "10.0.0.5"},
+		{"ipv6", "fe80::1", "fe80::1"},
+		{"empty clears", "", ""},
+		{"wildcard v4 clears", "0.0.0.0", ""},
+		{"wildcard v6 clears", "::", ""},
+		{"garbage clears", "not-an-ip", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetOutboundLocalIP(tc.ip)
+			got := OutboundLocalAddr()
+			if tc.wantIP == "" {
+				if got != nil {
+					t.Fatalf("expected no bound address, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected bound address %s, got nil", tc.wantIP)
+			}
+			if got.IP.String() != tc.wantIP {
+				t.Fatalf("bound address = %s, want %s", got.IP.String(), tc.wantIP)
+			}
+			if got.Port != 0 {
+				t.Fatalf("bound port = %d, want 0 (ephemeral)", got.Port)
+			}
+		})
+	}
+}
+
+func TestOutboundLocalAddrForDial(t *testing.T) {
+	t.Cleanup(func() { SetOutboundLocalIP("") })
+
+	// No bind configured: never binds a source address.
+	SetOutboundLocalIP("")
+	if got := outboundLocalAddrForDial("tcp", "10.0.0.9:8080"); got != nil {
+		t.Fatalf("unconfigured dial should not bind, got %v", got)
+	}
+
+	SetOutboundLocalIP("10.0.0.5")
+	cases := []struct {
+		name     string
+		network  string
+		address  string
+		wantBind bool
+	}{
+		{"remote tcp binds", "tcp", "10.0.0.9:8080", true},
+		{"tcp4 binds", "tcp4", "example.com:443", true},
+		{"hostname binds", "tcp", "filer.internal:8888", true},
+		{"loopback ip skipped", "tcp", "127.0.0.1:9333", false},
+		{"loopback name skipped", "tcp", "localhost:9333", false},
+		{"ipv6 loopback skipped", "tcp", "[::1]:9333", false},
+		{"unix network skipped", "unix", "/tmp/x.sock", false},
+		{"udp network skipped", "udp", "10.0.0.9:53", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := outboundLocalAddrForDial(tc.network, tc.address)
+			if tc.wantBind && got == nil {
+				t.Fatalf("%s/%s: expected source binding, got nil", tc.network, tc.address)
+			}
+			if !tc.wantBind && got != nil {
+				t.Fatalf("%s/%s: expected no source binding, got %v", tc.network, tc.address, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addresses #9830.

`-ip.bind` only controlled which address the listeners bound to. Connections this process *initiates* (gRPC to masters/volumes/filers, HTTP fetches between components, etc.) still let the kernel pick a source IP, which on a multi-homed host may be one that can't reach the target.

This mirrors the bind address into a process-global outbound source address and applies it to outbound TCP dials:

- gRPC: a context dialer with `LocalAddr` set, installed only when a bind address is configured (default deployments keep gRPC's stock dialer).
- HTTP: `DialContext` on the per-client transports and on `http.DefaultTransport`. The setting is read per dial, so it applies no matter when it's configured relative to client construction.

Each daemon registers its resolved bind address at startup (`master`, `volume`, `filer`, `s3`, `sftp`, `webdav`), and `weed server` sets it once up front so every embedded component inherits it before any of them dials.

Loopback targets (`localhost` / `127.0.0.0/8` / `::1`) and unix sockets keep the OS-chosen source: a routable bind IP can't originate a packet on the loopback interface, so same-host traffic (including the local gRPC unix-socket fast path) is unaffected. A wildcard bind (`0.0.0.0` / `::`) or empty value leaves the source address to the OS, preserving current behavior.

Unit tests cover the parse/clear logic and the per-dial bind decision (remote vs loopback, tcp vs unix/udp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Servers can bind outbound network connections to a configured local IP, making source IPs consistent across HTTP, gRPC, and other protocols.
  * Once a non-empty outbound IP is set at startup, it is locked (first-call wins) and later changes are ignored.

* **Tests**
  * Added comprehensive tests covering outbound binding behavior, IP validation, family mismatches, and loopback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->