### PR TITLE
fix(helm): suspend bucket versioning for YAML bool false

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -448,10 +448,7 @@ jobs:
 
           echo ""
           echo "=== Testing bucket versioning: YAML bool false suspends like string \"false\" ==="
-          # Regression: createBuckets[].versioning given as a YAML bool false must
-          # Suspend the bucket, matching the string forms ("false"/"disable"/"suspended").
-          # Before the fix, bool false was a silent no-op while string "false" suspended,
-          # so the same logical value behaved differently depending on its YAML type.
+          # bool false used to be a silent no-op while string "false" suspended.
           BOOL_FALSE=$(helm template test $CHART_DIR \
             --set s3.enabled=true \
             --set s3.createBuckets[0].name=verbucket \

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -446,6 +446,19 @@ jobs:
           sys.exit(1 if failed else 0)
           PYEOF
 
+          echo ""
+          echo "=== Testing bucket versioning: YAML bool false suspends like string \"false\" ==="
+          # Regression: createBuckets[].versioning given as a YAML bool false must
+          # Suspend the bucket, matching the string forms ("false"/"disable"/"suspended").
+          # Before the fix, bool false was a silent no-op while string "false" suspended,
+          # so the same logical value behaved differently depending on its YAML type.
+          BOOL_FALSE=$(helm template test $CHART_DIR \
+            --set s3.enabled=true \
+            --set s3.createBuckets[0].name=verbucket \
+            --set s3.createBuckets[0].versioning=false | grep 's3.bucket.versioning -name verbucket' || true)
+          echo "$BOOL_FALSE" | grep -q -- '-status Suspended' || { echo "FAIL: bool false versioning did not Suspend the bucket"; exit 1; }
+          echo "✓ Bucket versioning: YAML bool false suspends consistently with string \"false\""
+
           echo "✅ All template rendering tests passed!"
 
       - name: Create kind cluster

--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -143,6 +143,8 @@ spec:
           {{- if kindIs "bool" .versioning }}
             {{- if .versioning }}
               {{- $bucketVersioning = "Enabled" }}
+            {{- else }}
+              {{- $bucketVersioning = "Suspended" }}
             {{- end }}
           {{- else if kindIs "string" .versioning }}
             {{- $versioningLower := lower .versioning }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -919,7 +919,7 @@ filer:
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
     # objectLock enables S3 Object Lock (irreversible, forces versioning)
-    # versioning: Enabled or Suspended (or true to enable)
+    # versioning: Enabled or Suspended (or bool true/false)
     # createBuckets:
     #   - name: bucket-a
     #     anonymousRead: true
@@ -972,7 +972,7 @@ s3:
   # Buckets may be exposed publicly by setting `anonymousRead` to `true`
   # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
   # objectLock enables S3 Object Lock (irreversible, forces versioning)
-  # versioning: Enabled or Suspended (or true to enable)
+  # versioning: Enabled or Suspended (or bool true/false)
   # createBuckets:
   #   - name: bucket-a
   #     anonymousRead: true
@@ -1526,7 +1526,7 @@ allInOne:
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
     # objectLock enables S3 Object Lock (irreversible, forces versioning)
-    # versioning: Enabled or Suspended (or true to enable)
+    # versioning: Enabled or Suspended (or bool true/false)
     # createBuckets:
     #   - name: bucket-a
     #     anonymousRead: true


### PR DESCRIPTION
# What problem are we solving?

The chart's `createBuckets[].versioning` value accepts both a YAML bool and a string, but the two types behave differently. The string branch maps `"false"`/`"disable"`/`"suspended"` to `Suspended`, while the bool branch only handled `true` (→ `Enabled`) and left `false` as a silent no-op. So `versioning: false` did nothing, whereas `versioning: "false"` suspended the bucket — the same logical value producing different results depending on its YAML type.

# How are we solving the problem?

Mirror the string branch in the bool branch: bool `false` now maps to `Suspended`, consistent with the string forms. Omitting `versioning` entirely remains a no-op (the bucket is left at its current state), so this only changes behavior for buckets that explicitly set `versioning: false`.

# How is the PR tested?

Added a render assertion to the chart CI (`.github/workflows/helm_ci.yml`) that renders `createBuckets` with a YAML bool `false` and asserts the post-install hook emits `-status Suspended`. Verified locally with `helm template` across bool false/true, string `"false"`, and omitted versioning; `helm lint` passes.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CI regression check to ensure S3 bucket versioning renders as the expected suspended state when configured as a YAML boolean.

* **Chores**
  * Adjusted template rendering behavior to normalize whitespace and ensure consistent script output for bucket versioning.

* **Documentation**
  * Clarified configuration comments to indicate versioning accepts boolean true/false values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->