### PR TITLE
master: migrate legacy raft identity to hashicorp raft, deprecate legacy raft

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -103,7 +103,7 @@ func init() {
 	m.raftResumeState = cmdMaster.Flag.Bool("resumeState", true, "resume previous state on start master server")
 	m.heartbeatInterval = cmdMaster.Flag.Duration("heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	m.electionTimeout = cmdMaster.Flag.Duration("electionTimeout", 10*time.Second, "election timeout of master servers")
-	m.raftHashicorp = cmdMaster.Flag.Bool("raftHashicorp", false, "use hashicorp raft")
+	m.raftHashicorp = cmdMaster.Flag.Bool("raftHashicorp", false, "use hashicorp raft (recommended; legacy seaweedfs/raft is deprecated)")
 	m.raftBootstrap = cmdMaster.Flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	m.telemetryUrl = cmdMaster.Flag.String("telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL to send usage statistics")
 	m.telemetryEnabled = cmdMaster.Flag.Bool("telemetry", false, "enable telemetry reporting")
@@ -229,6 +229,7 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 			glog.Fatalf("NewHashicorpRaftServer: %s", err)
 		}
 	} else {
+		glog.Warningf("legacy seaweedfs/raft is deprecated and will be removed; restart with -raftHashicorp to switch (cluster state is migrated automatically)")
 		raftServer, err = weed_server.NewRaftServer(raftServerOption)
 		if raftServer == nil {
 			glog.Fatalf("please verify %s is writable, see https://github.com/seaweedfs/seaweedfs/issues/717: %s", *masterOption.metaFolder, err)

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -430,7 +430,7 @@ func initMiniMasterFlags() {
 	miniMasterOptions.raftResumeState = cmdMini.Flag.Bool("master.resumeState", true, "resume previous state on start master server")
 	miniMasterOptions.heartbeatInterval = cmdMini.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	miniMasterOptions.electionTimeout = cmdMini.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
-	miniMasterOptions.raftHashicorp = cmdMini.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft")
+	miniMasterOptions.raftHashicorp = cmdMini.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft (recommended; legacy seaweedfs/raft is deprecated)")
 	miniMasterOptions.raftBootstrap = cmdMini.Flag.Bool("master.raftBootstrap", false, "whether to bootstrap the Raft cluster")
 	miniMasterOptions.telemetryUrl = cmdMini.Flag.String("master.telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL")
 	miniMasterOptions.telemetryEnabled = cmdMini.Flag.Bool("master.telemetry", false, "enable telemetry reporting")

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -103,7 +103,7 @@ func init() {
 	masterOptions.metricsAddress = cmdServer.Flag.String("master.metrics.address", "", "Prometheus gateway address")
 	masterOptions.metricsIntervalSec = cmdServer.Flag.Int("master.metrics.intervalSeconds", 15, "Prometheus push interval in seconds")
 	masterOptions.raftResumeState = cmdServer.Flag.Bool("master.resumeState", true, "resume previous state on start master server")
-	masterOptions.raftHashicorp = cmdServer.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft")
+	masterOptions.raftHashicorp = cmdServer.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft (recommended; legacy seaweedfs/raft is deprecated)")
 	masterOptions.raftBootstrap = cmdServer.Flag.Bool("master.raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	masterOptions.heartbeatInterval = cmdServer.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")

--- a/weed/server/raft_hashicorp.go
+++ b/weed/server/raft_hashicorp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/topology"
+	"github.com/seaweedfs/seaweedfs/weed/util/version"
 	"google.golang.org/grpc"
 )
 
@@ -31,7 +32,56 @@ const (
 	ldbFile            = "logs.dat"
 	sdbFile            = "stable.dat"
 	updatePeersTimeout = 15 * time.Minute
+
+	// legacyMigrationKey marks, in the hashicorp stable store, that this
+	// master's hashicorp raft state has already absorbed any pre-existing
+	// legacy seaweedfs/raft state. Its presence makes the import one-time so
+	// later restarts never re-read stale legacy state.
+	legacyMigrationKey = "seaweedfs.legacy.raft.migrated"
 )
+
+// migrateLegacyRaftStateIfNeeded performs the one-time legacy -> hashicorp raft
+// migration. It first checks the migration marker in the hashicorp stable
+// store; if already migrated it does nothing. Otherwise, when a legacy
+// seaweedfs/raft state is present, it imports the cluster identity
+// (TopologyId) and MaxVolumeId from it, then marks the migration done. With no
+// legacy state it just records the marker. Either way the master ends up
+// marked migrated, so the import runs at most once per cluster.
+func migrateLegacyRaftStateIfNeeded(sdb *boltdb.BoltStore, dataDir string, topo *topology.Topology) {
+	if _, err := sdb.Get([]byte(legacyMigrationKey)); err == nil {
+		return // marker present: already migrated
+	}
+	if legacyRaftStateExists(dataDir) {
+		glog.V(0).Infof("first hashicorp-raft start with legacy raft state in %s; migrating", dataDir)
+		importLegacyRaftState(dataDir, topo)
+	}
+	if err := sdb.Set([]byte(legacyMigrationKey), []byte(version.Version())); err != nil {
+		glog.Warningf("failed to record legacy raft migration marker: %v", err)
+	}
+}
+
+// importLegacyRaftState seeds TopologyId and MaxVolumeId from the latest legacy
+// snapshot. TopologyId is the cluster identity and must survive the engine
+// switch; MaxVolumeId is otherwise rebuilt from volume heartbeats, but carrying
+// it avoids reusing an id whose volume was deleted before the migration.
+func importLegacyRaftState(dataDir string, topo *topology.Topology) {
+	state, ok := readLegacyRaftSnapshotState(dataDir)
+	if !ok {
+		glog.V(0).Infof("legacy raft state present but no readable snapshot; " +
+			"TopologyId/MaxVolumeId will be rebuilt from volume heartbeats")
+		return
+	}
+	var cmd topology.MaxVolumeIdCommand
+	if err := json.Unmarshal(state, &cmd); err != nil {
+		glog.Warningf("failed to parse legacy raft snapshot state: %v", err)
+		return
+	}
+	topo.UpAdjustMaxVolumeId(cmd.MaxVolumeId)
+	if cmd.TopologyId != "" {
+		topo.SetTopologyId(cmd.TopologyId)
+	}
+	glog.V(0).Infof("migrated legacy raft state: MaxVolumeId=%d TopologyId=%s", cmd.MaxVolumeId, cmd.TopologyId)
+}
 
 func getPeerIdx(self pb.ServerAddress, mapPeers map[string]pb.ServerAddress) int {
 	peerIDs := make([]string, 0, len(mapPeers))
@@ -211,6 +261,11 @@ func NewHashicorpRaftServer(option *RaftServerOption) (*RaftServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("boltdb.NewBoltStore(%q): %v", filepath.Join(baseDir, "stable.dat"), err)
 	}
+
+	// Carry cluster identity forward when upgrading from legacy seaweedfs/raft.
+	// Runs once, before raft starts, so the seeded TopologyId is in place
+	// before ensureTopologyId would otherwise generate a fresh one.
+	migrateLegacyRaftStateIfNeeded(sdb, baseDir, option.Topo)
 
 	fss, err := raft.NewFileSnapshotStore(baseDir, 3, os.Stderr)
 	if err != nil {

--- a/weed/server/raft_migration_test.go
+++ b/weed/server/raft_migration_test.go
@@ -1,0 +1,116 @@
+package weed_server
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	boltdb "github.com/hashicorp/raft-boltdb/v2"
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/topology"
+)
+
+// writeLegacySnapshot writes a seaweedfs/raft (legacy) snapshot carrying the
+// given FSM state, in the on-disk format readLegacyRaftSnapshotState expects.
+func writeLegacySnapshot(t *testing.T, dataDir string, maxVolumeId needle.VolumeId, topologyId string) {
+	t.Helper()
+	snapshotDir := path.Join(dataDir, "snapshot")
+	if err := os.MkdirAll(snapshotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	state, err := json.Marshal(topology.MaxVolumeIdCommand{MaxVolumeId: maxVolumeId, TopologyId: topologyId})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(struct {
+		State json.RawMessage `json:"state"`
+	}{State: state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path.Join(snapshotDir, "0_1.ss"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintf(f, "%08x\n", crc32.ChecksumIEEE(body)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(body); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func openStableStore(t *testing.T, dataDir string) *boltdb.BoltStore {
+	t.Helper()
+	sdb, err := boltdb.NewBoltStore(filepath.Join(dataDir, sdbFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { sdb.Close() })
+	return sdb
+}
+
+func newTestTopology() *topology.Topology {
+	return topology.NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+}
+
+func TestMigrateLegacyRaftState_ImportsIdentityOnce(t *testing.T) {
+	dir := t.TempDir()
+	writeLegacySnapshot(t, dir, 4242, "cluster-abc")
+
+	sdb := openStableStore(t, dir)
+	topo := newTestTopology()
+
+	migrateLegacyRaftStateIfNeeded(sdb, dir, topo)
+
+	if got := topo.GetTopologyId(); got != "cluster-abc" {
+		t.Fatalf("TopologyId = %q, want cluster-abc", got)
+	}
+	if got := topo.GetMaxVolumeId(); got != needle.VolumeId(4242) {
+		t.Fatalf("MaxVolumeId = %d, want 4242", got)
+	}
+	if v, err := sdb.Get([]byte(legacyMigrationKey)); err != nil || len(v) == 0 {
+		t.Fatalf("migration marker not set: v=%q err=%v", v, err)
+	}
+
+	// Second run on a fresh topology must NOT re-import: the marker gates it.
+	topo2 := newTestTopology()
+	migrateLegacyRaftStateIfNeeded(sdb, dir, topo2)
+	if got := topo2.GetTopologyId(); got != "" {
+		t.Fatalf("re-import after marker set: TopologyId = %q, want empty", got)
+	}
+}
+
+func TestMigrateLegacyRaftState_NoLegacyJustMarks(t *testing.T) {
+	dir := t.TempDir()
+	sdb := openStableStore(t, dir)
+	topo := newTestTopology()
+
+	migrateLegacyRaftStateIfNeeded(sdb, dir, topo)
+
+	if got := topo.GetTopologyId(); got != "" {
+		t.Fatalf("TopologyId = %q, want empty (nothing to import)", got)
+	}
+	if v, err := sdb.Get([]byte(legacyMigrationKey)); err != nil || len(v) == 0 {
+		t.Fatalf("migration marker not set on fresh install: v=%q err=%v", v, err)
+	}
+}
+
+func TestLegacyRaftStateExists(t *testing.T) {
+	dir := t.TempDir()
+	if legacyRaftStateExists(dir) {
+		t.Fatal("empty dir reported as having legacy state")
+	}
+	if err := os.WriteFile(path.Join(dir, "log"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !legacyRaftStateExists(dir) {
+		t.Fatal("legacy log file not detected")
+	}
+}

--- a/weed/server/raft_server.go
+++ b/weed/server/raft_server.go
@@ -249,35 +249,47 @@ func (s *RaftServer) Peers() (members []string) {
 	return
 }
 
-// recoverTopologyIdFromSnapshot reads the TopologyId from the latest
-// seaweedfs/raft snapshot before state cleanup.
-func recoverTopologyIdFromSnapshot(dataDir string, topo *topology.Topology) {
+// legacyRaftStateExists reports whether a seaweedfs/raft (legacy) state is
+// present in dataDir. The legacy engine writes these names; hashicorp raft
+// uses logs.dat/stable.dat/snapshots, so there is no overlap.
+func legacyRaftStateExists(dataDir string) bool {
+	for _, name := range []string{"snapshot", "log", "conf", "state"} {
+		if _, err := os.Stat(path.Join(dataDir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// readLegacyRaftSnapshotState returns the raw FSM state JSON from the latest
+// seaweedfs/raft (legacy) snapshot, if a valid one exists.
+func readLegacyRaftSnapshotState(dataDir string) (json.RawMessage, bool) {
 	snapshotDir := path.Join(dataDir, "snapshot")
 	dir, err := os.Open(snapshotDir)
 	if err != nil {
-		return
+		return nil, false
 	}
 	defer dir.Close()
 	filenames, err := dir.Readdirnames(-1)
 	if err != nil || len(filenames) == 0 {
-		return
+		return nil, false
 	}
 
 	sort.Strings(filenames)
 	file, err := os.Open(path.Join(snapshotDir, filenames[len(filenames)-1]))
 	if err != nil {
-		return
+		return nil, false
 	}
 	defer file.Close()
 
 	// Snapshot format: 8-hex-digit CRC32 checksum, newline, JSON body.
 	var checksum uint32
 	if _, err := fmt.Fscanf(file, "%08x\n", &checksum); err != nil {
-		return
+		return nil, false
 	}
 	b, err := io.ReadAll(file)
 	if err != nil || crc32.ChecksumIEEE(b) != checksum {
-		return
+		return nil, false
 	}
 
 	// The snapshot JSON wraps the FSM state in a "state" field.
@@ -285,9 +297,17 @@ func recoverTopologyIdFromSnapshot(dataDir string, topo *topology.Topology) {
 		State json.RawMessage `json:"state"`
 	}
 	if err := json.Unmarshal(b, &snap); err != nil || len(snap.State) == 0 {
-		return
+		return nil, false
 	}
-	recoverTopologyIdFromState(snap.State, topo)
+	return snap.State, true
+}
+
+// recoverTopologyIdFromSnapshot reads the TopologyId from the latest
+// seaweedfs/raft snapshot before state cleanup.
+func recoverTopologyIdFromSnapshot(dataDir string, topo *topology.Topology) {
+	if state, ok := readLegacyRaftSnapshotState(dataDir); ok {
+		recoverTopologyIdFromState(state, topo)
+	}
 }
 
 // HasExistingState returns true when the raft log already contains entries,


### PR DESCRIPTION
## What

Make the legacy `seaweedfs/raft` -> hashicorp raft switch lossless, and deprecate the legacy engine.

### 1. Carry cluster identity into hashicorp raft

The master raft FSM holds only `{MaxVolumeId, TopologyId}`, and `MaxVolumeId` is rebuilt from volume heartbeats — so switching engines is "discard old state, rebuild." The one thing that is *not* recoverable is `TopologyId` (cluster identity). Previously the hashicorp server only recovered `TopologyId` from a hashicorp-format snapshot, so a master switching from legacy generated a brand-new identity.

On first start on hashicorp raft, `migrateLegacyRaftStateIfNeeded`:
- checks a marker in the hashicorp stable store; if present, it is already migrated and nothing happens;
- otherwise, if a legacy `snapshot/` exists, imports `TopologyId` + `MaxVolumeId` from it (seeded before raft starts, so `ensureTopologyId` won't generate a fresh id);
- marks migrated either way, so the import runs at most once and a fresh install never re-scans.

Safe across paths: stale legacy files next to live hashicorp state can't override it (raft replay re-asserts the real id, and `MaxVolumeId` only rises).

### 2. Deprecate legacy seaweedfs/raft

Startup warning when the legacy engine is selected, plus a deprecation note in `-raftHashicorp` help.

The default is intentionally **unchanged** in this PR: flipping it would silently turn a multi-master rolling upgrade into a mixed, incompatible-protocol cluster mid-restart. Operators opt in deliberately; the identity migration carries state across. The default flip can follow once this is proven.

## Commits
- `master: carry cluster identity from legacy raft into hashicorp raft`
- `master: deprecate legacy seaweedfs/raft`

## Tests
`raft_migration_test.go` covers import-once (marker gates re-import), no-legacy-just-marks, and the legacy-state existence check.

## Context
Surfaced by #9816, where a single-master legacy raft loop wedged after a hard power-off and stalled all volume growth via `NextVolumeId`. This makes hashicorp raft a safe, identity-preserving destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic state migration to seamlessly upgrade cluster configurations from legacy Raft to Hashicorp Raft during node startup.

* **Documentation**
  * Updated all CLI flag help text to recommend Hashicorp Raft and clearly indicate the legacy Raft implementation as deprecated.

* **Deprecation Notice**
  * Added warning message at startup when clusters are running with the deprecated legacy Raft implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->