### PR TITLE
s3: list directory key objects in versioned bucket version listings

### DIFF
--- a/test/s3/versioning/s3_directory_versioning_test.go
+++ b/test/s3/versioning/s3_directory_versioning_test.go
@@ -122,7 +122,7 @@ func TestListObjectVersionsIncludesDirectories(t *testing.T) {
 				assert.Equal(t, int64(0), *version.Size, "Directory %s should have size 0", expectedDir)
 				assert.True(t, *version.IsLatest, "Directory %s should be marked as latest", expectedDir)
 				assert.Equal(t, "\"d41d8cd98f00b204e9800998ecf8427e\"", *version.ETag, "Directory %s should have MD5 of empty string as ETag", expectedDir)
-				assert.Equal(t, types.ObjectStorageClassStandard, version.StorageClass, "Directory %s should have STANDARD storage class", expectedDir)
+				assert.Equal(t, types.ObjectVersionStorageClassStandard, version.StorageClass, "Directory %s should have STANDARD storage class", expectedDir)
 				break
 			}
 		}

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -802,8 +802,11 @@ func (vc *versionCollector) collectVersions(currentPath, relativePath string) er
 
 // processDirectory handles directory entries
 func (vc *versionCollector) processDirectory(currentPath, entryPath string, entry *filer_pb.Entry) error {
-	// Handle explicit S3 directory object
-	if entry.Attributes.Mime == s3_constants.FolderMimeType {
+	// Handle explicit S3 directory object. Match ListObjectsV2's
+	// IsDirectoryKeyObject (any non-empty mime), not just FolderMimeType:
+	// an SDK PutObject of "dir/" carries a default Content-Type, so the two
+	// listings must agree on what counts as a directory key.
+	if entry.IsDirectoryKeyObject() {
 		vc.processExplicitDirectory(entryPath, entry)
 	}
 


### PR DESCRIPTION
Explicit directory objects (a `PutObject` whose key ends in `/`) are visible in `ListObjectsV2` but were missing from `ListObjectVersions` on a versioned bucket.

`ListObjectVersions` gated directory keys on `Mime == FolderMimeType` (`httpd/unix-directory`). But an SDK `PutObject` of `dir/` carries a default `Content-Type` (e.g. `application/octet-stream`), so the stored directory entry's mime is not `FolderMimeType` and the key was dropped from the version listing - while `ListObjectsV2`, which keys off `IsDirectoryKeyObject` (any non-empty mime), still showed it. Use the same `IsDirectoryKeyObject` check so the two listings agree.

This makes `TestListObjectVersionsIncludesDirectories` exercise its directory assertions for the first time, which surfaced a latent bug in the test itself: it compared `types.ObjectStorageClassStandard` against `ObjectVersion.StorageClass` (`types.ObjectVersionStorageClass`) - same `"STANDARD"` value, different SDK enum types. Switched to the matching `ObjectVersionStorageClassStandard`.

Verified: `TestListObjectVersionsIncludesDirectories` passes (12 versions: 6 directories + 6 files); s3api unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directory entry handling in S3 object versioning responses. Directories are now correctly identified and classified in versioned object listings, ensuring consistent behavior with S3 API semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->