### PR TITLE
test(s3): address review feedback on the versioning suite

### DIFF
--- a/test/s3/versioning/Makefile
+++ b/test/s3/versioning/Makefile
@@ -12,8 +12,8 @@ FILER_PORT := 8888
 TEST_TIMEOUT := 10m
 # Run every test in the suite by default. "TestVersioning" used to leave whole
 # tests (bucket creation, suspended delete, directory/version listing) ungated.
-# Opt-in stress tests self-skip without ENABLE_STRESS_TESTS and run in their own
-# targets, so "." does not pull them in here.
+# Opt-in stress tests are matched by "." but self-skip without ENABLE_STRESS_TESTS
+# (they run with it set in their own targets), so they don't actually execute here.
 TEST_PATTERN := .
 
 .DEFAULT_GOAL := help

--- a/test/s3/versioning/s3_bucket_creation_test.go
+++ b/test/s3/versioning/s3_bucket_creation_test.go
@@ -135,7 +135,8 @@ func TestBucketCreationBehavior(t *testing.T) {
 // (versus BucketAlreadyOwnedByYou for the owner re-creating it).
 func TestBucketCreationWithDifferentUsers(t *testing.T) {
 	ctx := context.Background()
-	bucketName := "test-different-users-" + fmt.Sprintf("%d", time.Now().UnixNano())
+	// Tracked prefix + run id so cleanupAllTestBuckets sweeps it if the test leaks.
+	bucketName := getNewBucketName()
 
 	// User A owns the bucket.
 	clientA := getS3Client(t)

--- a/test/s3/versioning/s3_directory_versioning_test.go
+++ b/test/s3/versioning/s3_directory_versioning_test.go
@@ -669,6 +669,7 @@ func TestVersionedObjectListBehavior(t *testing.T) {
 	assert.NotContains(t, *listedObject.Key, versionId, "Object key should not contain version ID")
 
 	// Verify object properties
+	require.NotNil(t, listedObject.Size, "Object size should not be nil")
 	assert.Equal(t, int64(len(content)), *listedObject.Size, "Object size should match")
 	assert.NotNil(t, listedObject.ETag, "Object should have ETag")
 	assert.NotNil(t, listedObject.LastModified, "Object should have LastModified")


### PR DESCRIPTION
Small follow-ups to the review comments on the versioning-suite PRs:

- `TestBucketCreationWithDifferentUsers` now names its bucket via `getNewBucketName()` (tracked prefix + run id), so a leaked bucket is swept by `cleanupAllTestBuckets` instead of accumulating.
- Corrected the Makefile comment: `.` *does* match the opt-in stress tests, but they self-skip without `ENABLE_STRESS_TESTS` (and run in their dedicated targets), so they don't execute in the default run.
- Guarded the `Object.Size` dereference in `TestVersionedObjectListBehavior` with `require.NotNil`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Enhanced S3 bucket cleanup mechanisms to improve test reliability and prevent resource leaks in test environments
- Added robustness checks to S3 object versioning tests
- Updated test configuration documentation to clarify stress test behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->