### PR TITLE
worker: drop ec.balance from the default admin script

### DIFF
--- a/weed/plugin/worker/admin_script_handler.go
+++ b/weed/plugin/worker/admin_script_handler.go
@@ -25,8 +25,7 @@ const (
 	adminScriptDetectTickMinutes = 17
 )
 
-const defaultAdminScript = `ec.balance -apply
-fs.log.purge -daysAgo=7
+const defaultAdminScript = `fs.log.purge -daysAgo=7
 volume.deleteEmpty -quietFor=24h -apply
 volume.fix.replication -apply
 s3.clean.uploads -timeAgo=24h`


### PR DESCRIPTION
The dedicated `ec_balance` task worker (`weed/worker/tasks/ec_balance`) now handles EC shard balancing, so the periodic admin script no longer needs to run `ec.balance -apply`. Drop it from `defaultAdminScript` to avoid the two paths racing on the same work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default admin script configuration to modify the order and inclusion of administrative commands, adding log purge functionality and adjusting the command sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->