### PR TITLE
s3: actually bind outbound connections when -ip.bind is set

### DIFF
--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -261,6 +261,9 @@ func (s3opt *S3Options) resolvePaths() {
 
 func (s3opt *S3Options) startS3Server() bool {
 
+	// Before the first filer dial below; gRPC caches conns and binds at dial time.
+	util.SetOutboundLocalIP(*s3opt.bindIp)
+
 	filerAddresses := pb.ServerAddresses(*s3opt.filer).ToAddresses()
 
 	filerBucketsPath := "/buckets"
@@ -324,7 +327,6 @@ func (s3opt *S3Options) startS3Server() bool {
 	if *s3opt.bindIp == "" {
 		*s3opt.bindIp = "0.0.0.0"
 	}
-	util.SetOutboundLocalIP(*s3opt.bindIp)
 
 	defaultFileMode, fileModeErr := s3opt.parseDefaultFileMode()
 	if fileModeErr != nil {

--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -212,11 +212,14 @@ func GrpcDial(ctx context.Context, address string, waitForReady bool, opts ...gr
 			var d net.Dialer
 			return d.DialContext(ctx, "unix", socketPath)
 		}))
-	} else if util.OutboundLocalAddr() != nil {
-		// Bind outbound gRPC connections to the configured -ip.bind source
-		// address. Only installed when a source address is set, so default
-		// deployments keep gRPC's stock dialer behavior.
+	} else {
+		// Always install so a conn cached before SetOutboundLocalIP binds once set;
+		// the stock net.Dialer until then preserves gRPC's default dial behavior.
 		options = append(options, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			if util.OutboundLocalAddr() == nil {
+				var d net.Dialer
+				return d.DialContext(ctx, "tcp", addr)
+			}
 			return util.OutboundDialContext(ctx, "tcp", addr)
 		}))
 	}


### PR DESCRIPTION
Follow-up to #9834. Reported there: standalone `weed s3` still reached out from a foreign source IP despite `-ip.bind`.

Two ordering issues kept the s3->filer gRPC connection on the OS-chosen source address:

1. **`SetOutboundLocalIP` ran too late.** `startS3Server` dialed the filer for `GetFilerConfiguration` before calling `SetOutboundLocalIP`. gRPC conns are cached by address (`grpcClients[address]`) and reuse their original dialer on every reconnect, so that first connection — built with the stock dialer and no `LocalAddr` — kept leaving from the wrong source for the life of the process, even though the bind IP was set a moment later. The other daemons (`master`, `sftp`, `webdav`) and `weed server` already set it before their first dial; only standalone `weed s3` was out of order. Moved the call to the top of `startS3Server`.

2. **The gRPC dialer baked in its decision at dial time.** `GrpcDial` installed the bind dialer only `else if OutboundLocalAddr() != nil`, so a conn dialed before the bind IP was configured never bound. The HTTP transport already installs `OutboundDialContext` unconditionally and decides per dial; this makes gRPC match — the dialer is always installed and `OutboundDialContext` no-ops when no source is set, so the bind applies on the next reconnect regardless of ordering.

Each change is its own commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apply network binding earlier during startup so backend service connections use the configured outbound address from the first connection attempt.
  * Ensure outbound IP binding is consistently respected for gRPC connections across all non-Unix-socket scenarios, while preserving default dial behavior when no outbound address is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->