### PR TITLE
admin: default -dataDir to "." so maintenance task state persists across restarts

### DIFF
--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -65,7 +65,7 @@ func init() {
 	a.grpcPort = cmdAdmin.Flag.Int("port.grpc", 0, "gRPC server port for worker connections (default: http port + 10000)")
 	a.master = cmdAdmin.Flag.String("master", "localhost:9333", "comma-separated master servers")
 	a.masters = cmdAdmin.Flag.String("masters", "", "comma-separated master servers (deprecated, use -master instead)")
-	a.dataDir = cmdAdmin.Flag.String("dataDir", "", "directory to store admin configuration and data files")
+	a.dataDir = cmdAdmin.Flag.String("dataDir", ".", "directory to store admin configuration and data files (default current dir; required for maintenance task state to persist)")
 
 	a.adminUser = cmdAdmin.Flag.String("adminUser", "admin", "admin interface username")
 	a.adminPassword = cmdAdmin.Flag.String("adminPassword", "", "admin interface password (if empty, auth is disabled)")
@@ -248,7 +248,6 @@ func runAdmin(cmd *Command, args []string) bool {
 		fmt.Println("WARNING: Admin interface is running without authentication!")
 		fmt.Println("         Set -adminPassword for production use")
 	}
-
 	fmt.Printf("Starting SeaweedFS Admin Interface on port %d\n", *a.port)
 	fmt.Printf("Worker gRPC server will run on port %d\n", *a.grpcPort)
 	fmt.Printf("Masters: %s\n", *a.master)


### PR DESCRIPTION
## What

Default `weed admin -dataDir` to `.` (previously empty).

## Why

With an empty `-dataDir` the admin's maintenance scheduler can't persist task state — `config_persistence.go: SaveTaskState` returns `no data directory specified, cannot save task state`, logged on every maintenance cycle. Defaulting to `.` (the process working directory, which under the standard systemd unit is the admin's data dir) gives durable task storage and stops the log flood.

## Scope note

The scheduler runs on **in-memory** task state (`mq.tasks` / `mq.pendingTasks`); a `saveTaskState` failure only logs and continues. So this is a **durability + log-cleanliness** fix, not a correctness fix for EC scheduling.

Two related issues I hit while diagnosing an EC-shard degradation on a live cluster (separate PRs/follow-ups, noted here for context):
1. **EC move/encode verification gap** — an `ec.balance` move reports success once the copy/mount RPCs return, without confirming the shard is actually loadable (with its `.ecx`) at the destination. The master keeps seeing the imbalance and the scanner re-issues the same move every cycle, churning shards. This is the real cause of the shard churn.
2. **Persistence is currently write-only** — `LoadTasksFromPersistence` deletes saved task files on startup and re-detects from cluster state rather than reloading them, so persisted task state is never consumed at runtime today. If restart-durability is the intent, that load path needs wiring up.

Happy to follow up on both.