### PR TITLE
admin/maintenance: reload in-flight tasks on startup instead of discarding them

### DIFF
--- a/weed/admin/maintenance/maintenance_queue.go
+++ b/weed/admin/maintenance/maintenance_queue.go
@@ -34,16 +34,52 @@ func (mq *MaintenanceQueue) SetPersistence(persistence TaskPersistence) {
 	glog.V(1).Infof("Maintenance queue configured with task persistence")
 }
 
-// LoadTasksFromPersistence is called on startup. Previous task states are NOT loaded
-// into memory — the maintenance scanner will re-detect current needs from the live
-// cluster state. Stale task files from previous runs are deleted from disk.
+// LoadTasksFromPersistence is called on startup to restore in-flight tasks
+// across an admin restart. Non-terminal tasks (pending/assigned/in_progress)
+// are re-queued as pending — the worker that held an in-flight task is gone
+// after a restart, and maintenance tasks are idempotent, so re-running a
+// partially-done one is safe. Terminal task files are deleted. Anything missed
+// is still re-detected by the scanner from live cluster state.
 func (mq *MaintenanceQueue) LoadTasksFromPersistence() error {
-	if mq.persistence != nil {
-		if err := mq.persistence.DeleteAllTaskStates(); err != nil {
-			glog.Warningf("Failed to clean up old task files: %v", err)
+	if mq.persistence == nil {
+		glog.Infof("Task queue initialized (no persistence configured)")
+		return nil
+	}
+	tasks, err := mq.persistence.LoadAllTaskStates()
+	if err != nil {
+		glog.Warningf("Failed to load persisted task states: %v; starting with an empty queue", err)
+		return nil
+	}
+
+	var terminal []string
+	mq.mutex.Lock()
+	requeued := 0
+	for _, task := range tasks {
+		switch task.Status {
+		case TaskStatusPending, TaskStatusAssigned, TaskStatusInProgress:
+			task.Status = TaskStatusPending
+			task.WorkerID = ""
+			task.Progress = 0
+			mq.tasks[task.ID] = task
+			mq.pendingTasks = append(mq.pendingTasks, task)
+			requeued++
+		default:
+			terminal = append(terminal, task.ID)
 		}
 	}
-	glog.Infof("Task queue initialized (previous tasks will be re-detected by scanner)")
+	sort.Slice(mq.pendingTasks, func(i, j int) bool {
+		if mq.pendingTasks[i].Priority != mq.pendingTasks[j].Priority {
+			return mq.pendingTasks[i].Priority > mq.pendingTasks[j].Priority
+		}
+		return mq.pendingTasks[i].ScheduledAt.Before(mq.pendingTasks[j].ScheduledAt)
+	})
+	mq.mutex.Unlock()
+
+	// Delete stale terminal files outside the lock to avoid blocking on disk I/O.
+	for _, id := range terminal {
+		mq.deleteTaskState(id)
+	}
+	glog.Infof("Task queue initialized: re-queued %d in-flight task(s) from persistence; scanner will re-detect the rest", requeued)
 	return nil
 }
 

--- a/weed/admin/maintenance/maintenance_queue.go
+++ b/weed/admin/maintenance/maintenance_queue.go
@@ -52,9 +52,13 @@ func (mq *MaintenanceQueue) LoadTasksFromPersistence() error {
 	}
 
 	var terminal []string
+	var restored []*MaintenanceTask
 	mq.mutex.Lock()
 	requeued := 0
 	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
 		switch task.Status {
 		case TaskStatusPending, TaskStatusAssigned, TaskStatusInProgress:
 			task.Status = TaskStatusPending
@@ -62,6 +66,7 @@ func (mq *MaintenanceQueue) LoadTasksFromPersistence() error {
 			task.Progress = 0
 			mq.tasks[task.ID] = task
 			mq.pendingTasks = append(mq.pendingTasks, task)
+			restored = append(restored, snapshotTask(task))
 			requeued++
 		default:
 			terminal = append(terminal, task.ID)
@@ -74,6 +79,15 @@ func (mq *MaintenanceQueue) LoadTasksFromPersistence() error {
 		return mq.pendingTasks[i].ScheduledAt.Before(mq.pendingTasks[j].ScheduledAt)
 	})
 	mq.mutex.Unlock()
+
+	// ActiveTopology is in-memory and starts empty, so restored tasks must be
+	// re-synced or GetNextTask's AssignTask would reject them as unknown and
+	// they'd sit pending forever. Done outside the lock, like the retry path.
+	if mq.integration != nil {
+		for _, task := range restored {
+			mq.integration.SyncTask(task)
+		}
+	}
 
 	// Delete stale terminal files outside the lock to avoid blocking on disk I/O.
 	for _, id := range terminal {

--- a/weed/admin/maintenance/maintenance_queue_test.go
+++ b/weed/admin/maintenance/maintenance_queue_test.go
@@ -697,8 +697,7 @@ func (m *MockPersistence) DeleteAllTaskStates() error                           
 func (m *MockPersistence) CleanupCompletedTasks() error                             { return nil }
 func (m *MockPersistence) SaveTaskPolicy(taskType string, policy *TaskPolicy) error { return nil }
 
-func TestMaintenanceQueue_LoadTasksStartsEmpty(t *testing.T) {
-	// Setup
+func TestMaintenanceQueue_LoadRequeuesInFlightTasks(t *testing.T) {
 	policy := &MaintenancePolicy{
 		TaskPolicies: map[string]*worker_pb.TaskPolicy{
 			"balance": {MaxConcurrent: 1},
@@ -706,24 +705,30 @@ func TestMaintenanceQueue_LoadTasksStartsEmpty(t *testing.T) {
 	}
 	mq := NewMaintenanceQueue(policy)
 
-	// Setup mock persistence with tasks — these should NOT be loaded
-	mockTask := &MaintenanceTask{
-		ID:     "old_task_123",
-		Type:   "balance",
-		Status: TaskStatusPending,
-	}
-	mq.SetPersistence(&MockPersistence{tasks: []*MaintenanceTask{mockTask}})
+	// Non-terminal tasks must be re-queued across a restart; an in-progress
+	// task is reset to pending (its worker is gone). Terminal tasks are dropped.
+	mq.SetPersistence(&MockPersistence{tasks: []*MaintenanceTask{
+		{ID: "pending_1", Type: "balance", Status: TaskStatusPending},
+		{ID: "inprogress_1", Type: "balance", Status: TaskStatusInProgress, WorkerID: "gone", Progress: 42},
+		{ID: "done_1", Type: "balance", Status: TaskStatusCompleted},
+	}})
 
-	// LoadTasksFromPersistence should be a no-op — scanner will re-detect
-	err := mq.LoadTasksFromPersistence()
-	if err != nil {
+	if err := mq.LoadTasksFromPersistence(); err != nil {
 		t.Fatalf("LoadTasksFromPersistence failed: %v", err)
 	}
 
-	// Queue should be empty — tasks will be re-detected by scanner
-	stats := mq.GetStats()
-	if stats.TotalTasks != 0 {
-		t.Errorf("Expected 0 tasks after startup, got %d", stats.TotalTasks)
+	if stats := mq.GetStats(); stats.TotalTasks != 2 {
+		t.Errorf("expected 2 re-queued tasks, got %d", stats.TotalTasks)
+	}
+	ip := mq.tasks["inprogress_1"]
+	if ip == nil {
+		t.Fatal("in-progress task was not re-queued")
+	}
+	if ip.Status != TaskStatusPending || ip.WorkerID != "" || ip.Progress != 0 {
+		t.Errorf("in-progress task not reset to pending: status=%q worker=%q progress=%v", ip.Status, ip.WorkerID, ip.Progress)
+	}
+	if mq.tasks["done_1"] != nil {
+		t.Error("completed task should not be re-queued")
 	}
 }
 


### PR DESCRIPTION
## Problem

`MaintenanceQueue.LoadTasksFromPersistence` (called once at admin startup) **deletes all persisted task files** and relies on the scanner to re-detect needs from live cluster state. It never calls `LoadAllTaskStates`, so persisted task state is **write-only** — `saveTaskState` writes it on every task transition, but nothing ever reads it back. An admin restart therefore loses all in-flight maintenance task state.

## Change

Reload non-terminal tasks (`pending` / `assigned` / `in_progress`) into the in-memory queue on startup. In-flight tasks are reset to `pending` (the worker that held them is gone after a restart, and maintenance tasks are idempotent, so re-running a partially-done one is safe). Terminal task files (`completed` / `failed` / `cancelled`) are deleted. The scanner still backfills anything not persisted, and the existing duplicate-suppression keeps re-detected needs from double-queuing a reloaded task.

## Test

Updated the queue test: a persisted `pending` and `in_progress` task are re-queued (the in-progress one reset to pending with its worker/progress cleared), while a `completed` task is dropped. `go build ./weed/...` and `go test ./weed/admin/maintenance/` pass.

## Context

Found while diagnosing an EC-shard degradation on a live cluster (the admin was also running without `-dataDir`, so persistence was failing outright — separate PR defaults that to `.`). With both fixes, an admin restart preserves in-flight maintenance work instead of dropping it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In-flight maintenance tasks persisted at shutdown are now restored and re-queued on startup.
  * Tasks that were in-progress are reset to pending with worker assignments cleared and progress reset.
  * Completed/terminal tasks are cleaned from persistence and removed from the queue.
  * Restored pending work is ordered by priority and scheduled time.

* **Tests**
  * Added test coverage for persistence-based recovery and task re-queuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->