### PR TITLE
ec.balance: verify shard landed on destination before deleting the source

### DIFF
--- a/weed/worker/tasks/ec_balance/ec_balance_task.go
+++ b/weed/worker/tasks/ec_balance/ec_balance_task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/worker/types"
 	"github.com/seaweedfs/seaweedfs/weed/worker/types/base"
 	"google.golang.org/grpc"
@@ -98,6 +99,16 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 		return fmt.Errorf("copy and mount shard: %v", err)
 	}
 
+	// Step 1.5: confirm the destination actually registered the shard(s)
+	// before removing them from the source. A copy/mount RPC can return OK
+	// while the shard isn't loadable on the destination; deleting the source
+	// then would lose the shard. On a mismatch we keep the source so the
+	// scanner retries (the move is reported failed).
+	t.reportProgress(40.0, "Verifying EC shard(s) on destination")
+	if err := t.verifyShardsOnDestination(ctx, params.VolumeId, targetAddr, source.ShardIds); err != nil {
+		return err
+	}
+
 	// Step 2: Unmount shard on source
 	t.reportProgress(50.0, "Unmounting EC shard from source")
 	if err := t.unmountShard(ctx, params.VolumeId, sourceAddr, source.ShardIds); err != nil {
@@ -177,6 +188,22 @@ func (t *ECBalanceTask) unmountShard(ctx context.Context, volumeID uint32, addr 
 			})
 			return err
 		})
+}
+
+// verifyShardsOnDestination confirms targetAddr has registered every shard in
+// shardIDs for volumeID, so the caller can safely delete the source copies.
+func (t *ECBalanceTask) verifyShardsOnDestination(ctx context.Context, volumeID uint32, targetAddr pb.ServerAddress, shardIDs []uint32) error {
+	_, perServer := erasure_coding.VerifyShardsAcrossServers(ctx, volumeID, []string{string(targetAddr)}, t.grpcDialOption)
+	inv := perServer[string(targetAddr)]
+	if inv.QueryError != nil {
+		return fmt.Errorf("verify shard(s) on destination %s for volume %d: %v", targetAddr, volumeID, inv.QueryError)
+	}
+	for _, sid := range shardIDs {
+		if !inv.Bits.Has(erasure_coding.ShardId(sid)) {
+			return fmt.Errorf("destination %s missing EC shard %d.%d after copy/mount; keeping source", targetAddr, volumeID, sid)
+		}
+	}
+	return nil
 }
 
 // deleteShard deletes EC shards from a server

--- a/weed/worker/tasks/ec_balance/ec_balance_task.go
+++ b/weed/worker/tasks/ec_balance/ec_balance_task.go
@@ -194,7 +194,10 @@ func (t *ECBalanceTask) unmountShard(ctx context.Context, volumeID uint32, addr 
 // shardIDs for volumeID, so the caller can safely delete the source copies.
 func (t *ECBalanceTask) verifyShardsOnDestination(ctx context.Context, volumeID uint32, targetAddr pb.ServerAddress, shardIDs []uint32) error {
 	_, perServer := erasure_coding.VerifyShardsAcrossServers(ctx, volumeID, []string{string(targetAddr)}, t.grpcDialOption)
-	inv := perServer[string(targetAddr)]
+	inv, ok := perServer[string(targetAddr)]
+	if !ok {
+		return fmt.Errorf("verify shard(s) on destination %s for volume %d: no inventory returned", targetAddr, volumeID)
+	}
 	if inv.QueryError != nil {
 		return fmt.Errorf("verify shard(s) on destination %s for volume %d: %v", targetAddr, volumeID, inv.QueryError)
 	}


### PR DESCRIPTION
## Problem

`ECBalanceTask.Execute` copies+mounts a shard to the destination, then unmounts and deletes it from the source, reporting success as soon as the RPCs return. But a `VolumeEcShardsCopy`/`VolumeEcShardsMount` can return OK while the shard isn't actually registered/loadable on the destination. Deleting the source then loses the shard; the master still sees the imbalance, and the scanner re-issues the same move every scan cycle — churning shards indefinitely.

Observed on a live cluster: repeated identical `moves ec shard X.Y to <node>` every maintenance cycle, with shards ending up orphaned and EC volumes degraded.

## Change

Insert a verification step between the destination copy/mount and the source delete: query the destination with `VolumeEcShardsInfo` (via the existing `erasure_coding.VerifyShardsAcrossServers`) and confirm it reports every moved shard. If not, the task fails and the **source is kept**, so the move is retried rather than losing data. This mirrors the safety gate the EC *encode* task already runs (`verifyEcShardsBeforeDelete`) before deleting originals.

`VolumeEcShardsInfo` already aggregates shards across a node's disks, so this also tolerates the legitimate case where a shard and its `.ecx` live on different disks of the same node.

## Test

`go build ./weed/...`, `go vet`, and `go test ./weed/worker/tasks/ec_balance/` pass. (The verify path makes a volume-server RPC; it follows the same pattern as the encode task's verification, which is exercised by the existing EC integration tests.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a verification step to EC shard rebalancing that confirms all expected shards are present on the destination before any source unmount/delete. If verification fails, source cleanup is skipped and the operation returns an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->