### PR TITLE
fix(s3api): reject zero default retention years

### DIFF
--- a/weed/s3api/object_lock_utils.go
+++ b/weed/s3api/object_lock_utils.go
@@ -326,6 +326,11 @@ func validateDefaultRetention(retention *DefaultRetention) error {
 		return ErrInvalidRetentionPeriod
 	}
 
+	// Check for invalid Years value (zero is invalid when explicitly provided)
+	if retention.YearsSet && retention.Years == 0 {
+		return ErrInvalidRetentionPeriod
+	}
+
 	// Check for neither Days nor Years being specified
 	if !retention.DaysSet && !retention.YearsSet {
 		return ErrDefaultRetentionMissingPeriod

--- a/weed/s3api/s3api_object_retention_test.go
+++ b/weed/s3api/s3api_object_retention_test.go
@@ -786,6 +786,16 @@ func TestValidateDefaultRetention(t *testing.T) {
 			expectError: true,
 			errorMsg:    "default retention must specify either Days or Years",
 		},
+		{
+			name: "Zero years",
+			retention: &DefaultRetention{
+				Mode:     "GOVERNANCE",
+				Years:    0,
+				YearsSet: true,
+			},
+			expectError: true,
+			errorMsg:    "invalid retention period specified",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# What problem are we solving?

Default S3 Object Lock retention validation currently accepts an explicitly provided Years value of 0.

A default retention period should be positive when it is present. The existing validation already rejects Days=0, but Years=0 was not rejected, which made the behavior inconsistent and allowed an invalid default retention configuration to pass validation.

# How are we solving the problem?

This change updates validateDefaultRetention to reject an explicitly provided zero Years value.

When YearsSet is true and Years == 0, the function now returns ErrInvalidRetentionPeriod, matching the existing behavior for Days=0.

The change is intentionally minimal and only touches the missing validation branch.

# How is the PR tested?

Tested with:

bash go test ./weed/s3api -run TestValidateDefaultRetention -count=1 go test ./weed/s3api -count=1 git diff --check git diff --cached --check 

Before the fix, TestValidateDefaultRetention failed because the zero-years case returned nil instead of ErrInvalidRetentionPeriod.

After the fix, the targeted test and the full weed/s3api package tests pass.

# Checks

- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs

- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed S3 object lock retention validation to properly reject invalid retention configurations when years are set to zero, closing a gap in validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->