### PR TITLE
vacuum: compact a read-only volume when an explicit volumeId is given

### DIFF
--- a/weed/topology/topology_vacuum.go
+++ b/weed/topology/topology_vacuum.go
@@ -240,6 +240,9 @@ func (t *Topology) Vacuum(grpcDialOption grpc.DialOption, garbageThreshold float
 					vid := needle.VolumeId(volumeId)
 					volumeLayout.accessLock.RLock()
 					locationList, ok := volumeLayout.vid2location[vid]
+					if ok {
+						locationList = locationList.Copy()
+					}
 					volumeLayout.accessLock.RUnlock()
 					if ok {
 						t.vacuumOneVolumeId(grpcDialOption, volumeLayout, c, garbageThreshold, locationList, vid, preallocate, false)

--- a/weed/topology/topology_vacuum.go
+++ b/weed/topology/topology_vacuum.go
@@ -242,7 +242,7 @@ func (t *Topology) Vacuum(grpcDialOption grpc.DialOption, garbageThreshold float
 					locationList, ok := volumeLayout.vid2location[vid]
 					volumeLayout.accessLock.RUnlock()
 					if ok {
-						t.vacuumOneVolumeId(grpcDialOption, volumeLayout, c, garbageThreshold, locationList, vid, preallocate)
+						t.vacuumOneVolumeId(grpcDialOption, volumeLayout, c, garbageThreshold, locationList, vid, preallocate, false)
 					}
 				} else {
 					t.vacuumOneVolumeLayout(grpcDialOption, volumeLayout, c, garbageThreshold, maxParallelVacuumPerServer, preallocate, automatic)
@@ -311,7 +311,7 @@ func (t *Topology) vacuumOneVolumeLayout(grpcDialOption grpc.DialOption, volumeL
 			wg.Add(1)
 			executor.Execute(func() {
 				defer wg.Done()
-				t.vacuumOneVolumeId(grpcDialOption, volumeLayout, c, garbageThreshold, locationList, vid, preallocate)
+				t.vacuumOneVolumeId(grpcDialOption, volumeLayout, c, garbageThreshold, locationList, vid, preallocate, true)
 				// credit the quota
 				for _, dn := range locationList.list {
 					limiterLock.Lock()
@@ -336,14 +336,20 @@ func (t *Topology) vacuumOneVolumeLayout(grpcDialOption grpc.DialOption, volumeL
 
 }
 
-func (t *Topology) vacuumOneVolumeId(grpcDialOption grpc.DialOption, volumeLayout *VolumeLayout, c *Collection, garbageThreshold float64, locationList *VolumeLocationList, vid needle.VolumeId, preallocate int64) {
+// skipReadOnly is set by the background scan and all-volumes sweep, where a
+// read-only flag usually means an unhealthy disk. An explicit volumeId clears
+// it so a benignly read-only (full/oversized) volume can be reclaimed.
+func (t *Topology) vacuumOneVolumeId(grpcDialOption grpc.DialOption, volumeLayout *VolumeLayout, c *Collection, garbageThreshold float64, locationList *VolumeLocationList, vid needle.VolumeId, preallocate int64, skipReadOnly bool) {
 	volumeLayout.accessLock.RLock()
 	isReadOnly := volumeLayout.readonlyVolumes.IsTrue(vid)
 	isEnoughCopies := volumeLayout.enoughCopies(vid)
 	volumeLayout.accessLock.RUnlock()
 
 	if isReadOnly {
-		return
+		if skipReadOnly {
+			return
+		}
+		glog.V(0).Infof("vacuuming read-only volume %d on explicit request", vid)
 	}
 	if !isEnoughCopies {
 		glog.Warningf("skip vacuuming: not enough copies for volume:%d", vid)


### PR DESCRIPTION
A volume that goes read-only (full/oversized, or after a transient disk issue and recovery) keeps accumulating garbage that automatic vacuum never reclaims, because `vacuumOneVolumeId` returns early on `isReadOnly`. The only way out was `volume.mark -writable` followed by `volume.vacuum` — and worse, `volume.vacuum -volumeId X` on such a volume silently did nothing.

The volume server itself has no read-only guard on compact/commit; on a bad disk a read just fails and rolls back via cleanup, so no data is lost. The only blocker is this one master-side check.

Now the on-demand path (a specific `-volumeId`) lifts the guard, so an operator can reclaim a benignly read-only volume directly. The background scan and the all-volumes sweep still skip read-only volumes, where the flag usually signals an unhealthy disk or low space and bulk-compacting would be risky.

Closes #9859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit/targeted volume vacuum operations can now include read-only volumes, allowing maintenance and targeted cleanup on them. Automatic/periodic vacuum sweeps still skip read-only volumes to avoid interfering with normal read-only workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->