### PR TITLE
rust release: fix large-disk/normal binary overwrite + publish md5 checksums

### DIFF
--- a/.github/workflows/rust_binaries_release.yml
+++ b/.github/workflows/rust_binaries_release.yml
@@ -87,13 +87,21 @@ jobs:
           tar czf weed-volume_${{ matrix.asset_suffix }}.tar.gz weed-volume-normal
           rm weed-volume-normal
 
+      - name: Generate md5 checksums
+        run: |
+          for f in weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz weed-volume_${{ matrix.asset_suffix }}.tar.gz; do
+            md5sum "$f" > "$f.md5"
+          done
+
       - name: Upload release assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
           files: |
             weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz.md5
             weed-volume_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_${{ matrix.asset_suffix }}.tar.gz.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -104,7 +112,9 @@ jobs:
           name: rust-volume-${{ matrix.asset_suffix }}
           path: |
             weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz.md5
             weed-volume_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_${{ matrix.asset_suffix }}.tar.gz.md5
 
   build-rust-volume-darwin:
     permissions:
@@ -164,13 +174,21 @@ jobs:
           tar czf weed-volume_${{ matrix.asset_suffix }}.tar.gz weed-volume-normal
           rm weed-volume-normal
 
+      - name: Generate md5 checksums
+        run: |
+          for f in weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz weed-volume_${{ matrix.asset_suffix }}.tar.gz; do
+            md5 -r "$f" > "$f.md5"
+          done
+
       - name: Upload release assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
           files: |
             weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz.md5
             weed-volume_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_${{ matrix.asset_suffix }}.tar.gz.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -181,7 +199,9 @@ jobs:
           name: rust-volume-${{ matrix.asset_suffix }}
           path: |
             weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz.md5
             weed-volume_${{ matrix.asset_suffix }}.tar.gz
+            weed-volume_${{ matrix.asset_suffix }}.tar.gz.md5
 
   build-rust-volume-windows:
     permissions:
@@ -233,13 +253,22 @@ jobs:
           7z a weed-volume_windows_amd64.zip weed-volume-normal.exe
           rm weed-volume-normal.exe
 
+      - name: Generate md5 checksums
+        shell: bash
+        run: |
+          for f in weed-volume_large_disk_windows_amd64.zip weed-volume_windows_amd64.zip; do
+            md5sum "$f" > "$f.md5"
+          done
+
       - name: Upload release assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
           files: |
             weed-volume_large_disk_windows_amd64.zip
+            weed-volume_large_disk_windows_amd64.zip.md5
             weed-volume_windows_amd64.zip
+            weed-volume_windows_amd64.zip.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -250,4 +279,6 @@ jobs:
           name: rust-volume-windows_amd64
           path: |
             weed-volume_large_disk_windows_amd64.zip
+            weed-volume_large_disk_windows_amd64.zip.md5
             weed-volume_windows_amd64.zip
+            weed-volume_windows_amd64.zip.md5

--- a/.github/workflows/rust_binaries_release.yml
+++ b/.github/workflows/rust_binaries_release.yml
@@ -66,24 +66,24 @@ jobs:
           SEAWEEDFS_COMMIT: ${{ github.sha }}
         run: |
           cd seaweed-volume
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }} --target-dir target/large-disk
 
       - name: Build Rust volume server (normal)
         env:
           SEAWEEDFS_COMMIT: ${{ github.sha }}
         run: |
           cd seaweed-volume
-          cargo build --release --target ${{ matrix.target }} --no-default-features
+          cargo build --release --target ${{ matrix.target }} --no-default-features --target-dir target/normal
 
       - name: Package binaries
         run: |
           # Large disk (default, 5bytes feature)
-          cp seaweed-volume/target/${{ matrix.target }}/release/weed-volume weed-volume-large-disk
+          cp seaweed-volume/target/large-disk/${{ matrix.target }}/release/weed-volume weed-volume-large-disk
           tar czf weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz weed-volume-large-disk
           rm weed-volume-large-disk
 
           # Normal volume size
-          cp seaweed-volume/target/${{ matrix.target }}/release/weed-volume weed-volume-normal
+          cp seaweed-volume/target/normal/${{ matrix.target }}/release/weed-volume weed-volume-normal
           tar czf weed-volume_${{ matrix.asset_suffix }}.tar.gz weed-volume-normal
           rm weed-volume-normal
 
@@ -155,22 +155,22 @@ jobs:
           SEAWEEDFS_COMMIT: ${{ github.sha }}
         run: |
           cd seaweed-volume
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }} --target-dir target/large-disk
 
       - name: Build Rust volume server (normal)
         env:
           SEAWEEDFS_COMMIT: ${{ github.sha }}
         run: |
           cd seaweed-volume
-          cargo build --release --target ${{ matrix.target }} --no-default-features
+          cargo build --release --target ${{ matrix.target }} --no-default-features --target-dir target/normal
 
       - name: Package binaries
         run: |
-          cp seaweed-volume/target/${{ matrix.target }}/release/weed-volume weed-volume-large-disk
+          cp seaweed-volume/target/large-disk/${{ matrix.target }}/release/weed-volume weed-volume-large-disk
           tar czf weed-volume_large_disk_${{ matrix.asset_suffix }}.tar.gz weed-volume-large-disk
           rm weed-volume-large-disk
 
-          cp seaweed-volume/target/${{ matrix.target }}/release/weed-volume weed-volume-normal
+          cp seaweed-volume/target/normal/${{ matrix.target }}/release/weed-volume weed-volume-normal
           tar czf weed-volume_${{ matrix.asset_suffix }}.tar.gz weed-volume-normal
           rm weed-volume-normal
 
@@ -233,23 +233,23 @@ jobs:
           SEAWEEDFS_COMMIT: ${{ github.sha }}
         run: |
           cd seaweed-volume
-          cargo build --release
+          cargo build --release --target-dir target/large-disk
 
       - name: Build Rust volume server (normal)
         env:
           SEAWEEDFS_COMMIT: ${{ github.sha }}
         run: |
           cd seaweed-volume
-          cargo build --release --no-default-features
+          cargo build --release --no-default-features --target-dir target/normal
 
       - name: Package binaries
         shell: bash
         run: |
-          cp seaweed-volume/target/release/weed-volume.exe weed-volume-large-disk.exe
+          cp seaweed-volume/target/large-disk/release/weed-volume.exe weed-volume-large-disk.exe
           7z a weed-volume_large_disk_windows_amd64.zip weed-volume-large-disk.exe
           rm weed-volume-large-disk.exe
 
-          cp seaweed-volume/target/release/weed-volume.exe weed-volume-normal.exe
+          cp seaweed-volume/target/normal/release/weed-volume.exe weed-volume-normal.exe
           7z a weed-volume_windows_amd64.zip weed-volume-normal.exe
           rm weed-volume-normal.exe
 


### PR DESCRIPTION
# What problem are we solving?

Two issues in the versioned Rust volume-server release (`rust_binaries_release.yml`):

1. **Wrong binary in the large-disk asset.** Each job ran two cargo builds to the *same* output path (`target/<triple>/release/weed-volume`): large-disk (default features) then normal (`--no-default-features`). The second overwrote the first, and the "Package binaries" step then copied that single binary into **both** tarballs — so `weed-volume_large_disk_*` actually shipped the *normal* binary. (The dev workflow avoids this by packaging the large-disk binary between the two builds.)
2. **No checksums.** The assets had no `.md5` sidecars, so downloaders can't verify integrity. The Go releases get `.md5` automatically via `go-release-action`; this workflow uses `softprops/action-gh-release` directly, which doesn't. seaweed-up's installer verifies an `.md5` before installing `weed-volume`.

# How are we solving the problem?

1. Build each variant into its own `--target-dir` — `target/large-disk` and `target/normal` (both under `target/`, so the existing cache `path` still covers them) — and copy each tarball's binary from its own directory. Applied to all three jobs (linux, darwin, windows).
2. Add a "Generate md5 checksums" step per job that writes `<asset>.md5` next to each archive (`md5sum` on linux/windows-bash, `md5 -r` on macOS) and include the `.md5` files in both the tag-release and non-tag uploads.

No change to asset names, triggers, or platforms.

# How is the PR tested?

- Validated the workflow YAML parses.
- Verified each variant now copies from its own `target/large-disk` / `target/normal` dir (no remaining copies from the shared path), so the large-disk and normal tarballs get distinct binaries.
- Verified each platform's md5 tool emits the `<hash>  <file>` line a downloader can parse (e.g. seaweed-up does `awk '{print $1}'`).
- Release-only workflow; runs on the next tag push.

# Checks
- [x] I have added unit tests if possible. (N/A — CI workflow only.)
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Binary release artifacts now include MD5 checksum files for download integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->