### PR TITLE
fix(s3api): accept HTTP-date conditionals

### DIFF
--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1469,7 +1469,7 @@ func (s3a *S3ApiServer) validateConditionalCopyHeaders(r *http.Request, entry *f
 
 	// Check X-Amz-Copy-Source-If-Modified-Since
 	if ifModifiedSince := r.Header.Get(s3_constants.AmzCopySourceIfModifiedSince); ifModifiedSince != "" {
-		t, err := time.Parse(time.RFC1123, ifModifiedSince)
+		t, err := http.ParseTime(ifModifiedSince)
 		if err != nil {
 			glog.V(3).Infof("CopyObjectHandler: Invalid If-Modified-Since header: %v", err)
 			return s3err.ErrInvalidRequest
@@ -1482,7 +1482,7 @@ func (s3a *S3ApiServer) validateConditionalCopyHeaders(r *http.Request, entry *f
 
 	// Check X-Amz-Copy-Source-If-Unmodified-Since
 	if ifUnmodifiedSince := r.Header.Get(s3_constants.AmzCopySourceIfUnmodifiedSince); ifUnmodifiedSince != "" {
-		t, err := time.Parse(time.RFC1123, ifUnmodifiedSince)
+		t, err := http.ParseTime(ifUnmodifiedSince)
 		if err != nil {
 			glog.V(3).Infof("CopyObjectHandler: Invalid If-Unmodified-Since header: %v", err)
 			return s3err.ErrInvalidRequest

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1469,7 +1469,7 @@ func (s3a *S3ApiServer) validateConditionalCopyHeaders(r *http.Request, entry *f
 
 	// Check X-Amz-Copy-Source-If-Modified-Since
 	if ifModifiedSince := r.Header.Get(s3_constants.AmzCopySourceIfModifiedSince); ifModifiedSince != "" {
-		t, err := http.ParseTime(ifModifiedSince)
+		t, err := parseHTTPDate(ifModifiedSince)
 		if err != nil {
 			glog.V(3).Infof("CopyObjectHandler: Invalid If-Modified-Since header: %v", err)
 			return s3err.ErrInvalidRequest
@@ -1482,7 +1482,7 @@ func (s3a *S3ApiServer) validateConditionalCopyHeaders(r *http.Request, entry *f
 
 	// Check X-Amz-Copy-Source-If-Unmodified-Since
 	if ifUnmodifiedSince := r.Header.Get(s3_constants.AmzCopySourceIfUnmodifiedSince); ifUnmodifiedSince != "" {
-		t, err := http.ParseTime(ifUnmodifiedSince)
+		t, err := parseHTTPDate(ifUnmodifiedSince)
 		if err != nil {
 			glog.V(3).Infof("CopyObjectHandler: Invalid If-Unmodified-Since header: %v", err)
 			return s3err.ErrInvalidRequest

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -1992,7 +1992,7 @@ func parseConditionalHeaders(r *http.Request) (conditionalHeaders, s3err.ErrorCo
 	// Parse date headers with validation
 	var err error
 	if ifModifiedSinceStr != "" {
-		headers.ifModifiedSince, err = time.Parse(time.RFC1123, ifModifiedSinceStr)
+		headers.ifModifiedSince, err = http.ParseTime(ifModifiedSinceStr)
 		if err != nil {
 			glog.V(3).Infof("parseConditionalHeaders: Invalid If-Modified-Since format: %v", err)
 			return headers, s3err.ErrInvalidRequest
@@ -2000,7 +2000,7 @@ func parseConditionalHeaders(r *http.Request) (conditionalHeaders, s3err.ErrorCo
 	}
 
 	if ifUnmodifiedSinceStr != "" {
-		headers.ifUnmodifiedSince, err = time.Parse(time.RFC1123, ifUnmodifiedSinceStr)
+		headers.ifUnmodifiedSince, err = http.ParseTime(ifUnmodifiedSinceStr)
 		if err != nil {
 			glog.V(3).Infof("parseConditionalHeaders: Invalid If-Unmodified-Since format: %v", err)
 			return headers, s3err.ErrInvalidRequest

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -1971,6 +1971,17 @@ type conditionalHeaders struct {
 	isSet             bool // true if any conditional headers are present
 }
 
+// parseHTTPDate parses a conditional date header. It accepts the three HTTP-date
+// formats required by RFC 9110 via http.ParseTime, then falls back to RFC1123 so
+// the non-standard "UTC" zone that Go clients emit with t.UTC().Format(time.RFC1123)
+// keeps working as it did before http.ParseTime was adopted.
+func parseHTTPDate(value string) (time.Time, error) {
+	if t, err := http.ParseTime(value); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC1123, value)
+}
+
 // parseConditionalHeaders extracts and validates conditional headers from the request
 func parseConditionalHeaders(r *http.Request) (conditionalHeaders, s3err.ErrorCode) {
 	headers := conditionalHeaders{
@@ -1992,7 +2003,7 @@ func parseConditionalHeaders(r *http.Request) (conditionalHeaders, s3err.ErrorCo
 	// Parse date headers with validation
 	var err error
 	if ifModifiedSinceStr != "" {
-		headers.ifModifiedSince, err = http.ParseTime(ifModifiedSinceStr)
+		headers.ifModifiedSince, err = parseHTTPDate(ifModifiedSinceStr)
 		if err != nil {
 			glog.V(3).Infof("parseConditionalHeaders: Invalid If-Modified-Since format: %v", err)
 			return headers, s3err.ErrInvalidRequest
@@ -2000,7 +2011,7 @@ func parseConditionalHeaders(r *http.Request) (conditionalHeaders, s3err.ErrorCo
 	}
 
 	if ifUnmodifiedSinceStr != "" {
-		headers.ifUnmodifiedSince, err = http.ParseTime(ifUnmodifiedSinceStr)
+		headers.ifUnmodifiedSince, err = parseHTTPDate(ifUnmodifiedSinceStr)
 		if err != nil {
 			glog.V(3).Infof("parseConditionalHeaders: Invalid If-Unmodified-Since format: %v", err)
 			return headers, s3err.ErrInvalidRequest

--- a/weed/s3api/s3api_object_routed_write_test.go
+++ b/weed/s3api/s3api_object_routed_write_test.go
@@ -135,6 +135,40 @@ func TestParseConditionalHeadersAcceptsHTTPDateFormats(t *testing.T) {
 	}
 }
 
+func TestValidateConditionalCopyHeadersAcceptsHTTPDateFormats(t *testing.T) {
+	testCases := []struct {
+		name   string
+		header string
+		value  string
+		mtime  int64 // source mtime chosen so the condition passes
+	}{
+		{
+			name:   "X-Amz-Copy-Source-If-Modified-Since RFC850",
+			header: s3_constants.AmzCopySourceIfModifiedSince,
+			value:  "Sunday, 06-Nov-94 08:49:37 GMT",
+			mtime:  1577836800, // 2020-01-01, modified after the 1994 header
+		},
+		{
+			name:   "X-Amz-Copy-Source-If-Unmodified-Since ANSIC",
+			header: s3_constants.AmzCopySourceIfUnmodifiedSince,
+			value:  "Sun Nov  6 08:49:37 1994",
+			mtime:  631152000, // 1990-01-01, not modified after the 1994 header
+		},
+	}
+
+	var s3a *S3ApiServer // method does not use the receiver
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := reqWith(map[string]string{testCase.header: testCase.value})
+			entry := &filer_pb.Entry{Attributes: &filer_pb.FuseAttributes{Mtime: testCase.mtime}}
+
+			if errCode := s3a.validateConditionalCopyHeaders(r, entry); errCode != s3err.ErrNone {
+				t.Fatalf("expected %s to be accepted, got %v", testCase.header, errCode)
+			}
+		})
+	}
+}
+
 func TestBuildDeleteCondition(t *testing.T) {
 	t.Run("no If-Match is unconditional", func(t *testing.T) {
 		cond, ok := buildDeleteCondition(reqWith(nil))

--- a/weed/s3api/s3api_object_routed_write_test.go
+++ b/weed/s3api/s3api_object_routed_write_test.go
@@ -3,6 +3,7 @@ package s3api
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -104,19 +105,31 @@ func TestBuildWriteCondition(t *testing.T) {
 
 func TestParseConditionalHeadersAcceptsHTTPDateFormats(t *testing.T) {
 	testCases := []struct {
-		name   string
-		header string
-		value  string
+		name     string
+		header   string
+		value    string
+		expected time.Time
 	}{
 		{
-			name:   "If-Modified-Since RFC850",
-			header: s3_constants.IfModifiedSince,
-			value:  "Sunday, 06-Nov-94 08:49:37 GMT",
+			name:     "If-Modified-Since RFC850",
+			header:   s3_constants.IfModifiedSince,
+			value:    "Sunday, 06-Nov-94 08:49:37 GMT",
+			expected: time.Date(1994, time.November, 6, 8, 49, 37, 0, time.UTC),
 		},
 		{
-			name:   "If-Unmodified-Since ANSIC",
-			header: s3_constants.IfUnmodifiedSince,
-			value:  "Sun Nov  6 08:49:37 1994",
+			name:     "If-Unmodified-Since ANSIC",
+			header:   s3_constants.IfUnmodifiedSince,
+			value:    "Sun Nov  6 08:49:37 1994",
+			expected: time.Date(1994, time.November, 6, 8, 49, 37, 0, time.UTC),
+		},
+		{
+			// Go clients build this with t.UTC().Format(time.RFC1123); the "UTC"
+			// zone is rejected by http.ParseTime but was accepted before, so the
+			// RFC1123 fallback must keep it working.
+			name:     "If-Modified-Since RFC1123 UTC zone",
+			header:   s3_constants.IfModifiedSince,
+			value:    "Wed, 21 Oct 2015 07:28:00 UTC",
+			expected: time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC),
 		},
 	}
 
@@ -130,6 +143,13 @@ func TestParseConditionalHeadersAcceptsHTTPDateFormats(t *testing.T) {
 			}
 			if !headers.isSet {
 				t.Fatal("expected conditional headers to be marked set")
+			}
+			parsed := headers.ifModifiedSince
+			if testCase.header == s3_constants.IfUnmodifiedSince {
+				parsed = headers.ifUnmodifiedSince
+			}
+			if !parsed.Equal(testCase.expected) {
+				t.Fatalf("expected parsed time %v, got %v", testCase.expected, parsed)
 			}
 		})
 	}

--- a/weed/s3api/s3api_object_routed_write_test.go
+++ b/weed/s3api/s3api_object_routed_write_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
 func reqWith(headers map[string]string) *http.Request {
@@ -99,6 +100,39 @@ func TestBuildWriteCondition(t *testing.T) {
 			t.Fatal("time condition must not take the fast path")
 		}
 	})
+}
+
+func TestParseConditionalHeadersAcceptsHTTPDateFormats(t *testing.T) {
+	testCases := []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{
+			name:   "If-Modified-Since RFC850",
+			header: s3_constants.IfModifiedSince,
+			value:  "Sunday, 06-Nov-94 08:49:37 GMT",
+		},
+		{
+			name:   "If-Unmodified-Since ANSIC",
+			header: s3_constants.IfUnmodifiedSince,
+			value:  "Sun Nov  6 08:49:37 1994",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := reqWith(map[string]string{testCase.header: testCase.value})
+
+			headers, errCode := parseConditionalHeaders(r)
+			if errCode != s3err.ErrNone {
+				t.Fatalf("expected %s to be accepted, got %v", testCase.header, errCode)
+			}
+			if !headers.isSet {
+				t.Fatal("expected conditional headers to be marked set")
+			}
+		})
+	}
 }
 
 func TestBuildDeleteCondition(t *testing.T) {


### PR DESCRIPTION

# What problem are we solving?

S3 object conditional headers currently reject valid HTTP-date values when `If-Modified-Since` or `If-Unmodified-Since` is encoded in RFC850 or ANSIC format.

These are valid HTTP-date representations, but `parseConditionalHeaders` only accepted `time.RFC1123`, causing requests with RFC850 or ANSIC date values to fail with `ErrInvalidRequest`.
https://www.rfc-editor.org/rfc/rfc9110.html

# How are we solving the problem?

Parse conditional date headers with `http.ParseTime` instead of `time.Parse(time.RFC1123)`.

This keeps RFC1123 support and also accepts the standard RFC850 and ANSIC HTTP-date formats handled by Go's `net/http` package.

# How is the PR tested?

```bash
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/s3api -run TestParseConditionalHeadersAcceptsHTTPDateFormats -count=1
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/s3api -count=1
git diff --check
git diff --cached --check
```


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved parsing of HTTP date formats in conditional request headers, now accepting multiple standard HTTP-date variants and a fallback for non-standard "UTC" zone strings to reduce invalid-request errors.

* **Tests**
  * Added tests validating acceptance of diverse HTTP-date formats for conditional headers, including copy-source conditional headers, to ensure compatibility across variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->