### PR TITLE
fix(remote): correct content and permissions when syncing/caching remote objects

### DIFF
--- a/weed/remote_storage/azure/azure_storage_client.go
+++ b/weed/remote_storage/azure/azure_storage_client.go
@@ -324,7 +324,7 @@ func (az *azureRemoteStorageClient) ReadFileWithConcurrency(loc *remote_pb.Remot
 	}
 
 	data = make([]byte, size)
-	_, err = blobClient.DownloadBuffer(context.Background(), data, &blob.DownloadBufferOptions{
+	n, err := blobClient.DownloadBuffer(context.Background(), data, &blob.DownloadBufferOptions{
 		Range: blob.HTTPRange{
 			Offset: offset,
 			Count:  size,
@@ -334,6 +334,11 @@ func (az *azureRemoteStorageClient) ReadFileWithConcurrency(loc *remote_pb.Remot
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to download file %s%s: %w", loc.Bucket, loc.Path, err)
+	}
+	// Pre-sized buffer: a short read stays zero-padded. Reject it rather than
+	// cache corrupt content.
+	if n != size {
+		return nil, fmt.Errorf("short read from %s%s at offset %d: got %d bytes, want %d", loc.Bucket, loc.Path, offset, n, size)
 	}
 
 	return data, nil

--- a/weed/remote_storage/s3/s3_storage_client.go
+++ b/weed/remote_storage/s3/s3_storage_client.go
@@ -243,13 +243,19 @@ func (s *s3RemoteStorageClient) ReadFileWithConcurrency(loc *remote_pb.RemoteSto
 	dataSlice := make([]byte, int(size))
 	writerAt := aws.NewWriteAtBuffer(dataSlice)
 
-	_, err = downloader.Download(writerAt, &s3.GetObjectInput{
+	n, err := downloader.Download(writerAt, &s3.GetObjectInput{
 		Bucket: aws.String(loc.Bucket),
 		Key:    aws.String(loc.Path[1:]),
 		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", offset, offset+size-1)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to download file %s%s: %v", loc.Bucket, loc.Path, err)
+	}
+	// The buffer is pre-sized to size, so a short read leaves the tail
+	// zero-padded and would be cached as valid-looking but corrupt content.
+	// Reject it instead.
+	if n != size {
+		return nil, fmt.Errorf("short read from %s%s at offset %d: got %d bytes, want %d", loc.Bucket, loc.Path, offset, n, size)
 	}
 
 	return writerAt.Bytes(), nil

--- a/weed/server/volume_grpc_remote.go
+++ b/weed/server/volume_grpc_remote.go
@@ -229,6 +229,12 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 	if readRemoteErr != nil {
 		return nil, fmt.Errorf("read from remote %+v: %w", remoteStorageLocation, readRemoteErr)
 	}
+	// The chunk is recorded with the requested size, so a short read would be
+	// cached as a full-size chunk with a zero-padded or truncated tail. Fail
+	// loudly instead of persisting silently corrupt content.
+	if int64(len(data)) != req.Size {
+		return nil, fmt.Errorf("read from remote %+v: got %d bytes, want %d", remoteStorageLocation, len(data), req.Size)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/weed/shell/command_remote_cache.go
+++ b/weed/shell/command_remote_cache.go
@@ -273,7 +273,7 @@ func (c *commandRemoteCache) doComprehensiveSync(commandEnv *CommandEnv, writer 
 						Attributes: &filer_pb.FuseAttributes{
 							FileSize: uint64(remoteEntry.RemoteSize),
 							Mtime:    remoteEntry.RemoteMtime,
-							FileMode: uint32(0644),
+							FileMode: remoteEntryFileMode(isDirectory),
 						},
 						RemoteEntry: remoteEntry,
 					},

--- a/weed/shell/command_remote_meta_sync.go
+++ b/weed/shell/command_remote_meta_sync.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -121,6 +122,20 @@ If entry.RemoteEntry == nil, this is a new local change and should not be overwr
 	  the remote version is updated, need to pull meta
 	}
 */
+
+// remoteEntryFileMode returns the POSIX mode for an entry synced from a remote
+// whose listing carries no mode. It matches what SeaweedFS S3 assigns native
+// objects (files 0660) so a mounted bucket matches the source, deriving the
+// directory mode with the same 0111 traversal mask the filer uses for
+// auto-created parents (0660 -> 0771).
+func remoteEntryFileMode(isDirectory bool) uint32 {
+	mode := uint32(0660)
+	if isDirectory {
+		mode = uint32(os.ModeDir) | mode | 0111
+	}
+	return mode
+}
+
 func pullMetadata(commandEnv *CommandEnv, writer io.Writer, localMountedDir util.FullPath, remoteMountedLocation *remote_pb.RemoteStorageLocation, dirToCache util.FullPath, remoteConf *remote_pb.RemoteConf) error {
 
 	// visit remote storage
@@ -159,7 +174,7 @@ func pullMetadata(commandEnv *CommandEnv, writer io.Writer, localMountedDir util
 						Attributes: &filer_pb.FuseAttributes{
 							FileSize: uint64(remoteEntry.RemoteSize),
 							Mtime:    remoteEntry.RemoteMtime,
-							FileMode: uint32(0644),
+							FileMode: remoteEntryFileMode(isDirectory),
 							TtlSec:   0, // Remote entries should not have TTL
 						},
 						RemoteEntry: remoteEntry,


### PR DESCRIPTION
Addresses #9866 (mounting one SeaweedFS cluster's bucket onto another via `remote.mount`). Two distinct problems.

## 1. Cached content is NULL while the size matches

The on-demand cache fetch never validated that the bytes read from the remote matched the requested size:

- The S3 client (`ReadFileWithConcurrency`) pre-allocates `make([]byte, size)`, wraps it in `aws.NewWriteAtBuffer`, and discards the downloaded byte count. The AWS SDK's `io.Copy` doesn't check it received the full requested range, so a short-but-well-formed response (stale listing size, truncated/flaky response) leaves the buffer **zero-padded** and returns `nil` error. Azure's client has the identical pre-sized-buffer / discarded-count bug.
- `FetchAndWriteNeedle` then records the chunk with the *requested* size, so the file looks complete.

Result: a cached file whose size matches but whose tail is NULL. Worse, the entry is marked cached and the remote-only flag cleared, so the corruption is sticky and never re-fetches.

Reproduced with a proxy that reports size 3600000 in the listing but delivers only 100 bytes on the ranged GET: before, HTTP 200 with 3599900 NULL bytes, persisted as cached; after, 503 + Retry-After, the entry stays remote-only, and the log shows `short read ... got 100 bytes, want 3600000`. Healthy full reads still cache correctly.

Fix: check the downloaded byte count against the requested size in the S3 and Azure clients, plus a backend-agnostic `len(data) == req.Size` guard in `FetchAndWriteNeedle`.

## 2. Permissions diverge from the source

Remote object listings carry no POSIX mode, so synced entries were created with a hardcoded `0644`. Against a SeaweedFS remote — whose S3 layer writes objects as `0660` and auto-creates directories as `0771` (`0660|0111`) — the mounted copy ended up `0644`/`0755`, visibly different from the source.

Fix: default to the S3 modes (files `0660`, directories `0771`) in `pullMetadata` and `remote.cache`. The filer derives parent-dir modes from the child as `fileMode|0111`, so fixing the file default brings the directories into line too. Verified the mounted copy now matches the source (`0660` files, `0771` dirs).

Directory **mtimes** still reflect sync time: S3 listings don't enumerate directories, so the remote's directory timestamps aren't retrievable over the S3 protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote reads (Azure, S3, and remote fetch) now validate the exact number of bytes returned and error on short reads to avoid treating zero-padded data as valid.
  * Remote cache and metadata sync now set file and directory permissions to S3-style defaults (files 0660, directories 0771) instead of a fixed permissive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->