### PR TITLE
fix(shell): move files into existing destination directories

### DIFF
--- a/weed/shell/command_fs_mv.go
+++ b/weed/shell/command_fs_mv.go
@@ -66,8 +66,8 @@ func (c *commandFsMv) Do(args []string, commandEnv *CommandEnv, writer io.Writer
 
 		// collect destination entry info
 		destinationRequest := &filer_pb.LookupDirectoryEntryRequest{
-			Name:      destinationDir,
-			Directory: destinationName,
+			Directory: destinationDir,
+			Name:      destinationName,
 		}
 		respDestinationLookupEntry, err := filer_pb.LookupEntry(context.Background(), client, destinationRequest)
 

--- a/weed/shell/command_fs_mv_test.go
+++ b/weed/shell/command_fs_mv_test.go
@@ -71,7 +71,7 @@ func TestFsMvMovesIntoExistingDestinationDirectory(t *testing.T) {
 func newFsMvTestCommandEnv(t *testing.T, filerServer filer_pb.SeaweedFilerServer) (*CommandEnv, func()) {
 	t.Helper()
 
-	socketDir, err := os.MkdirTemp("/private/tmp", "swmv-")
+	socketDir, err := os.MkdirTemp("", "swmv-")
 	if err != nil {
 		t.Fatalf("create socket dir: %v", err)
 	}

--- a/weed/shell/command_fs_mv_test.go
+++ b/weed/shell/command_fs_mv_test.go
@@ -1,0 +1,107 @@
+package shell
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type fsMvTestFilerServer struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+
+	lookupReq *filer_pb.LookupDirectoryEntryRequest
+	renameReq *filer_pb.AtomicRenameEntryRequest
+}
+
+func (s *fsMvTestFilerServer) LookupDirectoryEntry(_ context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+	s.lookupReq = req
+	if req.Directory == "/dst" && req.Name == "dir" {
+		return &filer_pb.LookupDirectoryEntryResponse{
+			Entry: &filer_pb.Entry{
+				Name:        "dir",
+				IsDirectory: true,
+				Attributes:  &filer_pb.FuseAttributes{},
+			},
+		}, nil
+	}
+	return nil, status.Error(codes.NotFound, "not found")
+}
+
+func (s *fsMvTestFilerServer) AtomicRenameEntry(_ context.Context, req *filer_pb.AtomicRenameEntryRequest) (*filer_pb.AtomicRenameEntryResponse, error) {
+	s.renameReq = req
+	return &filer_pb.AtomicRenameEntryResponse{}, nil
+}
+
+func TestFsMvMovesIntoExistingDestinationDirectory(t *testing.T) {
+	filerServer := &fsMvTestFilerServer{}
+	commandEnv, cleanup := newFsMvTestCommandEnv(t, filerServer)
+	defer cleanup()
+
+	var output bytes.Buffer
+	err := (&commandFsMv{}).Do([]string{"/src/file", "/dst/dir"}, commandEnv, &output)
+	if err != nil {
+		t.Fatalf("fs.mv returned error: %v", err)
+	}
+
+	if filerServer.lookupReq == nil {
+		t.Fatal("expected fs.mv to look up destination entry")
+	}
+	if filerServer.lookupReq.Directory != "/dst" || filerServer.lookupReq.Name != "dir" {
+		t.Fatalf("destination lookup = directory %q name %q, want /dst dir", filerServer.lookupReq.Directory, filerServer.lookupReq.Name)
+	}
+	if filerServer.renameReq == nil {
+		t.Fatal("expected fs.mv to issue rename")
+	}
+	if filerServer.renameReq.NewDirectory != "/dst/dir" || filerServer.renameReq.NewName != "file" {
+		t.Fatalf("rename target = directory %q name %q, want /dst/dir file", filerServer.renameReq.NewDirectory, filerServer.renameReq.NewName)
+	}
+}
+
+func newFsMvTestCommandEnv(t *testing.T, filerServer filer_pb.SeaweedFilerServer) (*CommandEnv, func()) {
+	t.Helper()
+
+	socketDir, err := os.MkdirTemp("/private/tmp", "swmv-")
+	if err != nil {
+		t.Fatalf("create socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+
+	socketPath := filepath.Join(socketDir, "filer.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(grpcServer, filerServer)
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	grpcPort := 47000 + os.Getpid()%1000
+	pb.RegisterLocalGrpcSocket("127.0.0.1", grpcPort, socketPath)
+
+	cleanup := func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	}
+
+	return &CommandEnv{
+		option: &ShellOptions{
+			FilerAddress:   pb.ServerAddress(fmt.Sprintf("127.0.0.1:8888.%d", grpcPort)),
+			GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+			Directory:      "/",
+		},
+	}, cleanup
+}


### PR DESCRIPTION

# What problem are we solving?

fs.mv /src/file /dst/dir treats an existing destination directory as a destination file path, so it renames the source to /dst/dir instead of moving it into /dst/dir/file.

Root cause: commandFsMv builds the destination LookupDirectoryEntryRequest with Directory and Name swapped, so the destination directory lookup misses.

# How are we solving the problem?

Populate LookupDirectoryEntryRequest with Directory=destinationDir and Name=destinationName before deciding whether the destination is a directory.

# How is the PR tested?

```
gofmt -w weed/shell/command_fs_mv.go weed/shell/command_fs_mv_test.go;
git diff --check;
git diff --cached --check;
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/shell -run TestFsMvMovesIntoExistingDestinationDirectory -count=1;
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/shell -count=1

```
# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the fs.mv command that caused incorrect destination lookups during file move/rename operations, ensuring targets are resolved correctly so moves into existing directories behave as expected.

* **Tests**
  * Added a test that verifies moving a file into an existing destination directory performs the correct lookup and atomic rename behavior, with setup/teardown for a local test server to validate end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->