### PR TITLE
fix(mongodb): merge URI auth fields with username/password override

### DIFF
--- a/weed/filer/mongodb/mongodb_store.go
+++ b/weed/filer/mongodb/mongodb_store.go
@@ -74,10 +74,14 @@ func (store *MongodbStore) connection(uri string, poolSize uint64, ssl bool, ssl
 	}
 
 	if username != "" && password != "" {
-		creds := options.Credential{
-			Username: username,
-			Password: password,
+		// Keep auth fields parsed from the URI (AuthSource, AuthMechanism, ...)
+		// and only override the credentials.
+		creds := options.Credential{}
+		if opts.Auth != nil {
+			creds = *opts.Auth
 		}
+		creds.Username = username
+		creds.Password = password
 		opts.SetAuth(creds)
 	}
 

--- a/weed/filer/mongodb/mongodb_store.go
+++ b/weed/filer/mongodb/mongodb_store.go
@@ -82,6 +82,7 @@ func (store *MongodbStore) connection(uri string, poolSize uint64, ssl bool, ssl
 		}
 		creds.Username = username
 		creds.Password = password
+		creds.PasswordSet = true
 		opts.SetAuth(creds)
 	}
 


### PR DESCRIPTION
When both `uri` and explicit `username`/`password` are configured for the MongoDB filer store, `opts.SetAuth(creds)` replaced the entire `Credential` object that `ApplyURI` parsed from the URI. Fields like `AuthSource`, `AuthMechanism`, and `AuthMechanismProperties` were silently dropped, so credentials scoped to a specific auth database failed authentication.

Now the parsed `opts.Auth` is used as the base and only `Username`/`Password` are overridden.

Fixes #9888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MongoDB connection authentication now preserves authentication details provided in connection URIs while allowing configured username/password to override credentials.
  * Resolves connection and authentication failures with complex MongoDB deployments (custom mechanisms, auth sources), improving reliability when explicit credentials are supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->