### PR TITLE
fix(http): accept no content delete responses

### DIFF
--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -172,7 +172,7 @@ func Delete(url string, jwt string) error {
 		return err
 	}
 	switch resp.StatusCode {
-	case http.StatusNotFound, http.StatusAccepted, http.StatusOK:
+	case http.StatusNotFound, http.StatusNoContent, http.StatusAccepted, http.StatusOK:
 		return nil
 	}
 	m := make(map[string]interface{})

--- a/weed/util/http/http_global_client_util_test.go
+++ b/weed/util/http/http_global_client_util_test.go
@@ -108,7 +108,9 @@ func TestDeleteTreatsNoContentAsSuccess(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
-			t.Fatalf("expected DELETE, got %s", r.Method)
+			t.Errorf("expected DELETE, got %s", r.Method)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/weed/util/http/http_global_client_util_test.go
+++ b/weed/util/http/http_global_client_util_test.go
@@ -103,6 +103,22 @@ func TestDeleteReturnsInvalidRequestErrorBeforeAddingAuth(t *testing.T) {
 	}
 }
 
+func TestDeleteTreatsNoContentAsSuccess(t *testing.T) {
+	InitGlobalHttpClient()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	if err := Delete(server.URL, ""); err != nil {
+		t.Fatalf("expected 204 DELETE to succeed, got %v", err)
+	}
+}
+
 func TestDeleteProxiedReturnsInvalidRequestErrorBeforeAddingAuth(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
# What problem are we solving?

`util/http.Delete` reports an error when a DELETE request succeeds with HTTP `204 No Content`.

HTTP `204` is a standard successful response for DELETE endpoints, so callers should not receive an error for this status.

# How are we solving the problem?

Include `http.StatusNoContent` in the success status set handled by `Delete`, alongside the existing accepted statuses.

# How is the PR tested?

- `go test ./weed/util/http -run TestDeleteTreatsNoContentAsSuccess -count=1`
- `go test ./weed/util/http -count=1`
- `git diff --check`
- `git diff --cached --check`

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delete operations now correctly recognize additional HTTP response codes as successful, improving reliability across different server implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->