### PR TITLE
ci: route Docker Hub pulls through a mirror to cut registry timeouts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Configure Docker Hub mirror
+      run: |
+        echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
       

--- a/.github/workflows/kafka-quicktest.yml
+++ b/.github/workflows/kafka-quicktest.yml
@@ -32,6 +32,11 @@ jobs:
           **/go.sum
       id: go
 
+    - name: Configure Docker Hub mirror
+      run: |
+        echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -31,6 +31,11 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v6
 
+    - name: Configure Docker Hub mirror
+      run: |
+        echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/s3-proxy-signature-tests.yml
+++ b/.github/workflows/s3-proxy-signature-tests.yml
@@ -28,6 +28,11 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/s3-spark-tests.yml
+++ b/.github/workflows/s3-spark-tests.yml
@@ -33,15 +33,19 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - name: Install SeaweedFS
         run: |
           go install -buildvcs=false ./weed
 
       - name: Pre-pull Spark image
-        run: docker pull apache/spark:3.5.8
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull apache/spark:3.5.8
 
       - name: Run S3 Spark integration tests
         working-directory: test/s3/spark

--- a/.github/workflows/s3-tables-tests.yml
+++ b/.github/workflows/s3-tables-tests.yml
@@ -83,6 +83,11 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Run go mod tidy
         run: go mod tidy
 
@@ -139,11 +144,15 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - name: Pre-pull Trino image
-        run: docker pull trinodb/trino:479
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull trinodb/trino:479
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -205,14 +214,16 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
-      - name: Pre-pull Dremio image
-        run: docker pull dremio/dremio-oss:25.2.0
-
-      - name: Pre-pull Python image for PyIceberg writer
-        run: docker pull python:3.11-slim
+      - name: Pre-pull images
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull dremio/dremio-oss:25.2.0
+          pull python:3.11-slim
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -276,14 +287,16 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
-      - name: Pre-pull Doris image
-        run: docker pull apache/doris:doris-all-in-one-2.1.0
-
-      - name: Pre-pull Python image for PyIceberg writer
-        run: docker pull python:3.11-slim
+      - name: Pre-pull images
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull apache/doris:doris-all-in-one-2.1.0
+          pull python:3.11-slim
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -354,8 +367,15 @@ jobs:
         run: |
           go install -buildvcs=false ./weed
 
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Pre-pull Polaris image
-        run: docker pull apache/polaris:latest
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull apache/polaris:latest
 
       - name: Run Polaris Integration Tests
         timeout-minutes: 25
@@ -408,11 +428,15 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - name: Pre-pull Spark image
-        run: docker pull apache/spark:3.5.1
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull apache/spark:3.5.1
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -474,13 +498,16 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - name: Pre-pull RisingWave image
         run: |
-          docker pull risingwavelabs/risingwave:v2.5.0
-          docker pull postgres:16-alpine
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull risingwavelabs/risingwave:v2.5.0
+          pull postgres:16-alpine
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -542,11 +569,15 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - name: Pre-pull Python image
-        run: docker pull python:3
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull python:3
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -608,14 +639,17 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
-      - name: Pre-pull Python image
-        run: docker pull python:3
-        
-      - name: Pre-pull LocalStack image (if needed)
-        run: docker pull localstack/localstack:latest || true
+      - name: Pre-pull images
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull python:3
+          # localstack is optional; best-effort pull
+          for i in 1 2 3; do docker pull localstack/localstack:latest && break; sleep 15; done
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -677,14 +711,16 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
-      - name: Pre-pull Unity Catalog image
-        run: docker pull unitycatalog/unitycatalog:v0.4.0
-
-      - name: Pre-pull Python image for delta-rs writer
-        run: docker pull python:3.11-slim
+      - name: Pre-pull images
+        run: |
+          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
+          pull unitycatalog/unitycatalog:v0.4.0
+          pull python:3.11-slim
 
       - name: Run go mod tidy
         run: go mod tidy


### PR DESCRIPTION
## Problem

Docker test jobs flake at the **Set up Docker** step with:

```
ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

`docker/setup-buildx-action` bootstraps a `docker-container` builder by pulling `moby/buildkit` from Docker Hub. When that pull (or any later image pull) times out, the job dies before tests run.

## Change

Point the runner's Docker daemon at a Docker Hub pull-through cache (`mirror.gcr.io`) via `/etc/docker/daemon.json`, so pulls are served from the cache with automatic fallback to Docker Hub on a miss. No secrets, so it works on fork PRs too. Where there are explicit `docker pull`s, retry them a few times to ride out transient timeouts.

**`s3-tables-tests.yml`** (10 jobs) and **`s3-spark-tests.yml`** only `docker pull`/`docker run` images — they never `docker buildx build`, so the buildx setup was pure overhead and an extra Docker Hub dependency. Dropped it and pull through the mirror with retries. (The `iceberg-catalog` job already builds images with no buildx setup and works fine, which confirms it's safe to drop.)

**`kafka-quicktest.yml`, `s3-proxy-signature-tests.yml`, `e2e.yml`, `postgres-tests.yml`** build via `docker compose`/buildx and genuinely need buildx (e2e/postgres export a local layer cache with `--cache-to type=local`, which the default `docker` driver can't do). Kept buildx and inserted the mirror **before** it, so even the `moby/buildkit` bootstrap pull is served from the cache.

**Left alone:** `samba-integration.yml` / `pjdfstest.yml` build-push a SeaweedFS image to a local `registry:5000` and pull from `localhost` — buildx is required there and there's no Docker Hub runtime pull to mirror. The `container_*.yml` release builders are a separate concern (they build+push and already authenticate to Docker Hub).

Mirror coverage is reliable for library images (`python`, `postgres`, `localstack`, `spark`) and best-effort for third-party namespaced images; the retry loop covers the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by configuring a Docker registry mirror for test workflows to speed and stabilize image pulls.
  * Replaced brittle pre-pull steps with retry-style image retrieval across integration and end-to-end jobs to reduce transient failures.
  * Applied the same mirroring and retry approach consistently to all relevant test workflows to improve overall test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->