### PR TITLE
fix(s3api): normalize checksum trailer header names

### DIFF
--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -31,6 +31,7 @@ import (
 	"hash/crc32"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -138,6 +139,7 @@ func (iam *IdentityAccessManagement) newChunkedReader(req *http.Request) (io.Rea
 
 func extractChecksumAlgorithm(amzTrailerHeader string) (ChecksumAlgorithm, error) {
 	// Extract checksum algorithm from the x-amz-trailer header.
+	amzTrailerHeader = strings.ToLower(strings.TrimSpace(amzTrailerHeader))
 	switch amzTrailerHeader {
 	case "x-amz-checksum-crc32":
 		return ChecksumAlgorithmCRC32, nil

--- a/weed/s3api/chunked_reader_v4_test.go
+++ b/weed/s3api/chunked_reader_v4_test.go
@@ -30,6 +30,16 @@ const (
 	defaultRegion          = "us-east-1"
 )
 
+func TestExtractChecksumAlgorithmIsCaseInsensitive(t *testing.T) {
+	got, err := extractChecksumAlgorithm("X-Amz-Checksum-Crc32")
+	if err != nil {
+		t.Fatalf("extractChecksumAlgorithm returned error: %v", err)
+	}
+	if got != ChecksumAlgorithmCRC32 {
+		t.Fatalf("extractChecksumAlgorithm() = %v, want %v", got, ChecksumAlgorithmCRC32)
+	}
+}
+
 func generateStreamingUnsignedPayloadTrailerPayload(includeFinalCRLF bool) string {
 	// This test will implement the following scenario:
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html


### PR DESCRIPTION
# What problem are we solving?

SigV4 chunked upload checksum trailer parsing rejected mixed-case checksum trailer header names, even though HTTP header field names are case-insensitive.

For example, a trailer value or trailer key such as `X-Amz-Checksum-Crc32` could be rejected as an unsupported checksum algorithm instead of being treated the same as `x-amz-checksum-crc32`.

# How are we solving the problem?

Normalize checksum trailer header names before matching supported checksum algorithms:

- trim surrounding whitespace
- convert the header name to lowercase
- keep writing and comparing the canonical lowercase checksum algorithm names internally

The shared parser is used both when reading the advertised `x-amz-trailer` header and when parsing the checksum header from the trailer chunk, so the normalization applies to both places.

A regression test covers mixed-case checksum trailer header names.

# How is the PR tested?

- `go test ./weed/s3api -run TestExtractChecksumAlgorithmIsCaseInsensitive -count=1`
- `go test ./weed/s3api -run TestNewSignV4ChunkedReaderStreamingUnsignedPayloadTrailer -count=1`
- `go test ./weed/s3api -run TestSignedStreamingUploadWithTrailer -count=1`
- `go test ./weed/s3api -count=1`
- `git diff --check HEAD~1..HEAD`

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checksum algorithm detection for S3 chunked uploads is now case-insensitive and ignores surrounding whitespace in header values.
* **Tests**
  * Added a unit test to verify checksum header parsing behavior across casing and whitespace variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->