### PR TITLE
add elastic8 filer store for Elasticsearch 8

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -366,6 +366,21 @@ healthcheck_enabled = false
 # increase the value is recommend, be sure the value in Elastic is greater or equal here
 index.max_result_window = 10000
 
+# for Elasticsearch 8.x clusters
+[elastic8]
+enabled = false
+servers = [
+    "http://localhost1:9200",
+    "http://localhost2:9200",
+    "http://localhost3:9200",
+]
+username = ""
+password = ""
+sniff_enabled = false
+healthcheck_enabled = false
+# increase the value is recommend, be sure the value in Elastic is greater or equal here
+index.max_result_window = 10000
+
 
 [arangodb] # in development dont use it
 enabled = false

--- a/weed/filer/elastic/v7/elastic_store.go
+++ b/weed/filer/elastic/v7/elastic_store.go
@@ -219,8 +219,10 @@ func (store *ElasticStore) listDirectoryEntries(
 	parentId := weed_util.Md5String([]byte(fullpath))
 	if _, err = store.client.Refresh(index).Do(ctx); err != nil {
 		if elastic.IsNotFound(err) {
-			store.client.CreateIndex(index).Do(ctx)
-			return
+			if _, err := store.client.CreateIndex(index).Do(ctx); err != nil {
+				return lastFileName, fmt.Errorf("create index(%s) %v", index, err)
+			}
+			return lastFileName, nil
 		}
 	}
 	for {
@@ -278,6 +280,11 @@ func (store *ElasticStore) listDirectoryEntries(
 	return
 }
 
+func (store *ElasticStore) listSorter() elastic.Sorter {
+	// unmapped_type tolerates indexes with no documents yet
+	return elastic.NewFieldSort("_id").Desc().UnmappedType("keyword")
+}
+
 func (store *ElasticStore) search(ctx context.Context, index, parentId string) (result *elastic.SearchResult, err error) {
 	if count, err := store.client.Count(index).Do(ctx); err == nil && count == 0 {
 		return &elastic.SearchResult{
@@ -289,7 +296,7 @@ func (store *ElasticStore) search(ctx context.Context, index, parentId string) (
 		Index(index).
 		Query(elastic.NewMatchQuery("ParentId", parentId)).
 		Size(store.maxPageSize).
-		Sort("_id", false).
+		SortBy(store.listSorter()).
 		Do(ctx)
 	return queryResult, err
 }
@@ -300,7 +307,7 @@ func (store *ElasticStore) searchAfter(ctx context.Context, index, parentId, aft
 		Query(elastic.NewMatchQuery("ParentId", parentId)).
 		SearchAfter(after).
 		Size(store.maxPageSize).
-		Sort("_id", false).
+		SortBy(store.listSorter()).
 		Do(ctx)
 	return queryResult, err
 

--- a/weed/filer/elastic/v7/elastic_store.go
+++ b/weed/filer/elastic/v7/elastic_store.go
@@ -34,6 +34,7 @@ var (
 
 type ESEntry struct {
 	ParentId string `json:"ParentId"`
+	Id       string `json:"Id,omitempty"`
 	Entry    *filer.Entry
 }
 
@@ -43,15 +44,31 @@ type ESKVEntry struct {
 
 func init() {
 	filer.Stores = append(filer.Stores, &ElasticStore{})
+	filer.Stores = append(filer.Stores, &Elastic8Store{})
 }
 
 type ElasticStore struct {
 	client      *elastic.Client
 	maxPageSize int
+	es8         bool
 }
 
 func (store *ElasticStore) GetName() string {
 	return "elastic7"
+}
+
+// Elastic8Store sorts listings on an indexed Id field since Elasticsearch 8 disallows _id fielddata.
+type Elastic8Store struct {
+	ElasticStore
+}
+
+func (store *Elastic8Store) GetName() string {
+	return "elastic8"
+}
+
+func (store *Elastic8Store) Initialize(configuration weed_util.Configuration, prefix string) (err error) {
+	store.es8 = true
+	return store.ElasticStore.Initialize(configuration, prefix)
 }
 
 func (store *ElasticStore) Initialize(configuration weed_util.Configuration, prefix string) (err error) {
@@ -109,6 +126,9 @@ func (store *ElasticStore) InsertEntry(ctx context.Context, entry *filer.Entry) 
 	esEntry := &ESEntry{
 		ParentId: weed_util.Md5String([]byte(dir)),
 		Entry:    entry,
+	}
+	if store.es8 {
+		esEntry.Id = id
 	}
 	value, err := jsoniter.Marshal(esEntry)
 	if err != nil {
@@ -281,8 +301,12 @@ func (store *ElasticStore) listDirectoryEntries(
 }
 
 func (store *ElasticStore) listSorter() elastic.Sorter {
+	field := "_id"
+	if store.es8 {
+		field = "Id.keyword"
+	}
 	// unmapped_type tolerates indexes with no documents yet
-	return elastic.NewFieldSort("_id").Desc().UnmappedType("keyword")
+	return elastic.NewFieldSort(field).Desc().UnmappedType("keyword")
 }
 
 func (store *ElasticStore) search(ctx context.Context, index, parentId string) (result *elastic.SearchResult, err error) {


### PR DESCRIPTION
Elasticsearch 8 disables `_id` fielddata by default, so elastic7 directory listings fail against an 8.x cluster. The new `elastic8` store shares the client and configuration options with `elastic7`, but indexes each document id as an `Id` field and sorts listings on `Id.keyword`. The first commit fixes pre-existing listing errors on empty or missing per-directory indexes.

Verified against dockerized 8.17.0 and 7.17.9: store CRUD, paginated and resumed listings, kv ops, plus a full weed server on `[elastic8]`. Data written by elastic7 has no `Id` field, so switching an existing cluster to elastic8 requires a reindex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Elasticsearch 8.x support as a filer store option with configurable server endpoints, authentication, and operational settings.

* **Improvements**
  * Optimized directory listing pagination and sorting behavior for Elasticsearch 8 deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->