### PR TITLE
log_buffer: stop dumping the whole log entry on callback errors

### DIFF
--- a/weed/util/log_buffer/log_read.go
+++ b/weed/util/log_buffer/log_read.go
@@ -286,7 +286,7 @@ func (logBuffer *LogBuffer) LoopProcessLogData(readerName string, startPosition 
 			lastReadPosition = NewMessagePosition(logEntry.TsNs, batchIndex)
 
 			if isDone, err = eachLogDataFn(logEntry); err != nil {
-				glog.Errorf("LoopProcessLogData: %s process log entry %d %v: %v", readerName, batchSize+1, logEntry, err)
+				glog.Errorf("LoopProcessLogData: %s process log entry %d key:%q ts_ns:%d offset:%d size:%d: %v", readerName, batchSize+1, logEntry.Key, logEntry.TsNs, logEntry.Offset, len(logEntry.Data), err)
 				return
 			}
 			if isDone {
@@ -556,7 +556,7 @@ func (logBuffer *LogBuffer) LoopProcessLogDataWithOffset(readerName string, star
 
 			glog.V(4).Infof("Calling eachLogDataFn for entry at offset %d, next position will be %d", logEntry.Offset, logEntry.Offset+1)
 			if isDone, err = eachLogDataFn(logEntry, logEntry.Offset); err != nil {
-				glog.Errorf("LoopProcessLogDataWithOffset: %s process log entry %d %v: %v", readerName, batchSize+1, logEntry, err)
+				glog.Errorf("LoopProcessLogDataWithOffset: %s process log entry %d key:%q ts_ns:%d offset:%d size:%d: %v", readerName, batchSize+1, logEntry.Key, logEntry.TsNs, logEntry.Offset, len(logEntry.Data), err)
 				return
 			}
 			if isDone {


### PR DESCRIPTION
When a metadata subscriber's stream breaks mid-send, the error path in `LoopProcessLogData`/`LoopProcessLogDataWithOffset` logged the entire LogEntry proto. An entry carrying a large chunk manifest turns that into a single log line of several hundred KB of escaped bytes, with the actual error (typically `transport is closing` from a routine peer disconnect) buried at the end.

Log the entry's key, timestamp, offset and data size instead:

```
E ... LoopProcessLogData: localMeta:filer:... process log entry 4 key:/data/pvc-106 ts_ns:1781118318677145006 offset:38155 size:33571: rpc error: code = Unavailable desc = transport is closing
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved per-entry error logging to include relevant entry metadata (key, timestamp, offset, size) alongside processing errors to aid troubleshooting and reduce ambiguity when diagnosing failures. This change makes logs clearer and more actionable for operators investigating processing issues without exposing internal structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->