### PR TITLE
ci(s3tables): stop Lakekeeper flaking on Docker Hub pull timeouts

### DIFF
--- a/.github/workflows/s3-spark-tests.yml
+++ b/.github/workflows/s3-spark-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Pre-pull Spark image
         run: |
           pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
-          pull apache/spark:3.5.8
+          pull apache/spark:3.5.1
 
       - name: Run S3 Spark integration tests
         working-directory: test/s3/spark

--- a/.github/workflows/s3-tables-tests.yml
+++ b/.github/workflows/s3-tables-tests.yml
@@ -574,10 +574,34 @@ jobs:
           echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
 
-      - name: Pre-pull Python image
+      - name: Week stamp for image cache key
+        id: week
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore python:3 image cache
+        id: python-image
+        uses: actions/cache@v5
+        with:
+          path: /tmp/python3-image.tar
+          key: python3-image-${{ steps.week.outputs.week }}
+          restore-keys: |
+            python3-image-
+
+      - name: Load or pull python:3
         run: |
+          if [ "${{ steps.python-image.outputs.cache-hit }}" = "true" ]; then
+            docker load -i /tmp/python3-image.tar
+            exit 0
+          fi
           pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
-          pull python:3
+          if pull python:3; then
+            docker save -o /tmp/python3-image.tar python:3
+          elif [ -f /tmp/python3-image.tar ]; then
+            # Docker Hub unreachable; fall back to last week's cached image
+            docker load -i /tmp/python3-image.tar
+          else
+            exit 1
+          fi
 
       - name: Run go mod tidy
         run: go mod tidy

--- a/.github/workflows/s3-tables-tests.yml
+++ b/.github/workflows/s3-tables-tests.yml
@@ -639,18 +639,6 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      - name: Configure Docker Hub mirror
-        run: |
-          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Pre-pull images
-        run: |
-          pull() { for i in 1 2 3; do docker pull "$1" && return 0; sleep 15; done; return 1; }
-          pull python:3
-          # localstack is optional; best-effort pull
-          for i in 1 2 3; do docker pull localstack/localstack:latest && break; sleep 15; done
-
       - name: Run go mod tidy
         run: go mod tidy
 

--- a/test/s3tables/lakekeeper/lakekeeper_test.go
+++ b/test/s3tables/lakekeeper/lakekeeper_test.go
@@ -68,7 +68,6 @@ func TestLakekeeperIntegration(t *testing.T) {
 	env.StartSeaweedFS(t)
 	fmt.Printf(">>> SeaweedFS started.\n")
 
-	// Run python script in docker to test STS and S3 operations
 	runLakekeeperRepro(t, env)
 }
 
@@ -80,7 +79,6 @@ func TestLakekeeperTableBucketIntegration(t *testing.T) {
 	env.StartSeaweedFS(t)
 	fmt.Printf(">>> SeaweedFS started.\n")
 
-	// Run python script in docker to test STS and S3 Tables operations
 	runLakekeeperTableBucketRepro(t, env)
 }
 


### PR DESCRIPTION
The Lakekeeper job keeps dying in its pre-pull step when Docker Hub is unreachable (https://github.com/seaweedfs/seaweedfs/actions/runs/27298549905/job/80637711319), even after the mirror routing. Turns out the lakekeeper repro has been pure Go for a while — the python:3 and localstack pulls are leftovers from the old python-in-docker harness, so the job was failing on images it never runs. Drop the pre-pull and mirror steps there, plus the stale comments in the test.

The STS job has the same pre-pull but actually does `docker run python:3`, so registry flakiness still applies. Back that pull with an actions/cache'd image tarball under a weekly key: exact hit loads from cache without touching any registry, miss pulls fresh and refreshes the cache, and if the pull fails a previous week's tarball is the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Docker image caching for CI to speed up integration tests, with weekly cache rotation and fallback behavior to handle pull failures.
  * Updated pre-pull behavior to streamline test jobs and removed redundant image pre-pull steps.
  * Updated the Spark container version used in CI.

* **Tests**
  * Cleaned up integration test flow by removing placeholder steps so tests proceed directly to their verification runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->