### PR TITLE
fix(tests): 32-bit build of EC e2e tests, type-check linux/386 in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,21 @@ jobs:
         # Fail only if there are actual vet errors (not counting the filtered lock warnings)
         if grep -q "vet:" vet-output.txt; then exit 1; fi
 
+  vet-32bit:
+    name: Go Vet 32-bit
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+    - name: Go Vet linux/386 (type-checks code and tests for 32-bit int overflows)
+      run: |
+        GOOS=linux GOARCH=386 go vet ./... 2>&1 | grep -v "MessageState contains sync.Mutex" | grep -v "IdentityAccessManagement contains sync.RWMutex" | tee vet-32bit-output.txt
+        if grep -q "vet:" vet-32bit-output.txt; then exit 1; fi
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/test/s3/s3client/s3client.go
+++ b/test/s3/s3client/s3client.go
@@ -77,7 +77,7 @@ func MyAwsConfig(cfg MyConfig) (*aws.Config, error) {
 		config.WithEndpointResolverWithOptions(customResolver),
 		config.WithRetryer(func() aws.Retryer {
 			r := retry.AddWithMaxAttempts(retry.NewStandard(), *cfg.MaxRetryAttempts)
-			return retry.AddWithMaxBackoffDelay(r, time.Duration(*cfg.MaxBackoffDelay*1000*1000))
+			return retry.AddWithMaxBackoffDelay(r, time.Duration(*cfg.MaxBackoffDelay)*time.Millisecond)
 		}))
 	return &awsCfg, err
 }

--- a/test/s3/s3client/s3client.go
+++ b/test/s3/s3client/s3client.go
@@ -23,7 +23,7 @@ func main() {
 			Name:       "newbucket",
 			Versioning: false,
 		},
-		MaxBackoffDelay:  aws.Int(int(time.Second * 5)),
+		MaxBackoffDelay:  aws.Int(int((5 * time.Second).Milliseconds())),
 		MaxRetryAttempts: aws.Int(1),
 	}
 

--- a/weed/worker/tasks/erasure_coding/ec_task_encode_files_e2e_test.go
+++ b/weed/worker/tasks/erasure_coding/ec_task_encode_files_e2e_test.go
@@ -51,7 +51,7 @@ func TestEcEncodeLeavesRightFilesAndRemovesStubAndSource(t *testing.T) {
 	framework.AllocateVolume(t, clientA, volumeID, collection)
 	httpClient := framework.NewHTTPClient()
 	for i := 0; i < 8; i++ {
-		fid := framework.NewFileID(volumeID, uint64(948000+i), uint32(0x9490CA00+i))
+		fid := framework.NewFileID(volumeID, uint64(948000+i), 0x9490CA00+uint32(i))
 		payload := make([]byte, 4096)
 		for j := range payload {
 			payload[j] = byte(i + 1)

--- a/weed/worker/tasks/erasure_coding/ec_task_julor_layout_e2e_test.go
+++ b/weed/worker/tasks/erasure_coding/ec_task_julor_layout_e2e_test.go
@@ -66,7 +66,7 @@ func TestEcEncodeJulorLayoutConverges(t *testing.T) {
 	framework.AllocateVolume(t, clients[srcServer], volumeID, collection)
 	httpClient := framework.NewHTTPClient()
 	for i := 0; i < 8; i++ {
-		fid := framework.NewFileID(volumeID, uint64(950000+i), uint32(0x9500CA00+i))
+		fid := framework.NewFileID(volumeID, uint64(950000+i), 0x9500CA00+uint32(i))
 		payload := make([]byte, 4096)
 		for j := range payload {
 			payload[j] = byte(i + 1)


### PR DESCRIPTION
The EC e2e tests added the fid cookie constants 0x9490CA00 / 0x9500CA00 to an int loop variable before converting, which overflows 32-bit int at compile time. The addition now stays in uint32.

A GOOS=linux GOARCH=386 vet sweep of the whole module turned up one more: the s3client example passed MaxBackoffDelay as nanoseconds where the field takes milliseconds — wrong on 64-bit too, and an overflow on 32-bit.

Since this is the third round of these, CI now type-checks code and tests for linux/386 in the build workflow. That also covers the released 32-bit arm binaries, which share the same int size.

Fixes #9921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected S3 client retry configuration to properly calculate backoff delays.

* **Tests**
  * Updated test file identifier generation in erasure coding tests for consistency.

* **Chores**
  * CI pipeline enhanced with an additional 32-bit vet job to catch integer/overflow-type issues and fail on remaining vet errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->