### PR TITLE
ci: run weed tests on linux/386

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,3 +77,19 @@ jobs:
         go-version-file: 'go.mod'
     - name: Test
       run: cd weed; go test -tags "elastic gocdk sqlite ydb tarantool tikv rclone" -v ./...
+
+  test-32bit:
+    name: Test 32-bit
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+    # 386 test binaries run natively on the amd64 runner. This catches what vet
+    # can't: unaligned 64-bit atomics and arithmetic that wraps at runtime.
+    # -short skips the e2e suites already covered on amd64.
+    - name: Test linux/386
+      run: cd weed; GOOS=linux GOARCH=386 go test -short ./...


### PR DESCRIPTION
Follow-up to the linux/386 vet job: vet only catches what the type checker sees. The runtime class of 32-bit breakage — unaligned 64-bit atomics, arithmetic that wraps after a conversion — needs the tests to actually run on a 32-bit platform.

386 test binaries execute natively on the amd64 runner, so this costs no emulation. -short keeps the e2e suites on amd64 only; the unit tests are where the past runtime failures lived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded testing infrastructure to validate compatibility with 32-bit systems, enhancing code reliability across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->