### PR TITLE
fix(util): ignore comment only sql input

### DIFF
--- a/weed/util/sqlutil/splitter.go
+++ b/weed/util/sqlutil/splitter.go
@@ -133,7 +133,7 @@ func SplitStatements(query string) []string {
 		}
 	}
 
-	if statements == nil {
+	if len(statements) == 0 {
 		return []string{}
 	}
 	return statements

--- a/weed/util/sqlutil/splitter.go
+++ b/weed/util/sqlutil/splitter.go
@@ -133,10 +133,8 @@ func SplitStatements(query string) []string {
 		}
 	}
 
-	// If no statements found, return the original query as a single statement
-	if len(statements) == 0 {
-		return []string{strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))}
+	if statements == nil {
+		return []string{}
 	}
-
 	return statements
 }

--- a/weed/util/sqlutil/splitter_test.go
+++ b/weed/util/sqlutil/splitter_test.go
@@ -96,6 +96,16 @@ func TestSplitStatements(t *testing.T) {
 			input:    "   \n\t   ",
 			expected: []string{},
 		},
+		{
+			name:     "Only single line comment",
+			input:    "-- just a comment",
+			expected: []string{},
+		},
+		{
+			name:     "Only multi-line comment",
+			input:    "/* just a comment; with separator */",
+			expected: []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# What problem are we solving?

`sqlutil.SplitStatements` removes SQL comments while scanning input, but comment-only SQL input could still be returned as a statement because the old fallback returned the original query when no statements were found.

For example, inputs such as `-- just a comment` or `/* just a comment; with separator */` should not produce executable SQL statements.

# How are we solving the problem?

Remove the original-query fallback when scanning finds no statements.

After comments and whitespace are filtered out, `SplitStatements` now returns an explicit empty slice for comment-only input, while preserving the existing behavior for real single statements without a trailing semicolon.

Regression coverage is added for both single-line and multi-line comment-only SQL input.

# How is the PR tested?

- `gofmt -l weed/util/sqlutil/splitter.go weed/util/sqlutil/splitter_test.go`
- `env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/util/sqlutil -run TestSplitStatements -count=1`
- `env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/util/sqlutil -count=1`
- `git diff --check HEAD^ HEAD`
- `git diff --check`

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query parsing to correctly identify and handle queries containing only comments, returning appropriate empty results rather than treating comments as executable statements.

* **Tests**
  * Added test coverage to verify correct behavior when processing comment-only SQL queries, including single-line and multi-line comment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->