### PR TITLE
[volume] preserve compression state during replication

### DIFF
--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -33,6 +33,7 @@ type UploadOption struct {
 	Filename          string
 	Cipher            bool
 	IsInputCompressed bool
+	IsReplication     bool // preserve the source needle's compression state
 	MimeType          string
 	PairMap           map[string]string
 	Jwt               security.EncodedJwt
@@ -276,7 +277,7 @@ func (uploader *Uploader) retriedUploadData(ctx context.Context, data []byte, op
 func (uploader *Uploader) doUploadData(ctx context.Context, data []byte, option *UploadOption) (uploadResult *UploadResult, err error) {
 	contentIsGzipped := option.IsInputCompressed
 	shouldGzipNow := false
-	if !option.IsInputCompressed {
+	if !option.IsInputCompressed && !option.IsReplication {
 		if option.MimeType == "" {
 			option.MimeType = http.DetectContentType(data)
 			// println("detect1 mimetype to", MimeType)

--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -312,8 +312,8 @@ func (uploader *Uploader) doUploadData(ctx context.Context, data []byte, option 
 				contentIsGzipped = true
 			}
 		}
-	} else if option.IsInputCompressed {
-		// just to get the clear data length
+	} else if option.IsInputCompressed && !option.IsReplication {
+		// decompress only to report the clear data length; replication discards the result, so skip it
 		clearData, err = util.DecompressData(data)
 		if err == nil {
 			clearDataLen = len(clearData)

--- a/weed/operation/upload_content_test.go
+++ b/weed/operation/upload_content_test.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/security"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 )
 
 type scriptedHTTPResponse struct {
@@ -195,6 +197,60 @@ func TestUploadRewindsBodyOnConnectionReset(t *testing.T) {
 			if !bytes.Equal(client.bodies[0], client.bodies[1]) {
 				t.Fatalf("retry body length=%d differs from first attempt length=%d (body was not rewound)",
 					len(client.bodies[1]), len(client.bodies[0]))
+			}
+		})
+	}
+}
+
+func TestReplicationUploadPreservesUncompressedNeedle(t *testing.T) {
+	testCases := []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			name:    "unknown binary sampling",
+			payload: bytes.Repeat([]byte{0}, 32*1024),
+		},
+		{
+			name:    "receiver MIME detection",
+			payload: bytes.Repeat([]byte("plain text content\n"), 2048),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var replicatedNeedle *needle.Needle
+			var parseErr error
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				replicatedNeedle, _, _, parseErr = needle.CreateNeedleFromRequest(r, false, 1024*1024, &bytes.Buffer{})
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, `{"name":"payload.custom","size":32768}`)
+			}))
+			defer server.Close()
+
+			uploader := newUploader(server.Client())
+			_, err := uploader.UploadData(context.Background(), tc.payload, &UploadOption{
+				UploadUrl:     server.URL + "/3,01637037d6?type=replicate",
+				Filename:      "payload.custom",
+				IsReplication: true,
+				MaxAttempts:   1,
+			})
+			if err != nil {
+				t.Fatalf("replication upload failed: %v", err)
+			}
+			if parseErr != nil {
+				t.Fatalf("parse replicated upload: %v", parseErr)
+			}
+			if replicatedNeedle == nil {
+				t.Fatal("replica did not receive a needle")
+			}
+			if replicatedNeedle.IsCompressed() {
+				t.Fatal("replication changed an uncompressed needle to compressed")
+			}
+			if !bytes.Equal(replicatedNeedle.Data, tc.payload) {
+				t.Fatalf("replicated data differs: got %d bytes, want %d", len(replicatedNeedle.Data), len(tc.payload))
 			}
 		})
 	}

--- a/weed/server/volume_grpc_remote.go
+++ b/weed/server/volume_grpc_remote.go
@@ -268,6 +268,7 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 					Filename:          "",
 					Cipher:            false,
 					IsInputCompressed: false,
+					IsReplication:     true,
 					MimeType:          "",
 					PairMap:           nil,
 					Jwt:               security.EncodedJwt(req.Auth),

--- a/weed/server/volume_grpc_remote.go
+++ b/weed/server/volume_grpc_remote.go
@@ -237,6 +237,8 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 	}
 
 	var wg sync.WaitGroup
+	var localErr error
+	replicaErrs := make([]error, len(req.Replicas))
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -250,18 +252,16 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 		n.LastModified = uint64(time.Now().Unix())
 		n.SetHasLastModifiedDate()
 		if _, localWriteErr := vs.store.WriteVolumeNeedle(v.Id, n, true, false); localWriteErr != nil {
-			if err == nil {
-				err = fmt.Errorf("local write needle %d size %d: %v", req.NeedleId, req.Size, localWriteErr)
-			}
+			localErr = fmt.Errorf("local write needle %d size %d: %v", req.NeedleId, req.Size, localWriteErr)
 		} else {
 			resp.ETag = n.Etag()
 		}
 	}()
 	if len(req.Replicas) > 0 {
 		fileId := needle.NewFileId(v.Id, req.NeedleId, req.Cookie)
-		for _, replica := range req.Replicas {
+		for i, replica := range req.Replicas {
 			wg.Add(1)
-			go func(targetVolumeServer string) {
+			go func(idx int, targetVolumeServer string) {
 				defer wg.Done()
 				uploadOption := &operation.UploadOption{
 					UploadUrl:         fmt.Sprintf("http://%s/%s?type=replicate", targetVolumeServer, fileId.String()),
@@ -275,19 +275,27 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 				}
 
 				uploader, uploaderErr := operation.NewUploader()
-				if uploaderErr != nil && err == nil {
-					err = fmt.Errorf("remote write needle %d size %d: %v", req.NeedleId, req.Size, uploaderErr)
+				if uploaderErr != nil {
+					replicaErrs[idx] = fmt.Errorf("remote write needle %d size %d: %v", req.NeedleId, req.Size, uploaderErr)
 					return
 				}
 
-				if _, replicaWriteErr := uploader.UploadData(ctx, data, uploadOption); replicaWriteErr != nil && err == nil {
-					err = fmt.Errorf("remote write needle %d size %d: %v", req.NeedleId, req.Size, replicaWriteErr)
+				if _, replicaWriteErr := uploader.UploadData(ctx, data, uploadOption); replicaWriteErr != nil {
+					replicaErrs[idx] = fmt.Errorf("remote write needle %d size %d: %v", req.NeedleId, req.Size, replicaWriteErr)
 				}
-			}(replica.Url)
+			}(i, replica.Url)
 		}
 	}
 
 	wg.Wait()
+
+	// local write error wins; otherwise surface the first replica failure
+	err = localErr
+	for _, replicaErr := range replicaErrs {
+		if err == nil {
+			err = replicaErr
+		}
+	}
 
 	return resp, err
 }

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -95,6 +95,7 @@ func ParseUpload(r *http.Request, sizeLimit int64, bytesBuffer *bytes.Buffer) (p
 			pu.OriginalDataSize = int(n)
 		}
 	} else if r.URL.Query().Get("type") != "replicate" {
+		// replica writes must keep the source needle's compression state, not re-derive it
 		ext := filepath.Base(pu.FileName)
 		mimeType := pu.MimeType
 		if mimeType == "" {

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -94,7 +94,7 @@ func ParseUpload(r *http.Request, sizeLimit int64, bytesBuffer *bytes.Buffer) (p
 		} else if n, err := util.GunzipStream(io.Discard, bytes.NewReader(pu.Data)); err == nil {
 			pu.OriginalDataSize = int(n)
 		}
-	} else {
+	} else if r.URL.Query().Get("type") != "replicate" {
 		ext := filepath.Base(pu.FileName)
 		mimeType := pu.MimeType
 		if mimeType == "" {

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -110,6 +110,7 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 				Filename:          string(n.Name),
 				Cipher:            false,
 				IsInputCompressed: n.IsCompressed(),
+				IsReplication:     true,
 				MimeType:          string(n.Mime),
 				PairMap:           pairMap,
 				Jwt:               jwt,


### PR DESCRIPTION
## Summary

- preserve a needle's existing compression state when sending replica writes
- skip automatic compression when receiving `type=replicate` uploads
- cover both standard volume replication and remote-volume gRPC replication
- add an end-to-end regression test for unknown binary sampling and receiver MIME detection

## Root cause

Primary writes and replica writes passed through different compression decision paths. An uncompressed primary needle could be compressed by the uploader's unknown-type sampling fallback, or by the receiving volume server's MIME-based compression. That produced different on-disk sizes for replicas of the same needle and could make crowded-state reporting oscillate.

The compression decision now remains with the original write. Replica transport preserves the source needle's `IsCompressed` state instead of making another decision.

## Validation

The regression test failed before the fix with `replication changed an uncompressed needle to compressed` and passes after the fix.

- `go test ./weed/operation ./weed/storage/needle`
- `go test ./weed/topology ./weed/server`
- `go vet ./weed/operation ./weed/storage/needle ./weed/topology`
- `go test -race ./weed/operation -run TestReplicationUploadPreservesUncompressedNeedle -count=1`

Closes #9934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replication uploads now preserve the original compression state and avoid unnecessary recompression, ensuring accurate data integrity.
  * Improved error attribution for replica writes so local write failures are reported distinctly and replica failures are aggregated reliably.

* **Tests**
  * Added test coverage verifying replication uploads preserve uncompressed data as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->