### PR TITLE
fix(ec): don't fabricate a stub .vif when mounting an EC volume

### DIFF
--- a/weed/storage/erasure_coding/ec_volume.go
+++ b/weed/storage/erasure_coding/ec_volume.go
@@ -173,8 +173,13 @@ func NewEcVolume(diskType types.DiskType, dir string, dirIdx string, collection 
 			ev.ECContext = NewDefaultECContext(collection, vid)
 		}
 	} else {
-		glog.Warningf("vif file not found,volumeId:%d, filename:%s", vid, vifFileName)
-		volume_info.SaveVolumeInfo(dataBaseFileName+".vif", &volume_server_pb.VolumeInfo{Version: uint32(ev.Version)})
+		// Don't fabricate a stub .vif here: a version-only stub implies the
+		// default 10+4 ratio with DatFileSize=0 and no encode identity, which
+		// the custom-ratio resolver and the startup credibility checks must not
+		// mistake for an authoritative config. Mount with in-memory defaults and
+		// leave the real .vif to the encoder or a recovery tool (the Rust volume
+		// server already behaves this way).
+		glog.Warningf("vif file not found, using defaults, volumeId:%d, filename:%s", vid, vifFileName)
 		ev.ECContext = NewDefaultECContext(collection, vid)
 	}
 

--- a/weed/storage/erasure_coding/ec_volume_test.go
+++ b/weed/storage/erasure_coding/ec_volume_test.go
@@ -91,3 +91,31 @@ func TestNewEcVolumeLoadsEncodeTsNs(t *testing.T) {
 		t.Errorf("EncodeTsNs = %d, want %d", ev.EncodeTsNs, tsNs)
 	}
 }
+
+// TestNewEcVolumeDoesNotWriteStubVif pins that mounting an EC volume whose .vif
+// is missing does NOT fabricate a stub .vif. A version-only stub would imply
+// the default ratio with DatFileSize=0 and no encode identity, which the
+// custom-ratio resolver and startup credibility checks must not trust.
+func TestNewEcVolumeDoesNotWriteStubVif(t *testing.T) {
+	dir := t.TempDir()
+	const vid = needle.VolumeId(124)
+	base := EcShardFileName("", dir, int(vid))
+
+	if err := os.WriteFile(base+".ecx", nil, 0o644); err != nil {
+		t.Fatalf("write .ecx: %v", err)
+	}
+
+	ev, err := NewEcVolume(types.HardDriveType, dir, dir, "", vid)
+	if err != nil {
+		t.Fatalf("NewEcVolume: %v", err)
+	}
+	defer ev.Close()
+
+	if _, statErr := os.Stat(base + ".vif"); !os.IsNotExist(statErr) {
+		t.Fatalf("mounting without a .vif must not create one, stat err=%v", statErr)
+	}
+	// Mount still succeeds with the build's default EC ratio in memory.
+	if ev.ECContext == nil || ev.ECContext.DataShards != int(DataShardsCount) {
+		t.Fatalf("expected default EC context, got %+v", ev.ECContext)
+	}
+}


### PR DESCRIPTION
## Problem

When `NewEcVolume` mounts an EC volume whose `.vif` is missing, it wrote a stub `.vif` containing only the version:

```go
volume_info.SaveVolumeInfo(dataBaseFileName+".vif", &volume_server_pb.VolumeInfo{Version: uint32(ev.Version)})
```

That stub has no `EcShardConfig`, so it implies the build's default 10+4 ratio with `DatFileSize=0` and a zero encode identity. Once persisted, later code reads it as an authoritative config:

- The custom-ratio resolver treats the default-implied stub as the volume's real ratio, masking the actual ratio of a 9+3 / 16+4 volume.
- The startup credibility checks compare a shard's size against `DatFileSize` (now 0), so the byte-exact `.vif` gate can no longer make a confident judgement.

A volume that is merely missing its `.vif` is recoverable (the encoder or `weed fix` can rebuild the correct one from the shards); replacing it with a wrong stub is not.

## Fix

Mount with in-memory defaults and do not persist anything. The in-memory behaviour is unchanged (the stub was defaults too); the only difference is that no misleading `.vif` is written to disk, so a recovery tool can still reconstruct the correct one. The Rust volume server already behaves this way (it deliberately avoids writing a stub on the shard disk), so this only brings the Go side in line — no Rust mirror needed.

The `.ecj` is still opened with `O_CREATE` on mount; that side-effect is harmless (an empty journal reads as "no deletions") and reworking the hot delete path to lazy-create it is out of scope here.

## Tests

`TestNewEcVolumeDoesNotWriteStubVif` mounts an EC volume with a present `.ecx` but no `.vif` and asserts no `.vif` is created and the volume still mounts with the default EC context. The existing `TestNewEcVolumeLoadsEncodeTsNs` continues to cover the `.vif`-present path.

`go test ./weed/storage/erasure_coding/ ./weed/storage/` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EC volume initialization to no longer generate stub volume info files when the original file is missing.
  * Enhanced error logging with additional identification details for better diagnostics.

* **Tests**
  * Added test to verify EC volume behavior during initialization when volume info files are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->