### PR TITLE
fix(ec): group orphan-source completeness by encode generation (topology encode_ts_ns)

### DIFF
--- a/seaweed-volume/proto/master.proto
+++ b/seaweed-volume/proto/master.proto
@@ -147,7 +147,11 @@ message VolumeEcShardInformationMessage {
   repeated int64 shard_sizes = 7; // optimized: sizes for shards in order of set bits in ec_index_bits
   uint64 file_count = 8;   // total needles in the .ecx index (live + tombstoned)
   uint64 delete_count = 9; // node-local tombstones in the .ecj deletion journal
-  // fields 10-19 reserved for future upstream open-source additions.
+  // encode-run identity (unix nanos) from the .vif EcShardConfig; lets the admin
+  // group shards by encode generation. Numbered 14 (not 10) to skip the
+  // enterprise fork's reserved 10-13.
+  int64 encode_ts_ns = 14;
+  // fields 15-19 reserved for future upstream open-source additions.
   // fields 20+ are owned by the enterprise fork (e.g. data_shards/parity_shards)
   // and must not be used here without coordination.
 }

--- a/seaweed-volume/src/server/heartbeat.rs
+++ b/seaweed-volume/src/server/heartbeat.rs
@@ -314,6 +314,7 @@ fn collect_ec_shard_delta_messages(
                         disk_type: ec_vol.disk_type.to_string(),
                         expire_at_sec: ec_vol.expire_at_sec,
                         disk_id: disk_id as u32,
+                        encode_ts_ns: ec_vol.encode_ts_ns,
                         ..Default::default()
                     },
                 );

--- a/seaweed-volume/src/storage/erasure_coding/ec_volume.rs
+++ b/seaweed-volume/src/storage/erasure_coding/ec_volume.rs
@@ -448,6 +448,7 @@ impl EcVolume {
             disk_id,
             file_count,
             delete_count,
+            encode_ts_ns: self.encode_ts_ns,
             ..Default::default()
         }]
     }

--- a/weed/pb/master.proto
+++ b/weed/pb/master.proto
@@ -147,7 +147,11 @@ message VolumeEcShardInformationMessage {
   repeated int64 shard_sizes = 7; // optimized: sizes for shards in order of set bits in ec_index_bits
   uint64 file_count = 8;   // total needles in the .ecx index (live + tombstoned)
   uint64 delete_count = 9; // node-local tombstones in the .ecj deletion journal
-  // fields 10-19 reserved for future upstream open-source additions.
+  // encode-run identity (unix nanos) from the .vif EcShardConfig; lets the admin
+  // group shards by encode generation. Numbered 14 (not 10) to skip the
+  // enterprise fork's reserved 10-13.
+  int64 encode_ts_ns = 14;
+  // fields 15-19 reserved for future upstream open-source additions.
   // fields 20+ are owned by the enterprise fork (e.g. data_shards/parity_shards)
   // and must not be used here without coordination.
 }

--- a/weed/pb/master_pb/master.pb.go
+++ b/weed/pb/master_pb/master.pb.go
@@ -631,16 +631,20 @@ func (x *VolumeShortInformationMessage) GetDiskId() uint32 {
 }
 
 type VolumeEcShardInformationMessage struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Collection    string                 `protobuf:"bytes,2,opt,name=collection,proto3" json:"collection,omitempty"`
-	EcIndexBits   uint32                 `protobuf:"varint,3,opt,name=ec_index_bits,json=ecIndexBits,proto3" json:"ec_index_bits,omitempty"`
-	DiskType      string                 `protobuf:"bytes,4,opt,name=disk_type,json=diskType,proto3" json:"disk_type,omitempty"`
-	ExpireAtSec   uint64                 `protobuf:"varint,5,opt,name=expire_at_sec,json=expireAtSec,proto3" json:"expire_at_sec,omitempty"` // used to record the destruction time of ec volume
-	DiskId        uint32                 `protobuf:"varint,6,opt,name=disk_id,json=diskId,proto3" json:"disk_id,omitempty"`
-	ShardSizes    []int64                `protobuf:"varint,7,rep,packed,name=shard_sizes,json=shardSizes,proto3" json:"shard_sizes,omitempty"` // optimized: sizes for shards in order of set bits in ec_index_bits
-	FileCount     uint64                 `protobuf:"varint,8,opt,name=file_count,json=fileCount,proto3" json:"file_count,omitempty"`           // total needles in the .ecx index (live + tombstoned)
-	DeleteCount   uint64                 `protobuf:"varint,9,opt,name=delete_count,json=deleteCount,proto3" json:"delete_count,omitempty"`     // node-local tombstones in the .ecj deletion journal
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Id          uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Collection  string                 `protobuf:"bytes,2,opt,name=collection,proto3" json:"collection,omitempty"`
+	EcIndexBits uint32                 `protobuf:"varint,3,opt,name=ec_index_bits,json=ecIndexBits,proto3" json:"ec_index_bits,omitempty"`
+	DiskType    string                 `protobuf:"bytes,4,opt,name=disk_type,json=diskType,proto3" json:"disk_type,omitempty"`
+	ExpireAtSec uint64                 `protobuf:"varint,5,opt,name=expire_at_sec,json=expireAtSec,proto3" json:"expire_at_sec,omitempty"` // used to record the destruction time of ec volume
+	DiskId      uint32                 `protobuf:"varint,6,opt,name=disk_id,json=diskId,proto3" json:"disk_id,omitempty"`
+	ShardSizes  []int64                `protobuf:"varint,7,rep,packed,name=shard_sizes,json=shardSizes,proto3" json:"shard_sizes,omitempty"` // optimized: sizes for shards in order of set bits in ec_index_bits
+	FileCount   uint64                 `protobuf:"varint,8,opt,name=file_count,json=fileCount,proto3" json:"file_count,omitempty"`           // total needles in the .ecx index (live + tombstoned)
+	DeleteCount uint64                 `protobuf:"varint,9,opt,name=delete_count,json=deleteCount,proto3" json:"delete_count,omitempty"`     // node-local tombstones in the .ecj deletion journal
+	// encode-run identity (unix nanos) from the .vif EcShardConfig; lets the admin
+	// group shards by encode generation. Numbered 14 (not 10) to skip the
+	// enterprise fork's reserved 10-13.
+	EncodeTsNs    int64 `protobuf:"varint,14,opt,name=encode_ts_ns,json=encodeTsNs,proto3" json:"encode_ts_ns,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -734,6 +738,13 @@ func (x *VolumeEcShardInformationMessage) GetFileCount() uint64 {
 func (x *VolumeEcShardInformationMessage) GetDeleteCount() uint64 {
 	if x != nil {
 		return x.DeleteCount
+	}
+	return 0
+}
+
+func (x *VolumeEcShardInformationMessage) GetEncodeTsNs() int64 {
+	if x != nil {
+		return x.EncodeTsNs
 	}
 	return 0
 }
@@ -4439,7 +4450,7 @@ const file_master_proto_rawDesc = "" +
 	"\x03ttl\x18\n" +
 	" \x01(\rR\x03ttl\x12\x1b\n" +
 	"\tdisk_type\x18\x0f \x01(\tR\bdiskType\x12\x17\n" +
-	"\adisk_id\x18\x10 \x01(\rR\x06diskId\"\xb2\x02\n" +
+	"\adisk_id\x18\x10 \x01(\rR\x06diskId\"\xd4\x02\n" +
 	"\x1fVolumeEcShardInformationMessage\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x1e\n" +
 	"\n" +
@@ -4453,7 +4464,9 @@ const file_master_proto_rawDesc = "" +
 	"shardSizes\x12\x1d\n" +
 	"\n" +
 	"file_count\x18\b \x01(\x04R\tfileCount\x12!\n" +
-	"\fdelete_count\x18\t \x01(\x04R\vdeleteCount\"\xbe\x01\n" +
+	"\fdelete_count\x18\t \x01(\x04R\vdeleteCount\x12 \n" +
+	"\fencode_ts_ns\x18\x0e \x01(\x03R\n" +
+	"encodeTsNs\"\xbe\x01\n" +
 	"\x0eStorageBackend\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12I\n" +

--- a/weed/storage/erasure_coding/ec_volume.go
+++ b/weed/storage/erasure_coding/ec_volume.go
@@ -375,6 +375,7 @@ func (ev *EcVolume) ToVolumeEcShardInformationMessage(diskId uint32) (messages [
 				DiskId:      diskId,
 				FileCount:   fileCount,
 				DeleteCount: deleteCount,
+				EncodeTsNs:  ev.EncodeTsNs,
 			}
 			ecInfoPerVolume[s.VolumeId] = m
 		}

--- a/weed/storage/erasure_coding/ec_volume_info.go
+++ b/weed/storage/erasure_coding/ec_volume_info.go
@@ -15,6 +15,7 @@ type EcVolumeInfo struct {
 	ShardsInfo  *ShardsInfo
 	FileCount   uint64 // live needle count for this EC volume (same on every node holding shards)
 	DeleteCount uint64 // tombstoned needle count for this EC volume
+	EncodeTsNs  int64  // encode-run identity (unix nanos); one value per (volume, disk)
 }
 
 func (ecInfo *EcVolumeInfo) Minus(other *EcVolumeInfo) *EcVolumeInfo {
@@ -27,6 +28,7 @@ func (ecInfo *EcVolumeInfo) Minus(other *EcVolumeInfo) *EcVolumeInfo {
 		ExpireAtSec: ecInfo.ExpireAtSec,
 		FileCount:   ecInfo.FileCount,
 		DeleteCount: ecInfo.DeleteCount,
+		EncodeTsNs:  ecInfo.EncodeTsNs,
 	}
 }
 
@@ -41,5 +43,6 @@ func (evi *EcVolumeInfo) ToVolumeEcShardInformationMessage() (ret *master_pb.Vol
 		DiskId:      evi.DiskId,
 		FileCount:   evi.FileCount,
 		DeleteCount: evi.DeleteCount,
+		EncodeTsNs:  evi.EncodeTsNs,
 	}
 }

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -140,6 +140,7 @@ func NewStore(
 				DiskType:    string(location.DiskType),
 				ExpireAtSec: ecVolume.ExpireAtSec,
 				DiskId:      diskId,
+				EncodeTsNs:  ecVolume.EncodeTsNs,
 			}:
 			default:
 				// Channel full during startup - this is OK, heartbeat will report EC shards later

--- a/weed/storage/store_ec.go
+++ b/weed/storage/store_ec.go
@@ -263,6 +263,12 @@ func (s *Store) UnmountEcShards(vid needle.VolumeId, shardId erasure_coding.Shar
 		if !found {
 			continue
 		}
+		// Capture the encode generation before unloading so the deletion delta
+		// carries it like the mount delta does.
+		var encodeTsNs int64
+		if ecVolume, ok := location.FindEcVolume(vid); ok {
+			encodeTsNs = ecVolume.EncodeTsNs
+		}
 		if deleted := location.UnloadEcShard(vid, shardId); deleted {
 			si := erasure_coding.NewShardsInfo()
 			si.Set(erasure_coding.NewShardInfo(shardId, 0))
@@ -273,6 +279,7 @@ func (s *Store) UnmountEcShards(vid needle.VolumeId, shardId erasure_coding.Shar
 				ShardSizes:  si.SizesInt64(),
 				DiskType:    string(ecShard.DiskType),
 				DiskId:      uint32(diskId),
+				EncodeTsNs:  encodeTsNs,
 			}
 			glog.V(0).Infof("UnmountEcShards %d.%d disk_id:%d", vid, shardId, diskId)
 			unmountedAny = true

--- a/weed/storage/store_ec.go
+++ b/weed/storage/store_ec.go
@@ -218,6 +218,7 @@ func (s *Store) MountEcShards(collection string, vid needle.VolumeId, shardId er
 				DiskType:    string(ecVolume.DiskType()),
 				ExpireAtSec: ecVolume.ExpireAtSec,
 				DiskId:      uint32(diskId),
+				EncodeTsNs:  ecVolume.EncodeTsNs,
 			}
 			return nil
 		}

--- a/weed/topology/topology_ec.go
+++ b/weed/topology/topology_ec.go
@@ -28,6 +28,7 @@ func (t *Topology) SyncDataNodeEcShards(shardInfos []*master_pb.VolumeEcShardInf
 			ExpireAtSec: shardInfo.ExpireAtSec,
 			FileCount:   shardInfo.FileCount,
 			DeleteCount: shardInfo.DeleteCount,
+			EncodeTsNs:  shardInfo.EncodeTsNs,
 		}
 
 		shards = append(shards, ecVolumeInfo)
@@ -57,6 +58,7 @@ func (t *Topology) IncrementalSyncDataNodeEcShards(newEcShards, deletedEcShards 
 			ExpireAtSec: shardInfo.ExpireAtSec,
 			FileCount:   shardInfo.FileCount,
 			DeleteCount: shardInfo.DeleteCount,
+			EncodeTsNs:  shardInfo.EncodeTsNs,
 		}
 
 		newShards = append(newShards, ecVolumeInfo)
@@ -72,6 +74,7 @@ func (t *Topology) IncrementalSyncDataNodeEcShards(newEcShards, deletedEcShards 
 			ExpireAtSec: shardInfo.ExpireAtSec,
 			FileCount:   shardInfo.FileCount,
 			DeleteCount: shardInfo.DeleteCount,
+			EncodeTsNs:  shardInfo.EncodeTsNs,
 		}
 
 		deletedShards = append(deletedShards, ecVolumeInfo)

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -784,6 +784,9 @@ func countExistingEcShardsForVolume(activeTopology *topology.ActiveTopology, vol
 			for _, node := range rack.DataNodeInfos {
 				for _, diskInfo := range node.DiskInfos {
 					for _, ecShardInfo := range diskInfo.EcShardInfos {
+						if ecShardInfo == nil {
+							continue
+						}
 						if ecShardInfo.Id != volumeID || ecShardInfo.Collection != collection {
 							continue
 						}

--- a/weed/worker/tasks/erasure_coding/detection.go
+++ b/weed/worker/tasks/erasure_coding/detection.go
@@ -758,11 +758,18 @@ func cleanupOrphanSourceReplicas(ctx context.Context, clusterInfo *types.Cluster
 }
 
 // countExistingEcShardsForVolume returns the number of distinct EC shard IDs
-// for (volumeID, collection) present in the topology. Walks every disk's
-// EcIndexBits bitmap rather than trusting len(EcShardInfos), because a single
-// info entry can carry multiple shards. Used by the #9448 guard to decide
-// whether the EC shard set is complete enough that the orphaned regular
-// replica is safe to delete.
+// for (volumeID, collection) present in the topology, counting only the single
+// largest encode generation. Shards are grouped by encode_ts_ns (the per-encode
+// identity from .vif), so two interrupted encode runs whose shard sets overlap
+// are never unioned into a false-complete set that would wrongly trigger the
+// orphaned-source delete. Walks every disk's EcIndexBits bitmap rather than
+// trusting len(EcShardInfos), because a single info entry can carry multiple
+// shards. Shards reporting encode_ts_ns==0 (pre-upgrade servers) form their own
+// generation bucket.
+//
+// Limitation: the heartbeat carries one encode_ts_ns per (volume, disk), so this
+// separates generations living on different disks; same-disk mixing is prevented
+// upstream by the pre-encode artifact wipe and the cross-run read guard.
 func countExistingEcShardsForVolume(activeTopology *topology.ActiveTopology, volumeID uint32, collection string) int {
 	if activeTopology == nil {
 		return 0
@@ -771,7 +778,7 @@ func countExistingEcShardsForVolume(activeTopology *topology.ActiveTopology, vol
 	if topologyInfo == nil {
 		return 0
 	}
-	var seen erasure_coding.ShardBits
+	perGeneration := make(map[int64]erasure_coding.ShardBits)
 	for _, dc := range topologyInfo.DataCenterInfos {
 		for _, rack := range dc.RackInfos {
 			for _, node := range rack.DataNodeInfos {
@@ -780,11 +787,17 @@ func countExistingEcShardsForVolume(activeTopology *topology.ActiveTopology, vol
 						if ecShardInfo.Id != volumeID || ecShardInfo.Collection != collection {
 							continue
 						}
-						seen |= erasure_coding.ShardBits(ecShardInfo.EcIndexBits)
+						perGeneration[ecShardInfo.EncodeTsNs] |= erasure_coding.ShardBits(ecShardInfo.EcIndexBits)
 					}
 				}
 			}
 		}
 	}
-	return seen.Count()
+	best := 0
+	for _, bits := range perGeneration {
+		if c := bits.Count(); c > best {
+			best = c
+		}
+	}
+	return best
 }

--- a/weed/worker/tasks/erasure_coding/detection_ec_generation_test.go
+++ b/weed/worker/tasks/erasure_coding/detection_ec_generation_test.go
@@ -1,0 +1,92 @@
+package erasure_coding
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/admin/topology"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/stretchr/testify/require"
+)
+
+type ecShardSet struct {
+	bits       uint32
+	encodeTsNs int64
+}
+
+func ecBits(shardIds ...int) uint32 {
+	var b uint32
+	for _, id := range shardIds {
+		b |= uint32(1) << uint(id)
+	}
+	return b
+}
+
+// buildEcTopology builds an ActiveTopology where each shard set lives on its own
+// node, so countExistingEcShardsForVolume can be exercised across encode
+// generations spread over different disks.
+func buildEcTopology(t *testing.T, vid uint32, collection string, sets []ecShardSet) *topology.ActiveTopology {
+	t.Helper()
+	at := topology.NewActiveTopology(10)
+	nodes := make([]*master_pb.DataNodeInfo, 0, len(sets))
+	for i, set := range sets {
+		nodes = append(nodes, &master_pb.DataNodeInfo{
+			Id: fmt.Sprintf("10.0.0.%d:8080", i+1),
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"hdd": {
+					DiskId:         0,
+					MaxVolumeCount: 100,
+					EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+						{Id: vid, Collection: collection, EcIndexBits: set.bits, EncodeTsNs: set.encodeTsNs},
+					},
+				},
+			},
+		})
+	}
+	topologyInfo := &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id:        "dc1",
+			RackInfos: []*master_pb.RackInfo{{Id: "rack1", DataNodeInfos: nodes}},
+		}},
+	}
+	require.NoError(t, at.UpdateTopology(topologyInfo))
+	return at
+}
+
+// Two interrupted encode runs whose shard sets overlap in count must NOT be
+// unioned into a false-complete set. countExistingEcShardsForVolume returns the
+// largest single generation's shard count, not the cross-run union.
+func TestCountExistingEcShards_DoesNotUnionAcrossGenerations(t *testing.T) {
+	const vid = uint32(42)
+
+	// run A holds shards 0-6 (7 shards, encode_ts 1); run B holds shards 7-13
+	// (7 shards, encode_ts 2). The union would be all 14; the per-generation max
+	// is 7, so the orphan-source delete trigger (>= 14) must not fire.
+	at := buildEcTopology(t, vid, "", []ecShardSet{
+		{bits: ecBits(0, 1, 2, 3, 4, 5, 6), encodeTsNs: 1},
+		{bits: ecBits(7, 8, 9, 10, 11, 12, 13), encodeTsNs: 2},
+	})
+	require.Equal(t, 7, countExistingEcShardsForVolume(at, vid, ""))
+}
+
+// A single complete generation still counts as complete, so genuine stuck-source
+// cleanup keeps working.
+func TestCountExistingEcShards_SingleCompleteGeneration(t *testing.T) {
+	const vid = uint32(43)
+	at := buildEcTopology(t, vid, "", []ecShardSet{
+		{bits: ecBits(0, 1, 2, 3, 4, 5, 6), encodeTsNs: 5},
+		{bits: ecBits(7, 8, 9, 10, 11, 12, 13), encodeTsNs: 5},
+	})
+	require.Equal(t, 14, countExistingEcShardsForVolume(at, vid, ""))
+}
+
+// Shards from pre-upgrade servers report encode_ts_ns==0; a complete 0-generation
+// set is still recognized as complete (its own bucket).
+func TestCountExistingEcShards_PreUpgradeZeroGeneration(t *testing.T) {
+	const vid = uint32(44)
+	at := buildEcTopology(t, vid, "", []ecShardSet{
+		{bits: ecBits(0, 1, 2, 3, 4, 5, 6), encodeTsNs: 0},
+		{bits: ecBits(7, 8, 9, 10, 11, 12, 13), encodeTsNs: 0},
+	})
+	require.Equal(t, 14, countExistingEcShardsForVolume(at, vid, ""))
+}


### PR DESCRIPTION
## Problem

After an EC encode, detection deletes the orphaned regular source replica once the full EC shard set is present in the topology. `countExistingEcShardsForVolume` decided "full" by OR-ing every disk's `EcIndexBits` into a single bitmap. Two interrupted encode runs of the same volume — each holding a partial, overlapping shard set on different nodes — union into a *false-complete* set. The orphan-source delete then fires even though no single encode run is actually complete, and the only intact copy (the source replica) is removed.

This is the topology side of the EC worker-fencing work: the admin layer had no way to tell which encode run produced a given shard set.

## Fix

Carry the per-encode identity (`EncodeTsNs`, already stamped into each shard's `.vif` by the encode) all the way to the admin/worker topology, and group completeness by it:

1. **Propagate** — add `encode_ts_ns` (field 14) to `VolumeEcShardInformationMessage`, populate it from the EC volume on the full and incremental heartbeats, store it on the master's `EcVolumeInfo`, and re-emit it via `GetTopologyInfo`. Field 14 skips the enterprise fork's reserved 10-13.
2. **Consume** — `countExistingEcShardsForVolume` now groups shards by `encode_ts_ns` and returns the largest single generation's shard count, so the orphan-source trigger fires only when one run holds the full set. Shards from pre-upgrade servers (`encode_ts_ns==0`) form their own bucket, so a complete legacy set still works.

### Limitation (documented in code)

The heartbeat carries one `encode_ts_ns` per `(volume, disk)`, so this separates generations living on **different** disks. Same-disk cross-run mixing is prevented upstream by the pre-encode artifact wipe and the cross-run read guard added earlier.

## Rust mirror

The Rust volume server has its own `proto/master.proto` and emits the same heartbeat, so the proto field and both emit sites (`heartbeat.rs`, `ec_volume.rs`) are mirrored. A Rust-served EC volume now reports its encode generation to the Go master at the same field number.

## Tests

`TestCountExistingEcShards_DoesNotUnionAcrossGenerations` (two 7-shard runs on different nodes → counts 7, not 14), `..._SingleCompleteGeneration` (all 14, same generation → 14), and `..._PreUpgradeZeroGeneration` (complete `encode_ts_ns==0` set → 14). `go test ./weed/topology/ ./weed/storage/erasure_coding/ ./weed/worker/tasks/erasure_coding/` and `cargo test --lib` (316) are green.

This is the first of two PRs for the EC generation-fencing proto wave; the second adds `encode_ts_ns` to the shard-delete RPC for a generation-selective teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `encode_ts_ns` encode-run identifier to EC shard info records and propagated it through EC shard reporting and sync paths.

* **Bug Fixes**
  * Improved EC shard completeness detection to evaluate shard generations independently (based on `encode_ts_ns`), avoiding incorrect results when encode runs overlap or are interrupted.

* **Tests**
  * Added generation-aware detection tests covering interrupted runs, single complete generations, and pre-upgrade behavior where `encode_ts_ns` is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->