### PR TITLE
s3: give account-less identities a distinct owner instead of admin

### DIFF
--- a/weed/s3api/auth_account_collapse_test.go
+++ b/weed/s3api/auth_account_collapse_test.go
@@ -49,10 +49,8 @@ func TestUnscopedIdentitiesGetDistinctAccounts(t *testing.T) {
 	assert.Equal(t, AccountAdmin.Id, admin.Account.Id, "the admin identity keeps the admin account")
 }
 
-// TestCheckAccessByOwnershipDeniesNonOwner documents that a non-admin caller can
-// no longer reach an admin-owned bucket's ownership just by having an account-less
-// identity (which previously collapsed to the admin account). iam is nil here, so
-// isUserAdmin returns false and only true ownership grants access.
+// A distinct non-owner is denied an admin-owned bucket (iam nil => isUserAdmin
+// false, so only real ownership grants access).
 func TestCheckAccessByOwnershipDeniesNonOwner(t *testing.T) {
 	adminOwner := AccountAdmin.Id
 	s3a := &S3ApiServer{

--- a/weed/s3api/auth_account_collapse_test.go
+++ b/weed/s3api/auth_account_collapse_test.go
@@ -1,0 +1,74 @@
+package s3api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountForUnscopedIdentity(t *testing.T) {
+	assert.Equal(t, "alice", accountForUnscopedIdentity("alice").Id, "a named identity gets its own account id")
+	assert.NotEqual(t, AccountAdmin.Id, accountForUnscopedIdentity("alice").Id, "a named identity must not inherit the admin account")
+	assert.Same(t, &AccountAdmin, accountForUnscopedIdentity(AccountAdmin.Id), "the conventional admin keeps the admin account")
+	assert.Same(t, &AccountAdmin, accountForUnscopedIdentity(""), "an empty name falls back to the admin account")
+}
+
+func TestUnscopedIdentitiesGetDistinctAccounts(t *testing.T) {
+	resetMemoryStore()
+
+	config := `{
+  "identities": [
+    {"name": "alice", "credentials": [{"accessKey": "alice_ak", "secretKey": "alice_sk"}], "actions": ["Read"]},
+    {"name": "admin", "credentials": [{"accessKey": "admin_ak", "secretKey": "admin_sk"}], "actions": ["Admin"]}
+  ]
+}`
+	tmp, err := os.CreateTemp("", "s3-config-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(config)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: tmp.Name()}, nil, "memory")
+
+	alice, _, found := iam.LookupByAccessKey("alice_ak")
+	require.True(t, found)
+	require.NotNil(t, alice.Account)
+	assert.Equal(t, "alice", alice.Account.Id, "a non-admin account-less identity owns resources as itself, not as admin")
+
+	admin, _, found := iam.LookupByAccessKey("admin_ak")
+	require.True(t, found)
+	require.NotNil(t, admin.Account)
+	assert.Equal(t, AccountAdmin.Id, admin.Account.Id, "the admin identity keeps the admin account")
+}
+
+// TestCheckAccessByOwnershipDeniesNonOwner documents that a non-admin caller can
+// no longer reach an admin-owned bucket's ownership just by having an account-less
+// identity (which previously collapsed to the admin account). iam is nil here, so
+// isUserAdmin returns false and only true ownership grants access.
+func TestCheckAccessByOwnershipDeniesNonOwner(t *testing.T) {
+	adminOwner := AccountAdmin.Id
+	s3a := &S3ApiServer{
+		bucketRegistry: &BucketRegistry{
+			metadataCache: map[string]*BucketMetaData{
+				"b": {Name: "b", Owner: &s3.Owner{ID: &adminOwner}},
+			},
+			notFound: map[string]struct{}{},
+		},
+	}
+
+	nonOwner := httptest.NewRequest(http.MethodGet, "/b?ownershipControls=", nil)
+	nonOwner.Header.Set(s3_constants.AmzAccountId, "alice")
+	assert.Equal(t, s3err.ErrAccessDenied, s3a.checkAccessByOwnership(nonOwner, "b"), "a distinct non-owner is denied the admin-owned bucket")
+
+	owner := httptest.NewRequest(http.MethodGet, "/b?ownershipControls=", nil)
+	owner.Header.Set(s3_constants.AmzAccountId, AccountAdmin.Id)
+	assert.Equal(t, s3err.ErrNone, s3a.checkAccessByOwnership(owner, "b"), "the actual owner is still allowed")
+}

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -137,6 +137,22 @@ var (
 	}
 )
 
+// accountForUnscopedIdentity returns the account for an identity configured
+// without an explicit account block. Distinct identities get distinct account
+// ids derived from the identity name, so they are not collapsed into the shared
+// admin account for ownership and ACL checks. Admin capability is decided from
+// Actions, so a non-admin identity no longer inherits admin's ownership simply
+// by omitting an account.
+func accountForUnscopedIdentity(name string) *Account {
+	if name == "" || name == AccountAdmin.Id {
+		return &AccountAdmin
+	}
+	return &Account{
+		Id:          name,
+		DisplayName: name,
+	}
+}
+
 type Credential struct {
 	AccessKey  string
 	SecretKey  string
@@ -614,7 +630,7 @@ func (iam *IdentityAccessManagement) ReplaceS3ApiConfiguration(config *iam_pb.S3
 			t.Account = &AccountAnonymous
 			identityAnonymous = t
 		case ident.Account == nil:
-			t.Account = &AccountAdmin
+			t.Account = accountForUnscopedIdentity(t.Name)
 		default:
 			if account, ok := accounts[ident.Account.Id]; ok {
 				t.Account = account
@@ -833,7 +849,7 @@ func (iam *IdentityAccessManagement) MergeS3ApiConfiguration(config *iam_pb.S3Ap
 			t.Account = &AccountAnonymous
 			identityAnonymous = t
 		case ident.Account == nil:
-			t.Account = &AccountAdmin
+			t.Account = accountForUnscopedIdentity(t.Name)
 		default:
 			if account, ok := accounts[ident.Account.Id]; ok {
 				t.Account = account

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -137,12 +137,9 @@ var (
 	}
 )
 
-// accountForUnscopedIdentity returns the account for an identity configured
-// without an explicit account block. Distinct identities get distinct account
-// ids derived from the identity name, so they are not collapsed into the shared
-// admin account for ownership and ACL checks. Admin capability is decided from
-// Actions, so a non-admin identity no longer inherits admin's ownership simply
-// by omitting an account.
+// accountForUnscopedIdentity gives an identity with no configured account a
+// distinct account id from its name, so account-less identities are not all
+// collapsed into the shared admin account for ownership/ACL checks.
 func accountForUnscopedIdentity(name string) *Account {
 	if name == "" || name == AccountAdmin.Id {
 		return &AccountAdmin

--- a/weed/s3api/s3api_acp.go
+++ b/weed/s3api/s3api_acp.go
@@ -21,8 +21,13 @@ func (s3a *S3ApiServer) checkAccessByOwnership(r *http.Request, bucket string) s
 	if errCode != s3err.ErrNone {
 		return errCode
 	}
+	// Admin is decided by capability, not by the account id: account-less
+	// identities share the "admin" id but are not all administrators.
+	if s3a.isUserAdmin(r) {
+		return s3err.ErrNone
+	}
 	accountId := getAccountId(r)
-	if accountId == AccountAdmin.Id || accountId == *metadata.Owner.ID {
+	if metadata.Owner != nil && metadata.Owner.ID != nil && accountId == *metadata.Owner.ID {
 		return s3err.ErrNone
 	}
 	return s3err.ErrAccessDenied

--- a/weed/s3api/s3api_acp.go
+++ b/weed/s3api/s3api_acp.go
@@ -21,8 +21,7 @@ func (s3a *S3ApiServer) checkAccessByOwnership(r *http.Request, bucket string) s
 	if errCode != s3err.ErrNone {
 		return errCode
 	}
-	// Admin is decided by capability, not by the account id: account-less
-	// identities share the "admin" id but are not all administrators.
+	// Admin by capability, not account id: account-less identities share the "admin" id.
 	if s3a.isUserAdmin(r) {
 		return s3err.ErrNone
 	}

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -672,9 +672,8 @@ func (s3a *S3ApiServer) hasAccess(r *http.Request, entry *filer_pb.Entry) bool {
 // isUserAdmin securely checks if the authenticated user is an admin
 // This validates admin status through proper IAM authentication, not spoofable headers
 func (s3a *S3ApiServer) isUserAdmin(r *http.Request) bool {
-	// Prefer the identity the Auth middleware already verified and stored in the
-	// request context, to avoid re-running signature verification (which also
-	// fails once the request body has been consumed).
+	// Reuse the identity the Auth middleware stored; re-authenticating here would
+	// fail once the request body has been read.
 	if identityObj := s3_constants.GetIdentityFromContext(r); identityObj != nil {
 		if identity, ok := identityObj.(*Identity); ok {
 			return identity != nil && identity.isAdmin()

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -672,6 +672,14 @@ func (s3a *S3ApiServer) hasAccess(r *http.Request, entry *filer_pb.Entry) bool {
 // isUserAdmin securely checks if the authenticated user is an admin
 // This validates admin status through proper IAM authentication, not spoofable headers
 func (s3a *S3ApiServer) isUserAdmin(r *http.Request) bool {
+	// Prefer the identity the Auth middleware already verified and stored in the
+	// request context, to avoid re-running signature verification (which also
+	// fails once the request body has been consumed).
+	if identityObj := s3_constants.GetIdentityFromContext(r); identityObj != nil {
+		if identity, ok := identityObj.(*Identity); ok {
+			return identity.isAdmin()
+		}
+	}
 	if s3a.iam == nil {
 		return false
 	}

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -677,7 +677,7 @@ func (s3a *S3ApiServer) isUserAdmin(r *http.Request) bool {
 	// fails once the request body has been consumed).
 	if identityObj := s3_constants.GetIdentityFromContext(r); identityObj != nil {
 		if identity, ok := identityObj.(*Identity); ok {
-			return identity.isAdmin()
+			return identity != nil && identity.isAdmin()
 		}
 	}
 	if s3a.iam == nil {

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -672,6 +672,9 @@ func (s3a *S3ApiServer) hasAccess(r *http.Request, entry *filer_pb.Entry) bool {
 // isUserAdmin securely checks if the authenticated user is an admin
 // This validates admin status through proper IAM authentication, not spoofable headers
 func (s3a *S3ApiServer) isUserAdmin(r *http.Request) bool {
+	if s3a.iam == nil {
+		return false
+	}
 	// Use a minimal admin action to authenticate and check admin status
 	adminAction := Action("Admin")
 	identity, errCode := s3a.iam.authRequest(r, adminAction)


### PR DESCRIPTION
Identities configured without an `account` block all defaulted to the shared admin account (`Account.Id == "admin"`). Two effects:

- Distinct users got the same owner id, so object/bucket ownership and ACL owner checks could not tell them apart.
- `checkAccessByOwnership` treated that id as an admin bypass (`accountId == AccountAdmin.Id`), so any account-less caller passed the ownership check for any bucket.

Changes:

- Account-less identities get a distinct account id derived from their name. The conventional `admin` identity (or an empty name) still maps to the admin account.
- `checkAccessByOwnership` decides the admin bypass by Admin capability (`isUserAdmin`) instead of by account id, and only a real owner otherwise passes.
- `isUserAdmin` is now nil-safe.

Admin decisions elsewhere already key off `Actions`/`isAdmin`, so they are unchanged; this only affects ownership/ACL identity. Buckets/objects created by these identities are now owned by the identity name rather than `admin` — a real admin still owns anything stamped before the change. Full s3api suite passes; added unit and end-to-end coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved account “collapse” for non-admin identities when no account is explicitly configured; they now map to distinct, identity-specific accounts (empty/unscoped admin remains admin).
  * Improved bucket access checks to use capability-based admin detection and enforce owner-based authorization more safely.
* **Tests**
  * Added coverage for unscoped identity account mapping, distinct identity-to-account resolution, and ownership-based access denial/allow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->