### PR TITLE
s3: give STS sessions a distinct owner account instead of admin

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -433,13 +433,19 @@ func (iam *IdentityAccessManagement) validateSTSSessionToken(r *http.Request, se
 		claims[k] = v
 	}
 
-	// Create an identity for the STS session. Its account id is the assumed-role
-	// user so ownership stays distinct per principal instead of collapsing into
-	// the shared admin account; permissions come from the session policies, and
-	// admin is granted only through Actions, never by sharing the admin account.
+	// Resolve the principal to the OIDC subject so the same session maps to the
+	// same identity across the SigV4 and JWT auth paths (see s3_iam_middleware.go),
+	// falling back to the assumed-role user when no subject is present. Account and
+	// ownership stay distinct per principal rather than collapsing into the shared
+	// admin account; permissions come from the session policies, and admin is
+	// granted only through Actions.
+	principal := sessionInfo.Subject
+	if principal == "" {
+		principal = sessionInfo.AssumedRoleUser
+	}
 	identity := &Identity{
-		Name:         sessionInfo.AssumedRoleUser,
-		Account:      &Account{Id: sessionInfo.AssumedRoleUser, DisplayName: sessionInfo.AssumedRoleUser},
+		Name:         principal,
+		Account:      &Account{Id: principal, DisplayName: sessionInfo.SessionName, EmailAddress: principal + "@seaweedfs.local"},
 		Credentials:  []*Credential{cred},
 		PrincipalArn: sessionInfo.Principal,
 		PolicyNames:  sessionInfo.Policies, // Populate PolicyNames for IAM authorization

--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -433,12 +433,9 @@ func (iam *IdentityAccessManagement) validateSTSSessionToken(r *http.Request, se
 		claims[k] = v
 	}
 
-	// Resolve the principal to the OIDC subject so the same session maps to the
-	// same identity across the SigV4 and JWT auth paths (see s3_iam_middleware.go),
-	// falling back to the assumed-role user when no subject is present. Account and
-	// ownership stay distinct per principal rather than collapsing into the shared
-	// admin account; permissions come from the session policies, and admin is
-	// granted only through Actions.
+	// Key the principal on the OIDC subject so a session resolves to the same
+	// identity on the SigV4 and JWT paths (see s3_iam_middleware.go); fall back to
+	// the assumed-role user when absent. Distinct per principal, not shared admin.
 	principal := sessionInfo.Subject
 	if principal == "" {
 		principal = sessionInfo.AssumedRoleUser

--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -433,21 +433,18 @@ func (iam *IdentityAccessManagement) validateSTSSessionToken(r *http.Request, se
 		claims[k] = v
 	}
 
-	// Create an identity for the STS session
-	// The identity represents the assumed role user
+	// Create an identity for the STS session. Its account id is the assumed-role
+	// user so ownership stays distinct per principal instead of collapsing into
+	// the shared admin account; permissions come from the session policies, and
+	// admin is granted only through Actions, never by sharing the admin account.
 	identity := &Identity{
-		Name:         sessionInfo.AssumedRoleUser, // Use the assumed role user as the identity name
-		Account:      &AccountAdmin,               // STS sessions use admin account
+		Name:         sessionInfo.AssumedRoleUser,
+		Account:      &Account{Id: sessionInfo.AssumedRoleUser, DisplayName: sessionInfo.AssumedRoleUser},
 		Credentials:  []*Credential{cred},
 		PrincipalArn: sessionInfo.Principal,
 		PolicyNames:  sessionInfo.Policies, // Populate PolicyNames for IAM authorization
 		Claims:       claims,               // Populate Claims for policy variable substitution
 	}
-
-	// Restore admin privileges if the session was created by an admin
-	// if isAdmin, ok := claims["is_admin"].(bool); ok && isAdmin {
-	// 	identity.Actions = append(identity.Actions, s3_constants.ACTION_ADMIN)
-	// }
 
 	glog.V(2).Infof("Successfully validated STS session token for principal: %s, assumed role user: %s",
 		sessionInfo.Principal, sessionInfo.AssumedRoleUser)

--- a/weed/s3api/auth_signature_v4_sts_test.go
+++ b/weed/s3api/auth_signature_v4_sts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -14,11 +15,46 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
+// TestValidateSTSSessionTokenAssignsDistinctAccount asserts an STS session owns
+// resources as its assumed-role user rather than collapsing into the shared
+// admin account. Permissions still come from the session policies.
+func TestValidateSTSSessionTokenAssignsDistinctAccount(t *testing.T) {
+	iam := &IdentityAccessManagement{
+		iamIntegration: &MockIAMIntegration{
+			validateSessionFunc: func(ctx context.Context, token string) (*sts.SessionInfo, error) {
+				return &sts.SessionInfo{
+					AssumedRoleUser: "ReadOnlyRole/alice",
+					Principal:       "arn:aws:sts:::assumed-role/ReadOnlyRole/alice",
+					Subject:         "alice",
+					Credentials: &sts.Credentials{
+						AccessKeyId:     "AKIATEST",
+						SecretAccessKey: "secret",
+					},
+					ExpiresAt: time.Now().Add(time.Hour),
+					Policies:  []string{"ReadOnly"},
+				}, nil
+			},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://s3/test", nil)
+	require.NoError(t, err)
+
+	identity, _, errCode := iam.validateSTSSessionToken(req, "session-token", "AKIATEST")
+	require.Equal(t, s3err.ErrNone, errCode)
+	require.NotNil(t, identity)
+	require.NotNil(t, identity.Account)
+	assert.Equal(t, "ReadOnlyRole/alice", identity.Account.Id, "STS session owns resources as its assumed-role user")
+	assert.NotEqual(t, AccountAdmin.Id, identity.Account.Id, "STS session must not share the admin account")
+	assert.False(t, identity.isAdmin(), "an STS session has no admin action")
+}
+
 // MockIAMIntegration is a mock implementation of IAM integration for testing
 type MockIAMIntegration struct {
 	authenticateJWTFunc     func(ctx context.Context, r *http.Request) (*IAMIdentity, s3err.ErrorCode)
 	authorizeFunc           func(ctx context.Context, identity *IAMIdentity, action Action, bucket, object string, r *http.Request) s3err.ErrorCode
 	validateTrustPolicyFunc func(ctx context.Context, roleArn, principalArn string) error
+	validateSessionFunc     func(ctx context.Context, token string) (*sts.SessionInfo, error)
 	authCalled              bool
 }
 
@@ -38,6 +74,9 @@ func (m *MockIAMIntegration) AuthenticateJWT(ctx context.Context, r *http.Reques
 }
 
 func (m *MockIAMIntegration) ValidateSessionToken(ctx context.Context, token string) (*sts.SessionInfo, error) {
+	if m.validateSessionFunc != nil {
+		return m.validateSessionFunc(ctx, token)
+	}
 	return nil, nil // Not needed for these tests
 }
 

--- a/weed/s3api/auth_signature_v4_sts_test.go
+++ b/weed/s3api/auth_signature_v4_sts_test.go
@@ -16,37 +16,52 @@ import (
 )
 
 // TestValidateSTSSessionTokenAssignsDistinctAccount asserts an STS session owns
-// resources as its assumed-role user rather than collapsing into the shared
-// admin account. Permissions still come from the session policies.
+// resources as its own principal (the OIDC subject, matching the JWT path, or
+// the assumed-role user when no subject is present) rather than collapsing into
+// the shared admin account. Permissions still come from the session policies.
 func TestValidateSTSSessionTokenAssignsDistinctAccount(t *testing.T) {
-	iam := &IdentityAccessManagement{
-		iamIntegration: &MockIAMIntegration{
-			validateSessionFunc: func(ctx context.Context, token string) (*sts.SessionInfo, error) {
-				return &sts.SessionInfo{
-					AssumedRoleUser: "ReadOnlyRole/alice",
-					Principal:       "arn:aws:sts:::assumed-role/ReadOnlyRole/alice",
-					Subject:         "alice",
-					Credentials: &sts.Credentials{
-						AccessKeyId:     "AKIATEST",
-						SecretAccessKey: "secret",
-					},
-					ExpiresAt: time.Now().Add(time.Hour),
-					Policies:  []string{"ReadOnly"},
-				}, nil
-			},
-		},
+	cases := []struct {
+		name            string
+		subject         string
+		assumedRoleUser string
+		wantPrincipal   string
+	}{
+		{"prefers the subject", "alice", "ReadOnlyRole/alice", "alice"},
+		{"falls back to the assumed-role user", "", "ReadOnlyRole/bob", "ReadOnlyRole/bob"},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			iam := &IdentityAccessManagement{
+				iamIntegration: &MockIAMIntegration{
+					validateSessionFunc: func(ctx context.Context, token string) (*sts.SessionInfo, error) {
+						return &sts.SessionInfo{
+							AssumedRoleUser: tc.assumedRoleUser,
+							Principal:       "arn:aws:sts:::assumed-role/" + tc.assumedRoleUser,
+							Subject:         tc.subject,
+							SessionName:     "sess",
+							Credentials: &sts.Credentials{
+								AccessKeyId:     "AKIATEST",
+								SecretAccessKey: "secret",
+							},
+							ExpiresAt: time.Now().Add(time.Hour),
+							Policies:  []string{"ReadOnly"},
+						}, nil
+					},
+				},
+			}
 
-	req, err := http.NewRequest(http.MethodGet, "http://s3/test", nil)
-	require.NoError(t, err)
+			req, err := http.NewRequest(http.MethodGet, "http://s3/test", nil)
+			require.NoError(t, err)
 
-	identity, _, errCode := iam.validateSTSSessionToken(req, "session-token", "AKIATEST")
-	require.Equal(t, s3err.ErrNone, errCode)
-	require.NotNil(t, identity)
-	require.NotNil(t, identity.Account)
-	assert.Equal(t, "ReadOnlyRole/alice", identity.Account.Id, "STS session owns resources as its assumed-role user")
-	assert.NotEqual(t, AccountAdmin.Id, identity.Account.Id, "STS session must not share the admin account")
-	assert.False(t, identity.isAdmin(), "an STS session has no admin action")
+			identity, _, errCode := iam.validateSTSSessionToken(req, "session-token", "AKIATEST")
+			require.Equal(t, s3err.ErrNone, errCode)
+			require.NotNil(t, identity.Account)
+			assert.Equal(t, tc.wantPrincipal, identity.Account.Id, "STS session owns resources as its principal")
+			assert.Equal(t, tc.wantPrincipal, identity.Name)
+			assert.NotEqual(t, AccountAdmin.Id, identity.Account.Id, "STS session must not share the admin account")
+			assert.False(t, identity.isAdmin(), "an STS session has no admin action")
+		})
+	}
 }
 
 // MockIAMIntegration is a mock implementation of IAM integration for testing

--- a/weed/s3api/auth_signature_v4_sts_test.go
+++ b/weed/s3api/auth_signature_v4_sts_test.go
@@ -15,10 +15,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
-// TestValidateSTSSessionTokenAssignsDistinctAccount asserts an STS session owns
-// resources as its own principal (the OIDC subject, matching the JWT path, or
-// the assumed-role user when no subject is present) rather than collapsing into
-// the shared admin account. Permissions still come from the session policies.
+// An STS session owns resources as its own principal (OIDC subject, or the
+// assumed-role user when absent), not the shared admin account.
 func TestValidateSTSSessionTokenAssignsDistinctAccount(t *testing.T) {
 	cases := []struct {
 		name            string


### PR DESCRIPTION
STS sessions were built with `Account: &AccountAdmin`, so every assumed-role session shared the `admin` account id. That collapses ownership across sessions and matches the admin-account shortcut in ownership/ACL checks.

Resolve the session identity to the OIDC subject (`sessionInfo.Subject`), falling back to the assumed-role user when no subject is present, for both the identity name and the account id. This matches the JWT auth path (`s3_iam_middleware.go`, which uses `Subject`) so the same session resolves to the same identity regardless of whether the client authenticates via SigV4 or JWT bearer.

Session permissions are unchanged — they come from the session policies via the IAM authorizer, and admin is decided by `Actions`/`isAdmin`, never by the account id.

Regression test drives `validateSTSSessionToken` through the mock IAM integration for both the subject and fallback cases. Full s3api suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 STS session token authentication to derive the authenticated identity from session details, correctly handling assumed roles when session subject data is present or absent.
  * Updated STS-derived identity fields (including account and user attributes) to reflect the actual principal instead of defaulting to administrative identity data.

* **Tests**
  * Added coverage for STS session token validation to verify distinct account and identity assignment behavior across subject-present and subject-absent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->