### PR TITLE
metrics: guard time()-based dashboard panels against unset gauges

### DIFF
--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -5064,7 +5064,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - SeaweedFS_filerSync_sync_offset{cluster=~\"$cluster\"} / 1e9",
+              "expr": "time() - (SeaweedFS_filerSync_sync_offset{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "{{clientName}} {{path}}"
@@ -5160,7 +5160,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (clientName, path) (SeaweedFS_filer_last_send_timestamp_of_subscribe{cluster=~\"$cluster\"}) / 1e9",
+              "expr": "time() - max by (clientName, path) (SeaweedFS_filer_last_send_timestamp_of_subscribe{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "{{clientName}} {{path}}"

--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -1750,7 +1750,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - SeaweedFS_master_start_time_seconds{cluster=~\"$cluster\"}",
+              "expr": "time() - (SeaweedFS_master_start_time_seconds{cluster=~\"$cluster\"} > 0)",
               "range": true,
               "refId": "A",
               "legendFormat": "{{instance}}"
@@ -3585,7 +3585,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (mode) (SeaweedFS_volumeServer_scrub_last_time_seconds{cluster=~\"$cluster\"})",
+              "expr": "time() - max by (mode) (SeaweedFS_volumeServer_scrub_last_time_seconds{cluster=~\"$cluster\"} > 0)",
               "range": true,
               "refId": "A",
               "legendFormat": "{{mode}}"
@@ -3681,7 +3681,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - SeaweedFS_volumeServer_start_time_seconds{cluster=~\"$cluster\"}",
+              "expr": "time() - (SeaweedFS_volumeServer_start_time_seconds{cluster=~\"$cluster\"} > 0)",
               "range": true,
               "refId": "A",
               "legendFormat": "{{instance}}"
@@ -6804,7 +6804,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_cursor_min_ts_ns{cluster=~\"$cluster\"}) / 1e9",
+              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_cursor_min_ts_ns{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "shard {{shard}}"
@@ -7199,7 +7199,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_daily_run_last_walked_ns{cluster=~\"$cluster\"}) / 1e9",
+              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_daily_run_last_walked_ns{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "shard {{shard}}"


### PR DESCRIPTION
## Problem

The deployed dashboard shows **"Volume Server Uptime" ≈ 56.4 years**. That's `time() - 0` — time since the Unix epoch — because `SeaweedFS_volumeServer_start_time_seconds` is **0**: the Rust volume server doesn't set it, and Go components expose it registered-but-zero. Several other panels share the pattern.

## Fix

Guard every `time() - <gauge>` expression with `> 0`, so unset/zero series drop out (panel shows *no data*) instead of rendering ~56 years:

- **Master Uptime** — `time() - (SeaweedFS_master_start_time_seconds > 0)` (now shows only real masters)
- **Volume Server Uptime** — `... volumeServer_start_time_seconds > 0` (empty until a server actually reports it)
- **Time Since Last Scrub** — `... scrub_last_time_seconds > 0`
- **Lifecycle Cursor Lag** — `... cursor_min_ts_ns > 0`
- **Time Since Last Daily Walk** — `... daily_run_last_walked_ns > 0`

## Verified (live Prometheus)

`time() - (SeaweedFS_master_start_time_seconds > 0)` → 3 masters, ~25 h (sane). `time() - (SeaweedFS_volumeServer_start_time_seconds > 0)` → 0 series (no bogus 56 yr).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the accuracy of several Grafana “time since/lag” panels by refining their metric calculations to avoid basing elapsed-time results on raw zero/initial values.
  * Affected dashboards include uptime and lag tracking for master, volume server, filer sync, metadata subscription, lifecycle cursor, and daily walk metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->