### PR TITLE
filer: keep metadata-subscription send gauge fresh on idle heartbeat

### DIFF
--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -5077,8 +5077,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "title": "Metadata Subscription Lag",
-          "description": "Seconds since the filer last sent a metadata-subscription event (per client/path); only present with active subscribers",
+          "title": "Time Since Last Subscription Send",
+          "description": "Seconds since the filer last sent to a metadata subscription (real event or idle heartbeat), per client/path. Low for healthy caught-up subscribers; clients that don't request idle heartbeats show time since the last real event.",
           "type": "timeseries",
           "id": 156,
           "gridPos": {

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -567,7 +567,11 @@ func (fs *FilerServer) maybeSendIdleHeartbeat(req *filer_pb.SubscribeMetadataReq
 	// A heartbeat is a send too: advance the freshness gauge so an idle but
 	// healthy subscriber doesn't look stale. The gauge otherwise only moves on
 	// real matching events, which never arrive on a quiet path.
-	stats.FilerServerLastSendTsOfSubscribeGauge.WithLabelValues(fs.option.Host.String(), req.ClientName, req.PathPrefix).Set(float64(now))
+	var sourceFiler string
+	if fs.option != nil {
+		sourceFiler = fs.option.Host.String()
+	}
+	stats.FilerServerLastSendTsOfSubscribeGauge.WithLabelValues(sourceFiler, req.ClientName, req.PathPrefix).Set(float64(now))
 	return now
 }
 

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -564,6 +564,10 @@ func (fs *FilerServer) maybeSendIdleHeartbeat(req *filer_pb.SubscribeMetadataReq
 		glog.V(0).Infof("=> idle heartbeat to %s: %v", req.ClientName, err)
 		return lastHeartbeatNs
 	}
+	// A heartbeat is a send too: advance the freshness gauge so an idle but
+	// healthy subscriber doesn't look stale. The gauge otherwise only moves on
+	// real matching events, which never arrive on a quiet path.
+	stats.FilerServerLastSendTsOfSubscribeGauge.WithLabelValues(fs.option.Host.String(), req.ClientName, req.PathPrefix).Set(float64(now))
 	return now
 }
 


### PR DESCRIPTION
## Problem

`SeaweedFS_filer_last_send_timestamp_of_subscribe` is only `.Set()` when a **real metadata event matching the subscriber's path filter** is streamed (`filer_grpc_server_sub_meta.go`, in `eachEventNotificationFn`). On a quiet path, an idle but perfectly healthy subscriber never moves this gauge, so `time() - gauge` grows without bound and the Grafana "Metadata Subscription Lag" panel shows an alarming, misleading value (tens of thousands of seconds) on an otherwise idle cluster.

The idle-heartbeat path (`maybeSendIdleHeartbeat`) already sends an empty keepalive every 5s to caught-up subscribers that opted in, but it sent directly and never touched the gauge — so the metric could not reflect subscriber liveness.

## Fix

A heartbeat is a send too, so advance the gauge to `now` when an idle heartbeat is emitted. Subscribers that opt into idle heartbeats (today: `filer.sync`) now report true freshness (~0 lag while healthy); subscribers that don't opt in still show time since the last real event, which is the best signal available for them.

Also rename the dashboard panel from **"Metadata Subscription Lag"** to **"Time Since Last Subscription Send"** and clarify its description, so the panel isn't read as an error when a cluster is simply idle.

## Notes
- No new metric, no label changes; same gauge, one extra `.Set` on the existing heartbeat path.
- `go build` / `go vet ./weed/server/` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the metadata subscription timing metric’s title and description to clarify the meaning of “time since last subscription send,” including guidance for real events vs idle heartbeat behavior.
* **Chores**
  * Improved subscription idle-heartbeat metric reporting by recording the latest send timestamp immediately and enriching the metric with consistent labeling (including source filer when available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->