### PR TITLE
s3: honor canned ACL header in PutObjectAcl regardless of request body

### DIFF
--- a/weed/s3api/s3api_acl_helper.go
+++ b/weed/s3api/s3api_acl_helper.go
@@ -22,9 +22,23 @@ type AccountManager interface {
 
 // ExtractAcl extracts the acl from the request body, or from the header if request body is empty
 func ExtractAcl(r *http.Request, accountManager AccountManager, ownership, bucketOwnerId, ownerId, accountId string) (grants []*s3.Grant, errCode s3err.ErrorCode) {
-	if r.Body != nil && r.Body != http.NoBody {
+	if r.Body != nil {
 		defer util_http.CloseRequest(r)
+	}
 
+	// A canned ACL is specified via the x-amz-acl header and carries no ACP
+	// body. Clients such as the AWS SDK (with default request checksums) may
+	// still attach a body to the request — an empty payload, or one wrapped in
+	// aws-chunked framing with a checksum trailer. PutObjectAcl/PutBucketAcl do
+	// not de-chunk the body, so honor the canned header first instead of
+	// mis-parsing that body as an AccessControlPolicy and rejecting it with
+	// InvalidRequest.
+	if r.Header.Get(s3_constants.AmzCannedAcl) != "" {
+		_, grants, errCode = ParseAndValidateAclHeadersOrElseDefault(r, accountManager, ownership, bucketOwnerId, accountId, true)
+		return grants, errCode
+	}
+
+	if r.Body != nil && r.Body != http.NoBody {
 		var acp s3.AccessControlPolicy
 		err := xmlutil.UnmarshalXML(&acp, xml.NewDecoder(r.Body), "")
 		if err != nil || acp.Owner == nil || acp.Owner.ID == nil {
@@ -38,10 +52,10 @@ func ExtractAcl(r *http.Request, accountManager AccountManager, ownership, bucke
 		}
 
 		return ValidateAndTransferGrants(accountManager, acp.Grants)
-	} else {
-		_, grants, errCode = ParseAndValidateAclHeadersOrElseDefault(r, accountManager, ownership, bucketOwnerId, accountId, true)
-		return grants, errCode
 	}
+
+	_, grants, errCode = ParseAndValidateAclHeadersOrElseDefault(r, accountManager, ownership, bucketOwnerId, accountId, true)
+	return grants, errCode
 }
 
 // ParseAndValidateAclHeadersOrElseDefault will callParseAndValidateAclHeaders to get Grants, if empty, it will return Grant that grant `accountId` with `FullControl` permission

--- a/weed/s3api/s3api_acl_helper_test.go
+++ b/weed/s3api/s3api_acl_helper_test.go
@@ -1,0 +1,64 @@
+package s3api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+)
+
+// stubAccountManager satisfies AccountManager for ACL helper tests: any
+// non-empty id resolves to a name so canonical-user grants validate.
+type stubAccountManager struct{}
+
+func (stubAccountManager) GetAccountNameById(id string) string {
+	if id == "" {
+		return ""
+	}
+	return "account-" + id
+}
+
+func (stubAccountManager) GetAccountIdByEmail(string) string { return "" }
+
+// A canned-ACL request carries the ACL in the x-amz-acl header and no ACP body.
+// Newer AWS SDKs (default request checksums) still attach a body — an empty
+// payload or one wrapped in aws-chunked framing with a checksum trailer. Since
+// PutObjectAcl does not de-chunk, ExtractAcl must honor the canned header
+// instead of XML-parsing that body and returning InvalidRequest.
+func TestExtractAclCannedAclWithNonEmptyBody(t *testing.T) {
+	const accountId = "testAccount"
+	// Not valid AccessControlPolicy XML: stands in for aws-chunked framing /
+	// checksum trailer that the SDK attaches to a header-only request.
+	framedBody := "0\r\nx-amz-checksum-crc32:AAAAAA==\r\n\r\n"
+
+	r, err := http.NewRequest(http.MethodPut, "http://example.com/bucket/object?acl", strings.NewReader(framedBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Header.Set(s3_constants.AmzCannedAcl, s3_constants.CannedAclPrivate)
+
+	grants, errCode := ExtractAcl(r, stubAccountManager{}, "", accountId, accountId, accountId)
+	if errCode != s3err.ErrNone {
+		t.Fatalf("canned ACL with non-empty body: expected ErrNone, got %v", errCode)
+	}
+	if len(grants) != 1 {
+		t.Fatalf("canned private should yield 1 grant (owner full control), got %d", len(grants))
+	}
+}
+
+// Without a canned ACL header, ExtractAcl must still treat the body as an
+// AccessControlPolicy — a non-XML body is rejected with InvalidRequest. This
+// guards that the canned-header fast path didn't bypass body parsing entirely.
+func TestExtractAclNonXmlBodyWithoutCannedHeader(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPut, "http://example.com/bucket/object?acl", strings.NewReader("not-acp-xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, errCode := ExtractAcl(r, stubAccountManager{}, "", "owner", "owner", "owner")
+	if errCode != s3err.ErrInvalidRequest {
+		t.Fatalf("non-XML body without canned header: expected ErrInvalidRequest, got %v", errCode)
+	}
+}


### PR DESCRIPTION
## Problem

`TestVersionedObjectAcl` (S3 versioning suite) started failing: a canned `PutObjectAcl` (`ACL: private`) on a versioned object returns **400 InvalidRequest** —

```
PutObjectAcl … StatusCode: 400 … api error InvalidRequest: Invalid Request
```

## Root cause

`ExtractAcl` (`weed/s3api/s3api_acl_helper.go`) chose between an XML `AccessControlPolicy` body and ACL **headers** by checking whether the request had a body:

```go
if r.Body != nil && r.Body != http.NoBody { /* XML-parse body */ } else { /* parse headers */ }
```

A canned ACL is specified entirely via the `x-amz-acl` header and carries no ACP body. But:
- On the server, `r.Body` is never `http.NoBody`, and SigV4 auth re-buffers the body into a `NopCloser` — so the body branch is effectively always taken.
- Newer `aws-sdk-go-v2` (default request checksums, bumped in #9871) attaches a body even to header-only requests — an empty payload, or one wrapped in **aws-chunked** framing with a checksum trailer.
- `PutObjectAcl`/`PutBucketAcl` never call `getRequestDataReader`, so the body is **not de-chunked**.

So `ExtractAcl` tried to XML-parse an empty / aws-chunked-framed body and returned `ErrInvalidRequest`.

## Fix

Honor the canned ACL header (`x-amz-acl`) before inspecting the body, and drain the body on all paths. When no canned header is present, the XML `AccessControlPolicy` body path is unchanged.

## Tests

- `TestExtractAclCannedAclWithNonEmptyBody` — canned `private` + a non-XML (aws-chunked-framed) body now returns `ErrNone` with the expected grant. **Fails on the old code** (returns `ErrInvalidRequest`), passes with the fix.
- `TestExtractAclNonXmlBodyWithoutCannedHeader` — guards that the body is still parsed (and a non-XML body rejected) when no canned header is present.
- Full `go test ./weed/s3api/` passes.

This is the regression behind the S3 Versioning integration test failures seen on recent PRs/CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 ACL handling to correctly prioritize canned-ACL headers over request body content, ensuring proper compliance with S3 API specifications.

* **Tests**
  * Added comprehensive test coverage for S3 ACL extraction with canned-ACL headers and various request body formats to validate correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->