### PR TITLE
s3: register account-less identities' synthesized account so ACL/owner ids resolve

### DIFF
--- a/weed/s3api/auth_account_collapse_test.go
+++ b/weed/s3api/auth_account_collapse_test.go
@@ -96,3 +96,36 @@ func TestUnscopedIdentityAccountResolvesByName(t *testing.T) {
 	assert.Equal(t, "alice", iam.GetAccountNameById("alice"),
 		"account-less identity id must resolve to a display name for ACL/owner validation")
 }
+
+// When an account is explicitly configured with the same id an account-less
+// identity would synthesize, the identity must reuse that configured account so
+// its custom display name/email are preserved.
+func TestUnscopedIdentityReusesConfiguredAccount(t *testing.T) {
+	resetMemoryStore()
+
+	config := `{
+  "accounts": [
+    {"id": "alice", "displayName": "Alice Smith", "emailAddress": "alice@example.com"}
+  ],
+  "identities": [
+    {"name": "alice", "credentials": [{"accessKey": "alice_ak", "secretKey": "alice_sk"}], "actions": ["Read"]}
+  ]
+}`
+	tmp, err := os.CreateTemp("", "s3-config-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(config)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: tmp.Name()}, nil, "memory")
+
+	assert.Equal(t, "Alice Smith", iam.GetAccountNameById("alice"),
+		"explicitly configured account display name must be preserved")
+
+	alice, _, found := iam.LookupByAccessKey("alice_ak")
+	require.True(t, found)
+	require.NotNil(t, alice.Account)
+	assert.Equal(t, "Alice Smith", alice.Account.DisplayName,
+		"identity must reuse the configured account, not the synthesized one")
+}

--- a/weed/s3api/auth_account_collapse_test.go
+++ b/weed/s3api/auth_account_collapse_test.go
@@ -70,3 +70,29 @@ func TestCheckAccessByOwnershipDeniesNonOwner(t *testing.T) {
 	owner.Header.Set(s3_constants.AmzAccountId, AccountAdmin.Id)
 	assert.Equal(t, s3err.ErrNone, s3a.checkAccessByOwnership(owner, "b"), "the actual owner is still allowed")
 }
+
+// An account-less identity's synthesized account must be registered in the
+// account lookup so its id resolves to a display name. Otherwise ACL grantee
+// validation and owner display report the id as "not exists" — the regression
+// where a canned PutObjectAcl granting to the caller's own account returned
+// 400 InvalidRequest.
+func TestUnscopedIdentityAccountResolvesByName(t *testing.T) {
+	resetMemoryStore()
+
+	config := `{
+  "identities": [
+    {"name": "alice", "credentials": [{"accessKey": "alice_ak", "secretKey": "alice_sk"}], "actions": ["Read", "Write"]}
+  ]
+}`
+	tmp, err := os.CreateTemp("", "s3-config-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(config)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: tmp.Name()}, nil, "memory")
+
+	assert.Equal(t, "alice", iam.GetAccountNameById("alice"),
+		"account-less identity id must resolve to a display name for ACL/owner validation")
+}

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -627,13 +627,17 @@ func (iam *IdentityAccessManagement) ReplaceS3ApiConfiguration(config *iam_pb.S3
 			t.Account = &AccountAnonymous
 			identityAnonymous = t
 		case ident.Account == nil:
-			t.Account = accountForUnscopedIdentity(t.Name)
-			// Register the synthesized account so its id resolves to a display
-			// name. Account-less identities own resources under this id, and
-			// ACL grantee validation / owner display look the id up via
-			// GetAccountNameById; without this the id is reported "not exists".
-			if _, ok := accounts[t.Account.Id]; !ok {
-				accounts[t.Account.Id] = t.Account
+			// Account-less identities own resources under a distinct id derived
+			// from their name. Reuse an explicitly-configured account with that
+			// id if one exists (preserving its display name/email); otherwise
+			// synthesize one and register it so the id resolves via
+			// GetAccountNameById (ACL grantee validation, owner display).
+			synthesized := accountForUnscopedIdentity(t.Name)
+			if existing, ok := accounts[synthesized.Id]; ok {
+				t.Account = existing
+			} else {
+				t.Account = synthesized
+				accounts[synthesized.Id] = synthesized
 			}
 		default:
 			if account, ok := accounts[ident.Account.Id]; ok {
@@ -853,13 +857,17 @@ func (iam *IdentityAccessManagement) MergeS3ApiConfiguration(config *iam_pb.S3Ap
 			t.Account = &AccountAnonymous
 			identityAnonymous = t
 		case ident.Account == nil:
-			t.Account = accountForUnscopedIdentity(t.Name)
-			// Register the synthesized account so its id resolves to a display
-			// name. Account-less identities own resources under this id, and
-			// ACL grantee validation / owner display look the id up via
-			// GetAccountNameById; without this the id is reported "not exists".
-			if _, ok := accounts[t.Account.Id]; !ok {
-				accounts[t.Account.Id] = t.Account
+			// Account-less identities own resources under a distinct id derived
+			// from their name. Reuse an explicitly-configured account with that
+			// id if one exists (preserving its display name/email); otherwise
+			// synthesize one and register it so the id resolves via
+			// GetAccountNameById (ACL grantee validation, owner display).
+			synthesized := accountForUnscopedIdentity(t.Name)
+			if existing, ok := accounts[synthesized.Id]; ok {
+				t.Account = existing
+			} else {
+				t.Account = synthesized
+				accounts[synthesized.Id] = synthesized
 			}
 		default:
 			if account, ok := accounts[ident.Account.Id]; ok {

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -628,6 +628,13 @@ func (iam *IdentityAccessManagement) ReplaceS3ApiConfiguration(config *iam_pb.S3
 			identityAnonymous = t
 		case ident.Account == nil:
 			t.Account = accountForUnscopedIdentity(t.Name)
+			// Register the synthesized account so its id resolves to a display
+			// name. Account-less identities own resources under this id, and
+			// ACL grantee validation / owner display look the id up via
+			// GetAccountNameById; without this the id is reported "not exists".
+			if _, ok := accounts[t.Account.Id]; !ok {
+				accounts[t.Account.Id] = t.Account
+			}
 		default:
 			if account, ok := accounts[ident.Account.Id]; ok {
 				t.Account = account
@@ -847,6 +854,13 @@ func (iam *IdentityAccessManagement) MergeS3ApiConfiguration(config *iam_pb.S3Ap
 			identityAnonymous = t
 		case ident.Account == nil:
 			t.Account = accountForUnscopedIdentity(t.Name)
+			// Register the synthesized account so its id resolves to a display
+			// name. Account-less identities own resources under this id, and
+			// ACL grantee validation / owner display look the id up via
+			// GetAccountNameById; without this the id is reported "not exists".
+			if _, ok := accounts[t.Account.Id]; !ok {
+				accounts[t.Account.Id] = t.Account
+			}
 		default:
 			if account, ok := accounts[ident.Account.Id]; ok {
 				t.Account = account


### PR DESCRIPTION
## Problem

`TestVersionedObjectAcl` regressed: a canned `PutObjectAcl` (`ACL: private`) returns **400 InvalidRequest**. Server logs:

```
bucket_metadata.go:137  owner[id=some_admin_user] is invalid, bucket: test-versioned-acl
s3api_acl_helper.go:283  invalid canonical grantee! account id[some_admin_user] is not exists
```

## Root cause (trigger: #9962)

#9962 ("give account-less identities a distinct owner instead of admin") added `accountForUnscopedIdentity`, so an identity configured without an `account` block now owns resources under a distinct account id derived from its name (e.g. `some_admin_user`) instead of collapsing into the shared admin account.

But that synthesized account is assigned to the identity **without being registered in the `accounts` (id → account) map** that `GetAccountNameById` consults. So:

- `ValidateAndTransferGrants` rejects a canonical-user grant to that id (`account id … is not exists` → `ErrInvalidRequest`). A canned `private` ACL grants to the caller's *own* account, so any account-less identity's `PutObjectAcl` fails.
- bucket/object owner display is dropped (`owner … is invalid`).

This is unrelated to the request body / SDK checksum behavior — the empty body arrives as `http.NoBody` and the canned-ACL header path is taken correctly; the failure is downstream in account resolution.

## Fix

Register the synthesized account in the `accounts` map at config load (both `ReplaceS3ApiConfiguration` and `MergeS3ApiConfiguration`), so its id resolves to a display name for ACL grantee validation and owner display.

## Tests

- `TestUnscopedIdentityAccountResolvesByName` — after loading a config with an account-less identity, `GetAccountNameById(id)` returns its display name. **Fails on master** (empty), passes with the fix.
- #9962's existing tests (`TestAccountForUnscopedIdentity`, `TestUnscopedIdentitiesGetDistinctAccounts`, `TestCheckAccessByOwnershipDeniesNonOwner`) still pass.
- Full `go test ./weed/s3api/` passes.

Fixes the S3 Versioning suite failure (`TestVersionedObjectAcl`) seen on recent PRs/CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account-name lookups for identities without explicitly configured accounts by ensuring synthesized accounts are registered during both full configuration replacement and incremental merges.
  * Ensured that when an explicit account is configured for an id that could otherwise be synthesized, the configured account’s display details are preserved and reused.

* **Tests**
  * Added regression coverage for unscoped identity name resolution by id and for reuse of configured accounts instead of synthesized ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->