### PR TITLE
fix(command): preserve fuse option after writers

### DIFF
--- a/weed/command/fuse_std.go
+++ b/weed/command/fuse_std.go
@@ -165,7 +165,6 @@ func runFuse(cmd *Command, args []string) bool {
 				panic(fmt.Errorf("dirIdleEvictSec: %s", err))
 			}
 		case "concurrentWriters":
-			i++
 			if parsed, err := strconv.ParseInt(parameter.value, 0, 32); err == nil {
 				intValue := int(parsed)
 				mountOptions.concurrentWriters = &intValue

--- a/weed/command/fuse_std_test.go
+++ b/weed/command/fuse_std_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestRunFuseDoesNotSkipOptionAfterConcurrentWriters(t *testing.T) {
-	oldUmask := *mountOptions.umaskString
-	oldWriters := *mountOptions.concurrentWriters
-	oldReaders := *mountOptions.concurrentReaders
+	oldUmask := mountOptions.umaskString
+	oldWriters := mountOptions.concurrentWriters
+	oldReaders := mountOptions.concurrentReaders
 	oldFuseCommandPid := mountOptions.fuseCommandPid
-	oldDir := *mountOptions.dir
+	oldDir := mountOptions.dir
 	defer func() {
-		*mountOptions.umaskString = oldUmask
-		*mountOptions.concurrentWriters = oldWriters
-		*mountOptions.concurrentReaders = oldReaders
+		mountOptions.umaskString = oldUmask
+		mountOptions.concurrentWriters = oldWriters
+		mountOptions.concurrentReaders = oldReaders
 		mountOptions.fuseCommandPid = oldFuseCommandPid
-		*mountOptions.dir = oldDir
+		mountOptions.dir = oldDir
 
 		recovered := recover()
 		if recovered == nil {

--- a/weed/command/fuse_std_test.go
+++ b/weed/command/fuse_std_test.go
@@ -1,0 +1,38 @@
+//go:build darwin || freebsd || linux
+
+package command
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRunFuseDoesNotSkipOptionAfterConcurrentWriters(t *testing.T) {
+	oldUmask := *mountOptions.umaskString
+	oldWriters := *mountOptions.concurrentWriters
+	oldReaders := *mountOptions.concurrentReaders
+	oldFuseCommandPid := mountOptions.fuseCommandPid
+	oldDir := *mountOptions.dir
+	defer func() {
+		*mountOptions.umaskString = oldUmask
+		*mountOptions.concurrentWriters = oldWriters
+		*mountOptions.concurrentReaders = oldReaders
+		mountOptions.fuseCommandPid = oldFuseCommandPid
+		*mountOptions.dir = oldDir
+
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected invalid concurrentReaders option to be parsed")
+		}
+		if !strings.Contains(fmt.Sprint(recovered), "concurrentReaders") {
+			t.Fatalf("expected concurrentReaders parse error, got %v", recovered)
+		}
+	}()
+
+	runFuse(cmdMount, []string{
+		"/mnt",
+		"-o",
+		"child=1,concurrentWriters=2,concurrentReaders=bad,umask=bad",
+	})
+}


### PR DESCRIPTION
# What problem are we solving?

FUSE mount option parsing skipped the option immediately following `concurrentWriters`.

For example:

```text
-o child=1,concurrentWriters=2,concurrentReaders=10
```

`concurrentReaders` could be silently ignored and keep using the default value, because the parser advanced the option index twice after handling `concurrentWriters`.

# How are we solving the problem?

Remove the extra index increment in the `concurrentWriters` option handler, so the normal options loop continues with the next option.

Also add a regression test that places an invalid `concurrentReaders` value immediately after `concurrentWriters`, verifying that `concurrentReaders` is still parsed and reported.

# How is the PR tested?

```bash
go test ./weed/command -run TestRunFuseDoesNotSkipOptionAfterConcurrentWriters
```

Result:

```text
ok  	github.com/seaweedfs/seaweedfs/weed/command	0.094s
```

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FUSE mount option parsing to prevent an option from being accidentally skipped after handling `concurrentWriters`, ensuring subsequent options are interpreted correctly.

* **Tests**
  * Added a platform-targeted test to confirm `runFuse` does not skip options after `concurrentWriters` and that invalid related values (e.g., `concurrentReaders`) trigger the expected panic message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->