### PR TITLE
security.toml: document WEED_ env override for jwt signing keys

### DIFF
--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -4,7 +4,16 @@
 #    /etc/seaweedfs/security.toml
 # this file is read by master, volume server, filer, and worker
 
-# comma separated origins allowed to make requests to the filer and s3 gateway. 
+# Any value below can also be supplied as an environment variable instead of
+# living in this file: prefix the key with WEED_, upper-case it, and replace
+# "." with "_". This is the recommended way to inject the secrets in here from
+# a Kubernetes Secret (env valueFrom.secretKeyRef) rather than a ConfigMap.
+# The JWT signing keys map to:
+#   WEED_JWT_SIGNING_KEY, WEED_JWT_SIGNING_READ_KEY              (master <-> volume)
+#   WEED_JWT_FILER_SIGNING_KEY, WEED_JWT_FILER_SIGNING_READ_KEY  (s3/clients <-> filer)
+# A set env var wins over the file, so the file can stay empty (or absent).
+
+# comma separated origins allowed to make requests to the filer and s3 gateway.
 # enter in this format: https://domain.com, or http://localhost:port
 [cors.allowed_origins]
 values = "*"


### PR DESCRIPTION
The JWT signing keys in `security.toml` are HMAC secrets, but the scaffold only documented the `WEED_` env-var override for `[admin]` and `[s3.sse]`. The same override has always worked for every value (viper `AutomaticEnv`, prefix `WEED`, `.`->`_`), so spell it out for the jwt keys:

- `WEED_JWT_SIGNING_KEY`, `WEED_JWT_SIGNING_READ_KEY` (master, volume)
- `WEED_JWT_FILER_SIGNING_KEY`, `WEED_JWT_FILER_SIGNING_READ_KEY` (s3 gateway, filer, clients)

This is the answer to #9974: inject the keys from a Kubernetes Secret via `valueFrom.secretKeyRef` instead of keeping them in a ConfigMap. A set env var overrides the file, so the file entry can stay empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved security configuration documentation with clearer explanations of how environment variables can be used to configure security-related settings, including guidance on proper naming conventions and transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->